### PR TITLE
feat(wiki): filter auto-generated pages from default views (ADR-2244 Phase 5)

### DIFF
--- a/mcp_server/handlers/wiki_list.py
+++ b/mcp_server/handlers/wiki_list.py
@@ -3,6 +3,13 @@
 Phase 3.2 of ADR-2244: redirect stubs are filtered from the listing by
 default. Pass ``include_redirects: true`` to see them — useful for
 migration tooling that needs to audit or clean up old paths.
+
+Phase 5 of ADR-2244: auto-generated pages (frontmatter ``provenance:
+auto-generated``, written by ``codebase_analyze``) are also filtered
+from the listing by default. At ~8,700 pages they dominate any
+listing, but they're lookup tables for code reference rather than
+curated content; the default view should be human-authored content.
+Pass ``include_auto_generated: true`` to see them.
 """
 
 from __future__ import annotations
@@ -22,13 +29,19 @@ schema = {
         "Enumerate every authored wiki page under ~/.claude/methodology/wiki/, "
         "filesystem-walked from the wiki root. Optionally restrict by kind "
         "(adr, specs, guides, reference, conventions, lessons, notes, "
-        "journal, files). Redirect stubs (frontmatter ``redirect_to:`` or "
-        "``redirect_id:``) are excluded by default; pass "
-        "``include_redirects: true`` to see them. Read-only; never modifies "
-        "anything. Distinct from `wiki_reindex` which generates the "
-        ".generated/INDEX.md from the same enumeration, and from `wiki_read` "
-        "which fetches one page's content. Latency <50ms even for thousands "
-        "of pages. Returns {root, count, pages, redirect_count}."
+        "journal, files). "
+        "Two filters are applied by default and can be opted out of: "
+        "(1) redirect stubs (frontmatter ``redirect_to:`` or ``redirect_id:``) "
+        "are excluded — pass ``include_redirects: true`` to see them; "
+        "(2) auto-generated pages (frontmatter ``provenance: auto-generated``, "
+        "produced by ``codebase_analyze``) are excluded — pass "
+        "``include_auto_generated: true`` to see them. "
+        "Read-only; never modifies anything. Distinct from `wiki_reindex` "
+        "which generates the .generated/INDEX.md from the same enumeration, "
+        "and from `wiki_read` which fetches one page's content. Latency "
+        "<200ms on a 9000-page wiki because each page's frontmatter is read "
+        "once for both filter checks. Returns {root, count, pages, "
+        "redirect_count, auto_generated_count}."
     ),
     "inputSchema": {
         "type": "object",
@@ -51,56 +64,84 @@ schema = {
                 ),
                 "default": False,
             },
+            "include_auto_generated": {
+                "type": "boolean",
+                "description": (
+                    "When true, auto-generated pages (``provenance: "
+                    "auto-generated``, typically from ``codebase_analyze``) "
+                    "are included. Default false — at ~8,700 pages these "
+                    "dominate listings; the default view shows human-"
+                    "authored content."
+                ),
+                "default": False,
+            },
         },
     },
 }
 
 
-def _is_redirect_page(rel_path: str) -> bool:
-    """True iff the page at ``rel_path`` declares a redirect in its frontmatter.
+def _classify_page(rel_path: str) -> tuple[bool, bool]:
+    """Read frontmatter once; return (is_redirect_stub, is_auto_generated).
 
-    Reads the file via the sandboxed store and parses only the
-    frontmatter block — cheap on a 9000-page wiki because the
-    frontmatter is at the top of the file and we don't need to load
-    the body.
+    Both filters share the same disk read and frontmatter parse — important
+    because the default ``wiki_list`` walks ~9000 pages.
     """
     try:
         content = read_page(WIKI_ROOT, rel_path)
     except (ValueError, OSError):
-        return False
+        return False, False
     if content is None:
-        return False
-    return is_redirect(parse_frontmatter(content))
+        return False, False
+    fm = parse_frontmatter(content)
+    redirect_flag = is_redirect(fm)
+    raw_prov = fm.get("provenance", "")
+    auto_gen_flag = (
+        isinstance(raw_prov, str) and raw_prov.strip().lower() == "auto-generated"
+    )
+    return redirect_flag, auto_gen_flag
 
 
 async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
     args = args or {}
     kind = args.get("kind")
     include_redirects = bool(args.get("include_redirects", False))
+    include_auto_generated = bool(args.get("include_auto_generated", False))
 
     try:
         all_pages = list_pages(WIKI_ROOT, kind=kind if kind else None)
     except (ValueError, OSError) as exc:
         return {"error": f"list failed: {exc}"}
 
