### PR TITLE
fix(wiki): headless drain uses Claude subscription by default, API key opt-in

### DIFF
--- a/mcp_server/handlers/consolidation/headless_authoring.py
+++ b/mcp_server/handlers/consolidation/headless_authoring.py
@@ -262,6 +262,23 @@ class _AnchorCandidate:
     suggested_kind: str
 
 
+_API_CREDENTIAL_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+
+
+def _subprocess_env() -> dict[str, str]:
+    """Child env for ``claude -p``, choosing the auth method.
+
+    Default ``CORTEX_HEADLESS_AUTH=subscription`` strips API-key credentials
+    so the CLI uses the logged-in subscription (no API charge). Setting
+    ``CORTEX_HEADLESS_AUTH=api`` passes the parent env through unchanged, so a
+    present ``ANTHROPIC_API_KEY`` bills the API — an explicit user opt-in.
+    """
+    mode = os.getenv("CORTEX_HEADLESS_AUTH", "subscription").strip().lower()
+    if mode == "api":
+        return dict(os.environ)
+    return {k: v for k, v in os.environ.items() if k not in _API_CREDENTIAL_KEYS}
+
+
 async def _claude_invoke(
     prompt: str,
     *,
@@ -286,15 +303,30 @@ async def _claude_invoke(
         Source: https://code.claude.com/docs/en/cli-reference (--tools flag)
                 https://code.claude.com/docs/en/headless (headless mode)
 
-    Control 2 — ``--bare``
-        Skips hooks, skills, plugins, MCP servers, auto-memory, CLAUDE.md,
-        AND project/user settings (including .claude/settings.json). This
-        defeats the malicious-settings vector (permissions.allow:["Bash"])
-        and the malicious-hook vector. Because ``--bare`` disables
-        OAuth/keychain auth, credentials MUST come from ANTHROPIC_API_KEY
-        in the environment (subprocess inherits env by default). If
-        ANTHROPIC_API_KEY is absent we FAIL CLOSED (see guard below).
-        Source: https://code.claude.com/docs/en/headless (--bare flag)
+    Control 2 — ``--safe-mode``
+        Disables CLAUDE.md, skills, plugins, hooks, MCP servers, custom
+        commands/agents, and project/user settings. This defeats the same
+        malicious-settings vector (permissions.allow:["Bash"]) and the
+        malicious-hook vector that ``--bare`` did. We use ``--safe-mode``
+        rather than ``--bare`` deliberately: ``--bare`` documents
+        "Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper via
+        --settings (OAuth and keychain are never read)" — i.e. it forces
+        API-key *billing* and ignores a logged-in subscription. ``--safe-mode``
+        gives the same config isolation while leaving OAuth/keychain intact,
+        so the drain runs on the user's Claude subscription (no API charge).
+        Source: https://code.claude.com/docs/en/cli-reference (--safe-mode, --bare)
+
+    Auth — subscription by default, API key opt-in
+        ``--safe-mode`` imposes no auth method; the CLI picks API-key billing
+        whenever ``ANTHROPIC_API_KEY`` is in its env, otherwise it falls back
+        to the keychain/OAuth subscription. ``create_subprocess_exec`` inherits
+        the parent env by default, so the auth is chosen via the child env:
+          * ``CORTEX_HEADLESS_AUTH=subscription`` (default) — strip
+            ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN`` from the child env
+            so the call runs on the logged-in subscription (no API charge).
+          * ``CORTEX_HEADLESS_AUTH=api`` — pass the parent env through, so a
+            present ``ANTHROPIC_API_KEY`` bills the API (the user opted in).
+        See ``_subprocess_env``. Verified against claude CLI 2.1.197.
 
     Control 3 — ``--output-format json``
         Emits a single JSON object.  Documented top-level fields we
@@ -316,26 +348,18 @@ async def _claude_invoke(
         require ``--sandbox`` (out of scope here).
         Source: https://code.claude.com/docs/en/cli-reference (--add-dir flag)
     """
-    # Fail closed if ANTHROPIC_API_KEY is absent: --bare disables
-    # OAuth/keychain, so the subprocess would have no credentials.
-    if not os.environ.get("ANTHROPIC_API_KEY"):
-        logger.warning(
-            "headless-authoring: ANTHROPIC_API_KEY not set — "
-            "headless authoring requires ANTHROPIC_API_KEY in bare/sandboxed mode; "
-            "skipping invocation to avoid unauthenticated subprocess"
-        )
-        return InvokeResult(text=None, cost_usd=0.0)
-
     # Control 1: --tools restricts (removes) Bash/Edit/Write from the model
-    # context. Control 2: --bare isolates config (no malicious settings/hooks).
-    # Control 3: --output-format json for structured cost telemetry.
+    # context. Control 2: --safe-mode isolates config (no malicious
+    # settings/hooks) WITHOUT disabling OAuth/keychain, so the call runs on
+    # the user's Claude subscription. Control 3: --output-format json for
+    # structured cost telemetry.
     # source: https://code.claude.com/docs/en/cli-reference
     #         https://code.claude.com/docs/en/headless
     argv = [
         _CLAUDE_BIN,
         "--print",
         "--no-session-persistence",
-        "--bare",
+        "--safe-mode",
         "--tools",
         "Read,Glob,Grep",
         "--output-format",
@@ -348,12 +372,17 @@ async def _claude_invoke(
 
     call_timeout = timeout if timeout is not None else float(CLAUDE_CALL_TIMEOUT_SEC)
 
+    # Default to the subscription; pass the API key through only when the
+    # user opts in via CORTEX_HEADLESS_AUTH=api. See _subprocess_env.
+    child_env = _subprocess_env()
+
     try:
         proc = await asyncio.create_subprocess_exec(
             *argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=cwd,
+            env=child_env,
         )
     except FileNotFoundError:
         logger.warning("headless-authoring: claude binary not found on PATH")

--- a/mcp_server/handlers/consolidation/wiki_maintenance.py
+++ b/mcp_server/handlers/consolidation/wiki_maintenance.py
@@ -38,13 +38,18 @@ def _headless_authoring_enabled() -> bool:
     """Opt-in gate for the ``claude -p`` headless authoring drain.
 
     Default OFF. Even with concurrency + budget throttling now in place,
-    each cycle spends real money via ANTHROPIC_API_KEY and is therefore
-    opt-in. Set ``CORTEX_HEADLESS_AUTHORING=1`` to enable.
+    each cycle spends a real ``claude -p`` budget (subscription quota by
+    default, or the API if opted in) and is therefore opt-in. Set
+    ``CORTEX_HEADLESS_AUTHORING=1`` to enable.
 
     When enabled, the drain runs under:
+      * ``CORTEX_HEADLESS_AUTH`` (default ``subscription``) — ``subscription``
+        runs on the logged-in Claude session (no API charge); ``api`` bills
+        ``ANTHROPIC_API_KEY`` instead.
       * ``CORTEX_HEADLESS_CONCURRENCY`` (default 4) — max in-flight calls.
       * ``CORTEX_HEADLESS_BUDGET_SEC`` (default 300) — wall-clock deadline.
-      * ``CORTEX_HEADLESS_USD_BUDGET`` (default 5.0) — per-cycle USD cap.
+      * ``CORTEX_HEADLESS_USD_BUDGET`` (default 5.0) — per-cycle cap on the
+        CLI's reported cost estimate (a notional throttle under subscription).
       * ``CORTEX_HEADLESS_MAX_ANCHOR_DRAINS`` / ``_MAX_FILE_DRAINS`` (default 8 each).
     Ungroundable scopes (prd, decisions, changelog, roadmap, accessibility,
     localization) are silently skipped — autonomous authoring of those
@@ -186,10 +191,10 @@ async def run_wiki_maintenance(
     # loop closes without human intervention. See
     # ``consolidation/headless_authoring.py``.
     #
-    # Opt-in only (default OFF): each cycle spends real money via
-    # ANTHROPIC_API_KEY.  The worker is now fully async (asyncio.gather
-    # + semaphore + budget), so it no longer blocks the event loop.
-    # Enable via ``CORTEX_HEADLESS_AUTHORING=1``.
+    # Opt-in only (default OFF): each cycle spends a real claude -p budget
+    # (subscription quota by default; the API only if CORTEX_HEADLESS_AUTH=api).
+    # The worker is now fully async (asyncio.gather + semaphore + budget), so
+    # it no longer blocks the event loop. Enable via ``CORTEX_HEADLESS_AUTHORING=1``.
     if not _headless_authoring_enabled():
         out["headless_authoring"] = {"status": "disabled"}
     else:

--- a/tests_py/handlers/test_headless_authoring_throttle.py
+++ b/tests_py/handlers/test_headless_authoring_throttle.py
@@ -586,7 +586,6 @@ class TestCancellationCleanup:
     ) -> None:
         from mcp_server.handlers.consolidation import headless_authoring as ha
 
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
         proc = _HangingProc()
 
         async def _fake_exec(*_a: Any, **_k: Any) -> _HangingProc:
@@ -602,3 +601,70 @@ class TestCancellationCleanup:
 
         assert proc.killed, "subprocess.kill() must run in finally on cancellation"
         assert proc.waited, "must reap the killed subprocess via wait()"
+
+
+class TestSubscriptionAuth:
+    """The drain runs on the subscription by default, API key only on opt-in.
+
+    Enforcing facts: argv carries ``--safe-mode`` (config isolation that keeps
+    OAuth/keychain) and never ``--bare`` (which forces API-key billing); the
+    default child env strips ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN``
+    (subscription); and ``CORTEX_HEADLESS_AUTH=api`` passes them through so a
+    user who wants API billing still can.
+    """
+
+    @staticmethod
+    def _patch_exec(monkeypatch: pytest.MonkeyPatch, captured: dict[str, Any]) -> None:
+        class _OkProc:
+            returncode = 0
+
+            async def communicate(self) -> Any:
+                return (b'{"result": "OK", "total_cost_usd": 0.0}', b"")
+
+        async def _fake_exec(*argv: Any, **kwargs: Any) -> _OkProc:
+            captured["argv"] = list(argv)
+            captured["env"] = kwargs.get("env")
+            return _OkProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+    @pytest.mark.asyncio
+    async def test_default_uses_safe_mode_and_strips_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from mcp_server.handlers.consolidation import headless_authoring as ha
+
+        monkeypatch.delenv("CORTEX_HEADLESS_AUTH", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-be-stripped")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok-should-be-stripped")
+        captured: dict[str, Any] = {}
+        self._patch_exec(monkeypatch, captured)
+
+        result = await ha._claude_invoke("prompt")
+
+        assert result.text == "OK"
+        assert "--safe-mode" in captured["argv"]
+        assert "--bare" not in captured["argv"]
+        env = captured["env"]
+        assert env is not None, "must pass an explicit env to strip credentials"
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_AUTH_TOKEN" not in env
+
+    @pytest.mark.asyncio
+    async def test_api_mode_passes_api_key_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from mcp_server.handlers.consolidation import headless_authoring as ha
+
+        monkeypatch.setenv("CORTEX_HEADLESS_AUTH", "api")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-user-opted-in")
+        captured: dict[str, Any] = {}
+        self._patch_exec(monkeypatch, captured)
+
+        result = await ha._claude_invoke("prompt")
+
+        assert result.text == "OK"
+        assert "--safe-mode" in captured["argv"]
+        env = captured["env"]
+        assert env is not None
+        assert env.get("ANTHROPIC_API_KEY") == "sk-user-opted-in"


### PR DESCRIPTION
## What

The headless wiki-authoring drain (`_claude_invoke`) billed the **API** and ignored a logged-in **Claude subscription** — and on a subscription-only machine it never ran at all. This makes the subscription the default and keeps API billing as an explicit opt-in.

## Root cause

`--bare` documents (per `claude --help`, CLI 2.1.197): *"Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper via --settings (OAuth and keychain are never read)"*. So `--bare` forces API billing. Its companion fail-closed guard (`if not ANTHROPIC_API_KEY: skip`) meant the whole drain was skipped when only a subscription was present.

A second, subtler trap: even **without** `--bare`, the CLI prefers `ANTHROPIC_API_KEY` when it is in the env (billing the API). `create_subprocess_exec` inherits the parent env by default, so a stray key would still win.

## Change

- **`--bare` → `--safe-mode`**: same config isolation (no CLAUDE.md / skills / plugins / hooks / MCP / settings — security control B-1 intact), but `--safe-mode` leaves OAuth/keychain readable, so the call runs on the subscription.
- **Removed** the `ANTHROPIC_API_KEY` fail-closed guard.
- **New `_subprocess_env()`** selects auth via `CORTEX_HEADLESS_AUTH` (default `subscription`):
  - `subscription` — strip `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` from the child env → keychain/OAuth → **no API charge**.
  - `api` — pass the parent env through → `ANTHROPIC_API_KEY` bills the API (explicit user opt-in).
- Pass an explicit `env=` to `create_subprocess_exec`.
- Docstrings + `wiki_maintenance.py` env-knob docs updated. Note: under subscription, `total_cost_usd` (feeding `CORTEX_HEADLESS_USD_BUDGET`) is a **notional** estimate — a volume throttle, not real spend.

## Security

Control B-1 preserved: `--safe-mode` blocks the malicious-settings (`permissions.allow:["Bash"]`) and malicious-hook vectors that `--bare` blocked. Control 1 (`--tools Read,Glob,Grep`) unchanged.

## Verification

- Live smoke test: `claude --print --safe-mode --tools Read,Glob,Grep --output-format json` → returncode 0, `result: "OK"`, **no API key in env** (subscription path confirmed).
- `pytest tests_py/handlers/test_headless_authoring_throttle.py` — **16 passed** (added subscription + api-mode auth tests).
- `pytest tests_py/handlers/test_consolidate.py test_consolidate_telemetry.py tests_py/core/test_wiki_coverage.py` — **37 passed**.
- `ruff format --check .` + `ruff check .` — clean (0.15.20, matches CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019o58McF4LRfvGNNXaqG2Au