### PR TITLE
docs: fix stale test and type-check paths in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ project-specific rules:
 - **No mutable default arguments.** No globals except for read-once
   configuration objects.
 - **No bare `except:`.** Catch the specific exception you mean.
-- **Type-checked at `--strict`.** `mypy --strict src/cortex/` must pass.
+- **Type-checked at `--strict`.** `mypy --strict mcp_server/` must pass.
 - **§4.1 File ≤500 lines, §4.2 function ≤50 lines.**
 
 The full standard lives in
@@ -118,11 +118,11 @@ The full standard lives in
 ## Testing
 
 ```bash
-pytest                           # full suite (~2500 tests)
-pytest tests/unit                # unit only
-pytest tests/integration         # PostgreSQL-backed integration
-pytest tests/benchmark -k locomo # subset
-pytest -x --ff                   # stop on first fail, run failures first
+pytest                               # full suite (~2500 tests)
+pytest tests_py/core                 # one subsystem (unit-level)
+pytest tests_py/integration          # PostgreSQL-backed integration
+pytest tests_py/benchmarks -k locomo # subset
+pytest -x --ff                       # stop on first fail, run failures first
 ```
 
 Tests run against a local PostgreSQL instance. CI provisions a fresh DB


### PR DESCRIPTION
While following the contributor setup on a fresh clone, I hit a few paths in `CONTRIBUTING.md` that don't resolve:

- **Type-check:** `mypy --strict src/cortex/` — there's no `src/cortex/`. `pyproject.toml` sets `packages = ["mcp_server"]`, so it's `mypy --strict mcp_server/`.
- **Tests:** `pytest tests/unit|integration|benchmark` — `testpaths = ["tests_py"]`, and the suites live under `tests_py/` (`tests_py/integration`, `tests_py/benchmarks`, …). Updated the examples to real subdirectories and realigned the comments.

Docs-only, no behavior change.

Two more references look stale but I left them alone since I wasn't sure of the intended target: the "Adding an MCP tool" step points at `docs/MCP-TOOLS.md`, and "Modifying retrieval signals" points at `benchmarks/results.md` — neither is in the tree (there's a `benchmarks/results/` directory). Glad to follow up if you point me at the right spots.
