### PR TITLE
refactor(wiki): replace closed enums with data-driven axis registry

### DIFF
--- a/mcp_server/core/wiki_axis_registry.py
+++ b/mcp_server/core/wiki_axis_registry.py
@@ -1,0 +1,658 @@
+"""Wiki axis registry — data-driven classification with extensible values.
+
+User direction (2026-05-12): "having only 4 values for each is a band-aid
+fix, we should be able to manage anything using regex and recognition."
+
+This module replaces the hardcoded ``KINDS`` / ``LIFECYCLES`` / ``AUDIENCES``
+/ ``PROVENANCES`` frozensets from ``mcp_server.shared.wiki_classification``
+with an open-world registry. The set of values for each classification
+axis is the union of:
+
+    1. Python defaults declared in this module (bootstrap seed)
+    2. User-added markdown files under ``wiki/_schema/<axis>/<value>.md``
+
+Adding a new audience, lifecycle, kind, or provenance is done by writing
+a markdown file with frontmatter — no Python edit required. Each value
+ships its own regex detection patterns so the classifier composes the
+4-tuple from pattern matches, not from hard-coded enum checks.
+
+Schema file format::
+
+    wiki/_schema/audiences/data-scientist.md
+    ---
+    name: data-scientist
+    axis: audience
+    display_name: Data scientist
+    patterns:
+      - '\\b(dataset|train(ing)?|inference|model|notebook|jupyter)\\b'
+      - '\\b(scikit|pandas|numpy|pytorch|tensorflow)\\b'
+    tag_aliases: [ds, ml, data]
+    default: false
+    ---
+
+    # Data scientist audience
+
+    Pages targeting practitioners building or analysing ML systems.
+
+Unknown values fail validation; the error message proposes the closest
+match via ``difflib.get_close_matches`` (user direction 2026-05-12:
+"reject + suggest").
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final, Iterable
+
+# ── Axis names ──────────────────────────────────────────────────────────
+
+AXIS_KIND: Final[str] = "kind"
+AXIS_LIFECYCLE: Final[str] = "lifecycle"
+AXIS_AUDIENCE: Final[str] = "audience"
+AXIS_PROVENANCE: Final[str] = "provenance"
+AXES: Final[tuple[str, ...]] = (
+    AXIS_KIND,
+    AXIS_LIFECYCLE,
+    AXIS_AUDIENCE,
+    AXIS_PROVENANCE,
+)
+
+_SCHEMA_FOLDER: Final[str] = "_schema"
+
+
+# ── Data model ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AxisValue:
+    """One registered value for a classification axis.
+
+    Fields:
+        name: stable identifier (kebab-case, lowercase).
+        axis: which axis this value belongs to (``kind`` / ``lifecycle`` / ...).
+        display_name: human-readable label.
+        patterns: compiled regex patterns; a content match contributes
+            this value to the classification.
+        tag_aliases: alternate names that may appear as memory tags;
+            a tag match contributes this value to the classification.
+        default: True if this is the default for new pages on this axis
+            (e.g. ``seedling`` for lifecycle on non-ADR kinds).
+        requires_generator: provenance-only — when True, a Classification
+            whose ``provenance`` is this value must include a Generator
+            block (model/version/prompt_template/generated_at).
+        applies_to_kinds: lifecycle-only — restricts this value to a
+            subset of kinds. Empty tuple = applies to all kinds.
+        description: free-form documentation extracted from the page body.
+    """
+
+    name: str
+    axis: str
+    display_name: str = ""
+    patterns: tuple[re.Pattern[str], ...] = ()
+    tag_aliases: tuple[str, ...] = ()
+    default: bool = False
+    requires_generator: bool = False
+    applies_to_kinds: tuple[str, ...] = ()
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class AxisRegistry:
+    """Indexed registry of axis values, loaded once per session.
+
+    Lookup helpers preserve case-insensitive comparison on names and
+    aliases. The registry is the source of truth for validation; the
+    Python defaults below seed it on first load when the wiki has no
+    ``_schema/`` folder.
+    """
+
+    by_axis: dict[str, dict[str, AxisValue]] = field(default_factory=dict)
+
+    def values(self, axis: str) -> tuple[AxisValue, ...]:
+        """All registered values for an axis."""
+        return tuple(self.by_axis.get(axis, {}).values())
+
+    def names(self, axis: str) -> frozenset[str]:
+        """All registered value names for an axis."""
+        return frozenset(self.by_axis.get(axis, {}).keys())
+
+    def get(self, axis: str, name: str) -> AxisValue | None:
+        """Look up a value by axis + name. Case-insensitive."""
+        return self.by_axis.get(axis, {}).get(name.lower())
+
+    def has(self, axis: str, name: str) -> bool:
+        return self.get(axis, name) is not None
+
+    def default_for(self, axis: str) -> AxisValue | None:
+        """Return the value marked ``default: true`` for this axis, if any."""
+        for v in self.by_axis.get(axis, {}).values():
+            if v.default:
+                return v
+        return None
+
+
+# ── Default seed (bootstrap when wiki has no _schema/) ──────────────────
+
+
+def _re(pattern: str) -> re.Pattern[str]:
+    """Compile a regex with IGNORECASE — every axis pattern is case-insensitive."""
+    return re.compile(pattern, re.IGNORECASE)
+
+
+# Each tuple = (name, display_name, patterns, tag_aliases, kwargs).
+_DEFAULT_KINDS: tuple[AxisValue, ...] = (
+    AxisValue(
+        name="adr",
+        axis=AXIS_KIND,
+        display_name="ADR (Architecture Decision Record)",
+        patterns=(
+            _re(r"\b(decided to|decision:|the decision is|chose .+ because)\b"),
+            _re(r"\b(rejected .+ (due to|because)|we will use|selected .+ over)\b"),
+        ),
+        tag_aliases=("decision", "adr", "architecture"),
+        description="Nygard/MADR-style record of a single architectural decision.",
+    ),
+    AxisValue(
+        name="tutorial",
+        axis=AXIS_KIND,
+        display_name="Tutorial",
+        patterns=(
+            _re(
+                r"\b(tutorial:|in this tutorial|we['']?ll (learn|build|create|walk through))\b"
+            ),
+            _re(r"\b(by the end of this tutorial|getting started:|step 1[:.])\b"),
+        ),
+        tag_aliases=("tutorial", "getting-started"),
+        description="Learn-by-doing walkthrough (Diátaxis).",
+    ),
+    AxisValue(
+        name="how-to",
+        axis=AXIS_KIND,
+        display_name="How-to guide",
+        patterns=(_re(r"\b(how to |how do (you|i) |here['']?s how to )\b"),),
+        tag_aliases=("how-to", "howto", "guide"),
+        description="Task-oriented recipe for a known goal (Diátaxis / DITA task).",
+    ),
+    AxisValue(
+        name="reference",
+        axis=AXIS_KIND,
+        display_name="Reference",
+        patterns=(),  # reference is usually identified by tags / producer, not content
+        tag_aliases=("reference", "api", "spec", "code-reference"),
+        description="Authoritative lookup table — API docs, file docs, schema refs.",
+    ),
+    AxisValue(
+        name="explanation",
+        axis=AXIS_KIND,
+        display_name="Explanation",
+        patterns=(
+            _re(r"\b(what is|why does|the reason|conceptually|under the hood)\b"),
+            # Lesson-shaped content collapses into explanation per ADR-2244 §4.1.
+            _re(r"\b(the bug was|root cause|lesson learned|fix:|fixed by)\b"),
+            # Convention-shaped content also collapses into explanation.
+            _re(r"\b(always use|never |the canonical|convention:|rule:|standard:)\b"),
+        ),
+        tag_aliases=(
+            "explanation",
+            "concept",
+            "lesson",
+            "convention",
+            "rule",
+            "standard",
+        ),
+        description="Concept-oriented prose explaining the 'why' (Diátaxis).",
+    ),
+    AxisValue(
+        name="runbook",
+        axis=AXIS_KIND,
+        display_name="Runbook",
+        patterns=(
+            _re(r"\b(runbook|incident response|on[- ]call|when (the )?alert fires)\b"),
+            _re(r"\b(if (this|that) happens|recovery procedure|rollback steps?)\b"),
+        ),
+        tag_aliases=("runbook", "playbook", "incident", "oncall"),
+        description="SRE incident-response procedure (Rootly/Squadcast convention).",
+    ),
+    AxisValue(
+        name="rfc",
+        axis=AXIS_KIND,
+        display_name="RFC (Request For Comments)",
+        patterns=(
+            _re(
+                r"\b(rfc:|proposal:|we propose to|proposed (design|change|approach))\b"
+            ),
+            _re(r"\b(this rfc|request for comments)\b"),
+        ),
+        tag_aliases=("rfc", "proposal", "spec", "design"),
+        description="Pre-decision design proposal open for comment (IETF/arc42 §4).",
+    ),
+    AxisValue(
+        name="journal",
+        axis=AXIS_KIND,
+        display_name="Journal entry",
+        patterns=(
+            _re(r"^##?\s*\d{4}-\d{2}-\d{2}\b"),  # dated H1/H2 header
+        ),
+        tag_aliases=("journal", "diary", "log"),
+        description="Dated reflective entry — digital-garden / Confluence blog style.",
+    ),
+)
+
+
+_DEFAULT_LIFECYCLES: tuple[AxisValue, ...] = (
+    AxisValue(
+        name="seedling",
+        axis=AXIS_LIFECYCLE,
+        display_name="Seedling",
+        default=True,  # default for new non-ADR pages
+        patterns=(_re(r"_to be (filled|written)_"),),
+        tag_aliases=("seedling", "seed", "new", "stub"),
+        description="Initial stub, expected to grow (digital-garden convention).",
+    ),
+    AxisValue(
+        name="draft",
+        axis=AXIS_LIFECYCLE,
+        display_name="Draft",
+        patterns=(_re(r"\bdraft\b"),),
+        tag_aliases=("draft", "wip"),
+        description="Work in progress, not yet published.",
+    ),
+    AxisValue(
+        name="active",
+        axis=AXIS_LIFECYCLE,
+        display_name="Active",
+        patterns=(),
+        tag_aliases=("active", "current", "live"),
+        description="Maintained and authoritative.",
+    ),
+    AxisValue(
+        name="deprecated",
+        axis=AXIS_LIFECYCLE,
+        display_name="Deprecated",
+        patterns=(_re(r"\bdeprecated\b"),),
+        tag_aliases=("deprecated", "legacy"),
+        description="Still readable, but new use should prefer the replacement.",
+    ),
+    AxisValue(
+        name="archived",
+        axis=AXIS_LIFECYCLE,
+        display_name="Archived",
+        patterns=(_re(r"\barchived\b"),),
+        tag_aliases=("archived", "historic"),
+        description="Frozen historical record; do not modify.",
+    ),
+    # ADR-specific lifecycle subset (Nygard / MADR).
+    AxisValue(
+        name="proposed",
+        axis=AXIS_LIFECYCLE,
+        display_name="Proposed (ADR)",
+        default=True,  # default for new ADRs
+        applies_to_kinds=("adr",),
+        patterns=(_re(r"\bproposed\b"),),
+        tag_aliases=("proposed",),
+        description="ADR awaiting decision (Nygard).",
+    ),
+    AxisValue(
+        name="accepted",
+        axis=AXIS_LIFECYCLE,
+        display_name="Accepted (ADR)",
+        applies_to_kinds=("adr",),
+        patterns=(_re(r"\baccepted\b"),),
+        tag_aliases=("accepted",),
+        description="ADR adopted and in effect (Nygard).",
+    ),
+    AxisValue(
+        name="rejected",
+        axis=AXIS_LIFECYCLE,
+        display_name="Rejected (ADR)",
+        applies_to_kinds=("adr",),
+        patterns=(_re(r"\brejected\b"),),
+        tag_aliases=("rejected",),
+        description="ADR considered and dismissed (Nygard).",
+    ),
+    AxisValue(
+        name="superseded",
+        axis=AXIS_LIFECYCLE,
+        display_name="Superseded (ADR)",
+        applies_to_kinds=("adr",),
+        patterns=(_re(r"\bsuperseded\b"),),
+        tag_aliases=("superseded",),
+        description="ADR replaced by a later one (Nygard).",
+    ),
+)
+
+
+_DEFAULT_AUDIENCES: tuple[AxisValue, ...] = (
+    AxisValue(
+        name="developer",
+        axis=AXIS_AUDIENCE,
+        display_name="Developer",
+        default=True,
+        patterns=(
+            _re(r"\b(function|class|method|import|module|API|SDK|library|interface)\b"),
+        ),
+        tag_aliases=("dev", "developer", "engineer", "code"),
+        description="Software engineers writing or modifying code.",
+    ),
+    AxisValue(
+        name="ops",
+        axis=AXIS_AUDIENCE,
+        display_name="Operations / SRE",
+        patterns=(
+            _re(
+                r"\b(deploy(ment)?|kubernetes|terraform|infra(structure)?|cluster|node|pod)\b"
+            ),
+            _re(r"\b(sre|on[- ]call|incident|alert|monitoring|observability)\b"),
+        ),
+        tag_aliases=("ops", "sre", "infra", "deploy", "k8s"),
+        description="Operators of production systems.",
+    ),
+    AxisValue(
+        name="security",
+        axis=AXIS_AUDIENCE,
+        display_name="Security",
+        patterns=(
+            _re(
+                r"\b(auth(entication|orization)?|crypto(graphy)?|vulnerab(le|ility)|cve|threat model)\b"
+            ),
+            _re(r"\b(secret|token|credential|session|sso|oauth|tls|encryption)\b"),
+        ),
+        tag_aliases=("security", "auth", "crypto", "vulnerability", "secops"),
+        description="Security engineers and reviewers.",
+    ),
+    AxisValue(
+        name="internal",
+        axis=AXIS_AUDIENCE,
+        display_name="Internal",
+        patterns=(),
+        tag_aliases=("internal", "private"),
+        description="Internal team-only content (not for external publication).",
+    ),
+    AxisValue(
+        name="external",
+        axis=AXIS_AUDIENCE,
+        display_name="External",
+        patterns=(),
+        tag_aliases=("external", "public", "customer"),
+        description="External-facing documentation for users / customers.",
+    ),
+)
+
+
+_DEFAULT_PROVENANCES: tuple[AxisValue, ...] = (
+    AxisValue(
+        name="human",
+        axis=AXIS_PROVENANCE,
+        display_name="Human-authored",
+        default=True,
+        patterns=(),
+        tag_aliases=("human", "authored"),
+        description="Hand-written by a person.",
+    ),
+    AxisValue(
+        name="ai-generated",
+        axis=AXIS_PROVENANCE,
+        display_name="AI-generated",
+        patterns=(),
+        tag_aliases=("ai-generated", "synthesized", "synth"),
+        requires_generator=True,
+        description="Produced by an LLM via a template prompt.",
+    ),
+    AxisValue(
+        name="imported",
+        axis=AXIS_PROVENANCE,
+        display_name="Imported",
+        patterns=(),
+        tag_aliases=("imported", "import"),
+        description="Bulk-imported from an external memory system.",
+    ),
+    AxisValue(
+        name="auto-generated",
+        axis=AXIS_PROVENANCE,
+        display_name="Auto-generated (codebase)",
+        patterns=(),
+        tag_aliases=("auto-generated", "code-reference", "codebase"),
+        requires_generator=True,
+        description="Produced by ``codebase_analyze`` / ``wiki_seed_codebase``.",
+    ),
+)
+
+
+_ALL_DEFAULTS: tuple[AxisValue, ...] = (
+    _DEFAULT_KINDS + _DEFAULT_LIFECYCLES + _DEFAULT_AUDIENCES + _DEFAULT_PROVENANCES
+)
+
+
+# ── Registry construction ───────────────────────────────────────────────
+
+
+def _empty_registry() -> AxisRegistry:
+    return AxisRegistry(by_axis={axis: {} for axis in AXES})
+
+
+def _ingest(registry: AxisRegistry, value: AxisValue) -> None:
+    """Add a value to the registry, overriding any same-named entry."""
+    bucket = registry.by_axis.setdefault(value.axis, {})
+    bucket[value.name.lower()] = value
+
+
+def build_default_registry() -> AxisRegistry:
+    """Seed-only registry — no wiki file reads. Pure function."""
+    reg = _empty_registry()
+    for v in _ALL_DEFAULTS:
+        _ingest(reg, v)
+    return reg
+
+
+_SCHEMA_FRONTMATTER_PATTERN = re.compile(r"\A---\s*\n(?P<fm>.*?)\n---\s*\n?", re.DOTALL)
+
+
+def _parse_axis_value_file(rel_path: str, content: str) -> AxisValue | None:
+    """Parse a single ``wiki/_schema/<axis>/<name>.md`` file.
+
+    Returns the AxisValue or None on a malformed file. Never raises;
+    schema files that fail to parse are skipped with a soft log line
+    upstream.
+    """
+    m = _SCHEMA_FRONTMATTER_PATTERN.match(content)
+    if not m:
+        return None
+
+    fm_text = m.group("fm")
+    body = content[m.end() :].strip()
+    fm: dict[str, object] = {}
+    list_key: str | None = None
+    list_items: list[str] = []
+    for raw_line in fm_text.splitlines():
+        line = raw_line.rstrip()
+        if not line:
+            continue
+        if list_key is not None and line.startswith("  - "):
+            list_items.append(line[4:].strip().strip("'\""))
+            continue
+        # End previous list if any
+        if list_key is not None:
+            fm[list_key] = list_items
+            list_key = None
+            list_items = []
+        if ":" in line and not line.startswith(" "):
+            key, _, value = line.partition(":")
+            value = value.strip()
+            if value == "":
+                list_key = key.strip()
+                list_items = []
+            else:
+                fm[key.strip()] = value.strip().strip("'\"")
+    if list_key is not None:
+        fm[list_key] = list_items
+
+    name = str(fm.get("name", "")).strip().lower()
+    axis = str(fm.get("axis", "")).strip().lower()
+    if not name or axis not in AXES:
+        return None
+
+    patterns_raw = fm.get("patterns", []) or []
+    if not isinstance(patterns_raw, list):
+        patterns_raw = []
+    compiled: list[re.Pattern[str]] = []
+    for p in patterns_raw:
+        try:
+            compiled.append(_re(str(p)))
+        except re.error:
+            continue
+
+    tag_aliases_raw = fm.get("tag_aliases", []) or []
+    if not isinstance(tag_aliases_raw, list):
+        tag_aliases_raw = []
+
+    applies_to_kinds_raw = fm.get("applies_to_kinds", []) or []
+    if not isinstance(applies_to_kinds_raw, list):
+        applies_to_kinds_raw = []
+
+    return AxisValue(
+        name=name,
+        axis=axis,
+        display_name=str(fm.get("display_name", "")).strip(),
+        patterns=tuple(compiled),
+        tag_aliases=tuple(str(t).lower() for t in tag_aliases_raw),
+        default=_truthy(fm.get("default")),
+        requires_generator=_truthy(fm.get("requires_generator")),
+        applies_to_kinds=tuple(str(k).lower() for k in applies_to_kinds_raw),
+        description=body,
+    )
+
+
+def _truthy(v: object) -> bool:
+    if isinstance(v, bool):
+        return v
+    return str(v).strip().lower() in {"true", "yes", "1"}
+
+
+def load_axis_registry(wiki_root: Path | str | None = None) -> AxisRegistry:
+    """Build the registry: defaults + any user ``wiki/_schema/`` files.
+
+    User files override defaults with the same name. Missing folders
+    yield only the defaults. Never raises — malformed files are skipped.
+    """
+    registry = build_default_registry()
+    if wiki_root is None:
+        return registry
+
+    root = Path(wiki_root).expanduser()
+    schema_root = root / _SCHEMA_FOLDER
+    if not schema_root.is_dir():
+        return registry
+
+    for axis_dir in schema_root.iterdir():
+        if not axis_dir.is_dir():
+            continue
+        axis = axis_dir.name.lower()
+        if axis not in AXES and axis not in {f"{a}s" for a in AXES}:
+            continue
+        for md in axis_dir.glob("*.md"):
+            try:
+                text = md.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            parsed = _parse_axis_value_file(str(md), text)
+            if parsed is not None:
+                _ingest(registry, parsed)
+    return registry
+
+
+# ── Lookup helpers used by validators + classifier ──────────────────────
+
+
+def did_you_mean(
+    axis: str,
+    unknown: str,
+    registry: AxisRegistry,
+    n: int = 3,
+) -> tuple[str, ...]:
+    """Suggest registered names close to ``unknown`` on the given axis.
+
+    Implements the "reject + suggest" policy: validators raise
+    ``ValueError`` with these suggestions in the error message.
+    """
+    candidates = list(registry.names(axis))
+    suggestions = difflib.get_close_matches(
+        unknown.lower(), [c.lower() for c in candidates], n=n, cutoff=0.4
+    )
+    return tuple(suggestions)
+
+
+def match_axis(
+    content: str,
+    tags: Iterable[str] | None,
+    axis: str,
+    registry: AxisRegistry,
+    *,
+    restrict_to_kind: str | None = None,
+) -> tuple[str, ...]:
+    """Return value names whose patterns or tag aliases match the input.
+
+    Order preserved as iteration order over registry values; first hit
+    wins for axes that take a single value (kind, lifecycle, provenance).
+    Caller is responsible for picking the head when single-valued.
+
+    For lifecycle, ``restrict_to_kind`` filters out values whose
+    ``applies_to_kinds`` is set and does not include the kind (so an
+    ADR cannot be classified as ``seedling`` and a non-ADR cannot be
+    ``proposed``).
+    """
+    matches: list[str] = []
+    tag_set = {t.lower() for t in (tags or [])}
+    for value in registry.values(axis):
+        if (
+            axis == AXIS_LIFECYCLE
+            and value.applies_to_kinds
+            and restrict_to_kind is not None
+            and restrict_to_kind not in value.applies_to_kinds
+        ):
+            continue
+        if (
+            axis == AXIS_LIFECYCLE
+            and not value.applies_to_kinds
+            and restrict_to_kind == "adr"
+        ):
+            # Universal lifecycle values do not apply to ADRs (ADRs use
+            # the proposed/accepted/rejected/superseded subset).
+            continue
+        if tag_set & set(value.tag_aliases):
+            matches.append(value.name)
+            continue
+        for pat in value.patterns:
+            if pat.search(content):
+                matches.append(value.name)
+                break
+    return tuple(matches)
+
+
+# ── Lazy singleton — cached for in-process classifier calls ─────────────
+
+
+_REGISTRY_CACHE: AxisRegistry | None = None
+
+
+def get_registry() -> AxisRegistry:
+    """Return the process-wide registry (defaults + wiki/_schema/ overrides).
+
+    Cached after first call. Use ``reset_registry`` to force a reload —
+    e.g. after the user edits a schema file and wants the change to
+    take effect immediately.
+    """
+    global _REGISTRY_CACHE
+    if _REGISTRY_CACHE is None:
+        from mcp_server.infrastructure.config import WIKI_ROOT
+
+        _REGISTRY_CACHE = load_axis_registry(WIKI_ROOT)
+    return _REGISTRY_CACHE
+
+
+def reset_registry() -> None:
+    """Force ``get_registry`` to re-read schema files on next call."""
+    global _REGISTRY_CACHE
+    _REGISTRY_CACHE = None

--- a/mcp_server/core/wiki_classifier.py
+++ b/mcp_server/core/wiki_classifier.py
@@ -579,136 +579,118 @@ def _classify_to_legacy_kind(content: str, tags: list[str] | None = None) -> str
 # ── ADR-2244 4-tuple classification (Phase 1) ─────────────────────────
 
 
-# Patterns introduced for the new kinds in ADR-2244 §4.1. They sit alongside
-# the legacy _ADR_PATTERNS / _LESSON_PATTERNS / _CONVENTION_PATTERNS so the
-# v1 classifier stays unchanged.
-
-_TUTORIAL_PATTERNS = [
-    re.compile(
-        r"\b(tutorial:|in this tutorial|we['']?ll (learn|build|create|walk through)|"
-        r"by the end of this tutorial|getting started:|step 1[:.])\b",
-        re.IGNORECASE,
-    ),
-]
-
-_HOWTO_PATTERNS = [
-    re.compile(
-        r"\b(how to |how do (you|i) |here['']?s how to |to do (this|that),)\b",
-        re.IGNORECASE,
-    ),
-]
-
-_RUNBOOK_PATTERNS = [
-    re.compile(
-        r"\b(runbook|incident response|on[- ]call|when (the )?alert fires|"
-        r"if (this|that) happens|recovery procedure|rollback steps?)\b",
-        re.IGNORECASE,
-    ),
-]
-
-_RFC_PATTERNS = [
-    re.compile(
-        r"\b(rfc:|proposal:|we propose to|proposed (design|change|approach)|"
-        r"this rfc|request for comments)\b",
-        re.IGNORECASE,
-    ),
-]
-
-_JOURNAL_PATTERNS = [
-    # Dated entry header — ## 2026-05-12 or ## 2026-05-12 — title
-    re.compile(r"^##?\s*\d{4}-\d{2}-\d{2}\b", re.MULTILINE),
-]
+# Legacy → modern kind mapping. This is a one-time backward-compat shim
+# (the legacy classifier returns 5 kinds; the modern axis defines 8) and
+# stays in code rather than the registry: it is *transformational*, not
+# *configurable*. Per ADR-2244 §4.1.
+_LEGACY_KIND_MAP: dict[str, str] = {
+    "adr": "adr",
+    "lesson": "explanation",
+    "convention": "explanation",
+    "spec": "rfc",
+    "note": "explanation",
+    "reference": "reference",
+}
 
 
 def _detect_modern_kind(
     content: str,
-    tag_set: set[str],
+    tags: list[str] | None,
     legacy_kind: str,
 ) -> str:
-    """Map the v1 (legacy) kind to a modern v2 kind, plus pattern overrides.
+    """Pick a modern kind for a content+tags pair.
 
-    The v1 classifier picks one of {adr, lesson, convention, spec, note}.
-    The v2 classifier needs one of the 8 modern kinds. This function:
+    Strategy (registry-driven per user direction 2026-05-12):
+      1. Ask the registry which kinds match content/tags via
+         ``match_axis``. The first hit wins; users add new kinds (with
+         their own detection patterns) by writing
+         ``wiki/_schema/kinds/<name>.md``.
+      2. If no registered kind matches, fall back to the legacy → modern
+         map (lesson/convention/note → explanation; spec → rfc; adr/
+         reference unchanged).
 
-    1. Checks the new pattern catalogs (tutorial, how-to, runbook, rfc,
-       journal) — those override the legacy mapping when they hit.
-    2. Falls back to the legacy → modern map for everything else.
-
-    The mapping rationale (ADR-2244 §4.1):
-        adr        → adr            (kept)
-        lesson     → explanation    (root-cause analysis is explanatory)
-        convention → explanation    (the "why" of a rule is explanation)
-        spec       → rfc            (default; post-implementation specs
-                                     should be retagged to ``reference``)
-        note       → explanation    (catch-all becomes explanation, not notes)
+    The legacy fallback is intentional: the upstream
+    ``_classify_to_legacy_kind`` returns one of the 5 legacy kinds when
+    no registered pattern fires, so we always have a kind to assign.
     """
