### PR TITLE
fix(deps): bump authlib 1.7.0 → 1.7.2 (CVE-2026-44681 / GHSA-r95x-qfjj-fjj2)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -217,15 +217,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.7.0"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -1795,7 +1795,7 @@ wheels = [
 
 [[package]]
 name = "neuro-cortex-memory"
-version = "3.15.3"
+version = "3.15.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Closes [dependabot alert #4](https://github.com/cdeust/Cortex/security/dependabot/4).

Authlib 1.7.0 has an **unauthenticated open redirect** in `OpenIDImplicitGrant.validate_authorization_request` and `OpenIDHybridGrant.validate_authorization_request`. When the `openid` scope is omitted from the authorization request, the scope check fires *before* client / redirect_uri validation, so the raw attacker-controlled `redirect_uri` is rendered as an HTTP 302 `Location` header. CVSS 6.1 (medium). Patched upstream in 1.7.1; this PR lands 1.7.2 (current patch in the 1.7.x line).

## Cortex exposure

| Question | Answer |
|---|---|
| Is Cortex an OIDC authorization server? | **No.** |
| Does Cortex register `OpenIDImplicitGrant` or `OpenIDHybridGrant`? | **No.** |
| How does authlib end up in `uv.lock`? | Transitively via `fastmcp`. |
| Are the vulnerable code paths reachable in production? | **No.** |
| Practical exploitability for Cortex deployments? | **Zero.** |

The bump is hygiene + closes the dependabot alert + protects downstream applications that vendor Cortex's lockfile from inheriting the vulnerable resolution.

## Diff scope

`uv.lock` only — 8 lines (4 added, 4 removed). No application source changes.

- `authlib 1.7.0 → 1.7.2` (the security fix)
- `neuro-cortex-memory 3.15.3 → 3.15.4` (cosmetic — `uv lock` re-resolved this package against the v3.15.4 `pyproject.toml` that already landed in #29)

No cascading transitive bumps (`cryptography`, `joserfc` unchanged).

## References

- Advisory: https://github.com/authlib/authlib/security/advisories/GHSA-r95x-qfjj-fjj2
- Upstream fix tag: https://github.com/authlib/authlib/releases/tag/v1.7.1
- Dependabot alert: https://github.com/cdeust/Cortex/security/dependabot/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)