### PR TITLE
docs: refresh banner counts for v4.0

### DIFF
--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -21,7 +21,7 @@
   <text class="mono" x="32" y="174" fill="#e0e0e0" font-size="14" font-weight="700">persistent memory for Claude Code</text>
 
   <!-- Stats -->
-  <text class="mono" x="32" y="208" fill="#e0e0e0" font-size="12">43 MCP tools  ·  23 bio mechanisms  ·  9 hooks  ·  3000+ tests  ·  72 citations</text>
+  <text class="mono" x="32" y="208" fill="#e0e0e0" font-size="12">44 MCP tools  ·  36 bio mechanisms  ·  9 hooks  ·  3000+ tests  ·  97 citations</text>
 
   <!-- Benchmarks -->
   <text class="mono" x="32" y="244" fill="#bec3be" font-size="11">98.4% R@10 LongMemEval  ·  94.2% R@10 LoCoMo  ·  +33.4% BEAM-10M</text>


### PR DESCRIPTION
Updates the banner stat line to the v4.0 numbers (44 MCP tools · 36 bio mechanisms · 97 citations), matching the README/CLAUDE.md/bibliography. Cosmetic SVG-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4KjBXAdabUoy5K6Hi41GC