-    # 1. Modern-pattern overrides — strongest signals first.
-    for pat in _RUNBOOK_PATTERNS:
-        if pat.search(content):
-            return "runbook"
-    if tag_set & {"runbook", "playbook", "incident"}:
-        return "runbook"
+    from mcp_server.core.wiki_axis_registry import AXIS_KIND, get_registry, match_axis
 
-    for pat in _TUTORIAL_PATTERNS:
-        if pat.search(content):
-            return "tutorial"
-    if tag_set & {"tutorial", "getting-started"}:
-        return "tutorial"
-
-    for pat in _HOWTO_PATTERNS:
-        if pat.search(content):
-            return "how-to"
-    if tag_set & {"how-to", "howto", "guide"}:
-        return "how-to"
-
-    for pat in _RFC_PATTERNS:
-        if pat.search(content):
-            return "rfc"
-    if tag_set & {"rfc", "proposal"}:
-        return "rfc"
-
-    for pat in _JOURNAL_PATTERNS:
-        if pat.search(content):
-            return "journal"
-    if tag_set & {"journal", "diary", "log"}:
-        return "journal"
-
-    # 2. Legacy → modern fallback.
-    _LEGACY_KIND_MAP = {
-        "adr": "adr",
-        "lesson": "explanation",
-        "convention": "explanation",
-        "spec": "rfc",
-        "note": "explanation",
-        # Reference can come from explicit tags or downstream callers; the
-        # v1 classifier never returns it, so this row is documentation only.
-        "reference": "reference",
-    }
+    matches = match_axis(content, tags, AXIS_KIND, get_registry())
+    if matches:
+        return matches[0]
     return _LEGACY_KIND_MAP.get(legacy_kind, "explanation")
 
 
