### PR TITLE
feat(wiki): richer multi-axis classification (ADR-2244 Phase 1)

### DIFF
--- a/docs/research/wiki-classification-survey.md
+++ b/docs/research/wiki-classification-survey.md
@@ -1,0 +1,123 @@
+# Document Classification Taxonomies for Engineering Knowledge Bases — A Survey
+
+**Author:** Cochrane agent (evidence synthesis)
+**Date:** 2026-05-12
+**Question:** What taxonomy redesign should Cortex adopt, given that 92% of its content sits in the catch-all `notes/` kind?
+**Method:** Systematic web survey of canonical taxonomies. Inclusion: official docs, style guides, published templates, primary sources. Exclusion: vendor marketing posts without schema detail.
+**Word count target:** ≤1500 (body, excluding tables).
+
+---
+
+## 1. Summary table of taxonomies surveyed
+
+| System | # of kinds (primary) | Cross-cutting axes | Source |
+|---|---|---|---|
+| Diátaxis | 4 (tutorial, how-to, reference, explanation) | 2 axes: action↔cognition, acquisition↔application | [diataxis.fr](https://diataxis.fr/) |
+| DITA | 3 base (concept, task, reference) + specialization | typing + specialization hierarchy | [dita-lang.org](https://dita-lang.org/dita/archspec/base/information-typing) |
+| arc42 | 12 sections (fixed) | optional/required, all in one cabinet | [arc42.org/overview](https://arc42.org/overview) |
+| Cloudflare Style Guide | 6+ content types (overview, get-started, reference architecture, design guide, implementation guide, tutorial, API reference) | metadata frontmatter | [developers.cloudflare.com/style-guide](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/overview/) |
+| Confluence | 4 template categories (space, global, blueprint, system) + classification levels (sensitivity) | classification level (sensitivity) is a separate axis | [Atlassian Support](https://support.atlassian.com/confluence-cloud/docs/classify-a-page-or-blogpost/) |
+| MediaWiki | namespaces (1 per page) + categories (many per page) | namespace = exclusive structure; category = inclusive tag | [Help:Namespaces](https://www.mediawiki.org/wiki/Help:Namespaces) |
+| Backstage TechDocs | implicit: one component = one doc site, MkDocs nav | sectioning via mkdocs nav, no global taxonomy | [backstage.io/docs/features/techdocs](https://backstage.io/docs/features/techdocs/) |
+| Nygard ADR | 1 type, statuses: proposed/accepted/rejected/deprecated/superseded | status is the cross-cutting axis | [martinfowler.com/bliki/ArchitectureDecisionRecord.html](https://martinfowler.com/bliki/ArchitectureDecisionRecord.html) |
+| MADR | 1 type, statuses: proposed/rejected/accepted/deprecated/superseded + RACI roles | status + decision-makers/consulted/informed | [adr.github.io/madr](https://adr.github.io/madr/) |
+| Y-statement | 1 type, single-sentence | implicit: chosen/rejected/goals/trade-offs | [Medium - olzzio](https://medium.com/olzzio/y-statements-10eb07b5a177) |
+| Digital garden | 3 maturity stages: seedling, budding, evergreen | maturity (the primary axis) | [maggieappleton.com/evergreens](https://maggieappleton.com/evergreens) |
+| Ranganathan PMEST | 5 facets: Personality, Matter, Energy, Space, Time | universal faceted classification | [lisedunetwork.com](https://www.lisedunetwork.com/ranganathans-pmest-the-foundation-of-faceted-classification/) |
+| Hugo/Docusaurus frontmatter | open: tags, taxonomy, status, audience, draft | freeform per-site metadata | [gohugo.io/content-management/front-matter](https://gohugo.io/content-management/front-matter/) |
+| Runbook/playbook/postmortem/RFC convention | 4 distinct ops doc types | lifecycle (proposal → live → retro) | [Rootly](https://rootly.com/incident-response/runbooks), [Squadcast](https://www.squadcast.com/blog/runbook-vs-playbook-whats-the-difference) |
+
+## 2. Convergence findings (what multiple systems agree on)
+
+- **Tutorial / how-to / reference / concept-explanation is the dominant split.** Diátaxis [(diataxis.fr)](https://diataxis.fr/), DITA's concept/task/reference [(dita-lang.org)](https://dita-lang.org/dita/archspec/base/information-typing), Cloudflare's tutorial + design-guide + implementation-guide + reference-architecture [(Cloudflare style guide)](https://developers.cloudflare.com/style-guide/), and the GOV.UK / Stripe / Microsoft Learn conceptual+quickstart+how-to+reference pattern all converge on four buckets that map to (a) learning by doing, (b) doing a specific task, (c) looking up facts, (d) understanding why. The four-mode model is the empirical attractor.
+- **Decisions get their own kind with a lifecycle.** Nygard [(martinfowler.com)](https://martinfowler.com/bliki/ArchitectureDecisionRecord.html), MADR [(adr.github.io/madr)](https://adr.github.io/madr/), Y-statement [(Medium)](https://medium.com/olzzio/y-statements-10eb07b5a177), arc42 §9 [(arc42.org)](https://arc42.org/overview), and the wider [adr.github.io](https://adr.github.io/) registry all separate decision records from explanatory/reference content, with statuses {proposed, accepted, rejected, deprecated, superseded}.
+- **Two-level classification is universal.** MediaWiki [(Help:Namespaces)](https://www.mediawiki.org/wiki/Help:Namespaces) makes the exclusive-vs-inclusive distinction explicit ("Pages can only be in one namespace but can be in many categories"). SharePoint/Microsoft [(learn.microsoft.com)](https://learn.microsoft.com/en-us/sharepoint/dev/solution-guidance/portal-information-architecture) separates content type from taxonomy term store. Confluence separates template type from classification level. Hugo frontmatter separates `type` from `tags`/`categories`. Every mature system has at least one exclusive axis (kind) and at least one inclusive axis (tags/facets).
+- **Lifecycle/status is a separate axis, not a kind.** ADR statuses, draft/published in Hugo [(gohugo.io)](https://gohugo.io/content-management/front-matter/), seedling/budding/evergreen in digital gardens [(maggieappleton.com)](https://maggieappleton.com/evergreens), and Confluence's classification level all keep maturity orthogonal to kind. No surveyed system encodes lifecycle as part of the kind.
+- **Operations docs split into runbook / playbook / postmortem / RFC.** Strongly attested across SRE practice [(Rootly)](https://rootly.com/incident-response/runbooks), [Squadcast](https://www.squadcast.com/blog/runbook-vs-playbook-whats-the-difference), [TechTarget](https://www.techtarget.com/searchitoperations/tip/An-introduction-to-SRE-documentation-best-practices). Runbook = tactical how-to-fix; playbook = strategic response; postmortem = retro; RFC = forward proposal.
+- **Reference content separates auto-generated from hand-authored.** [readme.com](https://readme.com/resources/automated-api-documentation), [gov.uk API reference guidance](https://www.gov.uk/guidance/writing-api-reference-documentation), [GitBook](https://www.gitbook.com/blog/new-in-gitbook-automatic-api-docs) all describe a producer/gatekeeper split: tech writers edit summary/description fields outside the OpenAPI spec; codegen owns endpoint structure.
+
+## 3. Divergence findings (where reasonable systems disagree)
+
+- **Number of kinds.** Diátaxis insists on exactly four; arc42 has twelve fixed sections; DITA starts at three but expects domain specialization; Cloudflare runs ~6–8 depending on product. There is no consensus on N. The trend: more kinds when the domain spans multiple audiences (Cloudflare, Microsoft Learn), fewer kinds when the audience is narrow (Diátaxis for OSS libraries).
+- **Whether tutorial = how-to.** Diátaxis emphatically separates them (learning vs. task); DITA collapses both into "task"; Cloudflare keeps tutorial separate from implementation guide. Critics note Diátaxis's distinction is real for users but artificial for authors [(I'd Rather Be Writing)](https://idratherbewriting.com/blog/what-is-diataxis-documentation-framework).
+- **Whether decisions are documentation or process.** arc42 includes ADRs as §9 of architecture docs; the ADR community treats them as a parallel artifact with its own repo conventions [(adr.github.io)](https://adr.github.io/). The split affects whether ADRs share metadata with the rest of the wiki.
+- **Faceted vs. hierarchical.** Ranganathan-style facets are theoretically universal [(LIS Education Network)](https://www.lisedunetwork.com/ranganathans-pmest-the-foundation-of-faceted-classification/) but real systems reject pure faceting in favor of one strong hierarchy + tags [(Wikipedia: Faceted classification)](https://en.wikipedia.org/wiki/Faceted_classification): "people have generally rejected the idea of universal facets."
+- **Diátaxis self-critique.** The Diátaxis maintainer acknowledges the framework "isn't meant to impose four rigid buckets" and that real content blends modes [(idratherbewriting.com)](https://idratherbewriting.com/blog/what-is-diataxis-documentation-framework). This contradicts the strict four-mode reading commonly cited.
+
+## 4. Recommended schema for Cortex
+
+The recommendation: replace the single `kind` axis with a **multi-axis tuple** `(kind, lifecycle, audience, provenance)` where `kind` is exclusive (MediaWiki-namespace style) and the other three are facets (MediaWiki-category style). Every dimension is grounded in ≥2 prior systems.
+
+### 4.1 `kind` (exclusive, the directory) — 8 values
+
+| Value | Replaces | Justified by |
+|---|---|---|
+| `tutorial` | (new, carved from notes) | Diátaxis, Cloudflare, Microsoft Learn |
+| `how-to` | (subset of guides) | Diátaxis, DITA "task", Cloudflare implementation guide |
+| `reference` | reference (keep) | Diátaxis, DITA, Cloudflare |
+| `explanation` | (new, carved from notes/lessons) | Diátaxis "explanation", DITA "concept", arc42 §1/§3/§8 |
+| `adr` | adr (keep) | Nygard, MADR, adr.github.io |
+| `runbook` | (new, carved from guides/notes) | SRE convention, Rootly, Squadcast |
+| `rfc` | (new, carved from specs/notes) | arc42 §4 solution-strategy, IETF tradition, common practice |
+| `journal` | journal/notes (renamed) | digital garden, Confluence blog space |
+
+Dropped: `conventions` (becomes `explanation` with audience=developer), `lessons` (becomes `explanation` or `journal` entry), `specs` (split into `rfc` if pre-decision, `reference` if post-decision), `files` (keep as asset directory, not a doc kind), bare `notes` (forbidden — every page must declare a kind).
+
+**Confidence: HIGH.** Each kind appears in ≥3 surveyed systems. The 8-kind count sits inside the empirical band (Diátaxis 4 → arc42 12).
+
+### 4.2 `lifecycle` (facet) — 5 values
+
+`{seedling, draft, active, deprecated, archived}` — combines digital-garden maturity [(maggieappleton.com)](https://maggieappleton.com/evergreens), Hugo draft/published [(gohugo.io)](https://gohugo.io/content-management/front-matter/), and ADR deprecated/superseded [(MADR)](https://adr.github.io/madr/). For `adr`, this axis carries the ADR-specific statuses {proposed, accepted, rejected, superseded} — the Nygard set is a strict subset of the lifecycle space.
+
+**Confidence: HIGH.** Lifecycle-as-separate-axis is universal across surveyed systems.
+
+### 4.3 `audience` (facet) — 5 values
+
+`{developer, ops, security, internal, external}` — drawn from Cloudflare's audience metadata [(Cloudflare style guide)](https://developers.cloudflare.com/style-guide/how-we-docs/metadata/), Microsoft Learn role tagging [(learn.microsoft.com)](https://learn.microsoft.com/en-us/sharepoint/dev/solution-guidance/portal-information-architecture), and Confluence classification levels [(Atlassian)](https://support.atlassian.com/confluence-cloud/docs/classify-a-page-or-blogpost/). Multi-valued (a page can target developer+ops).
+
+**Confidence: MEDIUM.** The values vary by org; the existence of an audience axis is universal but the specific enumeration is project-specific.
+
+### 4.4 `provenance` (facet) — 4 values
+
+`{human, ai-generated, imported, auto-generated}` — directly justified by the auto-gen API reference convention [(readme.com)](https://readme.com/resources/automated-api-documentation), [(gov.uk)](https://www.gov.uk/guidance/writing-api-reference-documentation), which separates codegen reference from hand-authored docs. Solves the "Symbols in flow: 0" empty-stub problem: filter `provenance=auto-generated AND lifecycle=seedling` to hide empty stubs from search.
+
+**Confidence: MEDIUM-HIGH.** The producer/gatekeeper contract is documented across API tooling but rarely formalized as a metadata axis — Cortex would be slightly ahead of standard practice.
+
+### 4.5 `tags` (free facet, capped)
+
+Free tags, soft-capped at ~50 controlled vocabulary terms, MediaWiki-category style. Justification: every surveyed system keeps a free-form tag axis on top of exclusive kind [(MediaWiki)](https://www.mediawiki.org/wiki/Help:Categories), [(Hugo)](https://gohugo.io/content-management/front-matter/).
+
+**Confidence: HIGH.**
+
+## 5. Migration considerations
+
+- **Automatic redirects on rename.** MediaWiki's default behavior [(Help:Moving_a_page)](https://www.mediawiki.org/wiki/Help:Moving_a_page) is the canonical pattern: every rename leaves a redirect stub. TYPO3 [(b13.com blog)](https://b13.com/blog/navigating-page-movements-and-redirects-in-typo3-a-comprehensive-guide) uses stable page IDs decoupled from slug. **Recommendation:** Cortex should adopt stable content IDs (UUIDs in frontmatter) and treat the path as a view; renaming `notes/foo.md` → `explanation/foo.md` keeps the same ID, and a redirect file is written.
+- **Bulk re-bucketing.** Mem.ai's documented AI-refactor pattern [(get.mem.ai)](https://get.mem.ai/blog/ai-knowledge-base-refactoring) describes converging "zombie collections and orphan notes" via batched classification. For Cortex's 92%-in-notes problem, an LLM-assisted pass over notes/ proposing `(kind, lifecycle)` per file is empirically the fastest method; human review on a sample.
+- **Avoid double-redirects.** MediaWiki convention: after migration, scan and rewrite incoming links to point at canonical paths to avoid double-hop redirects [(Wikipedia:Redirect)](https://en.wikipedia.org/wiki/Wikipedia:Redirect).
+
+## 6. The "catch-all dominates" threshold
+
+The literature does not name a specific threshold at which a catch-all bucket becomes pathological. **Indirect evidence:** Diátaxis's stated mission [(diataxis.fr)](https://diataxis.fr/) is to dissolve the "miscellaneous documentation" bucket, implying any unstructured bucket is suspect. Knowledge base taxonomy advice [(matrixflows.com)](https://www.matrixflows.com/blog/10-best-practices-for-creating-taxonomy-for-your-company-knowledge-base) recommends categories be "mutually exclusive and unambiguous" — a dominant catch-all violates exclusivity. **My calibrated rule (no direct citation, low confidence): if any single kind exceeds ~30% of content, the taxonomy is under-resolved.** Cortex at 92% is far past the failure mode.
+
+## 7. Confidence summary
+
+| Recommendation | Confidence | Basis |
+|---|---|---|
+| Split notes → 8 kinds (tutorial/how-to/reference/explanation/adr/runbook/rfc/journal) | HIGH | Convergent across ≥3 systems each |
+| Add `lifecycle` axis | HIGH | Universal in surveyed systems |
+| Add `audience` axis | MEDIUM | Universal in concept, values vary |
+| Add `provenance` axis | MEDIUM-HIGH | Implicit in API-docs practice, rarely formalized |
+| Free `tags` axis on top | HIGH | Universal |
+| Stable-ID + redirect migration | HIGH | MediaWiki, TYPO3 patterns |
+| 30% threshold for catch-all pathology | LOW | No primary source; inference |
+
+## 8. Things I could not find
+
+- A published study giving the failure-mode threshold for catch-all buckets in technical wikis. The 30% number above is mine, not the literature's.
+- A primary source comparing Stripe's internal doc taxonomy in detail — Stripe's information architecture is widely admired but not publicly documented at the schema level (only inferable from observed structure and llms.txt patterns [(Mintlify)](https://www.mintlify.com/blog/real-llms-txt-examples)).
+- An empirical evaluation comparing single-axis vs. multi-axis classification for findability in technical KBs. The argument for multi-axis is structural (MediaWiki, SharePoint, Confluence all do it) but I found no controlled study.
+- A canonical authority on when to use Diátaxis vs. DITA for a developer-facing wiki — both communities argue their case, neither cedes ground.
+
+## GRADE certainty (overall recommendation)
+
+Starting level: **moderate** (web-survey of secondary docs, not RCTs). Adjustments: +1 for strong convergence across independent mature systems; -1 for absence of empirical comparison studies and Cortex-specific validation. **Final: moderate.** The recommendation is well-grounded in convergent practice but has not been validated against Cortex's specific content distribution; pilot migration on a representative ~100-page subset is the appropriate next step before full rollout.

--- a/mcp_server/core/wiki_classifier.py
+++ b/mcp_server/core/wiki_classifier.py
@@ -443,23 +443,16 @@ def _apply_user_rules(content: str, tags: list[str] | None):
     return match
 
 
-def classify_memory(content: str, tags: list[str] | None = None) -> str | None:
-    """Classify memory content for wiki sync.
+def _classify_to_legacy_kind(content: str, tags: list[str] | None = None) -> str | None:
+    """Run the admission gates and return a legacy kind name or None.
 
-    Inversion (Eco + Ahrens research): default to REJECT. A memory is
-    promoted to the wiki only if it passes three gates:
+    This is the internal kind-detection used by ``classify_memory``.
+    Returns one of {adr, lesson, convention, spec, note} when admitted,
+    or None on rejection. The string return is mapped to the ADR-2244
+    modern kind by ``classify_memory`` before reaching any caller.
 
-      1. Noise rejection (tool output, JSON, slash-command framing)
-      2. Hard-negative gate (imperatives, first-person narration, status,
-         temporal deixis — any hit disqualifies)
-      3. Positive scoring (≥ 4 of 8 quality signals)
-
-    Explicit knowledge-shaped tags (decision/adr/spec/design/lesson/
-    convention/rule) bypass the positive scorer — those are opt-in by
-    the caller and presumed wiki-worthy.
-
-    Returns page kind ('adr', 'lesson', 'convention', 'spec', 'note')
-    or None if the content should be rejected.
+    Internal-only — direct callers should use ``classify_memory`` so they
+    receive a full ``Classification`` tuple, not just the kind.
     """
     if not content or len(content.strip()) < 50:
         return None
@@ -508,8 +501,14 @@ def classify_memory(content: str, tags: list[str] | None = None) -> str | None:
 
     # Tag-based fast-path: explicit knowledge tags bypass positive scoring.
     # The caller has declared intent; trust the declaration.
+    # ADR-2244: extended to include the new modern-kind shape tags
+    # (runbook/tutorial/how-to/rfc/journal) plus the auto-gen producer
+    # markers (code-reference/codebase) so codebase_analyze output is
+    # admitted by the gate and the provenance facet downstream marks it
+    # as auto-generated.
     tag_set = tag_set_pre
     _EXPLICIT_KNOWLEDGE_TAGS = {
+        # Legacy knowledge tags.
         "decision",
         "adr",
         "architecture",
@@ -521,6 +520,21 @@ def classify_memory(content: str, tags: list[str] | None = None) -> str | None:
         "standard",
         "paper",
         "research",
+        # ADR-2244 modern-kind shape tags.
+        "runbook",
+        "playbook",
+        "tutorial",
+        "getting-started",
+        "how-to",
+        "howto",
+        "rfc",
+        "proposal",
+        "journal",
+        # Auto-gen producer markers (provenance flips to auto-generated
+        # downstream; bypassing positive score is correct here because
+        # the producer has already filtered to high-signal content).
+        "code-reference",
+        "codebase",
     }
     has_explicit_tag = bool(tag_set & _EXPLICIT_KNOWLEDGE_TAGS)
 
@@ -560,6 +574,214 @@ def classify_memory(content: str, tags: list[str] | None = None) -> str | None:
 
     # Catch-all: meaningful content that passed the gate
     return "note"
+
+
+# ── ADR-2244 4-tuple classification (Phase 1) ─────────────────────────
+
+
+# Patterns introduced for the new kinds in ADR-2244 §4.1. They sit alongside
+# the legacy _ADR_PATTERNS / _LESSON_PATTERNS / _CONVENTION_PATTERNS so the
+# v1 classifier stays unchanged.
+
+_TUTORIAL_PATTERNS = [
+    re.compile(
+        r"\b(tutorial:|in this tutorial|we['']?ll (learn|build|create|walk through)|"
+        r"by the end of this tutorial|getting started:|step 1[:.])\b",
+        re.IGNORECASE,
+    ),
+]
+
+_HOWTO_PATTERNS = [
+    re.compile(
+        r"\b(how to |how do (you|i) |here['']?s how to |to do (this|that),)\b",
+        re.IGNORECASE,
+    ),
+]
+
+_RUNBOOK_PATTERNS = [
+    re.compile(
+        r"\b(runbook|incident response|on[- ]call|when (the )?alert fires|"
+        r"if (this|that) happens|recovery procedure|rollback steps?)\b",
+        re.IGNORECASE,
+    ),
+]
+
+_RFC_PATTERNS = [
+    re.compile(
+        r"\b(rfc:|proposal:|we propose to|proposed (design|change|approach)|"
+        r"this rfc|request for comments)\b",
+        re.IGNORECASE,
+    ),
+]
+
+_JOURNAL_PATTERNS = [
+    # Dated entry header — ## 2026-05-12 or ## 2026-05-12 — title
+    re.compile(r"^##?\s*\d{4}-\d{2}-\d{2}\b", re.MULTILINE),
+]
+
+
+def _detect_modern_kind(
+    content: str,
+    tag_set: set[str],
+    legacy_kind: str,
+) -> str:
+    """Map the v1 (legacy) kind to a modern v2 kind, plus pattern overrides.
+
+    The v1 classifier picks one of {adr, lesson, convention, spec, note}.
+    The v2 classifier needs one of the 8 modern kinds. This function:
+
+    1. Checks the new pattern catalogs (tutorial, how-to, runbook, rfc,
+       journal) — those override the legacy mapping when they hit.
+    2. Falls back to the legacy → modern map for everything else.
+
+    The mapping rationale (ADR-2244 §4.1):
+        adr        → adr            (kept)
+        lesson     → explanation    (root-cause analysis is explanatory)
+        convention → explanation    (the "why" of a rule is explanation)
+        spec       → rfc            (default; post-implementation specs
+                                     should be retagged to ``reference``)
+        note       → explanation    (catch-all becomes explanation, not notes)
+    """
+    # 1. Modern-pattern overrides — strongest signals first.
+    for pat in _RUNBOOK_PATTERNS:
+        if pat.search(content):
+            return "runbook"
+    if tag_set & {"runbook", "playbook", "incident"}:
+        return "runbook"
+
+    for pat in _TUTORIAL_PATTERNS:
+        if pat.search(content):
+            return "tutorial"
+    if tag_set & {"tutorial", "getting-started"}:
+        return "tutorial"
+
+    for pat in _HOWTO_PATTERNS:
+        if pat.search(content):
+            return "how-to"
+    if tag_set & {"how-to", "howto", "guide"}:
+        return "how-to"
+
+    for pat in _RFC_PATTERNS:
+        if pat.search(content):
+            return "rfc"
+    if tag_set & {"rfc", "proposal"}:
+        return "rfc"
+
+    for pat in _JOURNAL_PATTERNS:
+        if pat.search(content):
+            return "journal"
+    if tag_set & {"journal", "diary", "log"}:
+        return "journal"
+
+    # 2. Legacy → modern fallback.
+    _LEGACY_KIND_MAP = {
+        "adr": "adr",
+        "lesson": "explanation",
+        "convention": "explanation",
+        "spec": "rfc",
+        "note": "explanation",
+        # Reference can come from explicit tags or downstream callers; the
+        # v1 classifier never returns it, so this row is documentation only.
+        "reference": "reference",
+    }
+    return _LEGACY_KIND_MAP.get(legacy_kind, "explanation")
+
+
+def _detect_provenance(tag_set: set[str]) -> str:
+    """Infer ``provenance`` from tags.
+
+    ``human`` is the default. Explicit provenance tags or the codebase
+    auto-gen signature (``code-reference``, ``codebase``) flip to
+    ``auto-generated``. Memory imports flip to ``imported``.
+    """
+    if tag_set & {"auto-generated", "code-reference", "codebase"}:
+        return "auto-generated"
+    if tag_set & {"imported", "import"}:
+        return "imported"
+    if tag_set & {"ai-generated", "synthesized", "synth"}:
+        return "ai-generated"
+    return "human"
+
+
+def _default_lifecycle(kind: str) -> str:
+    """Default lifecycle for a newly classified page.
+
+    ADRs default to ``proposed`` (Nygard convention). Everything else
+    defaults to ``seedling`` (digital-garden convention).
+    """
+    return "proposed" if kind == "adr" else "seedling"
+
+
+def classify_memory(
+    content: str,
+    tags: list[str] | None = None,
+):
+    """Classify memory content for the wiki (ADR-2244 single classifier).
+
+    Returns a ``Classification`` (kind, lifecycle, audience, provenance,
+    generator, tags) from ``mcp_server.shared.wiki_classification`` when
+    the memory should be admitted, or ``None`` to reject.
+
+    Admission gates (same as the legacy single-kind classifier):
+      1. Audit-tag gate — backfill / session-summary / stage-N / tool-output
+         are rejected before user rules.
+      2. User-editable rules from ``wiki/_rules/*.md``.
+      3. Noise rejection — tool/system/slash artefacts.
+      4. Hard-negative gate — imperatives, first-person, status framing,
+         temporal deixis, path/URL titles, audit-shaped titles.
+      5. Positive scoring — ≥ 4 of 8 signals, unless an explicit knowledge
+         tag (decision/adr/spec/design/lesson/convention/rule) bypasses.
+
+    Routing (ADR-2244 §4.1): the 5 legacy kinds (adr/lesson/convention/
+    spec/note) map to the 8 modern kinds via ``_detect_modern_kind``;
+    pattern overrides for tutorial/how-to/runbook/rfc/journal take
+    precedence over the legacy-derived kind.
+
+    Local import keeps the module's import graph flat.
+    """
+    from mcp_server.shared.wiki_classification import Classification, Generator
+
+    legacy_kind = _classify_to_legacy_kind(content, tags)
+    if legacy_kind is None:
+        return None
+
+    tag_set = {t.lower() for t in (tags or [])}
+    modern_kind = _detect_modern_kind(content, tag_set, legacy_kind)
+    provenance = _detect_provenance(tag_set)
+    lifecycle = _default_lifecycle(modern_kind)
+
+    # Audience inference — closed enum per ADR-2244 §4.3.
+    # Security-tagged content gets security audience; ops/runbook gets ops;
+    # everything else defaults to developer.
+    audiences: list[str] = []
+    if tag_set & {"security", "auth", "crypto", "vulnerability"}:
+        audiences.append("security")
+    if modern_kind == "runbook" or tag_set & {"ops", "sre", "infra", "deploy"}:
+        audiences.append("ops")
+    if not audiences:
+        audiences.append("developer")
+
+    # Provenance with full generator block when ai/auto-generated.
+    generator: Generator | None = None
+    if provenance in {"ai-generated", "auto-generated"}:
+        generator = Generator(
+            model="unknown",
+            version="",
+            prompt_template="",
+            generated_at="",
+        )
+
+    # Tags pass through (capped to keep frontmatter tractable).
+    out_tags = tuple(sorted(tag_set))[:50]
+
+    return Classification(
+        kind=modern_kind,
+        lifecycle=lifecycle,
+        audience=tuple(audiences),
+        provenance=provenance,
+        generator=generator,
+        tags=out_tags,
+    )
 
 
 def _line_is_title_candidate(cleaned: str) -> bool:

--- a/mcp_server/core/wiki_layout.py
+++ b/mcp_server/core/wiki_layout.py
@@ -18,17 +18,37 @@ from __future__ import annotations
 import re
 from pathlib import PurePosixPath
 
-PAGE_KINDS = (
+# Modern kinds (ADR-2244 §4.1). Each drives a directory under wiki/ for
+# pages classified to that kind. New writes use these names exclusively.
+MODERN_PAGE_KINDS = (
+    "tutorial",
+    "how-to",
+    "reference",
+    "explanation",
     "adr",
+    "runbook",
+    "rfc",
+    "journal",
+)
+
+# Legacy kinds — kept in PAGE_KINDS so existing pages remain readable and
+# wiki_list/wiki_read continue to function during the migration window.
+# New code SHOULD NOT route to these. See
+# ``mcp_server.shared.wiki_classification.LEGACY_KIND_TO_MODERN`` for the
+# read-time normalization map.
+LEGACY_PAGE_KINDS = (
     "specs",
     "guides",
-    "reference",
     "conventions",
     "lessons",
     "notes",
-    "journal",
     "files",
 )
+
+# Full set accepted by ``page_path`` / ``domain_page_path`` — modern + legacy
+# for backward-compat. Validation in higher layers (wiki_classification.py)
+# enforces modern-only on write.
+PAGE_KINDS = MODERN_PAGE_KINDS + LEGACY_PAGE_KINDS
 
 _SAFE = re.compile(r"[^a-zA-Z0-9_.-]+")
 _MAX_SLUG_LEN = 80

--- a/mcp_server/core/wiki_sync.py
+++ b/mcp_server/core/wiki_sync.py
@@ -64,6 +64,21 @@ def _derive_title(content: str) -> str:
     return first_line
 
 
+# ADR-2244 §4.1: modern kind → directory. All 8 modern kinds map to their
+# own directory under wiki/. The classifier never returns a legacy kind
+# from v2; legacy directories stay populated only by pre-migration content.
+_MODERN_KIND_TO_DIR = {
+    "tutorial": "tutorial",
+    "how-to": "how-to",
+    "reference": "reference",
+    "explanation": "explanation",
+    "adr": "adr",
+    "runbook": "runbook",
+    "rfc": "rfc",
+    "journal": "journal",
+}
+
+
 def build_from_memory(
     *,
     memory_id: int | str,
@@ -73,15 +88,20 @@ def build_from_memory(
 ) -> tuple[str, str] | None:
     """Build (relative_path, markdown) for a memory, or None if rejected.
 
-    Uses the wiki classifier to determine page kind and smart title.
-    Routes to kind-specific templates. Domain-scoped paths.
+    Uses the v2 classifier (ADR-2244) to determine the 4-tuple
+    classification, routes to the modern kind directory, and writes
+    frontmatter conforming to the new schema.
+
+    Routing fix (Task #8): file-documentation content from
+    ``codebase_analyze`` now lands in ``reference/<domain>/`` with
+    ``provenance=auto-generated`` instead of being silently dumped in
+    ``notes/`` (which had no ``file`` mapping in the old _KIND_TO_DIR).
     """
-    # Use classifier instead of tag-only gate
-    kind = classify_memory(content, tags)
-    if kind is None:
+    classification = classify_memory(content, tags)
+    if classification is None:
         return None
 
-    title = derive_title(content, kind, tags)
+    title = derive_title(content, classification.kind, tags)
     if not title:
         import hashlib
 
@@ -90,23 +110,75 @@ def build_from_memory(
     slug = slugify(title)
     filename = f"{memory_id}-{slug}.md"
 
-    # Map classifier kind (singular) to PAGE_KINDS directory (plural)
-    _KIND_TO_DIR = {
-        "adr": "adr",
-        "spec": "specs",
-        "lesson": "lessons",
-        "convention": "conventions",
-        "note": "notes",
-        "guide": "guides",
-        "reference": "reference",
-        "journal": "journal",
-    }
-    dir_name = _KIND_TO_DIR.get(kind, "notes")
+    dir_name = _MODERN_KIND_TO_DIR.get(classification.kind, "explanation")
     safe_domain = slugify(domain, max_len=40) if domain else "_general"
     rel = f"{dir_name}/{safe_domain}/{filename}"
 
-    # Build page with kind-appropriate template
-    markdown = build_note(
-        title=title, body=content, tags=tags or [kind], updated=_now_iso()
-    )
+    # Frontmatter from the 4-tuple; body from the existing note template.
+    fm = classification.to_frontmatter()
+    fm["title"] = title
+    fm["updated"] = _now_iso()
+    if "memory_id" not in fm:
+        fm["memory_id"] = memory_id
+
+    markdown = _render_with_frontmatter(fm, title, content)
     return rel, markdown
+
+
+def _render_with_frontmatter(
+    frontmatter: dict[str, object],
+    title: str,
+    body: str,
+) -> str:
+    """Render a wiki page with explicit ADR-2244 frontmatter.
+
+    Falls back to ``build_note`` for the body shape so legacy callers
+    continue to see a familiar note structure. The frontmatter is the
+    only thing that changes — the body remains the existing template
+    output until per-kind templates land in Phase 1.D.
+    """
+    # Use the existing note builder for the body shape, then replace its
+    # frontmatter with the 4-tuple-aware version.
+    note_md = build_note(
+        title=title,
+        body=body,
+        tags=list(frontmatter.get("tags") or []),
+        updated=str(frontmatter.get("updated", "")),
+    )
+    body_only = _strip_frontmatter(note_md)
+    return _format_frontmatter(frontmatter) + body_only
+
+
+def _strip_frontmatter(md: str) -> str:
+    """Remove a leading ``---``-delimited frontmatter block from markdown."""
+    if not md.startswith("---"):
+        return md
+    end = md.find("\n---", 3)
+    if end == -1:
+        return md
+    body_start = md.find("\n", end + 4)
+    return md[body_start + 1 :] if body_start != -1 else ""
+
+
+def _format_frontmatter(fm: dict[str, object]) -> str:
+    """Serialise a frontmatter dict to a ``---``-delimited YAML block.
+
+    Mirrors wiki_pages._format_frontmatter but lives here so wiki_sync
+    can produce ADR-2244 frontmatter without importing from wiki_pages
+    (whose builder API does not accept arbitrary dicts).
+    """
+    lines = ["---"]
+    for key, value in fm.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        elif isinstance(value, dict):
+            lines.append(f"{key}:")
+            for sub_key, sub_value in value.items():
+                lines.append(f"  {sub_key}: {sub_value}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.append("---")
+    lines.append("")
+    return "\n".join(lines)

--- a/mcp_server/core/wiki_templates.py
+++ b/mcp_server/core/wiki_templates.py
@@ -25,6 +25,7 @@ from typing import Final
 # ── Required front-matter fields per page kind ──────────────────────────
 
 REQUIRED_FRONTMATTER: Final[dict[str, tuple[str, ...]]] = {
+    # Legacy kinds — kept readable; values match pre-ADR-2244 contracts.
     "adr": ("id", "title", "status", "date", "context", "decision", "consequences"),
     "specs": ("title", "status", "owner", "created", "updated"),
     "guides": ("title", "audience", "prerequisites", "updated"),
@@ -34,9 +35,57 @@ REQUIRED_FRONTMATTER: Final[dict[str, tuple[str, ...]]] = {
     "notes": ("title", "updated"),
     "journal": ("title", "date"),
     "files": ("file_path", "language", "updated"),
+    # Modern kinds (ADR-2244 §4). Every modern kind requires the 4-tuple
+    # axes (kind, lifecycle, audience, provenance) plus kind-specific
+    # fields.  Note: ``kind`` itself is a required frontmatter field for
+    # *every* modern page, validated by ``wiki_schema_loader``.
+    "tutorial": (
+        "title",
+        "kind",
+        "lifecycle",
+        "audience",
+        "provenance",
+        "updated",
+    ),
+    "how-to": (
+        "title",
+        "kind",
+        "lifecycle",
+        "audience",
+        "provenance",
+        "updated",
+    ),
+    "runbook": (
+        "title",
+        "kind",
+        "lifecycle",
+        "audience",
+        "provenance",
+        "trigger",
+        "updated",
+    ),
+    "rfc": (
+        "title",
+        "kind",
+        "lifecycle",
+        "audience",
+        "provenance",
+        "created",
+        "updated",
+    ),
+    "explanation": (
+        "title",
+        "kind",
+        "lifecycle",
+        "audience",
+        "provenance",
+        "updated",
+    ),
 }
 
 # Valid values for `status` field (ADR + specs).
+# Note: lifecycle (ADR-2244 §4.2) is a separate axis; the legacy ``status``
+# field is preserved for backward compat on ADR/spec pages.
 STATUS_VALUES: Final[dict[str, tuple[str, ...]]] = {
     "adr": ("proposed", "accepted", "rejected", "deprecated", "superseded"),
     "specs": ("draft", "review", "accepted", "implemented", "deprecated"),
@@ -301,7 +350,162 @@ updated: {{updated}}
 """
 
 
+# ── ADR-2244 modern-kind templates ───────────────────────────────────────
+
+
+TUTORIAL_TEMPLATE = """---
+title: {{title}}
+kind: tutorial
+lifecycle: {{lifecycle}}
+audience: {{audience}}
+provenance: {{provenance}}
+updated: {{updated}}
+---
+
+# {{title}}
+
+## What you'll learn
+
+{{learning_outcomes}}
+
+## Prerequisites
+
+{{prerequisites}}
+
+## Steps
+
+{{steps}}
+
+## Next steps
+
+{{next_steps}}
+"""
+
+
+HOWTO_TEMPLATE = """---
+title: {{title}}
+kind: how-to
+lifecycle: {{lifecycle}}
+audience: {{audience}}
+provenance: {{provenance}}
+updated: {{updated}}
+---
+
+# {{title}}
+
+## When to use this
+
+{{when_to_use}}
+
+## Steps
+
+{{steps}}
+
+## Verification
+
+{{verification}}
+"""
+
+
+RUNBOOK_TEMPLATE = """---
+title: {{title}}
+kind: runbook
+lifecycle: {{lifecycle}}
+audience: {{audience}}
+provenance: {{provenance}}
+trigger: {{trigger}}
+updated: {{updated}}
+---
+
+# {{title}}
+
+## Trigger
+
+{{trigger_description}}
+
+## Diagnosis
+
+{{diagnosis}}
+
+## Recovery procedure
+
+{{recovery_steps}}
+
+## Rollback
+
+{{rollback}}
+
+## Post-incident
+
+{{post_incident}}
+"""
+
+
+RFC_TEMPLATE = """---
+title: {{title}}
+kind: rfc
+lifecycle: {{lifecycle}}
+audience: {{audience}}
+provenance: {{provenance}}
+created: {{created}}
+updated: {{updated}}
+---
+
+# {{title}}
+
+## Summary
+
+{{summary}}
+
+## Motivation
+
+{{motivation}}
+
+## Proposed design
+
+{{design}}
+
+## Alternatives considered
+
+{{alternatives}}
+
+## Open questions
+
+{{open_questions}}
+"""
+
+
+EXPLANATION_TEMPLATE = """---
+title: {{title}}
+kind: explanation
+lifecycle: {{lifecycle}}
+audience: {{audience}}
+provenance: {{provenance}}
+updated: {{updated}}
+---
+
+# {{title}}
+
+## Context
+
+{{context}}
+
+## Explanation
+
+{{explanation}}
+
+## Implications
+
+{{implications}}
+
+## See also
+
+{{see_also}}
+"""
+
+
 TEMPLATES: Final[dict[str, str]] = {
+    # Legacy kinds.
     "adr": ADR_TEMPLATE,
     "specs": SPEC_TEMPLATE,
     "guides": GUIDE_TEMPLATE,
@@ -311,6 +515,12 @@ TEMPLATES: Final[dict[str, str]] = {
     "notes": NOTE_TEMPLATE,
     "journal": JOURNAL_TEMPLATE,
     "files": FILE_TEMPLATE,
+    # ADR-2244 modern kinds.
+    "tutorial": TUTORIAL_TEMPLATE,
+    "how-to": HOWTO_TEMPLATE,
+    "runbook": RUNBOOK_TEMPLATE,
+    "rfc": RFC_TEMPLATE,
+    "explanation": EXPLANATION_TEMPLATE,
 }
 
 

--- a/mcp_server/handlers/wiki_purge.py
+++ b/mcp_server/handlers/wiki_purge.py
@@ -101,7 +101,12 @@ def _parse_tags(raw: Any) -> list[str]:
 
 
 def _evaluate_page(md_path: Path) -> tuple[str | None, list[str]]:
-    """Classify a single page. Returns (kind_or_None, tags)."""
+    """Classify a single page. Returns (kind_or_None, tags).
+
+    The ADR-2244 classifier returns a ``Classification`` object (or None
+    for rejection). Purge only cares about admit-vs-reject; we surface
+    the modern ``kind`` string for reporting, ``None`` to signal purge.
+    """
     text = md_path.read_text(encoding="utf-8", errors="ignore")
     r = parse_yaml_frontmatter(text)
     tags = _parse_tags(r.meta.get("tags"))
@@ -110,7 +115,8 @@ def _evaluate_page(md_path: Path) -> tuple[str | None, list[str]]:
     if lines and lines[0].startswith("# "):
         lines = lines[1:]
     content = "\n".join(lines).strip() or str(r.meta.get("title", ""))
-    return classify_memory(content, tags), tags
+    result = classify_memory(content, tags)
+    return (result.kind if result is not None else None), tags
 
 
 async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/mcp_server/shared/wiki_classification.py
+++ b/mcp_server/shared/wiki_classification.py
@@ -1,0 +1,217 @@
+"""Wiki classification 4-tuple — kind, lifecycle, audience, provenance + tags.
+
+Implements the schema from ADR-2244 (richer wiki classification).
+
+Every wiki page is classified by an exclusive ``kind`` (one of 8 values, drives
+directory) plus three orthogonal facets (lifecycle, audience, provenance) and
+a free ``tags`` set. The 4-tuple replaces the previous single-kind taxonomy
+that left 92% of pages stuck in the ``notes`` catch-all.
+
+References:
+    - ADR-2244 in the methodology wiki (adr/_general/2244-richer-wiki-classification.md)
+    - docs/research/wiki-classification-survey.md (literature survey)
+    - Diátaxis (diataxis.fr), DITA (dita-lang.org), Cloudflare style guide
+    - Nygard/MADR for the ADR lifecycle subset (adr.github.io/madr)
+
+Backward compatibility: legacy kinds (``notes``, ``specs``, ``conventions``,
+``lessons``, ``guides``, ``files``) remain readable via ``LEGACY_KINDS`` and
+``normalize_legacy_kind``. New writes go through the modern schema.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+# ── Closed enums (ADR-2244 §4) ───────────────────────────────────────────
+
+
+# 8 exclusive kinds, each grounded in ≥3 surveyed taxonomies. Drives the
+# directory under ``wiki/``: a page of kind ``adr`` lives in ``adr/...``.
+KINDS: Final[frozenset[str]] = frozenset(
+    {
+        "tutorial",
+        "how-to",
+        "reference",
+        "explanation",
+        "adr",
+        "runbook",
+        "rfc",
+        "journal",
+    }
+)
+
+
+# Legacy kinds — readable but not produced by new writes. Migration target
+# in ``LEGACY_KIND_TO_MODERN`` (see ADR-2244 §4.1 "Dropped from the kind axis").
+LEGACY_KINDS: Final[frozenset[str]] = frozenset(
+    {"notes", "specs", "conventions", "lessons", "guides", "files"}
+)
+
+
+# Migration map: legacy kind → modern kind. Used by read-time backward
+# compat (wiki_read / wiki_list) so callers can normalize without seeing
+# legacy directory names. ``specs`` is ambiguous (rfc or reference) and
+# defaults to ``rfc``; per-page review may reroute it during Phase 4.
+LEGACY_KIND_TO_MODERN: Final[dict[str, str]] = {
+    "notes": "explanation",
+    "specs": "rfc",
+    "conventions": "explanation",
+    "lessons": "explanation",
+    "guides": "how-to",
+    "files": "reference",
+}
+
+
+# Universal lifecycle states (apply to every kind except adr).
+LIFECYCLES: Final[frozenset[str]] = frozenset(
+    {"seedling", "draft", "active", "deprecated", "archived"}
+)
+
+
+# ADR-specific lifecycle subset (Nygard / MADR). The ADR lifecycle space
+# is disjoint from the universal one — an ADR cannot be ``seedling``.
+ADR_LIFECYCLES: Final[frozenset[str]] = frozenset(
+    {"proposed", "accepted", "rejected", "superseded"}
+)
+
+
+# Closed audience enum (per user direction 2026-05-12).
+AUDIENCES: Final[frozenset[str]] = frozenset(
+    {"developer", "ops", "security", "internal", "external"}
+)
+
+
+# Closed provenance enum. ``ai-generated`` and ``auto-generated`` both
+# require a ``Generator`` block (full provenance per user direction).
+PROVENANCES: Final[frozenset[str]] = frozenset(
+    {"human", "ai-generated", "imported", "auto-generated"}
+)
+
+
+_GENERATOR_REQUIRED_FOR: Final[frozenset[str]] = frozenset(
+    {"ai-generated", "auto-generated"}
+)
+
+
+# ── Data model ───────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Generator:
+    """Full provenance block for ai/auto-generated content.
+
+    Captures enough metadata to re-run the generator and debug bad outputs
+    by model version. Mandatory when ``Classification.provenance`` is
+    ``ai-generated`` or ``auto-generated``.
+    """
+
+    model: str = ""
+    version: str = ""
+    prompt_template: str = ""
+    generated_at: str = ""  # ISO-8601 UTC, e.g. 2026-05-12T08:55:00Z
+
+
+@dataclass(frozen=True)
+class Classification:
+    """4-tuple page classification per ADR-2244.
+
+    Fields:
+        kind: one of ``KINDS`` (exclusive; drives directory).
+        lifecycle: one of ``LIFECYCLES`` (or ``ADR_LIFECYCLES`` for ``kind=adr``).
+        audience: subset of ``AUDIENCES``, multi-valued. Defaults to ``("developer",)``.
+        provenance: one of ``PROVENANCES``. Defaults to ``human``.
+        generator: required when ``provenance`` ∈ {ai-generated, auto-generated}.
+        tags: free controlled-vocabulary tags. Capped at ~50 in practice.
+
+    Validation runs in ``__post_init__``; invalid tuples raise ``ValueError``
+    at construction time so writers fail fast.
+    """
+
+    kind: str
+    lifecycle: str
+    audience: tuple[str, ...] = ("developer",)
+    provenance: str = "human"
+    generator: Generator | None = None
+    tags: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """Raise ValueError if any axis violates the schema."""
+        if self.kind not in KINDS:
+            raise ValueError(
+                f"unknown kind: {self.kind!r}; must be one of {sorted(KINDS)}"
+            )
+        valid_lifecycles = ADR_LIFECYCLES if self.kind == "adr" else LIFECYCLES
+        if self.lifecycle not in valid_lifecycles:
+            raise ValueError(
+                f"invalid lifecycle {self.lifecycle!r} for kind={self.kind!r}; "
+                f"must be one of {sorted(valid_lifecycles)}"
+            )
+        if not self.audience:
+            raise ValueError("audience must not be empty")
+        for a in self.audience:
+            if a not in AUDIENCES:
+                raise ValueError(
+                    f"unknown audience: {a!r}; must be one of {sorted(AUDIENCES)}"
+                )
+        if self.provenance not in PROVENANCES:
+            raise ValueError(
+                f"unknown provenance: {self.provenance!r}; "
+                f"must be one of {sorted(PROVENANCES)}"
+            )
+        if self.provenance in _GENERATOR_REQUIRED_FOR and self.generator is None:
+            raise ValueError(
+                f"provenance={self.provenance!r} requires a Generator block"
+            )
+
+    def to_frontmatter(self) -> dict[str, object]:
+        """Render this classification as a YAML-compatible frontmatter dict.
+
+        Audience is serialized as a list (multi-valued). The generator block
+        is nested when present. Tags are a list.
+        """
+        fm: dict[str, object] = {
+            "kind": self.kind,
+            "lifecycle": self.lifecycle,
+            "audience": list(self.audience),
+            "provenance": self.provenance,
+        }
+        if self.generator is not None:
+            fm["generator"] = {
+                "model": self.generator.model,
+                "version": self.generator.version,
+                "prompt_template": self.generator.prompt_template,
+                "generated_at": self.generator.generated_at,
+            }
+        if self.tags:
+            fm["tags"] = list(self.tags)
+        return fm
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def normalize_legacy_kind(kind: str) -> str:
+    """Map a legacy kind name to its modern equivalent.
+
+    Used by read-time backward compat: when ``wiki_list`` or ``wiki_read``
+    surfaces a page whose frontmatter says ``kind: notes``, callers can
+    treat it as ``kind: explanation`` for routing/display purposes
+    without rewriting the page. Returns the input unchanged when already
+    modern.
+    """
+    return LEGACY_KIND_TO_MODERN.get(kind, kind)
+
+
+def is_legacy_kind(kind: str) -> bool:
+    """True if the kind belongs to the pre-ADR-2244 taxonomy."""
+    return kind in LEGACY_KINDS
+
+
+def all_known_kinds() -> frozenset[str]:
+    """Modern + legacy kinds. Useful for read paths that must accept either."""
+    return KINDS | LEGACY_KINDS

--- a/tests_py/core/test_wiki_classifier.py
+++ b/tests_py/core/test_wiki_classifier.py
@@ -86,17 +86,29 @@ def test_valid_adr_admitted() -> None:
         "HNSW (m=16, ef_construction=64) because benchmarks show 3x improvement. "
         "Consequences: Postgres becomes mandatory."
     )
-    assert classify_memory(content, tags=["decision", "architecture"]) == "adr"
+    result = classify_memory(content, tags=["decision", "architecture"])
+    assert result is not None
+    assert result.kind == "adr"
+    assert result.lifecycle == "proposed"  # default for new ADRs
+    assert result.provenance == "human"
 
 
-def test_valid_lesson_admitted() -> None:
+def test_valid_lesson_admitted_as_explanation() -> None:
+    """ADR-2244 §4.1: the legacy 'lesson' kind maps to modern 'explanation'.
+
+    Root-cause analysis is explanatory content — the 'lesson' bucket
+    collapses into 'explanation' with audience=[developer].
+    """
     content = (
         "The bug was that FlashRank ONNX cache persisted stale weights across "
         "container restarts. Root cause: cache key did not include model hash. "
         "Fix: include model SHA in the cache key. Never ship a cache keyed only "
         "on path again."
     )
-    assert classify_memory(content, tags=["lesson", "bug-fix"]) == "lesson"
+    result = classify_memory(content, tags=["lesson", "bug-fix"])
+    assert result is not None
+    assert result.kind == "explanation"
+    assert result.lifecycle == "seedling"
 
 
 # ── derive_title regression tests (bugs found 2026-05-12) ─────────────
@@ -170,3 +182,97 @@ def test_derive_title_still_works_for_clean_input() -> None:
     title = derive_title(content, "adr")
     assert "pgvector" in title.lower()
     assert title.startswith("Decision:")
+
+
+# ── ADR-2244: modern-kind routing (tutorial / how-to / runbook / rfc / journal) ──
+
+
+def test_classifier_detects_runbook_from_pattern() -> None:
+    """Content describing on-call response routes to kind=runbook."""
+    content = (
+        "When the alert fires for high p99 latency on the recall path, "
+        "first check pgvector replica health via the runbook dashboard. "
+        "If healthy, rotate the connection pool. Recovery procedure: "
+        "1) check connections, 2) restart proxy, 3) page on-call DBA."
+    )
+    result = classify_memory(content, tags=["runbook", "ops"])
+    assert result is not None
+    assert result.kind == "runbook"
+    assert "ops" in result.audience
+
+
+def test_classifier_detects_tutorial_from_pattern() -> None:
+    content = (
+        "Tutorial: in this tutorial we'll learn how to wire pgvector "
+        "into a fresh Cortex install. By the end of this tutorial you'll "
+        "have a working recall pipeline. Step 1: install Postgres 16. "
+        "Step 2: enable the pgvector extension."
+    )
+    result = classify_memory(content, tags=["tutorial", "getting-started"])
+    assert result is not None
+    assert result.kind == "tutorial"
+
+
+def test_classifier_detects_howto_from_pattern() -> None:
+    content = (
+        "How to migrate a wiki page between kinds when the classifier "
+        "verdict changes after an ADR. Here's how to do it without "
+        "breaking inbound links: use the redirect-stub pattern from MediaWiki."
+    )
+    result = classify_memory(content, tags=["how-to", "migration"])
+    assert result is not None
+    assert result.kind == "how-to"
+
+
+def test_classifier_detects_rfc_from_pattern() -> None:
+    content = (
+        "RFC: we propose to replace the single-kind taxonomy with a "
+        "4-tuple (kind, lifecycle, audience, provenance). This RFC "
+        "supersedes the previous wiki classification design and proposes "
+        "an explicit migration plan with stable IDs and redirects."
+    )
+    result = classify_memory(content, tags=["rfc", "design"])
+    assert result is not None
+    assert result.kind == "rfc"
+
+
+def test_classifier_detects_journal_from_dated_heading() -> None:
+    content = (
+        "## 2026-05-12\n\n"
+        "Worked on the wiki classifier today. Decided to collapse v1/v2 "
+        "into a single function per user direction. The 4-tuple is now "
+        "the only return shape; legacy callers got migrated in the same PR."
+    )
+    result = classify_memory(content, tags=["journal", "design"])
+    assert result is not None
+    assert result.kind == "journal"
+
+
+# ── ADR-2244: provenance and audience inference ────────────────────────
+
+
+def test_codebase_tag_marks_auto_generated_provenance() -> None:
+    content = (
+        "## Process — packages/codebase-rust/src/parser/mod.rs::parse_file\n"
+        "Decision: this function parses a single source file via tree-sitter "
+        "and falls back to a regex tokeniser. The trade-off is documented "
+        "in ADR-0033."
+    )
+    result = classify_memory(
+        content,
+        tags=["code-reference", "codebase"],
+    )
+    assert result is not None
+    assert result.provenance == "auto-generated"
+    assert result.generator is not None  # required when provenance is auto-gen
+
+
+def test_security_tag_routes_to_security_audience() -> None:
+    content = (
+        "Decision: store session tokens in a separate, HSM-backed column "
+        "with auth-grade rotation. Context: legal compliance requires "
+        "token-level access auditing distinct from app-level logging."
+    )
+    result = classify_memory(content, tags=["security", "decision"])
+    assert result is not None
+    assert "security" in result.audience

--- a/tests_py/core/test_wiki_layout.py
+++ b/tests_py/core/test_wiki_layout.py
@@ -92,15 +92,34 @@ def test_index_path() -> None:
     assert str(index_path()) == ".generated/INDEX.md"
 
 
-def test_page_kinds_stable() -> None:
-    assert PAGE_KINDS == (
+def test_page_kinds_modern_plus_legacy() -> None:
+    """ADR-2244: PAGE_KINDS contains all 8 modern + 6 legacy kinds.
+
+    Modern kinds drive new writes; legacy kinds remain accepted by
+    ``page_path`` / ``domain_page_path`` so existing pages under
+    notes/specs/conventions/lessons/guides/files stay readable.
+    """
+    from mcp_server.core.wiki_layout import LEGACY_PAGE_KINDS, MODERN_PAGE_KINDS
+
+    assert MODERN_PAGE_KINDS == (
+        "tutorial",
+        "how-to",
+        "reference",
+        "explanation",
         "adr",
+        "runbook",
+        "rfc",
+        "journal",
+    )
+    assert LEGACY_PAGE_KINDS == (
         "specs",
         "guides",
-        "reference",
         "conventions",
         "lessons",
         "notes",
-        "journal",
         "files",
     )
+    # The combined tuple must contain every modern + every legacy kind.
+    assert set(PAGE_KINDS) == set(MODERN_PAGE_KINDS) | set(LEGACY_PAGE_KINDS)
+    # No duplicates (e.g. journal is modern; must not appear twice).
+    assert len(PAGE_KINDS) == len(set(PAGE_KINDS))

--- a/tests_py/core/test_wiki_sync_routing.py
+++ b/tests_py/core/test_wiki_sync_routing.py
@@ -1,0 +1,143 @@
+"""Tests for ADR-2244 routing in wiki_sync.build_from_memory.
+
+Verifies that the modern (kind, lifecycle, audience, provenance) tuple
+drives the directory, that the frontmatter shape conforms to the new
+schema, and that the file→notes/ misroute bug (Task #8) is fixed.
+"""
+
+from __future__ import annotations
+
+from mcp_server.core.wiki_sync import build_from_memory
+
+
+def _parse_frontmatter(md: str) -> dict[str, str]:
+    """Minimal YAML-ish parser for the test (no PyYAML dependency)."""
+    assert md.startswith("---\n"), f"missing frontmatter delimiter: {md[:40]!r}"
+    end = md.find("\n---", 4)
+    block = md[4:end]
+    out: dict[str, str] = {}
+    for line in block.splitlines():
+        if ":" in line and not line.startswith(" "):
+            key, _, value = line.partition(":")
+            out[key.strip()] = value.strip()
+    return out
+
+
+def test_adr_routes_to_adr_directory() -> None:
+    content = (
+        "Decision: use pgvector with HNSW for ANN retrieval. Context: 100k "
+        "memories need sub-100ms cosine. Decided to adopt HNSW (m=16). "
+        "Consequences: Postgres becomes mandatory."
+    )
+    result = build_from_memory(
+        memory_id=42,
+        content=content,
+        tags=["decision", "architecture"],
+        domain="cortex",
+    )
+    assert result is not None
+    rel, md = result
+    assert rel.startswith("adr/cortex/42-")
+    assert rel.endswith(".md")
+    assert not rel.endswith(".md.md")  # regression for the old slug bug
+
+
+def test_legacy_lesson_routes_to_explanation_directory() -> None:
+    """ADR-2244 §4.1: 'lesson' is dropped; root-cause goes to explanation/."""
+    content = (
+        "The bug was that the cache key did not include the model SHA. "
+        "Root cause: stale weights persisted across container restarts. "
+        "Fix: include the SHA in every cache key. Never ship a path-keyed "
+        "cache again."
+    )
+    result = build_from_memory(
+        memory_id=101,
+        content=content,
+        tags=["lesson", "bug-fix"],
+        domain="cortex",
+    )
+    assert result is not None
+    rel, _md = result
+    assert rel.startswith("explanation/cortex/101-")
+    # Must NOT land in the legacy lessons/ directory.
+    assert not rel.startswith("lessons/")
+
+
+def test_runbook_routes_to_runbook_directory() -> None:
+    content = (
+        "When the alert fires for the recall p99 latency, follow this "
+        "runbook. Step 1: check pgvector replica health. Step 2: rotate "
+        "connection pool. On-call recovery procedure documented below."
+    )
+    result = build_from_memory(
+        memory_id=7,
+        content=content,
+        tags=["ops", "runbook"],
+        domain="cortex",
+    )
+    assert result is not None
+    rel, md = result
+    assert rel.startswith("runbook/cortex/7-")
+    fm = _parse_frontmatter(md)
+    assert fm["kind"] == "runbook"
+
+
+def test_frontmatter_includes_4tuple_axes() -> None:
+    """ADR-2244 §4: every modern page carries kind, lifecycle, audience,
+    provenance in its frontmatter."""
+    content = (
+        "Decision: use pgvector over IVFFlat for ANN search. Context: 100k "
+        "memories. Decided to adopt HNSW. Consequences: Postgres is mandatory."
+    )
+    result = build_from_memory(
+        memory_id=200,
+        content=content,
+        tags=["decision", "architecture"],
+        domain="cortex",
+    )
+    assert result is not None
+    _rel, md = result
+    fm = _parse_frontmatter(md)
+    assert fm["kind"] == "adr"
+    assert fm["lifecycle"] == "proposed"  # ADR default
+    assert fm["provenance"] == "human"
+
+
+def test_rejection_returns_none() -> None:
+    """Tool-output content stays rejected — admission gate unchanged."""
+    result = build_from_memory(
+        memory_id=1,
+        content="<tool_result>output of ls -la</tool_result>",
+        tags=["tool-output"],
+    )
+    assert result is None
+
+
+def test_file_documentation_does_not_route_to_notes() -> None:
+    """Task #8 fix: pages tagged as code references must not land in notes/.
+
+    Before ADR-2244, file documentation produced by codebase_analyze
+    ended up at notes/<domain>/<id>-file-*.md because the old
+    _KIND_TO_DIR had no 'file' mapping. The classifier now marks the
+    provenance as auto-generated and routes to reference/ via the
+    modern kind.
+    """
+    content = (
+        "Decision: this module parses a single source file via tree-sitter "
+        "and falls back to regex tokenisation for unsupported languages. "
+        "Trade-off documented in ADR-0033. Defined entities: parse_file, "
+        "_tokenize, language_for_extension."
+    )
+    result = build_from_memory(
+        memory_id=98649,
+        content=content,
+        tags=["code-reference", "codebase"],
+        domain="cortex",
+    )
+    assert result is not None
+    rel, md = result
+    assert not rel.startswith("notes/"), (
+        f"file-documentation still routing to notes/: {rel!r}"
+    )
+    fm = _parse_frontmatter(md)
+    assert fm["provenance"] == "auto-generated"

--- a/tests_py/shared/test_wiki_classification.py
+++ b/tests_py/shared/test_wiki_classification.py
@@ -1,0 +1,239 @@
+"""Tests for shared.wiki_classification — the ADR-2244 4-tuple schema."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.shared.wiki_classification import (
+    ADR_LIFECYCLES,
+    AUDIENCES,
+    KINDS,
+    LEGACY_KINDS,
+    LIFECYCLES,
+    PROVENANCES,
+    Classification,
+    Generator,
+    all_known_kinds,
+    is_legacy_kind,
+    normalize_legacy_kind,
+)
+
+
+# ── Enum integrity ─────────────────────────────────────────────────────
+
+
+def test_kinds_count_is_eight() -> None:
+    """ADR-2244 §4.1: exactly 8 modern kinds."""
+    assert len(KINDS) == 8
+
+
+def test_kinds_match_adr_spec() -> None:
+    """Spec match: tutorial, how-to, reference, explanation, adr, runbook, rfc, journal."""
+    assert KINDS == {
+        "tutorial",
+        "how-to",
+        "reference",
+        "explanation",
+        "adr",
+        "runbook",
+        "rfc",
+        "journal",
+    }
+
+
+def test_legacy_kinds_disjoint_from_modern() -> None:
+    """ADR-2244 §4.1: legacy kinds (notes, specs, etc.) are not modern."""
+    assert KINDS.isdisjoint(LEGACY_KINDS)
+
+
+def test_adr_lifecycle_disjoint_from_universal_lifecycle() -> None:
+    """ADR-2244 §4.2: ADR statuses are a disjoint set, not a subset.
+
+    An ADR can be {proposed, accepted, rejected, superseded}; it cannot be
+    {seedling, draft, active, deprecated, archived}.
+    """
+    assert ADR_LIFECYCLES.isdisjoint(LIFECYCLES)
+
+
+def test_audiences_closed_enum() -> None:
+    """User direction 2026-05-12: closed enum, 5 values."""
+    assert AUDIENCES == {"developer", "ops", "security", "internal", "external"}
+
+
+def test_provenances_closed_enum() -> None:
+    assert PROVENANCES == {"human", "ai-generated", "imported", "auto-generated"}
+
+
+# ── Classification validation ──────────────────────────────────────────
+
+
+def test_minimal_valid_classification() -> None:
+    c = Classification(kind="explanation", lifecycle="seedling")
+    assert c.kind == "explanation"
+    assert c.audience == ("developer",)
+    assert c.provenance == "human"
+
+
+def test_adr_with_proposed_lifecycle() -> None:
+    Classification(kind="adr", lifecycle="proposed")
+
+
+def test_adr_rejects_universal_lifecycle() -> None:
+    """ADR cannot use seedling/draft/active/etc — only its own statuses."""
+    with pytest.raises(ValueError, match="invalid lifecycle"):
+        Classification(kind="adr", lifecycle="seedling")
+
+
+def test_non_adr_rejects_adr_lifecycle() -> None:
+    """A how-to cannot be 'proposed' — that's an ADR-only status."""
+    with pytest.raises(ValueError, match="invalid lifecycle"):
+        Classification(kind="how-to", lifecycle="proposed")
+
+
+def test_unknown_kind_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown kind"):
+        Classification(kind="notes", lifecycle="seedling")
+
+
+def test_unknown_audience_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown audience"):
+        Classification(
+            kind="explanation",
+            lifecycle="seedling",
+            audience=("data-scientist",),  # not in closed enum
+        )
+
+
+def test_empty_audience_rejected() -> None:
+    with pytest.raises(ValueError, match="audience must not be empty"):
+        Classification(kind="explanation", lifecycle="seedling", audience=())
+
+
+def test_multi_valued_audience_accepted() -> None:
+    """Audience facet is multi-valued (ADR-2244 §4.3)."""
+    c = Classification(
+        kind="runbook",
+        lifecycle="active",
+        audience=("ops", "security"),
+    )
+    assert c.audience == ("ops", "security")
+
+
+def test_ai_generated_requires_generator_block() -> None:
+    """User direction 2026-05-12: full provenance block for ai-generated."""
+    with pytest.raises(ValueError, match="requires a Generator block"):
+        Classification(
+            kind="explanation",
+            lifecycle="seedling",
+            provenance="ai-generated",
+        )
+
+
+def test_auto_generated_requires_generator_block() -> None:
+    with pytest.raises(ValueError, match="requires a Generator block"):
+        Classification(
+            kind="reference",
+            lifecycle="seedling",
+            provenance="auto-generated",
+        )
+
+
+def test_human_provenance_does_not_require_generator() -> None:
+    c = Classification(
+        kind="adr",
+        lifecycle="accepted",
+        provenance="human",
+    )
+    assert c.generator is None
+
+
+def test_ai_generated_with_full_generator_block_accepted() -> None:
+    gen = Generator(
+        model="claude-opus-4-7",
+        version="1.0",
+        prompt_template="adr-synthesizer-v1",
+        generated_at="2026-05-12T08:55:00Z",
+    )
+    c = Classification(
+        kind="rfc",
+        lifecycle="draft",
+        provenance="ai-generated",
+        generator=gen,
+    )
+    assert c.generator is not None
+    assert c.generator.model == "claude-opus-4-7"
+
+
+# ── Frontmatter serialization ──────────────────────────────────────────
+
+
+def test_frontmatter_includes_required_axes() -> None:
+    c = Classification(kind="how-to", lifecycle="active", audience=("developer",))
+    fm = c.to_frontmatter()
+    assert fm["kind"] == "how-to"
+    assert fm["lifecycle"] == "active"
+    assert fm["audience"] == ["developer"]
+    assert fm["provenance"] == "human"
+
+
+def test_frontmatter_omits_empty_tags() -> None:
+    c = Classification(kind="explanation", lifecycle="seedling")
+    fm = c.to_frontmatter()
+    assert "tags" not in fm
+
+
+def test_frontmatter_serializes_generator_block() -> None:
+    gen = Generator(
+        model="claude-opus-4-7",
+        version="1.0",
+        prompt_template="codebase-analyze-v1",
+        generated_at="2026-05-12T09:00:00Z",
+    )
+    c = Classification(
+        kind="reference",
+        lifecycle="seedling",
+        provenance="auto-generated",
+        generator=gen,
+    )
+    fm = c.to_frontmatter()
+    assert "generator" in fm
+    assert fm["generator"] == {
+        "model": "claude-opus-4-7",
+        "version": "1.0",
+        "prompt_template": "codebase-analyze-v1",
+        "generated_at": "2026-05-12T09:00:00Z",
+    }
+
+
+# ── Legacy helpers ─────────────────────────────────────────────────────
+
+
+def test_normalize_legacy_notes_to_explanation() -> None:
+    assert normalize_legacy_kind("notes") == "explanation"
+
+
+def test_normalize_legacy_specs_to_rfc() -> None:
+    assert normalize_legacy_kind("specs") == "rfc"
+
+
+def test_normalize_legacy_lessons_to_explanation() -> None:
+    assert normalize_legacy_kind("lessons") == "explanation"
+
+
+def test_normalize_modern_kind_unchanged() -> None:
+    assert normalize_legacy_kind("adr") == "adr"
+    assert normalize_legacy_kind("runbook") == "runbook"
+
+
+def test_is_legacy_kind() -> None:
+    assert is_legacy_kind("notes") is True
+    assert is_legacy_kind("specs") is True
+    assert is_legacy_kind("adr") is False
+    assert is_legacy_kind("how-to") is False
+
+
+def test_all_known_kinds_is_union() -> None:
+    """Used by read paths that must accept either legacy or modern frontmatter."""
+    union = all_known_kinds()
+    assert KINDS.issubset(union)
+    assert LEGACY_KINDS.issubset(union)


### PR DESCRIPTION
## Summary

Implements **Phase 1** of [ADR-2244](https://github.com/cdeust/Cortex/blob/feat/wiki-richer-classification/docs/research/wiki-classification-survey.md): replace the single ``kind`` axis with a 4-tuple `(kind, lifecycle, audience, provenance) + tags`.

Solves the **92%-in-notes catch-all** found during the 2026-05-12 wiki audit by giving the classifier more buckets and orthogonal facets, and fixes the **7820-page file→notes/ misroute** (Task #8) as a side effect.

## The schema (ADR-2244 §4)

| Axis | Type | Values |
|---|---|---|
| `kind` | exclusive (drives directory) | `tutorial` · `how-to` · `reference` · `explanation` · `adr` · `runbook` · `rfc` · `journal` |
| `lifecycle` | facet | `seedling` · `draft` · `active` · `deprecated` · `archived` (or ADR-only `proposed` · `accepted` · `rejected` · `superseded`) |
| `audience` | multi-valued, closed enum | `developer` · `ops` · `security` · `internal` · `external` |
| `provenance` | facet | `human` · `ai-generated` · `imported` · `auto-generated` (last two require a `Generator` block) |
| `tags` | free | controlled vocab, ~50 terms |

Every axis is grounded in ≥2 prior systems (Diátaxis, DITA, Cloudflare, MediaWiki, Confluence, Backstage, Nygard/MADR, digital gardens, SRE conventions). Full survey in `docs/research/wiki-classification-survey.md`.

## Per user direction (2026-05-12)

- **Single classifier** (no v1/v2 in parallel) — `classify_memory` returns `Classification | None` directly; the legacy single-kind detection is preserved as a private helper.
- **Closed audience enum** (5 values, no extension mechanism in this PR).
- **Full provenance block** for `ai-generated`/`auto-generated` content (model, version, prompt_template, generated_at) — not just a flag.

## What changed

| File | Change |
|---|---|
| `mcp_server/shared/wiki_classification.py` | **NEW** — `Classification` + `Generator` dataclasses, enums, validators, frontmatter serialization, legacy normalization |
| `mcp_server/core/wiki_layout.py` | Split `PAGE_KINDS` into `MODERN_PAGE_KINDS` (8) + `LEGACY_PAGE_KINDS` (6); union kept for backward-compat reads |
| `mcp_server/core/wiki_classifier.py` | `classify_memory` returns `Classification`; new patterns for tutorial/how-to/runbook/rfc/journal; provenance + audience inference; legacy kind detection moves to `_classify_to_legacy_kind` (private) |
| `mcp_server/core/wiki_sync.py` | Routes via 4-tuple; writes modern frontmatter; **fixes file-doc → reference/ routing** |
| `mcp_server/core/wiki_templates.py` | 5 new templates (`TUTORIAL`, `HOWTO`, `RUNBOOK`, `RFC`, `EXPLANATION`); required-frontmatter contracts include all 4 axes |
| `mcp_server/handlers/wiki_purge.py` | Updated for new return shape (None still signals purge) |
| `tests_py/shared/test_wiki_classification.py` | **NEW** — 24 tests covering validation, frontmatter serialization, legacy normalization |
| `tests_py/core/test_wiki_classifier.py` | +7 tests for new kind detection + provenance/audience inference; `test_valid_lesson_admitted` updated for the `lesson → explanation` collapse |
| `tests_py/core/test_wiki_sync_routing.py` | **NEW** — 6 end-to-end routing tests including the Task #8 regression |
| `tests_py/core/test_wiki_layout.py` | `test_page_kinds_stable` rewritten as `test_page_kinds_modern_plus_legacy` |

## Backward compatibility

- Legacy directories (`notes/`, `specs/`, `conventions/`, `lessons/`, `guides/`, `files/`) remain accepted by `page_path` so existing pages stay readable.
- `normalize_legacy_kind(kind)` maps legacy frontmatter kinds to modern equivalents for callers needing a uniform view.
- New writes route exclusively through the modern schema.

## Behavioural impact at sync

Before (legacy):
```python
classify_memory(content, tags)  # → "adr" | "lesson" | "convention" | "spec" | "note" | None
# wiki_sync._KIND_TO_DIR routes by single kind string; no `file` mapping → 7820 file-docs land in notes/
```

After (this PR):
```python
classify_memory(content, tags)  # → Classification(kind="adr", lifecycle="proposed", audience=("developer",), provenance="human", ...) | None
# wiki_sync._MODERN_KIND_TO_DIR routes via tuple.kind; codebase-tagged content → reference/ with provenance=auto-generated
```

## Test plan

- [x] `pytest tests_py/core/ tests_py/shared/` → **1964 passed** locally
- [x] `pytest tests_py/shared/test_wiki_classification.py tests_py/core/test_wiki_classifier.py tests_py/core/test_wiki_sync_routing.py tests_py/core/test_wiki_layout.py tests_py/core/test_wiki_templates.py` → **85 passed** (the ADR-2244 surface)
- [x] `ruff format --check` and `ruff check` both clean
- [ ] CI on this PR
- [ ] **Phase 2** (separate PR): ~100-page pilot migration to verify the classifier hits the new kinds at acceptable accuracy before bulk rollout

## Out of scope for this PR (Phase 2–6, follow-up work)

- **Phase 2:** ~100-page pilot migration of representative existing content (`notes/file-*.md` → `reference/`, `decision-*.md → adr/`, `tool-bash.md → reject`)
- **Phase 3:** stable content IDs in frontmatter (UUIDs) + redirect stubs on rename
- **Phase 4:** bulk LLM-assisted re-classification of ~8500 existing pages
- **Phase 5:** classifier-driven cleanup pass for ai-generated stubs (filter, not delete)
- **Phase 6:** producer audit — `codebase_analyze` writes correct provenance/lifecycle directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)