### PR TITLE
feat(marketplace): list zetetic-team-subagents alongside cortex

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,6 +26,23 @@
       "category": "productivity",
       "runtime": ["cli", "cowork"],
       "runtime_notes": "CLI mode requires PostgreSQL 15+ with pgvector. Cowork/sandboxed mode falls back to SQLite automatically (set CORTEX_RUNTIME=cowork or leave DATABASE_URL unset)."
+    },
+    {
+      "name": "zetetic-team-subagents",
+      "source": {
+        "source": "github",
+        "repo": "cdeust/zetetic-team-subagents"
+      },
+      "description": "Zetetic agent team for Cortex — 97 genius reasoning patterns from history's greatest minds + 19 team specialists (architect, engineer, code-reviewer, refactorer, …), 63 skills, 24 commands, 18 tools, 17 hooks, under one epistemic standard none of them can bypass. Composes with Cortex memory: every agent recalls/remembers through the Cortex MCP and routes via /genius, /agent, /zetetic, /quality, /research commands.",
+      "author": {
+        "name": "Clement Deust",
+        "email": "admin@ai-architect.tools"
+      },
+      "homepage": "https://ai-architect.tools",
+      "repository": "https://github.com/cdeust/zetetic-team-subagents",
+      "license": "MIT",
+      "keywords": ["agents", "reasoning", "research", "zetetic", "epistemic", "claude-code", "refactoring", "clean-architecture"],
+      "category": "research"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds `zetetic-team-subagents` as a second plugin entry in `.claude-plugin/marketplace.json`, so the cortex-plugins marketplace now distributes both the Cortex memory plugin and the zetetic agent team.

## Why

Per the integration decision: the agent team (97 genius reasoning patterns + 19 team specialists, 63 skills, 24 commands, 18 tools, 17 hooks) should be usable *as part of cortex*. Listing it in the same marketplace makes both co-installable from one `/plugin marketplace add`, while each repo stays independently maintained (lowest coupling, no vendoring/duplication).

## How

```json
{
  "name": "zetetic-team-subagents",
  "source": { "source": "github", "repo": "cdeust/zetetic-team-subagents" },
  ...
}
```

- **github source object** — the canonical cross-repo reference (schema: [plugin-marketplaces docs](https://code.claude.com/docs/en/plugin-marketplaces)).
- **No `version`/`ref`/`sha` pin** — tracks the zetetic repo's default branch so the team stays current (every commit counts as a new version, per the version-resolution docs).
- The agents compose with Cortex memory: they recall/remember through the Cortex MCP and route via `/genius`, `/agent`, `/zetetic`, `/quality`, `/research` commands.

## Verification

- `marketplace.json` parses as valid JSON; `plugins[]` = `[cortex, zetetic-team-subagents]`.
- `source` object matches the documented `github` schema exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)