### PR TITLE
feat(wiki): deterministic bulk migration for the ~88 pollution paths (ADR-2244 Phase 4.1)

### DIFF
--- a/scripts/wiki_bulk_migrate.py
+++ b/scripts/wiki_bulk_migrate.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Bulk-rename the known wiki pollution patterns — Phase 4 of ADR-2244.
+
+The 2026-05-12 audit found three deterministic-rename pollution classes
+that this script targets:
+
+  Pattern                     Audit count   Target rename
+  ─────────────────────────────────────────────────────────────────────
+  ``*.md.md``                 58            strip the duplicate extension
+  ``*-decision-created-       10            derive slug from frontmatter
+   YYYY-MM-DDtHH-MM-SSz.md``                title or first body heading
+  ``*users-cdeust-... .md``   10            derive slug from frontmatter
+   (path-leak in slug)                      title; reject path-shaped
+                                            content
+
+Operation per page:
+
+  1. Read source; require a valid frontmatter ``id`` (Phase 3 invariant).
+     Run ``scripts/wiki_backfill_ids.py --apply`` first if missing.
+  2. Compute a clean destination path.
+  3. Call the ``wiki_rename`` handler, which (a) writes the content at
+     the new path, (b) replaces the old path with a redirect stub
+     (path-based + id-based) so inbound links keep resolving.
+
+Dry-run by default. ``--apply`` commits the moves. The script is
+idempotent: a second ``--apply`` run finds zero pollution paths to
+rename (the renames are gone; their stubs are detected and skipped).
+
+Out of scope for this script: the 7820-page ``notes/<domain>/<id>-file-*.md``
+→ ``reference/<domain>/<file-slug>.md`` re-bucket. That operation
+changes the *kind directory* and needs frontmatter rewrite (kind /
+provenance), not just a rename — separate Phase 4 follow-up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Ensure mcp_server is importable when run from the Cortex repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from mcp_server.core.wiki_identity import extract_page_id  # noqa: E402
+from mcp_server.core.wiki_layout import slugify  # noqa: E402
+from mcp_server.core.wiki_redirect import is_redirect, parse_frontmatter  # noqa: E402
+
+
+# ── Pollution classifiers ───────────────────────────────────────────────
+
+
+_DOUBLE_MD_SUFFIX = ".md.md"
+
+# Timestamp shape found in the 10 polluted ADRs (Audit 2026-05-12):
+# ``<num>-decision-created-2026-04-15t09-29-10z.md``.
+_TIMESTAMP_SLUG_RE = re.compile(
+    r"^(?P<prefix>\d+-)?decision-created-\d{4}-\d{2}-\d{2}t\d{2}-\d{2}-\d{2}z$",
+    re.IGNORECASE,
+)
+
+# Path-leak slug shape: the slug contains an absolute filesystem path
+# stripped of its leading slash (``users-cdeust-documents-developments-…``).
+_PATH_LEAK_SLUG_RE = re.compile(
+    r"(?:^|-)users-(?:cdeust|home|root)-"
+    r"(?:documents-developments|home|opt|etc|var|tmp)-",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class Pollution:
+    """One detected pollution case + proposed clean path."""
+
+    rel_path: str
+    pattern: str  # "double-md" | "timestamp-slug" | "path-leak"
+    proposed_path: str
+    reason: str  # what to put in the redirect stub
+    page_id: str | None  # None when source lacks an id
+    skipped_reason: str = ""  # non-empty when we cannot rename this page
+
+
+@dataclass
+class Summary:
+    """Counts surfaced to stdout for human review."""
+
+    scanned: int = 0
+    by_pattern: dict[str, int] = field(default_factory=dict)
+    skipped: dict[str, int] = field(default_factory=dict)
+    renamed: int = 0
+
+
+# ── Slug derivation ─────────────────────────────────────────────────────
+
+
+def _clean_title_candidate(title: str) -> bool:
+    """True iff a title is suitable to drive a slug.
+
+    Rejects: empty / very short / path-shaped / timestamp-shaped /
+    obviously synthetic ("memory-…").
+    """
+    if not title or len(title.strip()) < 4:
+        return False
+    t = title.strip()
+    if t.lower().startswith("memory-"):
+        return False
+    if re.search(r"/(Users|home|root|opt|var|etc|tmp)/", t, re.IGNORECASE):
+        return False
+    if re.search(r"\d{4}-\d{2}-\d{2}T\d{2}", t, re.IGNORECASE):
+        return False
+    return True
+
+
+def _derive_clean_slug(
+    text: str,
+    fm: dict[str, object],
+    fallback_prefix: str,
+) -> str:
+    """Pick a clean slug from frontmatter title, body H1, or a fallback.
+
+    The fallback is ``<fallback_prefix>-<hash6>`` — used only when the
+    page truly has no usable title.
+    """
+    title_raw = fm.get("title", "")
+    title = title_raw if isinstance(title_raw, str) else ""
+    if _clean_title_candidate(title):
+        return slugify(title)
+
+    # Try the first H1/H2 in the body.
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# ") or stripped.startswith("## "):
+            heading = stripped.lstrip("#").strip()
+            if _clean_title_candidate(heading):
+                return slugify(heading)
+
+    # Final fallback — short hash of the body content to keep the slug stable.
+    import hashlib
+
+    digest = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:6]
+    return f"{fallback_prefix}-{digest}"
+
+
+# ── Pollution detection ─────────────────────────────────────────────────
+
+
+def _detect_double_md(rel_path: str) -> tuple[bool, str]:
+    """``foo.md.md`` → propose ``foo.md``."""
+    if not rel_path.endswith(_DOUBLE_MD_SUFFIX):
+        return False, ""
+    return True, rel_path[: -len(_DOUBLE_MD_SUFFIX)] + ".md"
+
+
+def _stem(rel_path: str) -> str:
+    """The filename stem (no directories, no .md suffix(es))."""
+    name = rel_path.rsplit("/", 1)[-1]
+    while name.endswith(".md"):
+        name = name[:-3]
+    return name
+
+
+def _detect_timestamp_slug(rel_path: str) -> bool:
+    return _TIMESTAMP_SLUG_RE.match(_stem(rel_path)) is not None
+
+
+def _detect_path_leak_slug(rel_path: str) -> bool:
+    return _PATH_LEAK_SLUG_RE.search(_stem(rel_path)) is not None
+
+
+def _propose_timestamp_rename(rel_path: str, text: str, fm: dict[str, object]) -> str:
+    """Compute a clean target for a timestamp-slug ADR.
+
+    Preserves the leading numeric prefix (the ADR sequence number) when
+    present, replaces the polluted tail with a content-derived slug.
+    """
+    stem = _stem(rel_path)
+    m = _TIMESTAMP_SLUG_RE.match(stem)
+    prefix = m.group("prefix") if m and m.group("prefix") else ""
+    new_slug = _derive_clean_slug(text, fm, fallback_prefix="decision")
+    dirname = rel_path.rsplit("/", 1)[0] if "/" in rel_path else ""
+    new_name = f"{prefix}{new_slug}.md"
+    return f"{dirname}/{new_name}" if dirname else new_name
+
+
+def _propose_path_leak_rename(rel_path: str, text: str, fm: dict[str, object]) -> str:
+    """Compute a clean target for a path-leak slug page."""
+    stem = _stem(rel_path)
+    # Preserve a leading ``YYYY-MM-DD-`` date prefix if present (notes
+    # convention).  Otherwise no prefix.
+    m = re.match(r"^(\d{4}-\d{2}-\d{2}-)", stem)
+    prefix = m.group(1) if m else ""
+    new_slug = _derive_clean_slug(text, fm, fallback_prefix="page")
+    dirname = rel_path.rsplit("/", 1)[0] if "/" in rel_path else ""
+    new_name = f"{prefix}{new_slug}.md"
+    return f"{dirname}/{new_name}" if dirname else new_name
+
+
+# ── Walk + plan ─────────────────────────────────────────────────────────
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def plan(wiki_root: Path) -> list[Pollution]:
+    """Walk the wiki and return one Pollution record per detected case.
+
+    Pages that are themselves redirect stubs are skipped. Pages that
+    lack a valid frontmatter ``id`` are recorded with a non-empty
+    ``skipped_reason`` so the caller can surface them without erroring.
+    """
+    plans: list[Pollution] = []
+    for md in wiki_root.rglob("*.md"):
+        rel = md.relative_to(wiki_root)
+        if rel.parts and rel.parts[0].startswith("."):
+            continue
+        rel_str = str(rel)
+
+        is_double, double_target = _detect_double_md(rel_str)
+        is_timestamp = _detect_timestamp_slug(rel_str)
+        is_path_leak = _detect_path_leak_slug(rel_str)
+        if not (is_double or is_timestamp or is_path_leak):
+            continue
+
+        text = _read_text(md)
+        if text is None:
+            plans.append(
+                Pollution(
+                    rel_path=rel_str,
+                    pattern="errored",
+                    proposed_path="",
+                    reason="",
+                    page_id=None,
+                    skipped_reason="read failed",
+                )
+            )
+            continue
+
+        fm = parse_frontmatter(text)
+        if is_redirect(fm):
+            continue  # already a stub, leave it alone
+
+        page_id = extract_page_id(fm)
+        if page_id is None:
+            plans.append(
+                Pollution(
+                    rel_path=rel_str,
+                    pattern=(
+                        "double-md"
+                        if is_double
+                        else "timestamp-slug"
+                        if is_timestamp
+                        else "path-leak"
+                    ),
+                    proposed_path="",
+                    reason="",
+                    page_id=None,
+                    skipped_reason="missing frontmatter id — run wiki_backfill_ids.py first",
+                )
+            )
+            continue
+
+        if is_double:
+            plans.append(
+                Pollution(
+                    rel_path=rel_str,
+                    pattern="double-md",
+                    proposed_path=double_target,
+                    reason="strip .md.md duplicate extension",
+                    page_id=page_id,
+                )
+            )
+        elif is_timestamp:
+            plans.append(
+                Pollution(
+                    rel_path=rel_str,
+                    pattern="timestamp-slug",
+                    proposed_path=_propose_timestamp_rename(rel_str, text, fm),
+                    reason="replace timestamp-as-slug with content-derived slug",
+                    page_id=page_id,
+                )
+            )
+        else:  # is_path_leak
+            plans.append(
+                Pollution(
+                    rel_path=rel_str,
+                    pattern="path-leak",
+                    proposed_path=_propose_path_leak_rename(rel_str, text, fm),
+                    reason="remove filesystem path leaked into slug",
+                    page_id=page_id,
+                )
+            )
+    return plans
+
+
+# ── Apply (delegates to wiki_rename handler) ────────────────────────────
+
+
+async def _apply_plan(
+    plan_items: list[Pollution],
+    wiki_root: Path,
+) -> tuple[int, list[str]]:
+    """Run each non-skipped item through the wiki_rename handler.
+
+    Returns (renamed_count, error_messages). The handler is patched to
+    use ``wiki_root`` rather than the configured WIKI_ROOT so this
+    function is testable against a tmp_path.
+    """
+    # Local import keeps test fixtures lightweight when --apply isn't used.
+    from mcp_server.handlers import wiki_rename
+
+    # Point the handler at our wiki_root.
+    original = wiki_rename.WIKI_ROOT
+    wiki_rename.WIKI_ROOT = str(wiki_root)
+
+    renamed = 0
+    errors: list[str] = []
+    try:
+        for item in plan_items:
+            if item.skipped_reason:
+                continue
+            if not item.proposed_path:
+                continue
+            result = await wiki_rename.handler(
+                {
+                    "from_path": item.rel_path,
+                    "to_path": item.proposed_path,
+                    "reason": item.reason,
+                }
+            )
+            if "error" in result:
+                errors.append(f"{item.rel_path}: {result['error']}")
+            else:
+                renamed += 1
+    finally:
+        wiki_rename.WIKI_ROOT = original
+    return renamed, errors
+
+
+def summarize(plans: list[Pollution]) -> Summary:
+    summary = Summary()
+    summary.scanned = len(plans)
+    for item in plans:
+        if item.skipped_reason:
+            summary.skipped[item.skipped_reason] = (
+                summary.skipped.get(item.skipped_reason, 0) + 1
+            )
+            continue
+        summary.by_pattern[item.pattern] = summary.by_pattern.get(item.pattern, 0) + 1
+    return summary
+
+
+def _print_summary(summary: Summary, *, applied: bool) -> None:
+    print("", file=sys.stderr)
+    print("Wiki bulk-migration plan", file=sys.stderr)
+    print("========================", file=sys.stderr)
+    print(f"  Pollution paths detected: {summary.scanned}", file=sys.stderr)
+    for pattern, n in sorted(summary.by_pattern.items()):
+        print(f"    - {pattern:18s} {n}", file=sys.stderr)
+    if summary.skipped:
+        print("  Skipped:", file=sys.stderr)
+        for reason, n in sorted(summary.skipped.items()):
+            print(f"    - {reason:60s} {n}", file=sys.stderr)
+    if applied:
+        print(f"  Renamed (applied): {summary.renamed}", file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--wiki",
+        type=Path,
+        default=Path.home() / ".claude" / "methodology" / "wiki",
+        help="Wiki root directory.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Execute the renames in place. Default is dry-run.",
+    )
+    args = parser.parse_args()
+
+    wiki_root: Path = args.wiki.expanduser().resolve()
+    if not wiki_root.is_dir():
+        print(f"error: wiki root not found: {wiki_root}", file=sys.stderr)
+        return 2
+
+    print(
+        f"[{'APPLY' if args.apply else 'DRY-RUN'}] scanning {wiki_root}",
+        file=sys.stderr,
+    )
+    plans = plan(wiki_root)
+    summary = summarize(plans)
+
+    if args.apply:
+        renamed, errors = asyncio.run(_apply_plan(plans, wiki_root))
+        summary.renamed = renamed
+        _print_summary(summary, applied=True)
+        if errors:
+            print("", file=sys.stderr)
+            print(f"  Rename errors ({len(errors)}):", file=sys.stderr)
+            for err in errors[:20]:
+                print(f"    {err}", file=sys.stderr)
+            return 1
+        return 0
+
+    _print_summary(summary, applied=False)
+    # Show the first 10 proposed renames so a human can spot-check.
+    proposed = [p for p in plans if not p.skipped_reason]
+    if proposed:
+        print("", file=sys.stderr)
+        print("  Proposed renames (first 10):", file=sys.stderr)
+        for item in proposed[:10]:
+            print(f"    {item.rel_path}", file=sys.stderr)
+            print(f"    → {item.proposed_path}", file=sys.stderr)
+            print(f"      ({item.pattern}: {item.reason})", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests_py/scripts/test_wiki_bulk_migrate.py
+++ b/tests_py/scripts/test_wiki_bulk_migrate.py
@@ -1,0 +1,284 @@
+"""Tests for the Phase 4 bulk-migration script."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT))
+
+from wiki_bulk_migrate import (  # noqa: E402
+    _apply_plan,
+    _clean_title_candidate,
+    _detect_double_md,
+    _detect_path_leak_slug,
+    _detect_timestamp_slug,
+    _derive_clean_slug,
+    plan,
+)
+
+from mcp_server.core.wiki_identity import generate_page_id  # noqa: E402
+from mcp_server.core.wiki_redirect import parse_frontmatter  # noqa: E402
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _page(page_id: str, title: str, body: str = "Body.") -> str:
+    return f"---\nid: {page_id}\ntitle: {title}\n---\n\n# {title}\n\n{body}\n"
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# ── Detection ───────────────────────────────────────────────────────────
+
+
+def test_detect_double_md_strips_duplicate_suffix() -> None:
+    is_double, target = _detect_double_md("adr/_general/2234-zero-dependencies.md.md")
+    assert is_double
+    assert target == "adr/_general/2234-zero-dependencies.md"
+
+
+def test_detect_double_md_rejects_single_extension() -> None:
+    assert _detect_double_md("adr/foo.md") == (False, "")
+
+
+def test_detect_timestamp_slug_full_shape() -> None:
+    assert _detect_timestamp_slug(
+        "adr/_general/1828-decision-created-2026-04-15t09-29-10z.md"
+    )
+
+
+def test_detect_timestamp_slug_negative() -> None:
+    assert not _detect_timestamp_slug("adr/_general/2234-zero-dependencies.md")
+    assert not _detect_timestamp_slug("notes/2026-04-15-changelog.md")
+
+
+def test_detect_path_leak_slug() -> None:
+    assert _detect_path_leak_slug(
+        "specs/2026/2026-04-17-also-on-users-cdeust-documents-developments-ai.md"
+    )
+    assert _detect_path_leak_slug(
+        "notes/2026/2026-04-17-why-was-ls-users-cdeust-documents-developments-x.md"
+    )
+
+
+def test_detect_path_leak_slug_negative() -> None:
+    assert not _detect_path_leak_slug("notes/2026-04-15-changelog.md")
+    assert not _detect_path_leak_slug("adr/_general/2234-zero-dependencies.md")
+
+
+# ── Slug derivation ────────────────────────────────────────────────────
+
+
+def test_clean_title_accepts_real_titles() -> None:
+    assert _clean_title_candidate("Use pgvector for retrieval")
+    assert _clean_title_candidate("Zero external dependencies")
+
+
+def test_clean_title_rejects_path_shapes() -> None:
+    assert not _clean_title_candidate("/Users/cdeust/Documents/Developments/x")
+
+
+def test_clean_title_rejects_timestamp_shapes() -> None:
+    assert not _clean_title_candidate("2026-04-15T09:29:10Z")
+
+
+def test_clean_title_rejects_too_short() -> None:
+    assert not _clean_title_candidate("ok")
+
+
+def test_derive_clean_slug_uses_frontmatter_title() -> None:
+    text = "---\ntitle: Use pgvector for retrieval\n---\n\n# heading\n"
+    fm = {"title": "Use pgvector for retrieval"}
+    assert _derive_clean_slug(text, fm, "fallback") == "use-pgvector-for-retrieval"
+
+
+def test_derive_clean_slug_falls_back_to_body_heading() -> None:
+    text = "---\ntitle: \n---\n\n## Zero external dependencies\n\nBody."
+    fm = {"title": ""}
+    slug = _derive_clean_slug(text, fm, "fallback")
+    assert slug == "zero-external-dependencies"
+
+
+def test_derive_clean_slug_falls_back_to_hash() -> None:
+    text = "---\ntitle: /Users/cdeust/x\n---\n\nbody"
+    fm = {"title": "/Users/cdeust/x"}
+    slug = _derive_clean_slug(text, fm, "page")
+    assert slug.startswith("page-")
+    assert len(slug) > len("page-")
+
+
+# ── plan() ──────────────────────────────────────────────────────────────
+
+
+def test_plan_finds_all_three_pollution_classes(tmp_path: Path) -> None:
+    pid_a = generate_page_id()
+    pid_b = generate_page_id()
+    pid_c = generate_page_id()
+    pid_clean = generate_page_id()
+
+    _write(
+        tmp_path / "adr/_general/2234-zero-dependencies.md.md",
+        _page(pid_a, "Zero dependencies decision"),
+    )
+    _write(
+        tmp_path / "adr/_general/1828-decision-created-2026-04-15t09-29-10z.md",
+        _page(pid_b, "Adopt pgvector"),
+    )
+    _write(
+        tmp_path
+        / "specs/2026/2026-04-17-also-on-users-cdeust-documents-developments-x.md",
+        _page(pid_c, "Spec — pgvector adoption"),
+    )
+    _write(
+        tmp_path / "adr/_general/2300-clean.md",
+        _page(pid_clean, "A clean ADR"),
+    )
+
+    items = plan(tmp_path)
+    by_pattern = {p.pattern for p in items}
+    assert by_pattern == {"double-md", "timestamp-slug", "path-leak"}
+    assert len(items) == 3
+
+
+def test_plan_skips_pages_without_id(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "adr/_general/2234-zero-dependencies.md.md",
+        "---\ntitle: No id\n---\n\nbody\n",
+    )
+    items = plan(tmp_path)
+    assert len(items) == 1
+    assert items[0].skipped_reason.startswith("missing frontmatter id")
+
+
+def test_plan_skips_redirect_stubs(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "adr/_general/2234-zero-dependencies.md.md",
+        "---\nredirect_to: adr/_general/2234-zero-dependencies.md\n---\n\n# Moved\n",
+    )
+    assert plan(tmp_path) == []
+
+
+def test_plan_proposes_clean_target_for_timestamp_adr(tmp_path: Path) -> None:
+    pid = generate_page_id()
+    _write(
+        tmp_path / "adr/_general/1828-decision-created-2026-04-15t09-29-10z.md",
+        _page(pid, "Adopt pgvector for ANN"),
+    )
+    items = plan(tmp_path)
+    assert len(items) == 1
+    item = items[0]
+    assert item.pattern == "timestamp-slug"
+    # Preserves the numeric prefix and uses the frontmatter title.
+    assert item.proposed_path == "adr/_general/1828-adopt-pgvector-for-ann.md"
+
+
+def test_plan_proposes_clean_target_for_path_leak(tmp_path: Path) -> None:
+    pid = generate_page_id()
+    _write(
+        tmp_path
+        / "specs/2026/2026-04-17-also-on-users-cdeust-documents-developments-x.md",
+        _page(pid, "Spec for pgvector adoption"),
+    )
+    items = plan(tmp_path)
+    assert len(items) == 1
+    # Preserves the YYYY-MM-DD- date prefix observed in the wiki.
+    assert items[0].proposed_path == (
+        "specs/2026/2026-04-17-spec-for-pgvector-adoption.md"
+    )
+
+
+# ── Apply (end-to-end with wiki_rename) ────────────────────────────────
+
+
+def test_apply_renames_and_creates_stubs(tmp_path: Path) -> None:
+    pid = generate_page_id()
+    src = tmp_path / "adr/_general/2234-zero-dependencies.md.md"
+    _write(src, _page(pid, "Zero dependencies"))
+
+    items = plan(tmp_path)
+    assert len(items) == 1
+
+    renamed, errors = _run(_apply_plan(items, tmp_path))
+    assert renamed == 1
+    assert errors == []
+
+    # New path holds the content with the original id.
+    new = tmp_path / "adr/_general/2234-zero-dependencies.md"
+    assert new.exists()
+    new_fm = parse_frontmatter(new.read_text("utf-8"))
+    assert new_fm["id"] == pid
+
+    # Old path is now a redirect stub.
+    stub_fm = parse_frontmatter(src.read_text("utf-8"))
+    assert stub_fm["redirect_to"] == "adr/_general/2234-zero-dependencies.md"
+    assert stub_fm["redirect_id"] == pid
+
+
+def test_apply_is_idempotent(tmp_path: Path) -> None:
+    """A second --apply run finds zero pollution paths (the renames
+    landed; their stubs are detected and skipped)."""
+    pid = generate_page_id()
+    _write(
+        tmp_path / "adr/_general/2234-foo.md.md",
+        _page(pid, "Foo"),
+    )
+
+    first_items = plan(tmp_path)
+    _run(_apply_plan(first_items, tmp_path))
+
+    # Second plan finds nothing (the .md.md was renamed; the stub at
+    # the .md.md path is detected and skipped).
+    second_items = plan(tmp_path)
+    assert second_items == []
+
+
+def test_apply_handles_three_classes_in_one_pass(tmp_path: Path) -> None:
+    p1 = generate_page_id()
+    p2 = generate_page_id()
+    p3 = generate_page_id()
+    _write(
+        tmp_path / "adr/_general/2234-zero-dependencies.md.md",
+        _page(p1, "Zero dependencies"),
+    )
+    _write(
+        tmp_path / "adr/_general/1828-decision-created-2026-04-15t09-29-10z.md",
+        _page(p2, "Adopt pgvector"),
+    )
+    _write(
+        tmp_path
+        / "specs/2026/2026-04-17-also-on-users-cdeust-documents-developments-x.md",
+        _page(p3, "Spec page"),
+    )
+
+    items = plan(tmp_path)
+    renamed, errors = _run(_apply_plan(items, tmp_path))
+    assert renamed == 3
+    assert errors == []
+    # Every original path now holds a stub; every proposed path holds content.
+    for item in items:
+        src_fm = parse_frontmatter((tmp_path / item.rel_path).read_text("utf-8"))
+        assert "redirect_to" in src_fm
+        assert (tmp_path / item.proposed_path).exists()
+
+
+def test_apply_skips_id_less_pages_without_erroring(tmp_path: Path) -> None:
+    """When a polluted page lacks an id we skip it (plan() records the
+    skip reason) — apply must not crash on such items."""
+    _write(
+        tmp_path / "adr/_general/2234-foo.md.md",
+        "---\ntitle: No id\n---\n\nbody\n",
+    )
+    items = plan(tmp_path)
+    renamed, errors = _run(_apply_plan(items, tmp_path))
+    assert renamed == 0
+    assert errors == []


### PR DESCRIPTION
## Summary

Phase 4.1 of [ADR-2244](https://github.com/cdeust/Cortex/blob/main/docs/research/wiki-classification-survey.md) — the **deterministic half** of the bulk migration. Three pollution classes with mechanically computable target paths, all renamed via `wiki_rename` (from #34) so inbound links keep resolving.

**Depends on #33 + #34** (Phase 3 + Phase 3.2).

The LLM-assisted half (the 7820 file-doc re-bucket) is a separate scope and lands in Phase 4.2 — it changes the kind directory and rewrites frontmatter, which is a different operation.

## What gets renamed

| Pattern | Audit count | Target |
|---|---:|---|
| `*.md.md` | 58 | strip duplicate extension |
| `*-decision-created-YYYY-MM-DDt...z.md` | 10 | derive slug from frontmatter title or first body heading |
| `*users-cdeust-…` (path-leak in slug) | 11+ | derive slug from frontmatter title; reject path-shaped values |

**Live dry-run after this commit:**
```
Pollution paths detected: 70
Skipped: missing frontmatter id — run wiki_backfill_ids.py first (70)
```

That's the correct refusal — every polluted page lacks the Phase 3 stable id. After merging #33 + running `wiki_backfill_ids.py --apply`, this number flips to "would rename: 70".

## Slug derivation

`_derive_clean_slug` picks in order:

1. **Frontmatter `title`** — if non-empty and not path-shaped / timestamp-shaped / too short / synthetic (`memory-…`).
2. **First body `# ` or `## ` heading** — same cleanness check.
3. **Hash fallback** — `<kind>-<6-hex>` derived from body content (deterministic).

The hash fallback is rare; most pollution pages already have a proper `title` — it's the *slug* that's broken, not the metadata.

## Files

| File | Lines | What |
|---|---:|---|
| `scripts/wiki_bulk_migrate.py` | ~370 | walker + detection + slug derivation + apply loop wired through `wiki_rename` handler |
| `tests_py/scripts/test_wiki_bulk_migrate.py` | ~280 | **22 tests** covering all three patterns, plan correctness, end-to-end apply, and idempotency |

## Tests

- [x] `pytest tests_py/scripts/test_wiki_bulk_migrate.py` → **22 passed**
- [x] `ruff format --check` and `ruff check` clean
- [x] Live dry-run against the 9608-page wiki → 70 pollution paths, all correctly skipped pre-backfill
- [ ] CI on this PR

## Operational order (post-merge)

```bash
# Once #33, #34, and this PR are all merged on main:
python scripts/wiki_backfill_ids.py --apply           # adds id: to 9607 pages
python scripts/wiki_bulk_migrate.py                   # dry-run review
python scripts/wiki_bulk_migrate.py --apply           # commit moves
python scripts/wiki_bulk_migrate.py --apply           # second run = no-op (idempotent)
```

After step 4 the wiki has:
- 70 polluted paths replaced with redirect stubs
- 70 clean paths holding the actual content
- All inbound links (via `wiki_read`) resolve to the new content transparently

## Out of scope (follow-ups)

- **Phase 4.2** — file-doc re-bucket (7820 `notes/<domain>/<id>-file-*` → `reference/<domain>/<file-slug>.md` with provenance rewrite)
- **ID→path index** — for ID-only redirect resolution (path-based works today)
- **Phase 5** — classifier-driven cleanup for ai-generated stubs (filter, not delete)
- **Phase 6** — producer audit (`codebase_analyze` emits correct provenance/lifecycle directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)