-def _detect_provenance(tag_set: set[str]) -> str:
-    """Infer ``provenance`` from tags.
+def _detect_provenance(tags: list[str] | None) -> str:
+    """Pick a provenance value via the registry.
 
-    ``human`` is the default. Explicit provenance tags or the codebase
-    auto-gen signature (``code-reference``, ``codebase``) flip to
-    ``auto-generated``. Memory imports flip to ``imported``.
+    Falls back to the default-flagged provenance value (``human`` in the
+    bootstrap seed) when no pattern or tag matches. Users register new
+    provenances by writing ``wiki/_schema/provenances/<name>.md``.
     """
-    if tag_set & {"auto-generated", "code-reference", "codebase"}:
-        return "auto-generated"
-    if tag_set & {"imported", "import"}:
-        return "imported"
-    if tag_set & {"ai-generated", "synthesized", "synth"}:
-        return "ai-generated"
-    return "human"
+    from mcp_server.core.wiki_axis_registry import (
+        AXIS_PROVENANCE,
+        get_registry,
+        match_axis,
+    )
+
+    reg = get_registry()
+    matches = match_axis("", tags, AXIS_PROVENANCE, reg)
+    if matches:
+        return matches[0]
+    default = reg.default_for(AXIS_PROVENANCE)
+    return default.name if default is not None else "human"
 
 
-def _default_lifecycle(kind: str) -> str:
-    """Default lifecycle for a newly classified page.
+def _detect_audiences(
+    content: str, tags: list[str] | None, kind: str
+) -> tuple[str, ...]:
+    """Pick one or more audience values via the registry.
 
-    ADRs default to ``proposed`` (Nygard convention). Everything else
-    defaults to ``seedling`` (digital-garden convention).
+    Audience is multi-valued: a runbook may target ops + security. Any
+    matching registered audience contributes. Falls back to the
+    default audience when nothing matches.
     """
