### PR TITLE
fix(wiki): route codebase_analyze output to kind=reference (ADR-2244 Phase 6)

### DIFF
--- a/mcp_server/core/wiki_axis_registry.py
+++ b/mcp_server/core/wiki_axis_registry.py
@@ -196,7 +196,11 @@ _DEFAULT_KINDS: tuple[AxisValue, ...] = (
         axis=AXIS_KIND,
         display_name="Reference",
         patterns=(),  # reference is usually identified by tags / producer, not content
-        tag_aliases=("reference", "api", "spec", "code-reference"),
+        # Producer audit (ADR-2244 Phase 6): ``codebase`` is the bare tag
+        # written by ``codebase_analyze``; without it here, file-doc pages
+        # got routed to ``explanation`` instead of ``reference``, producing
+        # the 8734-page misroute Phase 4.2 had to clean up.
+        tag_aliases=("reference", "api", "spec", "code-reference", "codebase"),
         description="Authoritative lookup table — API docs, file docs, schema refs.",
     ),
     AxisValue(

--- a/tests_py/core/test_wiki_classifier.py
+++ b/tests_py/core/test_wiki_classifier.py
@@ -322,6 +322,37 @@ def test_architecture_tag_alone_does_not_route_to_adr() -> None:
         assert result.kind != "adr"
 
 
+def test_codebase_analyze_output_routes_to_reference_kind() -> None:
+    """Producer audit (ADR-2244 Phase 6): a page tagged ``codebase``
+    (the bare tag written by ``codebase_analyze``) must route to
+    ``kind=reference``, not ``kind=explanation``. Without this contract
+    the 8734-page file-doc misroute Phase 4.2 cleaned up would simply
+    keep happening on every new ``codebase_analyze`` run.
+    """
+    content = (
+        "# Process — packages/codebase-rust/src/parser/mod.rs::parse_file\n\n"
+        "- Entry kind: lib_entry\n"
+        "- BFS depth: 6\n"
+        "- Symbols in flow: 0\n"
+    )
+    # The exact tag set produced by codebase_analyze._build_tags:
+    #   [codebase, file:<path>, hash:<sha>, lang:<lang>, symbol:<name>...]
+    result = classify_memory(
+        content,
+        tags=[
+            "codebase",
+            "file:packages/codebase-rust/src/parser/mod.rs",
+            "hash:abcdef0123",
+            "lang:rust",
+            "symbol:parse_file",
+        ],
+    )
+    assert result is not None
+    assert result.kind == "reference"
+    assert result.provenance == "auto-generated"
+    assert result.generator is not None  # auto-generated requires it
+
+
 def test_crypto_module_name_does_not_flag_security_audience() -> None:
     """Pilot 2026-05-13 found ADR-001 (zero dependencies) tagged ``security``
     audience because its body listed ``crypto`` among Node built-in modules.


### PR DESCRIPTION
## Summary

Producer audit. **Root-causes** the 8,734-page file-doc misroute that Phase 4.2 (PR #37) has to clean up after the fact.

One line of registry edit + one regression test. Independent of PRs #36 and #37 — can land in any order.

## The bug

`codebase_analyze._build_tags` emits the bare tag **`codebase`** (plus `file:<path>`, `hash:<sha>`, `lang:<lang>`, `symbol:<name>...`).

Trace through `classify_memory`:

| Stage | Outcome |
|---|---|
| Admission gate | `codebase` is in `_EXPLICIT_KNOWLEDGE_TAGS` (from #28) → admitted ✅ |
| Provenance | `codebase` is in `auto-generated.tag_aliases` → `provenance=auto-generated` + generator block ✅ |
| **Kind detection** | `reference.tag_aliases` was `(reference, api, spec, code-reference)`. Note: `code-reference` (with hyphen) — producer writes `codebase` (bare). **No match.** |
| Pattern detection | File-doc body matches no kind patterns |
| Fallback | legacy → modern: `note → explanation` |

Net: every file-doc page routes to **`kind=explanation`** instead of `kind=reference`. The 8,734-page misroute.

## The fix

```python
# Before
tag_aliases=("reference", "api", "spec", "code-reference"),

# After
tag_aliases=("reference", "api", "spec", "code-reference", "codebase"),
```

That's the entire change to `mcp_server/core/wiki_axis_registry.py`. The producer/classifier contract now matches without touching the producer side.

## Regression test

`test_codebase_analyze_output_routes_to_reference_kind` pins the contract: a page tagged with the exact tag set `codebase_analyze` produces must classify as `kind=reference, provenance=auto-generated, generator != None`. If a later refactor renames either side, this test fails loudly.

## What this does NOT fix

The existing 8,734 misrouted pages still live under `notes/<domain>/<id>-file-*.md`. They need **Phase 4.2 (PR #37) applied** to actually move. The two are independent:

- **This PR**: future `codebase_analyze` writes go to the correct kind directly.
- **PR #37 + apply**: existing misrouted pages get moved to `reference/` with redirect stubs at the old paths.

## Test plan

- [x] `pytest tests_py/core/test_wiki_classifier.py tests_py/core/test_wiki_axis_registry.py tests_py/core/test_wiki_sync_routing.py tests_py/shared/test_wiki_classification.py` → **74 passed**
- [x] `ruff format --check` and `ruff check` clean
- [ ] CI on this PR

## Out of scope (follow-ups)

- `wiki_seed_codebase._kind_for()` still returns legacy kind names that flow into a `kind:<value>` tag the classifier doesn't actually read. Low-volume (README/ADR seeds, dozens not thousands); separate fix.
- **Phase 5** — filter ai-generated seedlings from default search views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)