### PR TITLE
ci: resilient HF pre-download + offline tests (fix main CI flake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,15 +83,35 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev,postgresql,codebase]"
 
+      # Populate the HuggingFace cache before the (offline) test run. A transient
+      # huggingface.co blip must not leave the cache empty — that surfaced as 58
+      # spurious "couldn't connect to huggingface.co" test failures on a single
+      # matrix leg (CI run 28495801728, Python 3.10, 2026-07-01) while every other
+      # leg was fine. Retry with backoff so a blip self-heals; fail loudly here (no
+      # continue-on-error) instead of cascading into a misleading test failure.
       - name: Pre-download embedding model
-        run: python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2', device='cpu')"
-        continue-on-error: true
+        run: |
+          for attempt in 1 2 3 4 5; do
+            python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2', device='cpu')" && exit 0
+            echo "HF pre-download attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
+            sleep $((attempt * 10))
+          done
+          echo "HF pre-download failed after 5 attempts" >&2
+          exit 1
 
+      # Offline: the model is already cached by the step above, so tests must never
+      # reach out to huggingface.co mid-suite — deterministic and flake-free.
       - name: Run tests
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
         run: pytest --tb=short -q
 
       - name: Run tests with coverage
         if: matrix.python-version == '3.12'
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
         run: pytest --cov=mcp_server --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage
@@ -139,11 +159,22 @@ jobs:
       - name: Install dependencies (no postgresql extra)
         run: pip install -e ".[dev,sqlite]"
 
+      # Retry-with-backoff, fail-loudly: see the `test` job's pre-download step
+      # for the root-cause rationale (CI run 28495801728, 2026-07-01).
       - name: Pre-download embedding model
-        run: python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2', device='cpu')"
-        continue-on-error: true
+        run: |
+          for attempt in 1 2 3 4 5; do
+            python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2', device='cpu')" && exit 0
+            echo "HF pre-download attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
+            sleep $((attempt * 10))
+          done
+          echo "HF pre-download failed after 5 attempts" >&2
+          exit 1
 
       - name: Run SQLite backend tests
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
         # Scope: the SQLite fallback is intentionally NOT at full feature parity
         # with the mandatory PostgreSQL backend (some SqliteMemoryStore methods
         # and PG-specific tests do not apply). Run the dedicated SQLite backend
@@ -192,14 +223,27 @@ jobs:
           mcp_server.core.staleness, mcp_server.doctor, mcp_server.doctor_mcp;
           print('windows import smoke OK')"
 
+      # Retry-with-backoff, fail-loudly: see the `test` job's pre-download step
+      # for the root-cause rationale (CI run 28495801728, 2026-07-01). shell: bash
+      # so the retry loop runs under Git Bash rather than the Windows default pwsh.
       - name: Pre-download embedding model
-        run: python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2', device='cpu')"
-        continue-on-error: true
+        shell: bash
+        run: |
+          for attempt in 1 2 3 4 5; do
+            python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2', device='cpu')" && exit 0
+            echo "HF pre-download attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
+            sleep $((attempt * 10))
+          done
+          echo "HF pre-download failed after 5 attempts" >&2
+          exit 1
 
       # Scope (explicit, not silent): the portability tests plus the modules
       # carrying Windows-specific branches and the SQLite backend suite. The
       # full PG suite is not run here — it is covered by the ubuntu `test` job.
       - name: Run portability + backend tests
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
         run: >-
           pytest --tb=short -q
           tests_py/shared/test_platform.py


### PR DESCRIPTION
## Problem

`main` CI failed on run **28495801728** — **58 tests** failed on the **Python 3.10** matrix leg only, all with:

> `OSError: We couldn't connect to 'https://huggingface.co' ... and couldn't find them in the cached files.`

The other legs (3.11/3.12/3.13) passed. This is a transient-network / cache-cold flake, not a code defect: the model (`all-MiniLM-L6-v2`) is fine.

## Root cause

The `Pre-download embedding model` step had **no retry** and `continue-on-error: true`. When huggingface.co blipped on the 3.10 runner, the step was masked as ✓ but the HF cache stayed empty. The test suite — which is not offline-aware — then tried to re-fetch the model at runtime and cascaded into 58 misleading failures.

## Fix (all three pre-download sites: `test`, `test-sqlite`, `test-windows`)

- **Retry** the download 5× with linear backoff → a transient blip self-heals.
- **Drop `continue-on-error`** → a genuine persistent failure surfaces clearly at the download step, not as a confusing test cascade.
- **`HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE`** on the test-run steps → the model is already cached, so tests never touch the network mid-suite (deterministic, flake-free).
- Windows pre-download runs under `shell: bash` for the retry loop.

## Verification

- YAML validated (`yaml.safe_load`).
- CI on this PR is the proof — all matrix legs must go green offline-from-cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)