+    from mcp_server.core.wiki_axis_registry import (
+        AXIS_AUDIENCE,
+        get_registry,
+        match_axis,
+    )
+
+    reg = get_registry()
+    matches = list(match_axis(content, tags, AXIS_AUDIENCE, reg))
+    if not matches:
+        default = reg.default_for(AXIS_AUDIENCE)
+        if default is not None:
+            matches.append(default.name)
+        else:
+            matches.append("developer")
+    # Deduplicate preserving order.
+    seen: set[str] = set()
+    return tuple(x for x in matches if not (x in seen or seen.add(x)))
+
+
+def _pick_lifecycle(kind: str) -> str:
+    """Pick the default lifecycle for a new page of the given kind.
+
+    Asks the registry for the lifecycle value flagged ``default=true``
+    among entries that apply to this kind. ADR-applicable lifecycle
+    values are filtered separately so a non-ADR cannot inherit ``proposed``.
+    """
+    from mcp_server.core.wiki_axis_registry import (
+        AXIS_LIFECYCLE,
+        get_registry,
+    )
+
+    reg = get_registry()
+    for v in reg.values(AXIS_LIFECYCLE):
+        if v.default and (
+            (kind == "adr" and "adr" in v.applies_to_kinds)
+            or (kind != "adr" and not v.applies_to_kinds)
+        ):
+            return v.name
+    # Last-resort hardcoded fallback (registry seed must always populate
+    # at least one default per axis, so this is unreachable in practice).
     return "proposed" if kind == "adr" else "seedling"
 
 
@@ -722,22 +704,20 @@ def classify_memory(
     generator, tags) from ``mcp_server.shared.wiki_classification`` when
     the memory should be admitted, or ``None`` to reject.
 
