### PR TITLE
fix(recall): filter low-signal tool-output captures from default results

### DIFF
--- a/mcp_server/handlers/recall.py
+++ b/mcp_server/handlers/recall.py
@@ -19,6 +19,7 @@ from mcp_server.core.query_intent import QueryIntent, classify_query_intent
 from mcp_server.handlers._tool_meta import READ_ONLY
 from mcp_server.handlers.recall_helpers import (
     build_enhancements,
+    filter_low_signal,
     inject_triggered_memories,
 )
 from mcp_server.infrastructure.embedding_engine import get_embedding_engine
@@ -147,6 +148,20 @@ schema = {
                 ),
                 "examples": ["engineer", "researcher", "reviewer"],
             },
+            "include_low_signal": {
+                "type": "boolean",
+                "description": (
+                    "When false (default), drops memories tagged as auto-"
+                    "captures (``auto-captured``, ``tool:edit``, ``_backfill``, "
+                    "``stage-N``, ``session-summary``, …) so curated content "
+                    "(ADRs, lessons, conventions) surfaces in the first few "
+                    "results. Spike 2026-05-13 showed unfiltered recall is "
+                    "drowned by tool-output captures even for queries about "
+                    "design decisions. Set true for debugging / replay "
+                    "tooling that needs the raw memory feed."
+                ),
+                "default": False,
+            },
         },
     },
 }
@@ -254,15 +269,22 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
     agent_topic = args.get("agent_topic")
     max_results = args.get("max_results", 10)
     min_heat = args.get("min_heat", 0.05)
+    include_low_signal = bool(args.get("include_low_signal", False))
     settings = get_memory_settings()
     store, emb = _get_store(), get_embedding_engine()
 
-    # Base retrieval: pg_recall (intent → PG weights → recall_memories → rerank)
+    # Base retrieval: pg_recall (intent → PG weights → recall_memories → rerank).
+    # Over-fetch when filtering is on so that after low-signal drops we
+    # still surface ``max_results`` curated items. Tool-output captures
+    # are common enough that a 3× headroom is a reasonable starting
+    # point — the alternative is iterative refill, which complicates
+    # the rerank ordering.
+    fetch_k = max_results * 3 if not include_low_signal else max_results
     results = pg_recall(
         query=query,
         store=store,
         embeddings=emb,
-        top_k=max_results,
+        top_k=fetch_k,
         domain=domain,
         directory=directory,
         agent_topic=agent_topic,
@@ -270,6 +292,16 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
         wrrf_k=settings.WRRF_K,
         momentum_state=_momentum_state,
     )
+
+    # Low-signal filter (spike 2026-05-13). Tool-output captures,
+    # backfilled imports, and stage reports dominate unfiltered recall
+    # even for queries about design decisions, drowning out curated
+    # ADRs / lessons / conventions. Filter unless the caller opts in.
+    low_signal_dropped = 0
+    if not include_low_signal:
+        results, low_signal_dropped = filter_low_signal(results)
+    # Cap to the caller-requested max_results after filtering.
+    results = results[:max_results]
 
     # Production enrichments on top of base retrieval
     results = inject_triggered_memories(results, query, store)
