### PR TITLE
fix: v3.15.3 hotfix — python-multipart CVE + recover from broken v3.15.2 tag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Persistent memory and cognitive profiling plugins for Claude Code",
-    "version": "3.15.2"
+    "version": "3.15.3"
   },
   "plugins": [
     {
       "name": "cortex",
       "source": "./",
       "description": "Persistent memory and cognitive profiling for Claude Code — thermodynamic memory with heat/decay, intent-aware retrieval, biological plasticity, codebase intelligence, and cognitive profiling. 47 MCP tools with enriched schemas. PostgreSQL + pgvector in CLI mode; automatic SQLite fallback in Cowork/sandboxed mode. Curated wiki (ADRs, specs, lessons) with audit-artefact filtering. Consolidate is set-based SQL batched — decay/plasticity/pruning run 100-500× faster on large stores. Workflow graph with caller-qualified CALLS chains rendering full method-to-method dependencies (native tree-sitter, no AP required). Side panel humanized for non-technical users. Ingests codebase analysis (ai-automatised-pipeline) and PRDs (prd-spec-generator) into wiki + memory + knowledge graph. Docker image available.",
-      "version": "3.15.2",
+      "version": "3.15.3",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [3.15.3] - 2026-05-09
+
+### Security
+- **python-multipart 0.0.26 → 0.0.27** — fixes a denial-of-service vulnerability in `MultipartParser` header parsing where an attacker could send unbounded multipart part headers (oversized individual values or many repeated headers without terminating the header block) causing CPU exhaustion. Affects FastMCP and any ASGI / Starlette / FastAPI app in the dependency chain. Patched version 0.0.27 enforces default header-count and header-size limits. ([Dependabot alert](https://github.com/cdeust/Cortex/security/dependabot))
+
+### Fixed
+- v3.15.2 GitHub release was tagged at the wrong commit (308ed41 instead of the PR-#22 merge commit 6b19ec4) due to a local fast-forward conflict during release scripting. The v3.15.2 tag now exists as a graveyard entry; v3.15.3 is the canonical version that includes both the MCP startup robustness work from PR #22 (originally intended for v3.15.2) AND this security bump.
+
+### Notes for users
+- If you're on v3.15.0, v3.15.1, or v3.15.2, upgrade directly to v3.15.3 to get the python-multipart security fix plus the MCP startup robustness improvements (`${CLAUDE_PLUGIN_ROOT}` substitution + `cortex-doctor mcp` diagnostic).
+
 ## [3.15.2] - 2026-05-09
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neuro-cortex-memory"
-version = "3.15.2"
+version = "3.15.3"
 description = "Scientifically-grounded memory system based on computational neuroscience research"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1795,7 +1795,7 @@ wheels = [
 
 [[package]]
 name = "neuro-cortex-memory"
-version = "3.15.0"
+version = "3.15.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -1874,8 +1874,8 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'benchmarks'", specifier = ">=2.2.0" },
     { name = "sentence-transformers", marker = "extra == 'dev'", specifier = ">=2.2.0" },
     { name = "sqlite-vec", marker = "extra == 'sqlite'", specifier = ">=0.1.1" },
-    { name = "tree-sitter", marker = "extra == 'codebase'", specifier = ">=0.24.0" },
-    { name = "tree-sitter-language-pack", marker = "extra == 'codebase'", specifier = ">=0.24.0" },
+    { name = "tree-sitter", marker = "extra == 'codebase'", specifier = ">=0.24.0,<0.26" },
+    { name = "tree-sitter-language-pack", marker = "extra == 'codebase'", specifier = ">=0.24.0,<1.7" },
 ]
 provides-extras = ["postgresql", "sqlite", "codebase", "viz-tile", "benchmarks", "dev"]
 
@@ -3211,11 +3211,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why a hotfix

Two issues converged.

### 1. CVE: python-multipart DoS via unbounded part headers
`python-multipart` 0.0.26 (transitive via fastmcp) has a denial-of-service vulnerability in `MultipartParser` header parsing. An attacker can send oversized individual header values OR many repeated headers without terminating the header block; both cause CPU exhaustion before request rejection. Affects every ASGI / Starlette / FastAPI app in the dep chain.

Patched in 0.0.27 by enforcing default parser limits for max header count and header size.

Dependabot opened PR #21 with this bump. I closed it earlier today thinking it was a routine patch bump — that was the wrong call given it carries a CVE fix. This hotfix re-applies the bump on a current branch.

### 2. v3.15.2 release was tagged at the wrong commit
PR #22 merged on GitHub at `6b19ec4` (with pyproject correctly bumped to 3.15.2 and the v3.15.2 CHANGELOG section). My local main was stuck at `308ed41` due to a stale uv.lock blocking the fast-forward, so when I ran `git tag -a v3.15.2 && git push`, the tag landed at `308ed41` (where pyproject still says 3.15.1, no v3.15.2 CHANGELOG, GitHub release notes empty).

The broken v3.15.2 tag stays as a graveyard entry (force-push of a tag that's been live ~10 minutes is destructive; not worth the rewrite). v3.15.3 is the canonical version that bundles BOTH PR #22's contents AND this security fix.

## What lands here

- `uv.lock`: python-multipart 0.0.26 → 0.0.27
- `pyproject.toml`: 3.15.2 → 3.15.3
- `.claude-plugin/marketplace.json`: 3.15.2 → 3.15.3
- `CHANGELOG.md`: new v3.15.3 section explaining both issues; v3.15.2 section preserved for history
- All v3.15.2-bound features (PR #22's robust .mcp.json + cortex-doctor mcp) carry through unchanged

52 targeted tests still pass locally.

## Upgrade path

If you're on v3.15.0, v3.15.1, or v3.15.2 — upgrade directly to v3.15.3. Skip v3.15.2 (broken tag).

## Process lessons

1. Never run `git tag` from a working tree that hasn't successfully `git pull`'d the merge commit. The release scripting now needs a guard.
2. Don't close dependabot PRs without checking the security tab first.