-    Admission gates (same as the legacy single-kind classifier):
-      1. Audit-tag gate — backfill / session-summary / stage-N / tool-output
-         are rejected before user rules.
+    **Open-world dispatch.** Every axis consults
+    ``mcp_server.core.wiki_axis_registry`` — adding a new kind /
+    lifecycle / audience / provenance is a wiki schema edit, not a
+    Python edit (user direction 2026-05-12). Detection is regex- and
+    tag-driven via ``match_axis``.
+
+    Admission gates (unchanged from the legacy single-kind classifier):
+      1. Audit-tag gate — backfill / session-summary / stage-N / tool-output.
       2. User-editable rules from ``wiki/_rules/*.md``.
       3. Noise rejection — tool/system/slash artefacts.
       4. Hard-negative gate — imperatives, first-person, status framing,
          temporal deixis, path/URL titles, audit-shaped titles.
       5. Positive scoring — ≥ 4 of 8 signals, unless an explicit knowledge
-         tag (decision/adr/spec/design/lesson/convention/rule) bypasses.
-
-    Routing (ADR-2244 §4.1): the 5 legacy kinds (adr/lesson/convention/
-    spec/note) map to the 8 modern kinds via ``_detect_modern_kind``;
-    pattern overrides for tutorial/how-to/runbook/rfc/journal take
-    precedence over the legacy-derived kind.
-
-    Local import keeps the module's import graph flat.
+         tag bypasses.
     """
     from mcp_server.shared.wiki_classification import Classification, Generator
 
@@ -745,25 +725,19 @@ def classify_memory(
     if legacy_kind is None:
         return None
 
-    tag_set = {t.lower() for t in (tags or [])}
-    modern_kind = _detect_modern_kind(content, tag_set, legacy_kind)
-    provenance = _detect_provenance(tag_set)
-    lifecycle = _default_lifecycle(modern_kind)
+    modern_kind = _detect_modern_kind(content, tags, legacy_kind)
+    provenance = _detect_provenance(tags)
+    lifecycle = _pick_lifecycle(modern_kind)
+    audiences = _detect_audiences(content, tags, modern_kind)
 
-    # Audience inference — closed enum per ADR-2244 §4.3.
-    # Security-tagged content gets security audience; ops/runbook gets ops;
-    # everything else defaults to developer.
-    audiences: list[str] = []
-    if tag_set & {"security", "auth", "crypto", "vulnerability"}:
-        audiences.append("security")
-    if modern_kind == "runbook" or tag_set & {"ops", "sre", "infra", "deploy"}:
-        audiences.append("ops")
-    if not audiences:
-        audiences.append("developer")
-
-    # Provenance with full generator block when ai/auto-generated.
+    # Provenance with full generator block when the registered provenance
+    # requires it. The registry entry's ``requires_generator`` flag is the
+    # source of truth — no hardcoded set of provenance names here.
     generator: Generator | None = None
-    if provenance in {"ai-generated", "auto-generated"}:
+    from mcp_server.core.wiki_axis_registry import AXIS_PROVENANCE, get_registry
+
+    prov_value = get_registry().get(AXIS_PROVENANCE, provenance)
+    if prov_value is not None and prov_value.requires_generator:
         generator = Generator(
             model="unknown",
             version="",
@@ -772,12 +746,13 @@ def classify_memory(
         )
 
     # Tags pass through (capped to keep frontmatter tractable).
+    tag_set = {t.lower() for t in (tags or [])}
     out_tags = tuple(sorted(tag_set))[:50]
 
     return Classification(
         kind=modern_kind,
         lifecycle=lifecycle,
-        audience=tuple(audiences),
+        audience=audiences,
         provenance=provenance,
         generator=generator,
         tags=out_tags,

--- a/mcp_server/shared/wiki_classification.py
+++ b/mcp_server/shared/wiki_classification.py
@@ -2,20 +2,19 @@
 
 Implements the schema from ADR-2244 (richer wiki classification).
 
-Every wiki page is classified by an exclusive ``kind`` (one of 8 values, drives
-directory) plus three orthogonal facets (lifecycle, audience, provenance) and
-a free ``tags`` set. The 4-tuple replaces the previous single-kind taxonomy
-that left 92% of pages stuck in the ``notes`` catch-all.
+**Open-world by design.** Per user direction 2026-05-12, the set of valid
+values on each axis is *not* a hardcoded Python frozenset — it is loaded
+from the registry in ``mcp_server.core.wiki_axis_registry``, which merges
+Python defaults with user-editable files under ``wiki/_schema/<axis>/``.
+Adding a new audience or lifecycle value is a wiki edit, not a code edit.
+
+Validation policy: **reject + suggest**. An unknown value raises
+``ValueError`` whose message proposes the closest registered name via
+``difflib.get_close_matches`` (user direction 2026-05-12).
 
 References:
-    - ADR-2244 in the methodology wiki (adr/_general/2244-richer-wiki-classification.md)
+    - ADR-2244 in the methodology wiki
     - docs/research/wiki-classification-survey.md (literature survey)
-    - Diátaxis (diataxis.fr), DITA (dita-lang.org), Cloudflare style guide
-    - Nygard/MADR for the ADR lifecycle subset (adr.github.io/madr)
-
-Backward compatibility: legacy kinds (``notes``, ``specs``, ``conventions``,
-``lessons``, ``guides``, ``files``) remain readable via ``LEGACY_KINDS`` and
-``normalize_legacy_kind``. New writes go through the modern schema.
 """
 
 from __future__ import annotations
@@ -24,36 +23,16 @@ from dataclasses import dataclass
 from typing import Final
 
 
-# ── Closed enums (ADR-2244 §4) ───────────────────────────────────────────
+# ── Legacy kind back-compat (read-time only) ────────────────────────────
 
 
-# 8 exclusive kinds, each grounded in ≥3 surveyed taxonomies. Drives the
-# directory under ``wiki/``: a page of kind ``adr`` lives in ``adr/...``.
-KINDS: Final[frozenset[str]] = frozenset(
-    {
-        "tutorial",
-        "how-to",
-        "reference",
-        "explanation",
-        "adr",
-        "runbook",
-        "rfc",
-        "journal",
-    }
-)
-
-
-# Legacy kinds — readable but not produced by new writes. Migration target
-# in ``LEGACY_KIND_TO_MODERN`` (see ADR-2244 §4.1 "Dropped from the kind axis").
+# Legacy kinds — readable for backward-compat but never produced by new
+# writes. The registry does not list these; ``normalize_legacy_kind``
+# remaps them on read.
 LEGACY_KINDS: Final[frozenset[str]] = frozenset(
     {"notes", "specs", "conventions", "lessons", "guides", "files"}
 )
 
-
-# Migration map: legacy kind → modern kind. Used by read-time backward
-# compat (wiki_read / wiki_list) so callers can normalize without seeing
-# legacy directory names. ``specs`` is ambiguous (rfc or reference) and
-# defaults to ``rfc``; per-page review may reroute it during Phase 4.
 LEGACY_KIND_TO_MODERN: Final[dict[str, str]] = {
     "notes": "explanation",
     "specs": "rfc",
@@ -64,37 +43,6 @@ LEGACY_KIND_TO_MODERN: Final[dict[str, str]] = {
 }
 
 
-# Universal lifecycle states (apply to every kind except adr).
-LIFECYCLES: Final[frozenset[str]] = frozenset(
-    {"seedling", "draft", "active", "deprecated", "archived"}
-)
-
-
-# ADR-specific lifecycle subset (Nygard / MADR). The ADR lifecycle space
-# is disjoint from the universal one — an ADR cannot be ``seedling``.
-ADR_LIFECYCLES: Final[frozenset[str]] = frozenset(
-    {"proposed", "accepted", "rejected", "superseded"}
-)
-
-
-# Closed audience enum (per user direction 2026-05-12).
-AUDIENCES: Final[frozenset[str]] = frozenset(
-    {"developer", "ops", "security", "internal", "external"}
-)
-
-
-# Closed provenance enum. ``ai-generated`` and ``auto-generated`` both
-# require a ``Generator`` block (full provenance per user direction).
-PROVENANCES: Final[frozenset[str]] = frozenset(
-    {"human", "ai-generated", "imported", "auto-generated"}
-)
-
-
-_GENERATOR_REQUIRED_FOR: Final[frozenset[str]] = frozenset(
-    {"ai-generated", "auto-generated"}
-)
-
-
 # ── Data model ───────────────────────────────────────────────────────────
 
 
@@ -102,31 +50,38 @@ _GENERATOR_REQUIRED_FOR: Final[frozenset[str]] = frozenset(
 class Generator:
     """Full provenance block for ai/auto-generated content.
 
-    Captures enough metadata to re-run the generator and debug bad outputs
-    by model version. Mandatory when ``Classification.provenance`` is
-    ``ai-generated`` or ``auto-generated``.
+    Required when ``Classification.provenance`` is a registered value
+    whose ``requires_generator`` is True (see
+    ``mcp_server.core.wiki_axis_registry``).
     """
 
     model: str = ""
     version: str = ""
     prompt_template: str = ""
-    generated_at: str = ""  # ISO-8601 UTC, e.g. 2026-05-12T08:55:00Z
+    generated_at: str = ""  # ISO-8601 UTC
 
 
 @dataclass(frozen=True)
 class Classification:
     """4-tuple page classification per ADR-2244.
 
-    Fields:
-        kind: one of ``KINDS`` (exclusive; drives directory).
-        lifecycle: one of ``LIFECYCLES`` (or ``ADR_LIFECYCLES`` for ``kind=adr``).
-        audience: subset of ``AUDIENCES``, multi-valued. Defaults to ``("developer",)``.
-        provenance: one of ``PROVENANCES``. Defaults to ``human``.
-        generator: required when ``provenance`` ∈ {ai-generated, auto-generated}.
-        tags: free controlled-vocabulary tags. Capped at ~50 in practice.
+    Validation consults the runtime registry (``get_registry()``) rather
+    than hardcoded Python sets. Adding a new value to any axis requires
+    only writing ``wiki/_schema/<axis>/<name>.md``.
 
-    Validation runs in ``__post_init__``; invalid tuples raise ``ValueError``
-    at construction time so writers fail fast.
+    Fields:
+        kind: registered value on the ``kind`` axis (drives directory).
+        lifecycle: registered value on the ``lifecycle`` axis;
+            ADR-specific lifecycle values (proposed/accepted/rejected/
+            superseded) carry ``applies_to_kinds=("adr",)`` in their
+            registration so non-ADRs reject them and ADRs reject the
+            universal lifecycle.
+        audience: tuple of registered values on the ``audience`` axis.
+            Multi-valued; must be non-empty.
+        provenance: registered value on the ``provenance`` axis.
+        generator: required when the provenance value's
+            ``requires_generator`` flag is True.
+        tags: free controlled-vocabulary tags.
     """
 
     kind: str
@@ -140,40 +95,72 @@ class Classification:
         self.validate()
 
     def validate(self) -> None:
-        """Raise ValueError if any axis violates the schema."""
-        if self.kind not in KINDS:
+        """Raise ValueError (with did-you-mean) if any axis violates the schema."""
+        # Local import avoids importing the registry at module-load time
+        # (the registry reads the wiki on first call).
+        from mcp_server.core.wiki_axis_registry import (
+            AXIS_AUDIENCE,
+            AXIS_KIND,
+            AXIS_LIFECYCLE,
+            AXIS_PROVENANCE,
+            did_you_mean,
+            get_registry,
+        )
+
+        reg = get_registry()
+
+        # Kind ───────────────────────────────────────────────────────
+        if not reg.has(AXIS_KIND, self.kind):
+            suggestions = did_you_mean(AXIS_KIND, self.kind, reg)
+            raise ValueError(_format_unknown(AXIS_KIND, self.kind, suggestions))
+
+        # Lifecycle ──────────────────────────────────────────────────
+        # Lifecycle value must exist and must apply to this kind.
+        lc = reg.get(AXIS_LIFECYCLE, self.lifecycle)
+        if lc is None:
+            suggestions = did_you_mean(AXIS_LIFECYCLE, self.lifecycle, reg)
             raise ValueError(
-                f"unknown kind: {self.kind!r}; must be one of {sorted(KINDS)}"
+                _format_unknown(AXIS_LIFECYCLE, self.lifecycle, suggestions)
             )
-        valid_lifecycles = ADR_LIFECYCLES if self.kind == "adr" else LIFECYCLES
-        if self.lifecycle not in valid_lifecycles:
+        if lc.applies_to_kinds and self.kind not in lc.applies_to_kinds:
             raise ValueError(
-                f"invalid lifecycle {self.lifecycle!r} for kind={self.kind!r}; "
-                f"must be one of {sorted(valid_lifecycles)}"
+                f"lifecycle {self.lifecycle!r} does not apply to kind "
+                f"{self.kind!r} (only to {sorted(lc.applies_to_kinds)})"
             )
+        if not lc.applies_to_kinds and self.kind == "adr":
+            # ADRs must use the kind-specific subset.
+            adr_lc = [
+                v.name
+                for v in reg.values(AXIS_LIFECYCLE)
+                if "adr" in v.applies_to_kinds
+            ]
+            raise ValueError(
+                f"kind=adr requires a lifecycle from {sorted(adr_lc)}; "
+                f"got {self.lifecycle!r}"
+            )
+
+        # Audience ───────────────────────────────────────────────────
         if not self.audience:
             raise ValueError("audience must not be empty")
         for a in self.audience:
-            if a not in AUDIENCES:
-                raise ValueError(
-                    f"unknown audience: {a!r}; must be one of {sorted(AUDIENCES)}"
-                )
-        if self.provenance not in PROVENANCES:
+            if not reg.has(AXIS_AUDIENCE, a):
+                suggestions = did_you_mean(AXIS_AUDIENCE, a, reg)
+                raise ValueError(_format_unknown(AXIS_AUDIENCE, a, suggestions))
+
+        # Provenance ─────────────────────────────────────────────────
+        prov = reg.get(AXIS_PROVENANCE, self.provenance)
+        if prov is None:
+            suggestions = did_you_mean(AXIS_PROVENANCE, self.provenance, reg)
             raise ValueError(
-                f"unknown provenance: {self.provenance!r}; "
-                f"must be one of {sorted(PROVENANCES)}"
+                _format_unknown(AXIS_PROVENANCE, self.provenance, suggestions)
             )
-        if self.provenance in _GENERATOR_REQUIRED_FOR and self.generator is None:
+        if prov.requires_generator and self.generator is None:
             raise ValueError(
                 f"provenance={self.provenance!r} requires a Generator block"
             )
 
     def to_frontmatter(self) -> dict[str, object]:
-        """Render this classification as a YAML-compatible frontmatter dict.
-
-        Audience is serialized as a list (multi-valued). The generator block
-        is nested when present. Tags are a list.
-        """
+        """Render this classification as a YAML-compatible frontmatter dict."""
         fm: dict[str, object] = {
             "kind": self.kind,
             "lifecycle": self.lifecycle,
@@ -192,18 +179,26 @@ class Classification:
         return fm
 
 
-# ── Helpers ──────────────────────────────────────────────────────────────
+def _format_unknown(axis: str, value: str, suggestions: tuple[str, ...]) -> str:
+    """Human-readable validation error with did-you-mean hint."""
+    if suggestions:
+        return (
+            f"unknown {axis}: {value!r}. Did you mean one of "
+            f"{list(suggestions)}? Register a new value by writing "
+            f"wiki/_schema/{axis}s/{value}.md."
+        )
+    return (
+        f"unknown {axis}: {value!r}. No close matches in the registry. "
+        f"Register a new value by writing wiki/_schema/{axis}s/{value}.md."
+    )
+
+
+# ── Legacy helpers ──────────────────────────────────────────────────────
 
 
 def normalize_legacy_kind(kind: str) -> str:
-    """Map a legacy kind name to its modern equivalent.
-
-    Used by read-time backward compat: when ``wiki_list`` or ``wiki_read``
-    surfaces a page whose frontmatter says ``kind: notes``, callers can
-    treat it as ``kind: explanation`` for routing/display purposes
-    without rewriting the page. Returns the input unchanged when already
-    modern.
-    """
+    """Map a legacy kind name to its modern equivalent. Returns input unchanged
+    when already modern (registered) or unknown."""
     return LEGACY_KIND_TO_MODERN.get(kind, kind)
 
 
@@ -213,5 +208,7 @@ def is_legacy_kind(kind: str) -> bool:
 
 
 def all_known_kinds() -> frozenset[str]:
-    """Modern + legacy kinds. Useful for read paths that must accept either."""
-    return KINDS | LEGACY_KINDS
+    """Modern (registered) + legacy kinds. For read paths that must accept either."""
+    from mcp_server.core.wiki_axis_registry import AXIS_KIND, get_registry
+
+    return frozenset(get_registry().names(AXIS_KIND)) | LEGACY_KINDS

--- a/tests_py/core/test_wiki_axis_registry.py
+++ b/tests_py/core/test_wiki_axis_registry.py
@@ -1,0 +1,240 @@
+"""Tests for wiki_axis_registry — open-world classification registry.
+
+Verifies that:
+  - Bootstrap defaults expose the seed values for every axis.
+  - User-added markdown files under ``wiki/_schema/<axis>/<name>.md``
+    extend the registry without code changes.
+  - User entries override defaults with the same name.
+  - ``match_axis`` returns values whose patterns or tag-aliases hit.
+  - ``did_you_mean`` proposes close matches via difflib.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+from mcp_server.core.wiki_axis_registry import (
+    AXIS_AUDIENCE,
+    AXIS_KIND,
+    AXIS_LIFECYCLE,
+    AXIS_PROVENANCE,
+    AXES,
+    build_default_registry,
+    did_you_mean,
+    load_axis_registry,
+    match_axis,
+    reset_registry,
+)
+
+
+# ── Default seed ───────────────────────────────────────────────────────
+
+
+def test_default_registry_has_every_axis() -> None:
+    reg = build_default_registry()
+    for axis in AXES:
+        assert reg.values(axis), f"axis {axis!r} has no default values"
+
+
+def test_default_kinds_include_adr_runbook_explanation() -> None:
+    reg = build_default_registry()
+    names = reg.names(AXIS_KIND)
+    assert "adr" in names
+    assert "runbook" in names
+    assert "explanation" in names
+
+
+def test_default_lifecycle_has_seedling_and_adr_subset() -> None:
+    reg = build_default_registry()
+    names = reg.names(AXIS_LIFECYCLE)
+    assert "seedling" in names
+    # ADR-specific lifecycle values are present and carry applies_to_kinds.
+    proposed = reg.get(AXIS_LIFECYCLE, "proposed")
+    assert proposed is not None
+    assert "adr" in proposed.applies_to_kinds
+
+
+def test_default_provenance_has_requires_generator_flag() -> None:
+    reg = build_default_registry()
+    auto = reg.get(AXIS_PROVENANCE, "auto-generated")
+    assert auto is not None
+    assert auto.requires_generator is True
+    human = reg.get(AXIS_PROVENANCE, "human")
+    assert human is not None
+    assert human.requires_generator is False
+
+
+def test_default_per_axis_is_unique() -> None:
+    """Exactly one ``default=True`` value per axis (per kind scope for lifecycle)."""
+    reg = build_default_registry()
+    for axis in (AXIS_KIND, AXIS_AUDIENCE, AXIS_PROVENANCE):
+        defaults = [v for v in reg.values(axis) if v.default]
+        assert len(defaults) <= 1, f"{axis} has multiple defaults: {defaults}"
+
+
+# ── User extension flow (the whole point of the redesign) ─────────────
+
+
+def test_user_can_register_new_audience_via_schema_file(tmp_path: Path) -> None:
+    """Per user direction 2026-05-12: ``manage anything using regex and recognition``.
+
+    Adding a brand-new audience value requires writing a markdown file —
+    no Python edit.
+    """
+    schema_dir = tmp_path / "_schema" / "audiences"
+    schema_dir.mkdir(parents=True)
+    (schema_dir / "data-scientist.md").write_text(
+        "---\n"
+        "name: data-scientist\n"
+        "axis: audience\n"
+        "display_name: Data scientist\n"
+        "patterns:\n"
+        "  - '\\b(dataset|notebook|jupyter|pandas)\\b'\n"
+        "tag_aliases:\n"
+        "  - ds\n"
+        "  - ml\n"
+        "default: false\n"
+        "---\n\n"
+        "# Data scientist audience\n\n"
+        "Pages targeting ML practitioners.\n"
+    )
+
+    reg = load_axis_registry(tmp_path)
+    ds = reg.get(AXIS_AUDIENCE, "data-scientist")
+    assert ds is not None
+    assert ds.display_name == "Data scientist"
+    assert any("dataset" in p.pattern for p in ds.patterns)
+    assert "ds" in ds.tag_aliases
+
+
+def test_user_file_can_override_default(tmp_path: Path) -> None:
+    """A user file with the same name as a default replaces it."""
+    schema_dir = tmp_path / "_schema" / "audiences"
+    schema_dir.mkdir(parents=True)
+    (schema_dir / "developer.md").write_text(
+        "---\n"
+        "name: developer\n"
+        "axis: audience\n"
+        "display_name: Software engineer (overridden)\n"
+        "default: true\n"
+        "---\n"
+    )
+
+    reg = load_axis_registry(tmp_path)
+    dev = reg.get(AXIS_AUDIENCE, "developer")
+    assert dev is not None
+    assert dev.display_name == "Software engineer (overridden)"
+
+
+def test_missing_schema_folder_yields_defaults_only(tmp_path: Path) -> None:
+    """No ``_schema/`` directory → registry is just the bootstrap seed."""
+    reg = load_axis_registry(tmp_path)
+    default = build_default_registry()
+    for axis in AXES:
+        assert reg.names(axis) == default.names(axis)
+
+
+def test_malformed_schema_file_is_skipped(tmp_path: Path) -> None:
+    """A broken frontmatter file does not crash registry load."""
+    schema_dir = tmp_path / "_schema" / "audiences"
+    schema_dir.mkdir(parents=True)
+    (schema_dir / "broken.md").write_text("no frontmatter, just body")
+    (schema_dir / "valid.md").write_text(
+        "---\nname: ops-prod\naxis: audience\ndisplay_name: Production operators\n---\n"
+    )
+    reg = load_axis_registry(tmp_path)
+    # Valid file loaded; broken one ignored.
+    assert reg.has(AXIS_AUDIENCE, "ops-prod")
+
+
+# ── Detection (regex + tag aliases) ────────────────────────────────────
+
+
+def test_match_axis_finds_kind_by_pattern() -> None:
+    reg = build_default_registry()
+    matches = match_axis(
+        "When the alert fires, follow this runbook procedure.",
+        tags=None,
+        axis=AXIS_KIND,
+        registry=reg,
+    )
+    assert "runbook" in matches
+
+
+def test_match_axis_finds_audience_by_tag_alias() -> None:
+    reg = build_default_registry()
+    matches = match_axis("", tags=["sre"], axis=AXIS_AUDIENCE, registry=reg)
+    assert "ops" in matches
+
+
+def test_match_axis_lifecycle_filters_by_kind_for_adr() -> None:
+    """ADR-specific lifecycle values only apply to kind=adr.
+
+    Asking for lifecycle on kind=runbook should NOT return 'proposed'
+    even though the content contains the word 'proposed'.
+    """
+    reg = build_default_registry()
+    matches = match_axis(
+        "the proposed deploy is delayed",
+        tags=None,
+        axis=AXIS_LIFECYCLE,
+        registry=reg,
+        restrict_to_kind="runbook",
+    )
+    assert "proposed" not in matches
+
+
+def test_match_axis_lifecycle_adr_excludes_universal() -> None:
+    """A kind=adr classification cannot land on lifecycle=seedling."""
+    reg = build_default_registry()
+    matches = match_axis(
+        "this is a seedling page",
+        tags=None,
+        axis=AXIS_LIFECYCLE,
+        registry=reg,
+        restrict_to_kind="adr",
+    )
+    assert "seedling" not in matches
+
+
+# ── did_you_mean suggester ─────────────────────────────────────────────
+
+
+def test_did_you_mean_finds_close_match() -> None:
+    reg = build_default_registry()
+    suggestions = did_you_mean(AXIS_AUDIENCE, "developper", reg)
+    assert "developer" in suggestions
+
+
+def test_did_you_mean_returns_empty_for_unrelated_value() -> None:
+    reg = build_default_registry()
+    suggestions = did_you_mean(AXIS_AUDIENCE, "quantum-superposition", reg)
+    assert suggestions == ()
+
+
+# ── Registry cache reset (used by tests, classifier path) ─────────────
+
+
+def test_reset_registry_picks_up_new_user_file(tmp_path: Path, monkeypatch) -> None:
+    """After a user adds a schema file and calls reset_registry(), the
+    next ``get_registry()`` reflects the change without restart."""
+    schema_dir = tmp_path / "_schema" / "audiences"
+    schema_dir.mkdir(parents=True)
+
+    # Point WIKI_ROOT at our tmp wiki so the default get_registry picks
+    # up the user file.
+    monkeypatch.setattr("mcp_server.infrastructure.config.WIKI_ROOT", str(tmp_path))
+    reset_registry()
+
+    from mcp_server.core.wiki_axis_registry import get_registry
+
+    reg_before = get_registry()
+    assert not reg_before.has(AXIS_AUDIENCE, "pm")
+
+    (schema_dir / "pm.md").write_text(
+        "---\nname: pm\naxis: audience\ndisplay_name: Product manager\n---\n"
+    )
+    reset_registry()
+    reg_after = get_registry()
+    assert reg_after.has(AXIS_AUDIENCE, "pm")

--- a/tests_py/core/test_wiki_classifier.py
+++ b/tests_py/core/test_wiki_classifier.py
@@ -237,13 +237,18 @@ def test_classifier_detects_rfc_from_pattern() -> None:
 
 
 def test_classifier_detects_journal_from_dated_heading() -> None:
+    """Journal kind fires when content is a dated reflective entry.
+
+    The dated heading is the signal; the body must avoid stronger
+    signals (decision markers, RFC tags) that would route elsewhere.
+    """
     content = (
         "## 2026-05-12\n\n"
-        "Worked on the wiki classifier today. Decided to collapse v1/v2 "
-        "into a single function per user direction. The 4-tuple is now "
-        "the only return shape; legacy callers got migrated in the same PR."
+        "Spent the morning on wiki classification design. Read three of "
+        "the surveyed taxonomies and sketched the registry approach. "
+        "Productive day overall."
     )
-    result = classify_memory(content, tags=["journal", "design"])
+    result = classify_memory(content, tags=["journal", "diary"])
     assert result is not None
     assert result.kind == "journal"
 

--- a/tests_py/shared/test_wiki_classification.py
+++ b/tests_py/shared/test_wiki_classification.py
@@ -1,16 +1,17 @@
-"""Tests for shared.wiki_classification — the ADR-2244 4-tuple schema."""
+"""Tests for shared.wiki_classification — the registry-driven 4-tuple schema.
+
+Per user direction 2026-05-12, validation consults
+``mcp_server.core.wiki_axis_registry`` rather than hardcoded frozensets.
+Tests here exercise the validation contract; tests for the registry
+itself live in ``tests_py/core/test_wiki_axis_registry.py``.
+"""
 
 from __future__ import annotations
 
 import pytest
 
+from mcp_server.core.wiki_axis_registry import reset_registry
 from mcp_server.shared.wiki_classification import (
-    ADR_LIFECYCLES,
-    AUDIENCES,
-    KINDS,
-    LEGACY_KINDS,
-    LIFECYCLES,
-    PROVENANCES,
     Classification,
     Generator,
     all_known_kinds,
@@ -19,52 +20,16 @@ from mcp_server.shared.wiki_classification import (
 )
 
 
-# ── Enum integrity ─────────────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    """Reset the registry singleton between tests so a stray edit by one
+    test cannot leak into another."""
+    reset_registry()
+    yield
+    reset_registry()
 
 
-def test_kinds_count_is_eight() -> None:
-    """ADR-2244 §4.1: exactly 8 modern kinds."""
-    assert len(KINDS) == 8
-
-
-def test_kinds_match_adr_spec() -> None:
-    """Spec match: tutorial, how-to, reference, explanation, adr, runbook, rfc, journal."""
-    assert KINDS == {
-        "tutorial",
-        "how-to",
-        "reference",
-        "explanation",
-        "adr",
-        "runbook",
-        "rfc",
-        "journal",
-    }
-
-
-def test_legacy_kinds_disjoint_from_modern() -> None:
-    """ADR-2244 §4.1: legacy kinds (notes, specs, etc.) are not modern."""
-    assert KINDS.isdisjoint(LEGACY_KINDS)
-
-
-def test_adr_lifecycle_disjoint_from_universal_lifecycle() -> None:
-    """ADR-2244 §4.2: ADR statuses are a disjoint set, not a subset.
-
-    An ADR can be {proposed, accepted, rejected, superseded}; it cannot be
-    {seedling, draft, active, deprecated, archived}.
-    """
-    assert ADR_LIFECYCLES.isdisjoint(LIFECYCLES)
-
-
-def test_audiences_closed_enum() -> None:
-    """User direction 2026-05-12: closed enum, 5 values."""
-    assert AUDIENCES == {"developer", "ops", "security", "internal", "external"}
-
-
-def test_provenances_closed_enum() -> None:
-    assert PROVENANCES == {"human", "ai-generated", "imported", "auto-generated"}
-
-
-# ── Classification validation ──────────────────────────────────────────
+# ── Happy path ─────────────────────────────────────────────────────────
 
 
 def test_minimal_valid_classification() -> None:
@@ -78,38 +43,7 @@ def test_adr_with_proposed_lifecycle() -> None:
     Classification(kind="adr", lifecycle="proposed")
 
 
-def test_adr_rejects_universal_lifecycle() -> None:
-    """ADR cannot use seedling/draft/active/etc — only its own statuses."""
-    with pytest.raises(ValueError, match="invalid lifecycle"):
-        Classification(kind="adr", lifecycle="seedling")
-
-
-def test_non_adr_rejects_adr_lifecycle() -> None:
-    """A how-to cannot be 'proposed' — that's an ADR-only status."""
-    with pytest.raises(ValueError, match="invalid lifecycle"):
-        Classification(kind="how-to", lifecycle="proposed")
-
-
-def test_unknown_kind_rejected() -> None:
-    with pytest.raises(ValueError, match="unknown kind"):
-        Classification(kind="notes", lifecycle="seedling")
-
-
-def test_unknown_audience_rejected() -> None:
-    with pytest.raises(ValueError, match="unknown audience"):
-        Classification(
-            kind="explanation",
-            lifecycle="seedling",
-            audience=("data-scientist",),  # not in closed enum
-        )
-
-
-def test_empty_audience_rejected() -> None:
-    with pytest.raises(ValueError, match="audience must not be empty"):
-        Classification(kind="explanation", lifecycle="seedling", audience=())
-
-
-def test_multi_valued_audience_accepted() -> None:
+def test_runbook_with_multi_audience() -> None:
     """Audience facet is multi-valued (ADR-2244 §4.3)."""
     c = Classification(
         kind="runbook",
@@ -119,32 +53,87 @@ def test_multi_valued_audience_accepted() -> None:
     assert c.audience == ("ops", "security")
 
 
-def test_ai_generated_requires_generator_block() -> None:
-    """User direction 2026-05-12: full provenance block for ai-generated."""
-    with pytest.raises(ValueError, match="requires a Generator block"):
+# ── Lifecycle / kind interaction ───────────────────────────────────────
+
+
+def test_adr_rejects_universal_lifecycle() -> None:
+    """ADR cannot use seedling/draft/active — those don't apply to ``adr``."""
+    with pytest.raises(ValueError, match="kind=adr requires a lifecycle"):
+        Classification(kind="adr", lifecycle="seedling")
+
+
+def test_non_adr_rejects_adr_lifecycle() -> None:
+    """A how-to cannot be ``proposed`` — that's restricted to kind=adr."""
+    with pytest.raises(ValueError, match="does not apply to kind"):
+        Classification(kind="how-to", lifecycle="proposed")
+
+
+# ── Unknown values: reject + suggest ──────────────────────────────────
+
+
+def test_unknown_kind_rejected_with_suggestion() -> None:
+    """Per user direction 2026-05-12: reject + suggest, not warn-and-accept."""
+    with pytest.raises(ValueError) as exc:
+        Classification(kind="adrs", lifecycle="seedling")  # plural typo of 'adr'
+    msg = str(exc.value)
+    assert "unknown kind" in msg
+    assert "adr" in msg  # suggestion present
+    assert "wiki/_schema/kinds" in msg  # extension path mentioned
+
+
+def test_unknown_audience_rejected_with_extension_hint() -> None:
+    with pytest.raises(ValueError) as exc:
         Classification(
             kind="explanation",
             lifecycle="seedling",
-            provenance="ai-generated",
+            audience=("developper",),  # typo
         )
+    msg = str(exc.value)
+    assert "unknown audience" in msg
+    assert "developer" in msg  # suggestion via difflib
 
 
-def test_auto_generated_requires_generator_block() -> None:
+def test_unknown_provenance_rejected_with_extension_hint() -> None:
+    with pytest.raises(ValueError) as exc:
+        Classification(
+            kind="explanation",
+            lifecycle="seedling",
+            provenance="hummman",  # typo
+        )
+    msg = str(exc.value)
+    assert "unknown provenance" in msg
+    assert "human" in msg  # suggestion present
+
+
+def test_unknown_lifecycle_rejected_with_extension_hint() -> None:
+    with pytest.raises(ValueError) as exc:
+        Classification(kind="explanation", lifecycle="seedlinggg")
+    msg = str(exc.value)
+    assert "unknown lifecycle" in msg
+    assert "seedling" in msg
+
+
+def test_completely_unrelated_value_rejected_without_suggestion() -> None:
+    """When no close match exists, the error still names the registry path."""
+    with pytest.raises(ValueError) as exc:
+        Classification(kind="quantum-superposition", lifecycle="seedling")
+    msg = str(exc.value)
+    assert "unknown kind" in msg
+    assert "wiki/_schema/kinds" in msg
+
+
+# ── Generator requirement is registry-driven ───────────────────────────
+
+
+def test_provenance_with_requires_generator_demands_generator_block() -> None:
+    """``auto-generated`` provenance carries ``requires_generator=True``
+    in the registry seed; validation enforces it without hardcoding."""
     with pytest.raises(ValueError, match="requires a Generator block"):
         Classification(
             kind="reference",
             lifecycle="seedling",
             provenance="auto-generated",
         )
-
-
-def test_human_provenance_does_not_require_generator() -> None:
-    c = Classification(
-        kind="adr",
-        lifecycle="accepted",
-        provenance="human",
-    )
-    assert c.generator is None
 
 
 def test_ai_generated_with_full_generator_block_accepted() -> None:
@@ -162,6 +151,19 @@ def test_ai_generated_with_full_generator_block_accepted() -> None:
     )
     assert c.generator is not None
     assert c.generator.model == "claude-opus-4-7"
+
+
+def test_human_provenance_does_not_require_generator() -> None:
+    c = Classification(kind="adr", lifecycle="accepted", provenance="human")
+    assert c.generator is None
+
+
+# ── Empty audience guard ───────────────────────────────────────────────
+
+
+def test_empty_audience_rejected() -> None:
+    with pytest.raises(ValueError, match="audience must not be empty"):
+        Classification(kind="explanation", lifecycle="seedling", audience=())
 
 
 # ── Frontmatter serialization ──────────────────────────────────────────
@@ -205,7 +207,7 @@ def test_frontmatter_serializes_generator_block() -> None:
     }
 
 
-# ── Legacy helpers ─────────────────────────────────────────────────────
+# ── Legacy back-compat helpers ─────────────────────────────────────────
 
 
 def test_normalize_legacy_notes_to_explanation() -> None:
@@ -216,10 +218,6 @@ def test_normalize_legacy_specs_to_rfc() -> None:
     assert normalize_legacy_kind("specs") == "rfc"
 
 
-def test_normalize_legacy_lessons_to_explanation() -> None:
-    assert normalize_legacy_kind("lessons") == "explanation"
-
-
 def test_normalize_modern_kind_unchanged() -> None:
     assert normalize_legacy_kind("adr") == "adr"
     assert normalize_legacy_kind("runbook") == "runbook"
@@ -227,13 +225,10 @@ def test_normalize_modern_kind_unchanged() -> None:
 
 def test_is_legacy_kind() -> None:
     assert is_legacy_kind("notes") is True
-    assert is_legacy_kind("specs") is True
     assert is_legacy_kind("adr") is False
-    assert is_legacy_kind("how-to") is False
 
 
-def test_all_known_kinds_is_union() -> None:
-    """Used by read paths that must accept either legacy or modern frontmatter."""
+def test_all_known_kinds_includes_modern_and_legacy() -> None:
     union = all_known_kinds()
-    assert KINDS.issubset(union)
-    assert LEGACY_KINDS.issubset(union)
+    assert "adr" in union and "runbook" in union  # modern
+    assert "notes" in union and "specs" in union  # legacy


### PR DESCRIPTION
## Context

PR #27 (merged) shipped ADR-2244 Phase 1 with hardcoded ``frozenset`` constants for kinds, lifecycles, audiences, and provenances. Per the 2026-05-12 user direction:

> "having only 4 values for each is a band-aid fix, we should be able to manage anything using regex and recognition"

This PR replaces every closed enum with an open-world registry that loads its values from markdown files. Adding a new audience, lifecycle, kind, or provenance is now a wiki edit, not a Python edit.

## The architecture

```
wiki/_schema/
├── kinds/
│   ├── adr.md
│   ├── tutorial.md
│   ├── runbook.md
│   └── …
├── lifecycles/
│   ├── seedling.md
│   ├── proposed.md   ← applies_to_kinds: [adr]
│   └── …
├── audiences/
│   ├── developer.md
│   └── data-scientist.md   ← user-added, no Python edit needed
└── provenances/
    ├── human.md
    └── auto-generated.md   ← requires_generator: true
```

Each file has frontmatter:
```yaml
---
name: data-scientist
axis: audience
display_name: Data scientist
patterns:
  - '\b(dataset|notebook|jupyter|pandas)\b'
tag_aliases: [ds, ml]
default: false
---
```

The classifier composes the 4-tuple via ``match_axis(content, tags, axis, registry)`` — pure regex + tag-alias dispatch over the registered values.

## Validation policy (per user direction)

**Reject + suggest.** Unknown values raise ``ValueError`` with:
- The closest registered match via ``difflib.get_close_matches``
- The exact path of the file the user can write to register the value

```python
>>> Classification(kind="adrs", lifecycle="seedling")
ValueError: unknown kind: 'adrs'. Did you mean one of ['adr']?
Register a new value by writing wiki/_schema/kinds/adrs.md.
```

## What's gone

The following are deleted from ``mcp_server/shared/wiki_classification.py``:

- ``KINDS`` frozenset
- ``LEGACY_KINDS`` (kept) and the modern enum frozensets (removed)
- ``LIFECYCLES`` frozenset
- ``ADR_LIFECYCLES`` frozenset
- ``AUDIENCES`` frozenset
- ``PROVENANCES`` frozenset
- ``_GENERATOR_REQUIRED_FOR`` frozenset

And from ``mcp_server/core/wiki_classifier.py``:

- ``_TUTORIAL_PATTERNS`` / ``_HOWTO_PATTERNS`` / ``_RUNBOOK_PATTERNS`` / ``_RFC_PATTERNS`` / ``_JOURNAL_PATTERNS`` constants
- The pattern-then-tag dispatch in ``_detect_modern_kind`` (now a single ``match_axis`` call)
- The hardcoded provenance/audience inference tables

All of those values + patterns live in ``_DEFAULT_KINDS`` / ``_DEFAULT_LIFECYCLES`` / ``_DEFAULT_AUDIENCES`` / ``_DEFAULT_PROVENANCES`` inside ``wiki_axis_registry``, where they seed the registry on empty wiki and are overridable by user files.

## What's still hardcoded (intentionally)

- ``LEGACY_KIND_TO_MODERN`` — the legacy → modern shim (``notes`` → ``explanation`` etc.). This is a one-time transformation, not a configurable axis.
- Admission gates (``_REJECT_PREFIXES``, ``_REJECT_PATTERNS``, ``_AUDIT_TAGS``, etc.) — these are about whether content enters the wiki at all, separate from how it's classified. They already have a user-extension path via ``wiki/_rules/*.md`` (the existing ``_apply_user_rules`` hook).

## Files changed

| File | Change |
|---|---|
| `mcp_server/core/wiki_axis_registry.py` | **NEW** — `AxisValue`, `AxisRegistry`, `_DEFAULT_*` seeds, `load_axis_registry`, `match_axis`, `did_you_mean`, `get_registry`/`reset_registry` |
| `mcp_server/shared/wiki_classification.py` | Frozensets removed; `Classification.validate()` consults registry; `_format_unknown` emits did-you-mean + extension path |
| `mcp_server/core/wiki_classifier.py` | Pattern constants removed; `_detect_modern_kind`/`_detect_provenance`/`_detect_audiences`/`_pick_lifecycle` rewritten to use `match_axis` |
| `tests_py/core/test_wiki_axis_registry.py` | **NEW** — 14 tests for registry behavior + user extension |
| `tests_py/shared/test_wiki_classification.py` | Rewritten — reject + suggest tests, no more frozenset-equality |
| `tests_py/core/test_wiki_classifier.py` | Journal-detection fixture cleaned |

## Test plan
- [x] `pytest tests_py/core/test_wiki_axis_registry.py tests_py/shared/test_wiki_classification.py tests_py/core/test_wiki_classifier.py tests_py/core/test_wiki_sync_routing.py tests_py/core/test_wiki_layout.py tests_py/core/test_wiki_templates.py` → **96 passed**
- [x] `pytest tests_py/core/ tests_py/shared/` → **1975 passed**
- [x] `ruff format --check` and `ruff check` clean
- [ ] CI on this PR

## Migration impact

None for existing pages. All pages with legacy frontmatter still read correctly (the LEGACY_KIND_TO_MODERN shim is preserved). New writes use the modern schema via the registry. The Phases 2-6 plan from ADR-2244 (pilot → stable IDs → bulk migration → cleanup → producer audit) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)