@@ -286,6 +318,7 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
     return {
         "results": results,
         "total": len(results),
+        "low_signal_dropped": low_signal_dropped,
         "query_intent": intent,
         "dispatch_tier": "pg",
         "signals": {},

--- a/mcp_server/handlers/recall_helpers.py
+++ b/mcp_server/handlers/recall_helpers.py
@@ -136,6 +136,82 @@ def parse_tags(tags: Any) -> list:
     return tags if tags else []
 
 
+# Low-signal tags: memories so tagged are auto-captures from tool
+# operations, backfill imports, or stage reports — useful for audit
+# replay but noise in semantic recall.
+#
+# Spike 2026-05-13: three diverse queries about ADR-2244 design
+# decisions returned exclusively ``# Tool: Edit`` captures from
+# unrelated repos. The curated wiki (31 ADRs + 21 lessons + 54
+# conventions) was drowned out because every captured tool call
+# scores high on WRRF + heat + recency.
+#
+# The wiki classifier (``mcp_server.core.wiki_classifier._AUDIT_TAGS``)
+# already maintains this concept and rejects such content from the
+# wiki. Recall reuses the same idea at the retrieval layer.
+LOW_SIGNAL_TAGS: frozenset[str] = frozenset(
+    {
+        "auto-captured",
+        "_backfill",
+        "imported",
+        "session-summary",
+        "tool-output",
+        "code-review",
+        "tool:edit",
+        "tool:bash",
+        "tool:read",
+        "tool:write",
+        "tool:grep",
+        "tool:glob",
+        "tool:search",
+        "tool:webfetch",
+        "tool:websearch",
+        "tool:notebookedit",
+        "stage-1",
+        "stage-2",
+        "stage-3",
+        "stage-4",
+        "stage-5",
+        "stage-6",
+        "stage-7",
+        "stage-8",
+        "stage-9",
+        "stage-10",
+        "stage-11",
+        "audit",
+        "automated",
+        "wip",
+        "progress",
+    }
+)
+
+
+def filter_low_signal(results: list[dict]) -> tuple[list[dict], int]:
+    """Drop memories whose tags mark them as low-signal noise.
+
+    Returns ``(kept_results, dropped_count)``. The dropped count is
+    surfaced in the response so callers see how much was filtered —
+    important for debugging the "why didn't I get the result I expected"
+    case.
+
+    Callers that explicitly want low-signal memories (debugging,
+    replay tooling) skip this filter via the ``include_low_signal``
+    input parameter on the recall handler.
+    """
+    kept: list[dict] = []
+    dropped = 0
+    for r in results:
+        tags = r.get("tags", [])
+        if isinstance(tags, str):
+            tags = parse_tags(tags)
+        tag_set = {str(t).lower() for t in tags}
+        if tag_set & LOW_SIGNAL_TAGS:
+            dropped += 1
+            continue
+        kept.append(r)
+    return kept, dropped
+
+
 def build_result(mem: dict, score: float, intent: str, settings: Any) -> dict:
     """Build a single result dict with recency boost."""
     created_at = mem.get("created_at", "")

--- a/tests_py/handlers/test_recall_low_signal_filter.py
+++ b/tests_py/handlers/test_recall_low_signal_filter.py
@@ -1,0 +1,159 @@
+"""Tests for the low-signal filter on the recall path.
+
+Spike 2026-05-13 found that recall results for design-decision queries
+were dominated by ``# Tool: Edit`` auto-captures from unrelated repos.
+The filter drops memories tagged ``auto-captured`` / ``tool:edit`` /
+``_backfill`` / ``stage-N`` etc. unless the caller opts in.
+"""
+
+from __future__ import annotations
+
+from mcp_server.handlers.recall_helpers import (
+    LOW_SIGNAL_TAGS,
+    filter_low_signal,
+)
+
+
+def _mem(content: str, *tags: str) -> dict:
+    """Build a minimal result dict that matches recall's output shape."""
+    return {
+        "memory_id": id(content),
+        "content": content,
+        "score": 0.9,
+        "tags": list(tags),
+    }
+
+
+# ── Filter behaviour ──────────────────────────────────────────────────
+
+
+def test_tool_edit_capture_is_dropped() -> None:
+    results = [_mem("# Tool: Edit\nfile.py changed", "auto-captured", "tool:edit")]
+    kept, dropped = filter_low_signal(results)
+    assert kept == []
+    assert dropped == 1
+
+
+def test_backfill_import_is_dropped() -> None:
+    results = [_mem("Some bulk-imported note", "imported", "_backfill")]
+    kept, dropped = filter_low_signal(results)
+    assert kept == []
+    assert dropped == 1
+
+
+def test_stage_report_is_dropped() -> None:
+    results = [_mem("stage 3 research verdict", "stage-3", "research")]
+    kept, dropped = filter_low_signal(results)
+    assert kept == []
+    assert dropped == 1
+
+
+def test_curated_lesson_is_kept() -> None:
+    """A lesson memory tagged with knowledge-shaped tags must survive."""
+    results = [_mem("The bug was X; the fix was Y.", "lesson", "bug-fix")]
+    kept, dropped = filter_low_signal(results)
+    assert len(kept) == 1
+    assert dropped == 0
+
+
+def test_decision_record_is_kept() -> None:
+    results = [_mem("Decision: adopt pgvector for ANN.", "decision", "architecture")]
+    kept, dropped = filter_low_signal(results)
+    assert len(kept) == 1
+    assert dropped == 0
+
+
+def test_convention_memory_is_kept() -> None:
+    results = [_mem("Always use slugify before .md append.", "convention", "rule")]
+    kept, dropped = filter_low_signal(results)
+    assert len(kept) == 1
+    assert dropped == 0
+
+
+# ── Mixed-batch realism: spike scenario ───────────────────────────────
+
+
+def test_filter_clears_tool_noise_so_lesson_floats_up() -> None:
+    """Models the exact spike result: 4 tool-output captures + 1 lesson.
+    Filtering must surface the lesson as the only kept hit."""
+    results = [
+        _mem("# Tool: Edit\nfile1.py changed", "auto-captured", "tool:edit"),
+        _mem("# Tool: Edit\nfile2.py changed", "auto-captured", "tool:edit"),
+        _mem("# Tool: Bash\ngit status", "auto-captured", "tool:bash"),
+        _mem(
+            "Decision: 001-zero-dependencies — use Node built-ins only.",
+            "decision",
+            "adr",
+        ),
+        _mem("# Tool: Read\nopened file", "auto-captured", "tool:read"),
+    ]
+    kept, dropped = filter_low_signal(results)
+    assert len(kept) == 1
+    assert dropped == 4
+    assert "Decision: 001-zero-dependencies" in kept[0]["content"]
+
+
+# ── String-encoded tags (PG returns tags as JSON-encoded string) ──────
+
+
+def test_tags_as_json_string_still_filtered() -> None:
+    """PG store can serialize tags as a JSON string; the filter must
+    parse and apply correctly either way."""
+    results = [
+        {
+            "memory_id": 1,
+            "content": "tool capture",
+            "tags": '["auto-captured", "tool:edit"]',
+        }
+    ]
+    kept, dropped = filter_low_signal(results)
+    assert kept == []
+    assert dropped == 1
+
+
+def test_empty_tags_kept() -> None:
+    """A memory with no tags at all is not low-signal."""
+    results = [{"memory_id": 1, "content": "untagged memory", "tags": []}]
+    kept, dropped = filter_low_signal(results)
+    assert len(kept) == 1
+    assert dropped == 0
+
+
+def test_missing_tags_key_kept() -> None:
+    """Defensive: a result dict that's missing the ``tags`` key is kept."""
+    results = [{"memory_id": 1, "content": "untagged memory"}]
+    kept, dropped = filter_low_signal(results)
+    assert len(kept) == 1
+
+
+# ── Set membership invariants ─────────────────────────────────────────
+
+
+def test_low_signal_tags_covers_known_polluters() -> None:
+    """Pin the canonical set so a refactor can't silently shrink it."""
+    must_include = {
+        "auto-captured",
+        "tool:edit",
+        "tool:bash",
+        "_backfill",
+        "imported",
+        "session-summary",
+        "stage-1",
+        "stage-11",
+    }
+    assert must_include.issubset(LOW_SIGNAL_TAGS)
+
+
+def test_low_signal_tags_does_not_include_knowledge_signals() -> None:
+    """Pin the negative: knowledge-shaped tags must NOT be in the filter."""
+    must_exclude = {
+        "decision",
+        "adr",
+        "lesson",
+        "convention",
+        "architecture",
+        "design",
+        "rule",
+        "standard",
+    }
+    assert not (must_exclude & LOW_SIGNAL_TAGS)


### PR DESCRIPTION
## Summary

**Spike 2026-05-13** revealed that Cortex `recall` returns auto-captured `# Tool: Edit` memories as the top-5 hits even for queries about design decisions. Three diverse queries about recent ADR-2244 work all returned **zero curated ADRs / lessons / conventions** — the wiki content the user spent days producing was drowned at retrieval.

This PR adds a tag-based low-signal filter to the recall path. The fix is small, well-tested, and reversible.

## Spike findings

| Query | Expected hit | Top-5 actually returned | Verdict |
|---|---|---|---|
| ".md extension... slug generation" | ADR-2244, slug-bug fix | 5× unrelated `# Tool: Edit` | MISS |
| "capping max_files... silent truncation" | PR #25 cap-removal | 5× unrelated `# Tool: Edit` + `_backfill` | MISS |
| "hardcoded enum frozenset... extensibility" | ADR-2244 §1.5 registry | 5× unrelated `# Tool: Edit` + `_backfill` | MISS |

## Root cause

Every tool call writes a memory tagged `["auto-captured", f"tool:{name.lower()}"]` (post_tool_capture.py:170). These rank high in WRRF because:
- high heat (frequent fresh writes)
- semantic similarity (file paths, code keywords)
- FlashRank rerank doesn't deprioritize them

The wiki classifier's `_AUDIT_TAGS` rejects tool-output from the **wiki** — but the same logic was never applied at the **retrieval** layer.

## Fix

New `filter_low_signal(results) -> (kept, dropped)` helper in `recall_helpers.py`. Canonical low-signal set: `auto-captured`, `tool:*`, `_backfill`, `imported`, `stage-N`, `session-summary`, `audit`, `wip`, `progress`.

Wired into `recall.handler`:
- **Default**: filter ON. Over-fetch 3× then cap to `max_results` after filtering.
- New `include_low_signal: bool = false` input param for debugging / replay tooling.
- Response gains `low_signal_dropped` so callers see how much was filtered.

## What this does NOT solve

These came up in the spike but are orthogonal scope:

- **Scoped recall is still empty.** `domain="cortex"` / `agent_topic="codebase"` return 0 hits — producers don't tag memories with those values. Separate fix.
- **Wiki content is not in the recall index.** The 31 ADRs + 21 lessons + 54 conventions live as markdown files on disk; they aren't queryable via recall unless `wiki_sync` writes them as memories. Separate fix.
- **Output schema mismatch** (`required: ["memories"]` but handler returns `"results"`). Real but orthogonal — chasing here would widen blast radius.

## Tests

`tests_py/handlers/test_recall_low_signal_filter.py` (NEW) — **12 tests**:

| Group | Tests |
|---|---:|
| Filter behaviour (tool/backfill/stage dropped, lesson/decision/convention kept) | 6 |
| Realistic spike batch (4 tool captures + 1 lesson → 1 kept) | 1 |
| Encoding robustness (JSON-string tags, empty tags, missing tags) | 3 |
| Set invariants (canonical low-signal pinned, knowledge tags NOT in filter) | 2 |

## Test plan

- [x] `pytest tests_py/handlers/test_recall_low_signal_filter.py` — 12 passed
- [x] `pytest tests_py/handlers/test_recall.py tests_py/handlers/test_recall_enhancements.py` — 28 existing tests still pass
- [x] `ruff format --check` and `ruff check` clean
- [ ] CI on this PR
- [ ] **Post-merge spike**: re-run the 3 design-decision queries; expect curated ADRs / lessons to surface in top-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)