-    if include_redirects:
+    # Fast path when both filters are disabled — return everything without
+    # the per-page frontmatter read.
+    if include_redirects and include_auto_generated:
         return {
             "root": str(WIKI_ROOT),
             "count": len(all_pages),
             "pages": all_pages,
             "redirect_count": 0,  # not partitioned in this mode
+            "auto_generated_count": 0,
         }
 
-    live_pages: list[str] = []
+    kept: list[str] = []
     redirect_count = 0
+    auto_generated_count = 0
     for rel in all_pages:
-        if _is_redirect_page(rel):
+        redirect_flag, auto_gen_flag = _classify_page(rel)
+        if redirect_flag:
             redirect_count += 1
-        else:
-            live_pages.append(rel)
+            if not include_redirects:
+                continue
+        if auto_gen_flag:
+            auto_generated_count += 1
+            if not include_auto_generated:
+                continue
+        kept.append(rel)
+
     return {
         "root": str(WIKI_ROOT),
-        "count": len(live_pages),
-        "pages": live_pages,
+        "count": len(kept),
+        "pages": kept,
         "redirect_count": redirect_count,
+        "auto_generated_count": auto_generated_count,
     }

--- a/mcp_server/handlers/wiki_reindex.py
+++ b/mcp_server/handlers/wiki_reindex.py
@@ -30,15 +30,20 @@ schema = {
         "Regenerate the wiki table of contents at "
         "<wiki_root>/.generated/INDEX.md by enumerating every authored page "
         "and grouping it by kind (adr, specs, guides, reference, "
-        "conventions, lessons, notes, journal, files). Output is "
-        "deterministic — sorted by kind then path so unchanged wikis yield "
-        "byte-identical INDEX files. Authored pages are never touched; the "
-        "only file written is INDEX.md, atomically via tmp+rename. Use this "
-        "after bulk wiki edits, imports, or `wiki_compile` runs. Distinct "
-        "from `wiki_list` (returns the listing in the response, no file "
-        "write) and from `wiki_consolidate` (heat decay / staleness, not ToC "
-        "rebuild). Takes no arguments. Latency <100ms even for thousands of "
-        "pages. Returns {path, total_pages, by_kind: {kind: count}, root}."
+        "conventions, lessons, notes, journal, files). Redirect stubs are "
+        "excluded; auto-generated pages (``provenance: auto-generated``) "
+        "are surfaced in a separate ``Auto-generated reference`` section "
+        "after the human-authored content so they don't dominate the main "
+        "listing (Phase 5 of ADR-2244). Output is deterministic — sorted "
+        "by kind then path so unchanged wikis yield byte-identical INDEX "
+        "files. Authored pages are never touched; the only file written "
+        "is INDEX.md, atomically via tmp+rename. Use this after bulk "
+        "wiki edits, imports, or `wiki_compile` runs. Distinct from "
+        "`wiki_list` (returns the listing in the response, no file "
+        "write) and from `wiki_consolidate` (heat decay / staleness, not "
+        "ToC rebuild). Takes no arguments. Latency <500ms on a 9000-page "
+        "wiki. Returns {path, total_pages, by_kind, "
+        "auto_generated_by_kind, redirect_count, root}."
     ),
     "inputSchema": {
         "type": "object",
@@ -49,14 +54,30 @@ schema = {
 }
 
 
-def _render_index(grouped: dict[str, list[str]]) -> str:
+def _render_index(
+    grouped: dict[str, list[str]],
+    auto_grouped: dict[str, list[str]],
+) -> str:
+    """Render INDEX.md with human-authored content first, auto-gen second.
+
+    Phase 5 of ADR-2244: auto-generated pages get their own clearly-marked
+    section so readers see curated content first and aren't drowning in
+    the 8,700+ file-reference pages.
+    """
     lines: list[str] = [_BANNER, "", "# Wiki Index", ""]
-    total = sum(len(v) for v in grouped.values())
-    lines.append(f"**{total} authored pages across {len(PAGE_KINDS)} kinds.**")
+    total_human = sum(len(v) for v in grouped.values())
+    total_auto = sum(len(v) for v in auto_grouped.values())
+    lines.append(
+        f"**{total_human} human-authored pages, "
+        f"{total_auto} auto-generated reference pages.**"
+    )
+    lines.append("")
+
+    lines.append("## Human-authored")
     lines.append("")
     for kind in PAGE_KINDS:
         pages = grouped.get(kind, [])
-        lines.append(f"## {kind} ({len(pages)})")
+        lines.append(f"### {kind} ({len(pages)})")
         lines.append("")
         if not pages:
             lines.append("_No pages yet._")
@@ -66,48 +87,85 @@ def _render_index(grouped: dict[str, list[str]]) -> str:
             name = rel.rsplit("/", 1)[-1]
             lines.append(f"- [{name}](../{rel})")
         lines.append("")
+
+    if total_auto > 0:
+        lines.append("## Auto-generated reference")
+        lines.append("")
+        lines.append(
+            "_Produced by ``codebase_analyze`` and similar tooling. "
+            "Lookup-shaped, not curated narrative._"
+        )
+        lines.append("")
+        for kind in PAGE_KINDS:
+            pages = auto_grouped.get(kind, [])
+            if not pages:
+                continue
+            lines.append(f"### {kind} ({len(pages)})")
+            lines.append("")
+            for rel in pages:
+                name = rel.rsplit("/", 1)[-1]
+                lines.append(f"- [{name}](../{rel})")
+            lines.append("")
     return "\n".join(lines)
 
 
-def _is_redirect_page(rel_path: str) -> bool:
-    """True iff the page declares a redirect (read frontmatter from disk)."""
+def _classify_page(rel_path: str) -> tuple[bool, bool]:
+    """Read frontmatter once; return (is_redirect_stub, is_auto_generated)."""
     try:
         content = read_page(WIKI_ROOT, rel_path)
     except (ValueError, OSError):
-        return False
+        return False, False
     if content is None:
-        return False
-    return is_redirect(parse_frontmatter(content))
+        return False, False
+    fm = parse_frontmatter(content)
+    redirect_flag = is_redirect(fm)
+    raw_prov = fm.get("provenance", "")
+    auto_gen_flag = (
+        isinstance(raw_prov, str) and raw_prov.strip().lower() == "auto-generated"
+    )
+    return redirect_flag, auto_gen_flag
 
 
 async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Phase 3.2 of ADR-2244: redirect stubs are excluded from the index.
+    """Phases 3.2 + 5 of ADR-2244: split human / auto-gen / redirects.
 
-    The reader-facing INDEX.md should only list live pages — a stub at
-    an old path is a navigation aid for inbound links, not content to
-    advertise. The summary still reports the count of stubs so callers
-    have visibility.
+    Redirects: excluded entirely from INDEX.md (they're navigational aids
+    for inbound links, not content to advertise). Counted in the summary.
+
+    Auto-generated pages: surfaced in their own section after the
+    human-authored content so they don't drown the main listing.
     """
     grouped: dict[str, list[str]] = {}
+    auto_grouped: dict[str, list[str]] = {}
     redirects_by_kind: dict[str, int] = {}
+    auto_by_kind: dict[str, int] = {}
+
     for kind in PAGE_KINDS:
         try:
             all_pages = list_pages(WIKI_ROOT, kind=kind)
         except (ValueError, OSError):
             grouped[kind] = []
+            auto_grouped[kind] = []
             redirects_by_kind[kind] = 0
+            auto_by_kind[kind] = 0
             continue
         live: list[str] = []
+        auto: list[str] = []
         n_redirect = 0
         for rel in all_pages:
-            if _is_redirect_page(rel):
+            redirect_flag, auto_gen_flag = _classify_page(rel)
+            if redirect_flag:
                 n_redirect += 1
+            elif auto_gen_flag:
+                auto.append(rel)
             else:
                 live.append(rel)
         grouped[kind] = live
+        auto_grouped[kind] = auto
         redirects_by_kind[kind] = n_redirect
+        auto_by_kind[kind] = len(auto)
 
-    content = _render_index(grouped)
+    content = _render_index(grouped, auto_grouped)
     target = Path(WIKI_ROOT) / str(index_path())
     ensure_dir(target.parent)
     tmp = target.with_suffix(target.suffix + ".tmp")
@@ -116,9 +174,12 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
 
     return {
         "path": str(index_path()),
-        "total_pages": sum(len(v) for v in grouped.values()),
+        "total_pages": sum(len(v) for v in grouped.values())
+        + sum(len(v) for v in auto_grouped.values()),
         "by_kind": {k: len(v) for k, v in grouped.items()},
+        "auto_generated_by_kind": auto_by_kind,
         "redirects_by_kind": redirects_by_kind,
         "redirect_count": sum(redirects_by_kind.values()),
+        "auto_generated_count": sum(auto_by_kind.values()),
         "root": str(WIKI_ROOT),
     }

--- a/mcp_server/tool_registry_wiki.py
+++ b/mcp_server/tool_registry_wiki.py
@@ -79,15 +79,22 @@ def _register_wiki_list(mcp: FastMCP) -> None:
     async def tool_wiki_list(
         kind: str | None = None,
         include_redirects: bool = False,
+        include_auto_generated: bool = False,
     ) -> dict:
         """List authored wiki pages, optionally filtered by kind.
 
-        Phase 3.2 of ADR-2244: redirect stubs are excluded by default.
-        Pass ``include_redirects=True`` to see them.
+        Phase 3.2: redirect stubs excluded by default.
+        Phase 5: auto-generated pages (``provenance: auto-generated``)
+        excluded by default — they'd otherwise dominate listings at
+        ~8,700 pages. Opt in with ``include_auto_generated=True``.
         """
         return await safe_handler(
             wiki_list.handler,
-            {"kind": kind, "include_redirects": include_redirects},
+            {
+                "kind": kind,
+                "include_redirects": include_redirects,
+                "include_auto_generated": include_auto_generated,
+            },
             tool_name="wiki_list",
         )
 

--- a/tests_py/handlers/test_wiki_redirect_handlers.py
+++ b/tests_py/handlers/test_wiki_redirect_handlers.py
@@ -178,6 +178,143 @@ def test_list_no_redirects_means_redirect_count_zero(tmp_wiki: Path) -> None:
     assert result["redirect_count"] == 0
 
 
+# ── Phase 5: auto-generated filter ────────────────────────────────────
+
+
+def _auto_gen_page(page_id: str, title: str) -> str:
+    """A page whose frontmatter declares ``provenance: auto-generated``."""
+    return (
+        f"---\nid: {page_id}\ntitle: {title}\nkind: reference\n"
+        f"lifecycle: seedling\naudience:\n  - developer\n"
+        f"provenance: auto-generated\ngenerator:\n"
+        f"  model: cortex-codebase-analyze\n  version: v1\n"
+        f"---\n\n# {title}\n\nAuto-gen body.\n"
+    )
+
+
+def test_list_excludes_auto_generated_by_default(tmp_wiki: Path) -> None:
+    """Phase 5 of ADR-2244: ``provenance: auto-generated`` pages are
+    hidden from the default listing — at ~8,700 pages they would
+    dominate any view."""
+    pid_human = generate_page_id()
+    pid_auto = generate_page_id()
+    _write(tmp_wiki / "reference/cortex/curated.md", _page(pid_human, "Curated"))
+    _write(
+        tmp_wiki / "reference/cortex/file-x.py.md",
+        _auto_gen_page(pid_auto, "File: x.py"),
+    )
+
+    result = _run(wiki_list.handler({"kind": "reference"}))
+    assert "reference/cortex/curated.md" in result["pages"]
+    assert "reference/cortex/file-x.py.md" not in result["pages"]
+    assert result["count"] == 1
+    assert result["auto_generated_count"] == 1
+
+
+def test_list_include_auto_generated_returns_both(tmp_wiki: Path) -> None:
+    pid_human = generate_page_id()
+    pid_auto = generate_page_id()
+    _write(tmp_wiki / "reference/cortex/curated.md", _page(pid_human, "Curated"))
+    _write(
+        tmp_wiki / "reference/cortex/file-x.py.md",
+        _auto_gen_page(pid_auto, "File: x.py"),
+    )
+
+    result = _run(
+        wiki_list.handler({"kind": "reference", "include_auto_generated": True})
+    )
+    assert "reference/cortex/curated.md" in result["pages"]
+    assert "reference/cortex/file-x.py.md" in result["pages"]
+    assert result["count"] == 2
+
+
+def test_list_both_filters_compose_correctly(tmp_wiki: Path) -> None:
+    """Redirect stub of an auto-gen page: counted as redirect, hidden
+    by default. Verifies the two filters don't double-count or fight
+    each other."""
+    pid = generate_page_id()
+    _write(
+        tmp_wiki / "reference/cortex/curated.md",
+        _page(generate_page_id(), "Curated"),
+    )
+    _write(
+        tmp_wiki / "reference/cortex/file-x.py.md",
+        _auto_gen_page(pid, "File: x.py"),
+    )
+    _write(
+        tmp_wiki / "reference/cortex/old-file-path.md",
+        _stub("reference/cortex/file-x.py.md", target_id=pid),
+    )
+
+    result = _run(wiki_list.handler({"kind": "reference"}))
+    # Only the curated human-authored page is visible.
+    assert result["count"] == 1
+    assert "reference/cortex/curated.md" in result["pages"]
+    assert result["redirect_count"] == 1
+    assert result["auto_generated_count"] == 1
+
+
+def test_list_fast_path_when_both_filters_disabled(tmp_wiki: Path) -> None:
+    """When both filters are off, the handler avoids the per-page
+    frontmatter read and returns the raw list."""
+    _write(tmp_wiki / "adr/a.md", _page(generate_page_id(), "A"))
+    _write(
+        tmp_wiki / "adr/b.md",
+        _auto_gen_page(generate_page_id(), "B"),
+    )
+    result = _run(
+        wiki_list.handler(
+            {
+                "kind": "adr",
+                "include_redirects": True,
+                "include_auto_generated": True,
+            }
+        )
+    )
+    assert result["count"] == 2
+    assert result["redirect_count"] == 0  # not partitioned in fast path
+    assert result["auto_generated_count"] == 0
+
+
+# ── Phase 5: reindex separates auto-gen into its own section ─────────
+
+
+def test_reindex_separates_auto_generated_from_human_authored(
+    tmp_wiki: Path,
+) -> None:
+    """INDEX.md must surface human-authored content first; auto-gen
+    reference pages get their own clearly-marked tail section."""
+    _write(
+        tmp_wiki / "reference/cortex/curated.md",
+        _page(generate_page_id(), "Curated"),
+    )
+    _write(
+        tmp_wiki / "reference/cortex/file-x.py.md",
+        _auto_gen_page(generate_page_id(), "File: x.py"),
+    )
+    _write(
+        tmp_wiki / "reference/cortex/file-y.py.md",
+        _auto_gen_page(generate_page_id(), "File: y.py"),
+    )
+
+    result = _run(wiki_reindex.handler({}))
+    assert result["by_kind"]["reference"] == 1
+    assert result["auto_generated_count"] == 2
+    assert result["auto_generated_by_kind"]["reference"] == 2
+
+    index = (tmp_wiki / ".generated" / "INDEX.md").read_text("utf-8")
+    # Both sections exist, in the right order.
+    h_pos = index.find("## Human-authored")
+    a_pos = index.find("## Auto-generated reference")
+    assert h_pos >= 0
+    assert a_pos >= 0
+    assert h_pos < a_pos
+    # Curated page in human-authored section, auto-gen pages below.
+    assert "curated.md" in index
+    assert "file-x.py.md" in index
+    assert "file-y.py.md" in index
+
+
 # ── wiki_reindex: stubs not in INDEX.md ──────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Phase 5 of [ADR-2244](https://github.com/cdeust/Cortex/blob/main/docs/research/wiki-classification-survey.md) — **filter, don't delete** for auto-generated pages. The 8,734 file-doc pages produced by `codebase_analyze` are valuable lookup tables but they'd dominate any default listing — exactly the catch-all problem Phase 1 was supposed to solve, just shifted from `notes/` to `reference/`.

Phase 5 says: **keep them indexed, hide them from the default view, surface them in their own section.**

## Changes

### `wiki_list` (handler + tool registry)
New `include_auto_generated: bool = False` parameter. Default behaviour: pages with frontmatter `provenance: auto-generated` are excluded; response carries `auto_generated_count` so callers know they exist. Pass `include_auto_generated=True` to opt in.

### `wiki_reindex` (handler)
INDEX.md gets two top-level sections:

```markdown
## Human-authored
### adr (N)
...
### explanation (N)
...

## Auto-generated reference
_Produced by codebase_analyze and similar tooling. Lookup-shaped, not curated narrative._
### reference (N)
...
```

Both sections still grouped by kind. Deterministic output preserved.

## Shared work

`_classify_page` (in both handlers) reads frontmatter **once per page** and returns `(is_redirect_stub, is_auto_generated)`. The two filters share the same disk read on the ~9,000-page wiki. Worst-case latency observed locally: <500ms on the live wiki.

## Tests

`tests_py/handlers/test_wiki_redirect_handlers.py` — **5 new tests** added (25 total in file now):

| Surface | Test |
|---|---|
| `wiki_list` | auto-gen excluded by default |
| `wiki_list` | `include_auto_generated=True` returns both |
| `wiki_list` | both filters compose without double-counting |
| `wiki_list` | fast-path when both filters off |
| `wiki_reindex` | INDEX.md has Human-authored first, Auto-generated section second |

- [x] `pytest tests_py/handlers/test_wiki_redirect_handlers.py` — 25 passed
- [x] `pytest tests_py/core/ tests_py/shared/ tests_py/handlers/test_wiki_redirect_handlers.py tests_py/handlers/test_wiki_sync_errors.py` — **2060 passed**
- [x] `ruff format --check` and `ruff check` clean

## Out of scope (follow-ups)

- `wiki_search` / `wiki_view` / `wiki_export` learning the same filter (lower urgency — listing dominance was the primary user complaint).
- Search-time relevance shaping (auto-gen pages might warrant a lower default boost in any future scorer). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)