### PR TITLE
fix(docker): use `python -m mcp_server` entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,8 @@ HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
 
 # MCP servers typically run stdio transport; no ports to expose.
 # Prometheus metrics endpoint is served by the sidecar in Phase 7.1.
-ENTRYPOINT ["neuro-cortex-memory"]
+#
+# Use `python -m mcp_server` because pyproject.toml registers only one
+# console script (`cortex-doctor`); there is no `neuro-cortex-memory`
+# entry point. The package's __main__.py documents this invocation.
+ENTRYPOINT ["python", "-m", "mcp_server"]


### PR DESCRIPTION
## Summary

The Dockerfile's `ENTRYPOINT ["neuro-cortex-memory"]` references a console script that is not registered in `pyproject.toml`. The only script declared under `[project.scripts]` is `cortex-doctor`. As a result, the image fails to start:

```
exec: "neuro-cortex-memory": executable file not found in $PATH
```

Switch to `python -m mcp_server`, which is the invocation the package itself documents in `mcp_server/__main__.py`:

```python
"""Bootstrap entry point for the methodology-agent MCP server.

Usage:
    python -m mcp_server
"""
```

## Verification

- `pyproject.toml` `[project.scripts]` only registers `cortex-doctor`
- `mcp_server/__main__.py` is present and exits cleanly via SIGTERM/SIGINT handlers
- Locally built image with this change: container starts, `mcp_server` registers FastMCP tools, MCP stdio handshake succeeds
- HEALTHCHECK still passes (it imports `memory_config`, unrelated to entrypoint)

## Scope

Single-line change inside the existing `Dockerfile` plus a short comment explaining why. No behavioral change beyond making the image actually launch. No changes to dependencies, build stages, or runtime image surface.

Discovered while standing up Cortex on a Windows host via Docker (the only practical install path on Windows since `setup.sh` is gated on `Darwin/Linux` in `detect_os()`). Found in 3.14.5; same line is present in 3.15.0.

## Test plan

- [ ] `docker build -t cortex:test .` succeeds
- [ ] `docker run --rm -e DATABASE_URL=postgresql://... cortex:test` starts (stdio mode; expect to feed/read MCP messages or pipe `/dev/null`)
- [ ] HEALTHCHECK exits 0 within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)