### PR TITLE
ci(pyright): add type-check ratchet gate, fix 15 None-deref bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,16 +181,35 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
-      - name: Install dependencies
+      # Pyright resolves third-party imports from ./.venv (pinned in
+      # pyrightconfig.json: venvPath="."/venv=".venv"). The full stub set MUST
+      # be installed or every import collapses to Unknown — and Unknown
+      # SUPPRESSES downstream type errors, making the baseline meaningless.
+      # source: measured 2026-06-18 — an unresolved env reports 566 errors, a
+      # fully-resolved env reports 593 (Unknown was masking 27+ real errors).
+      # flashrank (core reranker) + sqlite-vec live outside dev/postgresql/codebase.
+      - name: Create .venv with the full type-check environment
         run: |
-          pip install -e ".[dev]"
-          pip install pyright
+          python -m venv .venv
+          .venv/bin/pip install -U pip
+          .venv/bin/pip install -e ".[dev,postgresql,sqlite,codebase]" flashrank
+          # Pin pyright — diagnostic output drifts between releases, so the
+          # committed baseline is only comparable against the pinned version.
+          .venv/bin/pip install pyright==1.1.410
 
-      - name: Run type checker
-        run: pyright mcp_server/
-        continue-on-error: true
+      # The ratchet IS the gate. pyright always exits non-zero while the
+      # 568-error backlog stands, so its own exit is ignored (|| true); the
+      # build fails only when a --blocking rule regresses past its committed
+      # baseline (0). Add rules to --blocking as each batch drives them to
+      # their floor — see tasks/pyright-remediation-plan.md.
+      - name: Run pyright + per-rule ratchet gate
+        run: |
+          .venv/bin/python -m pyright --outputjson mcp_server/ > pyright-current.json || true
+          .venv/bin/python scripts/check_pyright_ratchet.py \
+            pyright-current.json typecheck-baseline.json \
+            --blocking reportOptionalMemberAccess reportOptionalSubscript
 
   build:
     name: Build Package

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,13 @@ docs/arxiv-*/*.fls
 docs/arxiv-*/*.fdb_latexmk
 docs/arxiv-*/*.synctex.gz
 
+# Local virtualenv (uv-managed; never committed)
+.venv/
+
+# Pyright ratchet — ephemeral per-run output; typecheck-baseline.json IS tracked
+pyright-current.json
+pyright-*.json
+
 # Runtime telemetry
 traces/
 

--- a/mcp_server/core/titans_memory.py
+++ b/mcp_server/core/titans_memory.py
@@ -194,7 +194,12 @@ class TitansMemory:
             prediction = M @ k
             loss = torch.sum((prediction - v) ** 2)
             loss.backward()
-            grad = M.grad.detach()
+            # backward() populates .grad on a leaf requiring grad; a None here
+            # means the autograd graph was broken — surface it, don't deref None.
+            grad_tensor = M.grad
+            if grad_tensor is None:
+                raise RuntimeError("titans surprise: gradient missing after backward()")
+            grad = grad_tensor.detach()
 
             # Surprise momentum update: S_t = eta * S_{t-1} - theta * grad
             self._S = self.eta * self._S - self.theta * grad

--- a/mcp_server/handlers/ingest_codebase_cypher.py
+++ b/mcp_server/handlers/ingest_codebase_cypher.py
@@ -111,9 +111,7 @@ def file_path_from_qn(qn: str) -> list[str]:
     return candidates
 
 
-async def _run_query(
-    graph_path: str, cypher: str
-) -> tuple[dict[str, Any] | None, str | None]:
+async def _run_query(graph_path: str, cypher: str) -> tuple[dict[str, Any], str | None]:
     """Run a single cypher query, draining upstream byte-budget pages.
 
     Upstream ``query_graph`` (automatised-pipeline ≥0.4.0,
@@ -130,9 +128,9 @@ async def _run_query(
     bounded by the caller's explicit LIMIT.
 
     Returns (result_dict, error_message). On upstream-reported errors
-    (status=error), result is None and the error_message is populated.
-    Transport errors raise; callers catch narrow transport classes and
-    surface them as diagnostics.
+    (status=error), result is an empty dict and the error_message is
+    populated. Transport errors raise; callers catch narrow transport
+    classes and surface them as diagnostics.
     """
     merged_rows: list[Any] = []
     offset = 0
@@ -145,9 +143,9 @@ async def _run_query(
         )
         page = normalise_mcp_payload(payload)
         if isinstance(page, dict) and page.get("status") == "error":
-            return None, str(page.get("message") or "<unknown upstream error>")
+            return {}, str(page.get("message") or "<unknown upstream error>")
         if not isinstance(page, dict):
-            return None, f"unexpected payload type: {type(page).__name__}"
+            return {}, f"unexpected payload type: {type(page).__name__}"
         result = page
         merged_rows.extend(page.get("rows") or [])
         next_offset = page.get("next_offset")
@@ -156,7 +154,7 @@ async def _run_query(
         if int(next_offset) <= offset:
             # Non-advancing cursor would loop forever — upstream contract
             # violation; surface it instead of spinning.
-            return None, f"non-advancing pagination cursor at offset {offset}"
+            return {}, f"non-advancing pagination cursor at offset {offset}"
         offset = int(next_offset)
     result = dict(result)
     result["rows"] = merged_rows
@@ -195,7 +193,7 @@ async def fetch_symbols_total(
             result, err = await _run_query(graph_path, cypher)
         except _TRANSPORT_ERRORS:
             return None
-        if err is not None or result is None:
+        if err is not None:
             return None
         rows = result.get("rows") or []
         if not rows or not rows[0]:

--- a/mcp_server/infrastructure/ap_bridge.py
+++ b/mcp_server/infrastructure/ap_bridge.py
@@ -291,6 +291,8 @@ class APBridge:
             raise ValueError(f"AP tool not in allowlist: {tool!r}")
         if not await self.connect():
             return None
+        if self._client is None:  # connect() success guarantees a client; defensive
+            return None
         try:
             return await self._client.call(tool, args or {})
         except Exception as exc:

--- a/mcp_server/infrastructure/pg_store.py
+++ b/mcp_server/infrastructure/pg_store.py
@@ -510,6 +510,8 @@ class PgMemoryStore(
             },
         ).fetchone()
         self._conn.commit()
+        if row is None:
+            raise RuntimeError("INSERT ... RETURNING id produced no row")
         return row["id"]
 
     def set_superseded_by(self, old_id: int, new_id: int) -> None:

--- a/mcp_server/infrastructure/pg_store_wiki.py
+++ b/mcp_server/infrastructure/pg_store_wiki.py
@@ -29,6 +29,19 @@ def body_hash(body: str) -> str:
     return hashlib.sha256(body.encode("utf-8")).hexdigest()
 
 
+def _returning_id(row: dict[str, Any] | tuple[Any, ...] | None) -> int:
+    """Extract the id from an ``INSERT ... RETURNING id`` fetchone() result.
+
+    A default psycopg cursor yields tuple rows; a ``dict_row`` cursor yields
+    dict rows — hence the isinstance split. An INSERT ... RETURNING always
+    produces exactly one row, so a None here is a broken query (or a silently
+    rolled-back transaction), not a normal path — surface it loudly.
+    """
+    if row is None:
+        raise RuntimeError("INSERT ... RETURNING id produced no row")
+    return row["id"] if isinstance(row, dict) else row[0]
+
+
 # ── wiki.pages ─────────────────────────────────────────────────────────
 
 
@@ -249,8 +262,7 @@ def insert_claim_events(conn: Connection, claims: list[dict]) -> list[int]:
                 "supersedes": c.get("supersedes"),
             }
             cur.execute(sql, params)
-            row = cur.fetchone()
-            out.append(row["id"] if isinstance(row, dict) else row[0])
+            out.append(_returning_id(cur.fetchone()))
     return out
 
 
@@ -578,8 +590,7 @@ def insert_concept(conn: Connection, concept: dict[str, Any]) -> int:
     }
     with conn.cursor() as cur:
         cur.execute(sql, params)
-        row = cur.fetchone()
-        return row["id"] if isinstance(row, dict) else row[0]
+        return _returning_id(cur.fetchone())
 
 
 def update_concept(conn: Connection, concept_id: int, fields: dict[str, Any]) -> bool:
@@ -648,8 +659,7 @@ def insert_draft(conn: Connection, draft: dict[str, Any]) -> int:
     }
     with conn.cursor() as cur:
         cur.execute(sql, params)
-        row = cur.fetchone()
-        return row["id"] if isinstance(row, dict) else row[0]
+        return _returning_id(cur.fetchone())
 
 
 def get_draft(conn: Connection, draft_id: int) -> dict | None:
@@ -799,8 +809,7 @@ def insert_citation(
     """
     with conn.cursor() as cur:
         cur.execute(sql, (page_id, session_id, domain, memory_id))
-        row = cur.fetchone()
-        return row["id"] if isinstance(row, dict) else row[0]
+        return _returning_id(cur.fetchone())
 
 
 # ── wiki.memos (grounded-theory audit trail) ──────────────────────────
@@ -839,8 +848,7 @@ def insert_memo(
                 author,
             ),
         )
-        row = cur.fetchone()
-        return row["id"] if isinstance(row, dict) else row[0]
+        return _returning_id(cur.fetchone())
 
 
 # ── Diagnostics ────────────────────────────────────────────────────────

--- a/mcp_server/infrastructure/workflow_graph_source_ast.py
+++ b/mcp_server/infrastructure/workflow_graph_source_ast.py
@@ -94,11 +94,12 @@ class _SyncLoop:
     def _ensure_loop(self) -> asyncio.AbstractEventLoop:
         if self._loop is None or self._loop.is_closed():
             self._loop = asyncio.new_event_loop()
+            loop = self._loop  # non-Optional local captured by the loop thread
             import threading
 
             def _run_forever():
-                asyncio.set_event_loop(self._loop)
-                self._loop.run_forever()
+                asyncio.set_event_loop(loop)
+                loop.run_forever()
 
             self._thread = threading.Thread(
                 target=_run_forever,

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": ["mcp_server"],
+  "exclude": [".claude", "tests_py", "benchmarks", "scripts", ".venv"],
+  "venvPath": ".",
+  "venv": ".venv",
+  "pythonVersion": "3.10",
+  "typeCheckingMode": "basic",
+  "reportMissingModuleSource": "none"
+}

--- a/scripts/check_pyright_ratchet.py
+++ b/scripts/check_pyright_ratchet.py
@@ -1,0 +1,125 @@
+"""Pyright per-rule ratchet gate.
+
+Compares current pyright error counts (grouped by rule) against a committed
+compact baseline and fails ONLY when a rule listed as ``--blocking`` exceeds
+its baseline count. Non-blocking rules are reported but never fail the build,
+so the type-check backlog can be burned down rule-by-rule while a rule that
+has already reached its floor can never silently regress.
+
+Why a compact ``{rule: count}`` baseline instead of the raw ``--outputjson``?
+The raw dump is ~200 KB of volatile ranges/messages; a per-rule count map is a
+few lines, reviewable in a PR diff, and is all the gate actually needs.
+
+Usage::
+
+    # regenerate the committed baseline from a fresh run:
+    pyright --outputjson mcp_server/ > pyright-current.json
+    python scripts/check_pyright_ratchet.py pyright-current.json \
+        typecheck-baseline.json --write-baseline
+
+    # gate (CI): fail if any blocking rule regressed past its baseline:
+    python scripts/check_pyright_ratchet.py pyright-current.json \
+        typecheck-baseline.json \
+        --blocking reportOptionalMemberAccess reportOptionalSubscript
+
+``current`` is the raw output of ``pyright --outputjson``.
+``baseline`` is the compact ``{rule: count}`` map this script writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def count_errors_by_rule(pyright_output: dict) -> dict[str, int]:
+    """Tally error-severity diagnostics by their pyright rule name."""
+    counts: dict[str, int] = {}
+    for diagnostic in pyright_output.get("generalDiagnostics", []):
+        if diagnostic.get("severity") != "error":
+            continue
+        rule = diagnostic.get("rule", "<no-rule>")
+        counts[rule] = counts.get(rule, 0) + 1
+    return counts
+
+
+def load_json(path: str) -> dict:
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def report(
+    current: dict[str, int],
+    baseline: dict[str, int],
+    blocking: set[str],
+) -> list[str]:
+    """Print a per-rule delta table; return the regressed blocking rules."""
+    regressed: list[str] = []
+    for rule in sorted(set(current) | set(baseline)):
+        now = current.get(rule, 0)
+        was = baseline.get(rule, 0)
+        marker = ""
+        if rule in blocking and now > was:
+            marker = "  <-- BLOCKING REGRESSION"
+            regressed.append(rule)
+        elif now < was:
+            marker = f"  (-{was - now} improved)"
+        elif now > was:
+            marker = f"  (+{now - was})"
+        gate = "[blocking]" if rule in blocking else "[tracked] "
+        print(f"  {gate} {rule}: {now} (baseline {was}){marker}")
+    return regressed
+
+
+def write_baseline(current: dict[str, int], path: str) -> int:
+    """Overwrite the baseline file from the current counts (sorted, stable)."""
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(dict(sorted(current.items())), handle, indent=2)
+        handle.write("\n")
+    total = sum(current.values())
+    print(f"Wrote baseline ({total} errors across {len(current)} rules) -> {path}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pyright per-rule ratchet gate")
+    parser.add_argument("current", help="pyright --outputjson output file")
+    parser.add_argument("baseline", help="compact {rule: count} baseline file")
+    parser.add_argument(
+        "--blocking",
+        nargs="*",
+        default=[],
+        help="rules that fail the build when their count exceeds baseline",
+    )
+    parser.add_argument(
+        "--write-baseline",
+        action="store_true",
+        help="overwrite the baseline from the current run and exit 0",
+    )
+    args = parser.parse_args()
+
+    current = count_errors_by_rule(load_json(args.current))
+
+    if args.write_baseline:
+        return write_baseline(current, args.baseline)
+
+    try:
+        baseline = load_json(args.baseline)
+    except FileNotFoundError:
+        print(f"FATAL: baseline {args.baseline} not found; run --write-baseline first")
+        return 2
+
+    total, baseline_total = sum(current.values()), sum(baseline.values())
+    print(f"Pyright ratchet — current {total} errors vs baseline {baseline_total}")
+    regressed = report(current, baseline, set(args.blocking))
+
+    if regressed:
+        print(f"\nFAIL: blocking rule(s) regressed past baseline: {sorted(regressed)}")
+        return 1
+    print("\nPASS: no blocking rule regressed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests_py/handlers/test_ingest_codebase.py
+++ b/tests_py/handlers/test_ingest_codebase.py
@@ -524,7 +524,9 @@ class TestUpstreamPagination:
 
         monkeypatch.setattr(cyp, "call_upstream", _call)
         result, err = await cyp._run_query("/g", "MATCH (n) RETURN n LIMIT 10")
-        assert result is None
+        # On any upstream error _run_query returns an empty dict (never None)
+        # plus a populated message — callers bail on err, not on result.
+        assert result == {}
         assert "non-advancing" in err
 
     @pytest.mark.asyncio

--- a/tests_py/invariants/test_I2_canonical_writer.py
+++ b/tests_py/invariants/test_I2_canonical_writer.py
@@ -33,12 +33,12 @@ _MCP_ROOT = _REPO_ROOT / "mcp_server"
 # OR be added here with a source-commented ADR justification.
 _ALLOWED_WRITERS: set[tuple[str, int]] = {
     # Canonical single-row writer (all callers route through this).
-    # bump_heat_raw — UPDATE at line 564 (shifted 548→564 by code added
+    # bump_heat_raw — UPDATE at line 566 (shifted 548→566 by code added
     # above it); still the one canonical single-row site.
-    ("infrastructure/pg_store.py", 564),
+    ("infrastructure/pg_store.py", 566),
     # A3 batched writer (homeostatic cohort branch + any other batch consumer).
-    # update_memories_heat_batch — SET line at 624 (shifted 608→624 likewise).
-    ("infrastructure/pg_store.py", 624),
+    # update_memories_heat_batch — SET line at 626 (shifted 608→626 likewise).
+    ("infrastructure/pg_store.py", 626),
     # SQLite parity (shifted 288→291, 332→335 by the P0-1a insert_memory
     # supersedes_id fix, which added rows above bump_heat_raw; both sites
     # remain the canonical bump_heat_raw / update_memories_heat_batch writers).

--- a/typecheck-baseline.json
+++ b/typecheck-baseline.json
@@ -1,0 +1,10 @@
+{
+  "reportArgumentType": 98,
+  "reportAssignmentType": 26,
+  "reportAttributeAccessIssue": 351,
+  "reportCallIssue": 37,
+  "reportGeneralTypeIssues": 2,
+  "reportMissingImports": 1,
+  "reportOperatorIssue": 1,
+  "reportReturnType": 52
+}


### PR DESCRIPTION
## Summary

Batch 0 of the pyright remediation. Introduces **deterministic pyright type checking in CI** with a per-rule baseline ratchet, and fixes the real **None-dereference bugs** that the two blocking rules surfaced.

## What changed

**Type-check infrastructure**
- `pyrightconfig.json` — `venvPath=.` / `venv=.venv`, basic mode, py3.10, `reportMissingModuleSource=none` for deterministic venv resolution.
- `scripts/check_pyright_ratchet.py` — per-rule gate (`--write-baseline`, `--blocking`); fails CI when a rule's error count rises above its recorded baseline.
- `typecheck-baseline.json` — current floor: 568 errors across 8 rules.
- `.github/workflows/ci.yml` — `typecheck` job builds `.venv`, installs deps + `pyright==1.1.410`; the gate **blocks** `reportOptionalMemberAccess` and `reportOptionalSubscript` (both now at 0), with **no `continue-on-error`**.
- `.gitignore` — ignore `.venv/` and `pyright-*.json`.

**Bug fixes — 15 None-deref guards**
- `handlers/ingest_codebase_cypher.py` — `_run_query` now returns `{}` (not `None`) on error paths; `tests_py/handlers/test_ingest_codebase.py` updated to the new `{}` contract.
- `infrastructure/pg_store.py` — guard `None` row.
- `infrastructure/pg_store_wiki.py` — new `_returning_id` helper applied across 5 sites.
- `infrastructure/ap_bridge.py` — guard `None` client.
- `infrastructure/workflow_graph_source_ast.py` — capture loop-local binding.
- `core/titans_memory.py` — guard `None` grad.

## Verification

- `reportOptionalMemberAccess` 9 → 0, `reportOptionalSubscript` 6 → 0.
- Zero regression on the remaining rules (baseline = 568).
- 46 targeted tests pass; `ruff` clean; `py_compile` OK.
- The CI ratchet gate re-verifies all of the above on this PR.

## Notes

The `--blocking` set is intentionally narrow (the two rules fully cleared) so the gate is green today while the 568-error baseline ratchets down in later batches. Working-doc files under `tasks/` are deliberately **not** part of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)