### PR TITLE
chore(release): v3.25.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Persistent memory and cognitive profiling plugins for Claude Code",
-    "version": "3.24.1"
+    "version": "3.25.0"
   },
   "plugins": [
     {
       "name": "cortex",
       "source": "./",
       "description": "Persistent memory and cognitive profiling for Claude Code — thermodynamic memory with heat/decay, intent-aware retrieval, biological plasticity, codebase intelligence, and cognitive profiling. 43 MCP tools (46 with the optional automatised-pipeline + prd-spec-generator integrations) with enriched schemas (visualization extracted to the standalone cortex-viz MCP). PostgreSQL + pgvector in CLI mode; automatic SQLite fallback in Cowork/sandboxed mode. v3.17.0 — autonomous per-project wiki: SessionStart auto-spawns a 6-hour consolidate cycle; a headless `claude -p` worker drains the curation-gap queue, calls codebase-intelligence MCP tools to ground each section in the real call graph, and authors missing anchor pages (architecture / services / api / data-flow / operations / decisions / PRD) per project from the source tree. 15 canonical scopes × 13 file sections; per-project dashboards under `wiki/_dashboards/`. Mermaid diagrams have a 🔍 lens with zoom + pan. Workflow graph with caller-qualified CALLS chains rendering full method-to-method dependencies (native tree-sitter, no AP required). Side panel humanized for non-technical users. Ingests codebase analysis (ai-automatised-pipeline) and PRDs (prd-spec-generator) into wiki + memory + knowledge graph. Docker image available.",
-      "version": "3.24.1",
+      "version": "3.25.0",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cortex",
   "description": "Persistent memory for Claude Code — remembers across sessions automatically. Install and forget. Scientific retrieval backed by 72 published references.",
-  "version": "3.24.1",
+  "version": "3.25.0",
   "author": {
     "name": "Clement Deust",
     "email": "admin@ai-architect.tools"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [3.25.0] - 2026-07-01
+
+Headless wiki-authoring hardened end-to-end (subscription billing, full zetetic
+agent roster, anti-recursion guard) plus the active-forgetting memory module and
+Windows portability fixes.
+
+### Added
+- **Active forgetting (Module #6).** `core/active_forgetting.py` +
+  `handlers/consolidation/forgetting.py`: two independent Drosophila dopaminergic
+  forgetting circuits — permanent Rac1 trace erosion (chronic interference ×
+  stage vulnerability) and transient DAMB retrieval block (Davis & Zhong 2017,
+  Sabandal et al. 2021). Shipped with a falsification harness left failing where
+  the model genuinely diverges from biology. (#69)
+- **Safe headless wiki-authoring drain.** Async `claude -p` invocation
+  (`asyncio.create_subprocess_exec` + `wait_for`) that no longer blocks the event
+  loop; per-cycle concurrency / wall-clock / USD budget via `CORTEX_HEADLESS_*`
+  knobs (defaults 4 / 300s / $5); anti-fabrication `Scope.groundable` filter so
+  non-derivable scopes (prd/decisions/changelog/roadmap/accessibility/
+  localization) are never authored from scratch. (#70)
+- **Full zetetic agent roster for wiki authoring.** Two-mode argv
+  (`claude_cli._build_argv`, gated on `CORTEX_HEADLESS_AGENTS`, default on):
+  agents mode loads the user roster only (`--setting-sources user`, project/local
+  excluded so a malicious repo cannot inject settings/hooks) with a hard
+  `--disallowedTools Write,Edit,Bash,NotebookEdit` deny ceiling that propagates to
+  delegated subagents; solo mode falls back to `--safe-mode`. New
+  `hooks/_headless_guard.py` no-ops every Cortex hook under
+  `CORTEX_HEADLESS_AUTHORING_CHILD=1`, stopping consolidation→authoring recursion
+  and memory pollution. (#72)
+
+### Fixed
+- **Windows cross-platform portability.** macOS/Linux compatibility preserved. (#68)
+- **Headless drain billing.** The drain now uses a logged-in Claude subscription
+  by default with API billing as explicit opt-in; previously `--bare` forced
+  `ANTHROPIC_API_KEY` and the fail-closed guard skipped the whole drain on
+  subscription-only machines. (#71)
+- **Silent drain failure since 3.24 (root cause).** The variadic `--add-dir`
+  swallowed the trailing positional prompt, so every drain with a `source_root`
+  failed silently; the prompt is now passed via STDIN. (#72)
+
+### Changed
+- Bump `pydantic-settings` 2.14.0 → 2.14.2 (upstream security patch:
+  `NestedSecretsSettingsSource` no longer follows symlinks outside
+  `secrets_dir`). (#67)
+
 ## [3.24.1] - 2026-06-23
 
 Cross-backend `recall` fix — PostgreSQL users could not use `recall`.

--- a/manifest.json
+++ b/manifest.json
@@ -133,5 +133,5 @@
       "type": "string"
     }
   },
-  "version": "3.24.1"
+  "version": "3.25.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hypermnesia-mcp"
-version = "3.24.1"
+version = "3.25.0"
 description = "Scientifically-grounded memory system based on computational neuroscience research"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/cdeust/Cortex",
     "source": "github"
   },
-  "version": "3.24.1",
+  "version": "3.25.0",
   "packages": [
     {
       "registry_type": "pypi",
       "identifier": "hypermnesia-mcp",
-      "version": "3.24.1",
+      "version": "3.25.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Release **v3.25.0** — version bump + CHANGELOG for everything merged since v3.24.1 (#67–#72).

## Semver rationale
`feat` commits since the last release (active forgetting #69, safe headless drain #70, full zetetic roster #72) → **minor** bump `3.24.1 → 3.25.0`.

## Changes in this release
### Added
- Active forgetting module — two Drosophila dopaminergic circuits, Rac1 erosion + DAMB block (#69)
- Safe headless wiki-authoring drain — async, budgeted, anti-fabrication (#70)
- Full zetetic agent roster for wiki authoring + anti-recursion hook guard (#72)
### Fixed
- Windows cross-platform portability (#68)
- Headless drain uses Claude subscription by default, API billing opt-in (#71)
- Root cause: variadic `--add-dir` swallowed the prompt → silent drain failure since 3.24 (#72)
### Changed
- `pydantic-settings` 2.14.0 → 2.14.2 security patch (#67)

## Files touched
Version string `3.24.1 → 3.25.0` across `pyproject.toml`, `server.json` (×2), `manifest.json`, `.claude-plugin/marketplace.json` (×2), `.claude-plugin/plugin.json`; new `[3.25.0]` CHANGELOG section.

## Post-merge
Tag `v3.25.0` on the merge commit → triggers `release.yml` (tests → GitHub Release w/ auto-notes → best-effort PyPI publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019o58McF4LRfvGNNXaqG2Au