### PR TITLE
fix(mcp): remember tool output validation — schema vs handler mismatches

### DIFF
--- a/mcp_server/core/write_gate.py
+++ b/mcp_server/core/write_gate.py
@@ -141,6 +141,7 @@ def build_rejection_response(
     """Build response when write gate rejects the memory."""
     return {
         "stored": False,
+        "action": "rejected",
         "reason": gate_reason,
         "novelty": _describe_signals(
             embedding_novelty,

--- a/mcp_server/handlers/remember.py
+++ b/mcp_server/handlers/remember.py
@@ -39,8 +39,8 @@ schema = {
                 "description": "True if content landed in the memory store (as new row or a merge into an existing one).",
             },
             "memory_id": {
-                "type": "string",
-                "description": "UUID of the resulting memory row. Present when stored=true.",
+                "type": "integer",
+                "description": "ID of the resulting memory row (PG bigint). Present when stored=true.",
             },
             "action": {
                 "type": "string",
@@ -52,8 +52,8 @@ schema = {
                 "description": "Human-readable explanation of the gate decision (e.g. 'low surprise', 'high entity overlap').",
             },
             "merged_with": {
-                "type": "string",
-                "description": "UUID of the existing memory when action=merged.",
+                "type": "integer",
+                "description": "ID of the existing memory (PG bigint) when action=merged.",
             },
             "heat": {
                 "type": "number",
@@ -260,7 +260,7 @@ def _parse_args(
 async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
     """Store a memory with thermodynamic properties and predictive coding gate."""
     if not args or not args.get("content"):
-        return {"stored": False, "reason": "no_content"}
+        return {"stored": False, "action": "rejected", "reason": "no_content"}
 
     # Phase 7: harden user-controlled content at the ingestion boundary
     # (NFC normalization, control/bidi strip, byte cap).
@@ -268,7 +268,7 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
 
     args["content"] = harden_content(args["content"])
     if not args["content"]:
-        return {"stored": False, "reason": "no_content"}
+        return {"stored": False, "action": "rejected", "reason": "no_content"}
 
     (
         content,

--- a/mcp_server/handlers/remember_response.py
+++ b/mcp_server/handlers/remember_response.py
@@ -66,10 +66,16 @@ def build_response(
     interf: float,
 ) -> dict[str, Any]:
     """Build the full success response dict."""
+    # Normalize internal curation action vocab → schema-canonical enum.
+    # try_curation returns "create"/"link" (present-tense ops); the public
+    # schema documents past-tense outcomes (stored / merged / rejected).
+    schema_action = {"create": "stored", "link": "stored", "merge": "merged"}.get(
+        action, action
+    )
     result = {
         "stored": True,
         "memory_id": mem_id,
-        "action": action,
+        "action": schema_action,
         "store_type": stype,
         "domain": domain,
         "heat": round(mod["heat"], 4),


### PR DESCRIPTION
## Summary
The `remember` MCP tool failed output validation on every code path due to schema/handler mismatches. Three independent fixes in one commit:

1. **`memory_id` / `merged_with` type** — schema declared `string` (UUID-style) but the handler returns `int` (PG bigint). Now `integer`, aligning with `anchor.py` / `forget.py` / `get_causal_chain.py` which already declare integer.
2. **Rejection paths missing `action`** — schema invariant `required: ["stored","action"]` was violated by both `no_content` early-exits in `remember.py` and by `write_gate.build_rejection_response()`. Added `"action": "rejected"` to each.
3. **Action enum mismatch** — schema enum was `["stored","merged","rejected"]` but the handler forwarded internal curation vocab `"create"` / `"link"` untouched, so every successful create/link failed with `'create' is not one of [...]`. Normalized at the response boundary in `build_response`: `create`/`link` → `stored`, `merge` → `merged`.

## Repro (before)
```
cortex:recall    → Output validation error: 'memories' is a required property  (separate bug, already fixed in trunk schema)
cortex:remember  → Output validation error: 'NNNN' is not of type 'string'
cortex:remember  → Output validation error: 'action' is a required property
cortex:remember  → Output validation error: 'create' is not one of ['stored', 'merged', 'rejected']
```

After this PR, the schema invariant `required:["stored","action"]` and the enum constraint are honoured on every code path (`no_content`, gate-rejected, created, linked, merged).

## Test plan
- [ ] Restart Cortex MCP server
- [ ] Call `remember({content: "test memory"})` — expect `{stored: true, memory_id: <int>, action: "stored", ...}`
- [ ] Call `remember({content: ""})` — expect `{stored: false, action: "rejected", reason: "no_content"}`
- [ ] Call `remember({content: "<duplicate of existing>"})` — expect `{stored: false, action: "rejected", reason: "<gate reason>", ...}` from write gate
- [ ] Call `remember({content: "<very similar to existing>", force: false})` — expect `{stored: true, action: "merged", merged_with: <int>, ...}`
- [ ] All four responses pass MCP output schema validation (no `Output validation error`)

## Files
- `mcp_server/handlers/remember.py` — schema types + early-exit `action`
- `mcp_server/handlers/remember_response.py` — `build_response` normalization
- `mcp_server/core/write_gate.py` — `build_rejection_response` action field

🤖 Generated with [Claude Code](https://claude.com/claude-code)