### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/cdeust/Cortex/security/code-scanning/1](https://github.com/cdeust/Cortex/security/code-scanning/1)

Generally, the fix is to add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the minimal scopes required. Because this workflow only needs to read the repository contents (for `actions/checkout`) and upload artifacts (which does not require repository write access), a root-level `permissions` block with `contents: read` is appropriate. This will apply to all jobs (`test`, `lint`, `typecheck`, `build`) since none define their own `permissions`.

The best fix without changing existing functionality is to add a top-level `permissions` section right after the `name` (or after `on`) in `.github/workflows/ci.yml`:

```yaml
permissions:
  contents: read
```

No other scopes (such as `pull-requests: write`, `issues: write`, etc.) appear necessary because the workflow does not interact with those APIs. No imports or additional definitions are needed—this is purely a YAML configuration change within the existing file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
