### PR TITLE
feat(memory): supersession write-path — remember(supersedes_id) + atomic insert+edge

### DIFF
--- a/mcp_server/handlers/remember.py
+++ b/mcp_server/handlers/remember.py
@@ -19,6 +19,7 @@ from mcp_server.handlers.remember_helpers import (
     try_block_replica_upsert,
     try_curation,
     update_user_mood_ema,
+    validate_supersede_target,
 )
 from mcp_server.handlers.remember_response import build_merge_response
 from mcp_server.infrastructure import wiki_store
@@ -48,8 +49,14 @@ schema = {
             },
             "action": {
                 "type": "string",
-                "enum": ["stored", "merged", "rejected"],
-                "description": "stored=new row; merged=folded into the most-similar existing memory; rejected=redundant per the predictive-coding gate.",
+                "enum": [
+                    "stored",
+                    "merged",
+                    "rejected",
+                    "superseded",
+                    "superseded_conflict",
+                ],
+                "description": "stored=new row; merged=folded into the most-similar existing memory; rejected=redundant per the predictive-coding gate; superseded=new row replaces an older version (append-only edge posted); superseded_conflict=another writer superseded the target first — nothing was kept, rebase and retry.",
             },
             "reason": {
                 "type": "string",
@@ -58,6 +65,18 @@ schema = {
             "merged_with": {
                 "type": "integer",
                 "description": "ID of the existing memory (PG bigint) when action=merged.",
+            },
+            "superseded_id": {
+                "type": "integer",
+                "description": "ID of the replaced memory when action=superseded.",
+            },
+            "supersede_target_id": {
+                "type": "integer",
+                "description": "Requested supersession target when the supersede path rejected or conflicted.",
+            },
+            "current_superseded_by_id": {
+                "type": ["integer", "null"],
+                "description": "The version that currently supersedes the target (present on supersede rejection/conflict so the caller can rebase).",
             },
             "heat": {
                 "type": "number",
@@ -137,9 +156,27 @@ schema = {
                 "type": "boolean",
                 "description": (
                     "Bypass the predictive-coding write gate and always insert. "
-                    "Use sparingly — anchored facts and curated lessons only."
+                    "Use sparingly — anchored facts and curated lessons only. "
+                    "Combined with supersedes_id this is the sovereign human "
+                    "correction: the gate is bypassed but the supersession "
+                    "edge is still posted."
                 ),
                 "default": False,
+            },
+            "supersedes_id": {
+                "type": "integer",
+                "minimum": 1,
+                "description": (
+                    "ID of the memory this content replaces (append-only "
+                    "correction). A new row is inserted, the target's "
+                    "superseded_by_id is compare-and-set to it, and recall "
+                    "demotes the old version. Rejected when the target is "
+                    "missing or already superseded — an existing version "
+                    "chain is never forked silently. Bypasses automatic "
+                    "curation (the intent is explicit); the write gate "
+                    "still applies unless force=true."
+                ),
+                "examples": [4255039],
             },
             "agent_topic": {
                 "type": "string",
@@ -295,6 +332,16 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
         initial_heat,
     ) = _parse_args(args)
     store, emb_engine = _get_store(), get_embedding_engine()
+
+    # Explicit supersession target (PRD dual-access increment 1, item ①):
+    # fail fast before any embedding/gate work when the target is missing
+    # or already superseded — an existing chain is never forked silently.
+    supersedes_id, supersede_rejection = validate_supersede_target(
+        args.get("supersedes_id"), store
+    )
+    if supersede_rejection is not None:
+        return supersede_rejection
+
     domain = _resolve_domain(directory, args.get("domain", ""))
     embedding = emb_engine.encode(content)
     valence = thermodynamics.compute_valence(content)
@@ -341,30 +388,40 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
     else:
         global_reason = "explicit"
 
-    # Block-replica upsert: if the incoming memory is a system-memory block
-    # snapshot (tagged 'memory-replica' + 'vpath:…'), refresh the existing row
-    # in-place rather than inserting a new one (one row per block file).
-    # Normal writes are completely unaffected — this branch exits early on
-    # any write that isn't a replica. contract: zetetic-team-subagents memory/contract.md §8b
-    upserted, upsert_id = try_block_replica_upsert(
-        content, embedding, tags, source, store
-    )
-    if upserted and upsert_id is not None:
-        return {
-            "stored": True,
-            "memory_id": upsert_id,
-            "action": "stored",
-            "reason": "block-replica-refreshed",
-        }
+    mid: int | None
+    if supersedes_id is not None:
+        # Explicit supersession: the caller's intent overrides automatic
+        # curation (no merge/link second-guessing) and the block-replica
+        # upsert. force=True composes with it — the gate was bypassed
+        # above, yet the edge is still posted below (sovereign human
+        # correction; previously force and supersede were exclusive
+        # because force early-returned "create" inside try_curation).
+        action, mid = "supersede", supersedes_id
+    else:
+        # Block-replica upsert: if the incoming memory is a system-memory block
+        # snapshot (tagged 'memory-replica' + 'vpath:…'), refresh the existing row
+        # in-place rather than inserting a new one (one row per block file).
+        # Normal writes are completely unaffected — this branch exits early on
+        # any write that isn't a replica. contract: zetetic-team-subagents memory/contract.md §8b
+        upserted, upsert_id = try_block_replica_upsert(
+            content, embedding, tags, source, store
+        )
+        if upserted and upsert_id is not None:
+            return {
+                "stored": True,
+                "memory_id": upsert_id,
+                "action": "stored",
+                "reason": "block-replica-refreshed",
+            }
 
-    action, mid = try_curation(
-        content, embedding, force, store, emb_engine, tags, mod["heat"]
-    )
-    if action == "merge":
-        # Mood signal still updates on merge — the user authored the content,
-        # whether we keep it as a new row or fold it into an existing one.
-        update_user_mood_ema(content, source, store)
-        return build_merge_response(mid, domain, mod, gate)
+        action, mid = try_curation(
+            content, embedding, force, store, emb_engine, tags, mod["heat"]
+        )
+        if action == "merge":
+            # Mood signal still updates on merge — the user authored the content,
+            # whether we keep it as a new row or fold it into an existing one.
+            update_user_mood_ema(content, source, store)
+            return build_merge_response(mid, domain, mod, gate)
 
     result = insert_and_post_process(
         content,

--- a/mcp_server/handlers/remember_helpers.py
+++ b/mcp_server/handlers/remember_helpers.py
@@ -576,9 +576,11 @@ def insert_and_post_process(
     if action == "supersede" and merged_id is not None:
         # Close the supersession chain: forward edge (new.supersedes_id)
         # is in the record above; this stamps the old row's back-pointer
-        # so recall_memories() demotes it as a stale version.
-        if hasattr(store, "set_superseded_by"):
-            store.set_superseded_by(merged_id, mem_id)
+        # so recall_memories() demotes it as a stale version. The edge is
+        # compare-and-set — False means another writer superseded the
+        # target between validation and here.
+        if not store.set_superseded_by(merged_id, mem_id):
+            return _build_supersede_conflict(mem_id, merged_id, store)
     tids, tagged, slot = _run_post_store(
         mem_id,
         content,
@@ -612,7 +614,76 @@ def insert_and_post_process(
     response["source_attribution"] = attribution
     if attribution == "inferred":
         response["confabulation_risk"] = True
+    if action == "supersede" and merged_id is not None:
+        response["superseded_id"] = merged_id
     return response
+
+
+def _build_supersede_conflict(
+    mem_id: int, merged_id: int, store: MemoryStore
+) -> dict[str, Any]:
+    """Undo the freshly inserted row after a lost supersession race.
+
+    Rollback-over-orphan: keeping the unlinked row would silently fork the
+    version chain (two competing heads at recall time), while the caller
+    still holds the content and can rebase on the winning version and
+    retry — so the insert is deleted and the conflict reported. Never
+    silent: the response names the target, the head that won, and — if
+    the delete itself failed — the orphaned row id.
+    """
+    current = store.get_memory(merged_id) or {}
+    response: dict[str, Any] = {
+        "stored": False,
+        "action": "superseded_conflict",
+        "reason": "supersede_target_no_longer_head",
+        "supersede_target_id": merged_id,
+        "current_superseded_by_id": current.get("superseded_by_id"),
+    }
+    if not store.delete_memory(mem_id):
+        response["orphan_memory_id"] = mem_id
+    return response
+
+
+def validate_supersede_target(
+    supersedes_raw: Any, store: MemoryStore
+) -> tuple[int | None, dict[str, Any] | None]:
+    """Resolve and validate an explicit supersession target.
+
+    Returns (supersedes_id, None) when the target is a valid chain head,
+    (None, rejection_response) when the argument is malformed, the target
+    is missing, or the target is already superseded — an existing chain is
+    never forked silently. The head-ness read here is advisory; the
+    compare-and-set in the store is the authority under concurrency.
+    """
+    if supersedes_raw is None:
+        return None, None
+    try:
+        supersedes_id = int(supersedes_raw)
+    except (TypeError, ValueError):
+        supersedes_id = 0
+    if supersedes_id <= 0:
+        return None, {
+            "stored": False,
+            "action": "rejected",
+            "reason": "invalid_supersedes_id",
+        }
+    target = store.get_memory(supersedes_id)
+    if target is None:
+        return None, {
+            "stored": False,
+            "action": "rejected",
+            "reason": "supersede_target_not_found",
+            "supersede_target_id": supersedes_id,
+        }
+    if target.get("superseded_by_id") is not None:
+        return None, {
+            "stored": False,
+            "action": "rejected",
+            "reason": "supersede_target_already_superseded",
+            "supersede_target_id": supersedes_id,
+            "current_superseded_by_id": target.get("superseded_by_id"),
+        }
+    return supersedes_id, None
 
 
 # ── User-mood EMA hook (Bower 1981 mood-congruent recall, signal side) ──

--- a/mcp_server/handlers/remember_helpers.py
+++ b/mcp_server/handlers/remember_helpers.py
@@ -571,16 +571,19 @@ def insert_and_post_process(
     )
     record["agent_context"] = agent_context
     record["is_global"] = is_global
-    mem_id = store.insert_memory(record)
-    _link_if_needed(action, merged_id, mem_id, store)
+    superseded_head: int | None = None
     if action == "supersede" and merged_id is not None:
-        # Close the supersession chain: forward edge (new.supersedes_id)
-        # is in the record above; this stamps the old row's back-pointer
-        # so recall_memories() demotes it as a stale version. The edge is
-        # compare-and-set — False means another writer superseded the
-        # target between validation and here.
-        if not store.set_superseded_by(merged_id, mem_id):
-            return _build_supersede_conflict(mem_id, merged_id, store)
+        # Atomic insert + supersession edge (biomimetic reconsolidation): the
+        # new row and the head's back-pointer commit as ONE transaction, so a
+        # lost compare-and-set rolls the insert back — never an orphaned,
+        # disconnected row. On a race the write rebases onto the current head;
+        # only pathological contention returns a conflict (nothing committed).
+        mem_id, superseded_head = store.supersede_atomic(record, merged_id)
+        if mem_id is None:
+            return _build_supersede_conflict(merged_id, superseded_head)
+    else:
+        mem_id = store.insert_memory(record)
+    _link_if_needed(action, merged_id, mem_id, store)
     tids, tagged, slot = _run_post_store(
         mem_id,
         content,
@@ -615,33 +618,34 @@ def insert_and_post_process(
     if attribution == "inferred":
         response["confabulation_risk"] = True
     if action == "supersede" and merged_id is not None:
-        response["superseded_id"] = merged_id
+        # The row actually superseded is the chain head the edge landed on —
+        # equal to merged_id unless a concurrent race rebased the write.
+        response["superseded_id"] = superseded_head
     return response
 
 
 def _build_supersede_conflict(
-    mem_id: int, merged_id: int, store: MemoryStore
+    target_id: int, current_head_id: int | None
 ) -> dict[str, Any]:
-    """Undo the freshly inserted row after a lost supersession race.
+    """Report a supersession that could not converge on a stable chain head.
 
-    Rollback-over-orphan: keeping the unlinked row would silently fork the
-    version chain (two competing heads at recall time), while the caller
-    still holds the content and can rebase on the winning version and
-    retry — so the insert is deleted and the conflict reported. Never
-    silent: the response names the target, the head that won, and — if
-    the delete itself failed — the orphaned row id.
+    Reached only when ``store.supersede_atomic`` exhausts its bounded
+    reconsolidation rebase: every attempt lost the compare-and-set to a
+    concurrent writer moving the head. Because each attempt runs the insert and
+    the edge inside ONE transaction, a lost attempt rolls the insert back —
+    nothing is ever committed, so no row is orphaned and none is left
+    disconnected. The caller still holds the content and the id of the current
+    head, so it can rebase and retry (optimistic concurrency, 409-style). There
+    is deliberately no delete and no orphan_memory_id: the atomic rollback makes
+    both impossible, a stronger guarantee than the former rollback-over-orphan.
     """
-    current = store.get_memory(merged_id) or {}
-    response: dict[str, Any] = {
+    return {
         "stored": False,
         "action": "superseded_conflict",
-        "reason": "supersede_target_no_longer_head",
-        "supersede_target_id": merged_id,
-        "current_superseded_by_id": current.get("superseded_by_id"),
+        "reason": "supersede_chain_head_moving",
+        "supersede_target_id": target_id,
+        "current_head_id": current_head_id,
     }
-    if not store.delete_memory(mem_id):
-        response["orphan_memory_id"] = mem_id
-    return response
 
 
 def validate_supersede_target(

--- a/mcp_server/infrastructure/pg_store.py
+++ b/mcp_server/infrastructure/pg_store.py
@@ -104,6 +104,29 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+# ── supersede_atomic operational bounds (engineering, not algorithmic) ──────
+# Bounded optimistic-concurrency retry for the reconsolidation rebase. On the
+# common single-writer path the first attempt commits; the bound only bites
+# under concurrent supersession of the SAME chain, where each retry re-walks to
+# the head another writer just moved. Exhausting it returns a 409-style conflict
+# to the caller (nothing committed) rather than looping forever.
+_SUPERSEDE_REBASE_ATTEMPTS = 5
+# Defensive recursion guard for the chain-head walk. Chains are acyclic by
+# construction — supersede_atomic only ever extends the OPEN head — so this cap
+# is a cycle backstop, not a semantic limit on how many times a fact may be
+# corrected.
+_CHAIN_HEAD_MAX_DEPTH = 100_000
+
+
+class _SupersedeCasConflict(Exception):
+    """The chain head moved under our compare-and-set.
+
+    Raised inside the supersede_atomic transaction to force a full rollback of
+    the attempt (the freshly inserted row is undone — never committed, never
+    orphaned) before rebasing onto the new head and retrying.
+    """
+
+
 class PgMemoryStore(
     PgEntityMixin,
     PgEntityMergeMixin,
@@ -440,27 +463,11 @@ class PgMemoryStore(
 
     # ── Memory CRUD ───────────────────────────────────────────────────
 
-    def insert_memory(self, data: dict[str, Any]) -> int:
-        """Insert a memory and return its ID."""
-        now = _now_iso()
-        embedding = self._bytes_to_vector(data.get("embedding"))
-        # Normalize free-form dates to ISO 8601 for proper recency ranking
-        raw_created = data.get("created_at")
-        if raw_created and isinstance(raw_created, str) and "T" not in raw_created:
-            from mcp_server.core.temporal import normalize_date_to_iso
-
-            raw_created = normalize_date_to_iso(raw_created) or raw_created
-        # A3 decay clock: anchor heat_base_set_at to the event date, not NOW().
-        # effective_heat() decays from COALESCE(heat_base_set_at, last_accessed,
-        # created_at); for a never-touched insert the faithful "last canonical
-        # touch" IS the event (created_at), so a historical-dated memory
-        # (import / benchmark loader) engages the SQL forgetting law instead of
-        # reading hours_elapsed≈0. No-op for fresh writes where created_at≈now.
-        # Source: docs/program/phase-3-a3-migration-design.md §3.1 (clock = last
-        # touch); benchmark root-cause memory 4202968.
-        heat_base_anchor = data.get("heat_base_set_at") or raw_created or now
-        row = self._execute(
-            """INSERT INTO memories (
+    # Single source of truth for the memory INSERT. insert_memory() runs it on
+    # a pooled autocommit connection (one row per statement); supersede_atomic()
+    # runs it inside an explicit transaction so the row and its supersession
+    # edge commit — or roll back — as one unit, never leaving a disconnected row.
+    _INSERT_MEMORY_SQL = """INSERT INTO memories (
                 content, embedding, tags, source, domain,
                 directory_context, created_at, last_accessed, heat_base_set_at,
                 heat_base, surprise_score, importance,
@@ -486,69 +493,162 @@ class PgMemoryStore(
                 %(is_global)s, %(stage_entered_at)s,
                 %(arousal)s, %(dominant_emotion)s, %(supersedes_id)s,
                 %(source_attribution)s, %(stimulus_signature)s, %(extinction_strength)s
-            ) RETURNING id""",
-            {
-                "content": data["content"],
-                "embedding": embedding,
-                "tags": json.dumps(data.get("tags", [])),
-                "source": data.get("source", ""),
-                "domain": data.get("domain", ""),
-                "directory_context": data.get("directory_context", ""),
-                "created_at": raw_created or now,
-                "last_accessed": now,
-                "heat_base_set_at": heat_base_anchor,
-                "heat": data.get("heat", 1.0),
-                "surprise_score": data.get("surprise_score", 0.0),
-                "importance": data.get("importance", 0.5),
-                "emotional_valence": data.get("emotional_valence", 0.0),
-                "confidence": data.get("confidence", 1.0),
-                "store_type": data.get("store_type", "episodic"),
-                "is_protected": data.get("is_protected", False),
-                "consolidation_stage": data.get("consolidation_stage", "labile"),
-                "theta_phase": data.get("theta_phase_at_encoding", 0.0),
-                "encoding_strength": data.get("encoding_strength", 1.0),
-                "separation_index": data.get("separation_index", 0.0),
-                "interference_score": data.get("interference_score", 0.0),
-                "schema_match_score": data.get("schema_match_score", 0.0),
-                "schema_id": data.get("schema_id"),
-                "hippocampal_dependency": data.get("hippocampal_dependency", 1.0),
-                "is_benchmark": data.get("is_benchmark", False),
-                "agent_context": data.get("agent_context", ""),
-                "is_global": data.get("is_global", False),
-                "stage_entered_at": data.get("stage_entered_at") or raw_created or now,
-                "arousal": data.get("arousal", 0.0),
-                "dominant_emotion": data.get("dominant_emotion", "neutral"),
-                "supersedes_id": data.get("supersedes_id"),
-                "source_attribution": data.get("source_attribution", "unknown"),
-                "stimulus_signature": data.get("stimulus_signature", ""),
-                "extinction_strength": data.get("extinction_strength", 0.0),
-            },
+            ) RETURNING id"""
+
+    def _build_insert_params(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Map a memory record to the _INSERT_MEMORY_SQL bind parameters.
+
+        A3 decay clock: anchor heat_base_set_at to the event date, not NOW().
+        effective_heat() decays from COALESCE(heat_base_set_at, last_accessed,
+        created_at); for a never-touched insert the faithful "last canonical
+        touch" IS the event (created_at), so a historical-dated memory
+        (import / benchmark loader) engages the SQL forgetting law instead of
+        reading hours_elapsed≈0. No-op for fresh writes where created_at≈now.
+        Source: docs/program/phase-3-a3-migration-design.md §3.1 (clock = last
+        touch); benchmark root-cause memory 4202968.
+        """
+        now = _now_iso()
+        embedding = self._bytes_to_vector(data.get("embedding"))
+        # Normalize free-form dates to ISO 8601 for proper recency ranking
+        raw_created = data.get("created_at")
+        if raw_created and isinstance(raw_created, str) and "T" not in raw_created:
+            from mcp_server.core.temporal import normalize_date_to_iso
+
+            raw_created = normalize_date_to_iso(raw_created) or raw_created
+        heat_base_anchor = data.get("heat_base_set_at") or raw_created or now
+        return {
+            "content": data["content"],
+            "embedding": embedding,
+            "tags": json.dumps(data.get("tags", [])),
+            "source": data.get("source", ""),
+            "domain": data.get("domain", ""),
+            "directory_context": data.get("directory_context", ""),
+            "created_at": raw_created or now,
+            "last_accessed": now,
+            "heat_base_set_at": heat_base_anchor,
+            "heat": data.get("heat", 1.0),
+            "surprise_score": data.get("surprise_score", 0.0),
+            "importance": data.get("importance", 0.5),
+            "emotional_valence": data.get("emotional_valence", 0.0),
+            "confidence": data.get("confidence", 1.0),
+            "store_type": data.get("store_type", "episodic"),
+            "is_protected": data.get("is_protected", False),
+            "consolidation_stage": data.get("consolidation_stage", "labile"),
+            "theta_phase": data.get("theta_phase_at_encoding", 0.0),
+            "encoding_strength": data.get("encoding_strength", 1.0),
+            "separation_index": data.get("separation_index", 0.0),
+            "interference_score": data.get("interference_score", 0.0),
+            "schema_match_score": data.get("schema_match_score", 0.0),
+            "schema_id": data.get("schema_id"),
+            "hippocampal_dependency": data.get("hippocampal_dependency", 1.0),
+            "is_benchmark": data.get("is_benchmark", False),
+            "agent_context": data.get("agent_context", ""),
+            "is_global": data.get("is_global", False),
+            "stage_entered_at": data.get("stage_entered_at") or raw_created or now,
+            "arousal": data.get("arousal", 0.0),
+            "dominant_emotion": data.get("dominant_emotion", "neutral"),
+            "supersedes_id": data.get("supersedes_id"),
+            "source_attribution": data.get("source_attribution", "unknown"),
+            "stimulus_signature": data.get("stimulus_signature", ""),
+            "extinction_strength": data.get("extinction_strength", 0.0),
+        }
+
+    def _insert_memory_on(
+        self, conn: psycopg.Connection, data: dict[str, Any]
+    ) -> int:
+        """Run the memory INSERT on ``conn`` WITHOUT committing.
+
+        The caller owns the transaction boundary: insert_memory() commits on a
+        pooled autocommit connection; supersede_atomic() commits or rolls back
+        the row together with its supersession edge.
+        """
+        row = conn.execute(
+            self._INSERT_MEMORY_SQL, self._build_insert_params(data)
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("INSERT ... RETURNING id produced no row")
+        return int(row["id"])
+
+    def insert_memory(self, data: dict[str, Any]) -> int:
+        """Insert a memory and return its ID."""
+        row = self._execute(
+            self._INSERT_MEMORY_SQL, self._build_insert_params(data)
         ).fetchone()
         self._conn.commit()
         if row is None:
             raise RuntimeError("INSERT ... RETURNING id produced no row")
-        return row["id"]
+        return int(row["id"])
 
-    def set_superseded_by(self, old_id: int, new_id: int) -> bool:
-        """Mark ``old_id`` as superseded by ``new_id`` (back-pointer edge).
+    def _current_chain_head(
+        self, conn: psycopg.Connection, target_id: int
+    ) -> int | None:
+        """Walk ``target_id``'s supersession chain to its open head.
 
-        The forward edge (new.supersedes_id = old) is set at insert time;
-        this closes the chain by stamping the old row's superseded_by_id.
-
-        Compare-and-set: the UPDATE lands only while the target is still
-        the head of its chain (superseded_by_id IS NULL), so two concurrent
-        correctors can never overwrite each other's edge. Returns True when
-        the edge was posted, False on conflict. Re-running with the same
-        args is therefore a detected conflict, not the former idempotent
-        no-op overwrite — callers own the conflict handling.
+        Follows forward ``superseded_by_id`` edges to the row whose
+        superseded_by_id IS NULL — the current head. Returns that id, or None
+        if ``target_id`` no longer exists. Runs on the caller's connection so
+        the walk and the CAS that follows share one transaction snapshot.
         """
-        cur = self._execute(
-            "UPDATE memories SET superseded_by_id = %s "
-            "WHERE id = %s AND superseded_by_id IS NULL",
-            (new_id, old_id),
-        )
-        self._conn.commit()
-        return cur.rowcount == 1
+        row = conn.execute(
+            """WITH RECURSIVE chain(id, superseded_by_id, hops) AS (
+                   SELECT id, superseded_by_id, 0
+                   FROM memories WHERE id = %s
+                   UNION ALL
+                   SELECT m.id, m.superseded_by_id, c.hops + 1
+                   FROM memories m JOIN chain c ON m.id = c.superseded_by_id
+                   WHERE c.hops < %s
+               )
+               SELECT id FROM chain
+               WHERE superseded_by_id IS NULL
+               ORDER BY hops DESC LIMIT 1""",
+            (target_id, _CHAIN_HEAD_MAX_DEPTH),
+        ).fetchone()
+        return int(row["id"]) if row else None
+
+    def supersede_atomic(
+        self, data: dict[str, Any], target_id: int
+    ) -> tuple[int | None, int | None]:
+        """Insert ``data`` as the supersessor of ``target_id``'s head, atomically.
+
+        Biomimetic reconsolidation (Nader, Schafe & LeDoux 2000): a corrected
+        memory is reconstructed on the CURRENT trace, never left physically
+        disconnected. One transaction inserts the new row (supersedes_id = the
+        walked head) and stamps that head's ``superseded_by_id`` — a
+        compare-and-set that lands only while the head is still open. If a
+        concurrent writer moved the head between the walk and the CAS, the whole
+        transaction rolls back (the insert is undone — no orphan is ever
+        committed) and we REBASE: re-walk ``target_id`` to the new head and
+        retry, bounded by _SUPERSEDE_REBASE_ATTEMPTS. On the common path (no
+        race) the head IS ``target_id`` and the first attempt commits.
+
+        Returns ``(new_id, head_id)`` on success — ``head_id`` is the row the
+        new memory now supersedes (== ``target_id`` unless a race rebased us).
+        Returns ``(None, last_head_id)`` when the bounded rebase exhausts
+        (pathological contention — nothing committed; the caller rebases and
+        retries), or ``(None, None)`` when the target vanished mid-write.
+        """
+        last_head: int | None = None
+        for _ in range(_SUPERSEDE_REBASE_ATTEMPTS):
+            with self.acquire_interactive() as conn:
+                try:
+                    with conn.transaction():
+                        head_id = self._current_chain_head(conn, target_id)
+                        if head_id is None:
+                            return None, None
+                        last_head = head_id
+                        data["supersedes_id"] = head_id
+                        new_id = self._insert_memory_on(conn, data)
+                        rowcount = conn.execute(
+                            "UPDATE memories SET superseded_by_id = %s "
+                            "WHERE id = %s AND superseded_by_id IS NULL",
+                            (new_id, head_id),
+                        ).rowcount
+                        if rowcount != 1:
+                            raise _SupersedeCasConflict()
+                except _SupersedeCasConflict:
+                    continue
+                return new_id, head_id
+        return None, last_head
 
     def get_memory(self, memory_id: int) -> dict[str, Any] | None:
         row = self._execute(

--- a/mcp_server/infrastructure/pg_store.py
+++ b/mcp_server/infrastructure/pg_store.py
@@ -26,6 +26,7 @@ from typing import Any, Iterator
 
 import numpy as np
 import psycopg
+from pgvector import Vector
 from pgvector.psycopg import register_vector
 from psycopg.rows import dict_row
 from psycopg_pool import ConnectionPool
@@ -459,6 +460,10 @@ class PgMemoryStore(
         """Convert pgvector result back to float32 bytes."""
         if vec is None:
             return None
+        if isinstance(vec, Vector):
+            # pgvector>=0.5.0 psycopg loaders return Vector, not ndarray
+            # source: pgvector-python CHANGELOG 0.5.0 (2026-07-06)
+            return vec.to_numpy().tobytes()
         return np.asarray(vec, dtype=np.float32).tobytes()
 
     # ── Memory CRUD ───────────────────────────────────────────────────
@@ -553,9 +558,7 @@ class PgMemoryStore(
             "extinction_strength": data.get("extinction_strength", 0.0),
         }
 
-    def _insert_memory_on(
-        self, conn: psycopg.Connection, data: dict[str, Any]
-    ) -> int:
+    def _insert_memory_on(self, conn: psycopg.Connection, data: dict[str, Any]) -> int:
         """Run the memory INSERT on ``conn`` WITHOUT committing.
 
         The caller owns the transaction boundary: insert_memory() commits on a

--- a/mcp_server/infrastructure/pg_store.py
+++ b/mcp_server/infrastructure/pg_store.py
@@ -529,18 +529,26 @@ class PgMemoryStore(
             raise RuntimeError("INSERT ... RETURNING id produced no row")
         return row["id"]
 
-    def set_superseded_by(self, old_id: int, new_id: int) -> None:
+    def set_superseded_by(self, old_id: int, new_id: int) -> bool:
         """Mark ``old_id`` as superseded by ``new_id`` (back-pointer edge).
 
         The forward edge (new.supersedes_id = old) is set at insert time;
         this closes the chain by stamping the old row's superseded_by_id.
-        Idempotent — re-running with the same args is a no-op overwrite.
+
+        Compare-and-set: the UPDATE lands only while the target is still
+        the head of its chain (superseded_by_id IS NULL), so two concurrent
+        correctors can never overwrite each other's edge. Returns True when
+        the edge was posted, False on conflict. Re-running with the same
+        args is therefore a detected conflict, not the former idempotent
+        no-op overwrite — callers own the conflict handling.
         """
-        self._execute(
-            "UPDATE memories SET superseded_by_id = %s WHERE id = %s",
+        cur = self._execute(
+            "UPDATE memories SET superseded_by_id = %s "
+            "WHERE id = %s AND superseded_by_id IS NULL",
             (new_id, old_id),
         )
         self._conn.commit()
+        return cur.rowcount == 1
 
     def get_memory(self, memory_id: int) -> dict[str, Any] | None:
         row = self._execute(

--- a/mcp_server/infrastructure/sqlite_store.py
+++ b/mcp_server/infrastructure/sqlite_store.py
@@ -45,6 +45,13 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+# Parity with PgMemoryStore's supersede_atomic operational bounds (engineering,
+# not algorithmic). Bounded optimistic-concurrency rebase retry; defensive
+# recursion cap on the acyclic chain walk.
+_SUPERSEDE_REBASE_ATTEMPTS = 5
+_CHAIN_HEAD_MAX_DEPTH = 100_000
+
+
 class SqliteMemoryStore(
     SqliteEntityMixin,
     SqliteEntityMergeMixin,
@@ -191,8 +198,13 @@ class SqliteMemoryStore(
 
     # ── Memory CRUD ───────────────────────────────────────────────────
 
-    def insert_memory(self, data: dict[str, Any]) -> int:
-        """Insert a memory into memories + FTS5 + vec tables."""
+    def _insert_memory_rows(self, data: dict[str, Any]) -> int:
+        """Insert a memory into memories + FTS5 + vec tables — no commit.
+
+        The caller owns the transaction boundary: insert_memory() commits;
+        supersede_atomic() commits or rolls back the row together with its
+        supersession edge so a lost race never leaves a disconnected row.
+        """
         now = _now_iso()
         raw_created = data.get("created_at")
         if raw_created and isinstance(raw_created, str) and "T" not in raw_created:
@@ -271,8 +283,77 @@ class SqliteMemoryStore(
                     "INSERT INTO memories_vec(rowid, embedding) VALUES (?, ?)",
                     (memory_id, vec.tobytes()),
                 )
-        self._conn.commit()
         return memory_id  # type: ignore[return-value]
+
+    def insert_memory(self, data: dict[str, Any]) -> int:
+        """Insert a memory into memories + FTS5 + vec tables."""
+        memory_id = self._insert_memory_rows(data)
+        self._conn.commit()
+        return memory_id
+
+    def _current_chain_head(self, target_id: int) -> int | None:
+        """Walk ``target_id``'s supersession chain to its open head.
+
+        Follows forward ``superseded_by_id`` edges to the row whose
+        superseded_by_id IS NULL. Returns that id, or None if the target no
+        longer exists. Mirrors PgMemoryStore._current_chain_head.
+        """
+        row = self._conn.execute(
+            """WITH RECURSIVE chain(id, superseded_by_id, hops) AS (
+                   SELECT id, superseded_by_id, 0
+                   FROM memories WHERE id = ?
+                   UNION ALL
+                   SELECT m.id, m.superseded_by_id, c.hops + 1
+                   FROM memories m JOIN chain c ON m.id = c.superseded_by_id
+                   WHERE c.hops < ?
+               )
+               SELECT id FROM chain
+               WHERE superseded_by_id IS NULL
+               ORDER BY hops DESC LIMIT 1""",
+            (target_id, _CHAIN_HEAD_MAX_DEPTH),
+        ).fetchone()
+        return int(row["id"]) if row else None
+
+    def supersede_atomic(
+        self, data: dict[str, Any], target_id: int
+    ) -> tuple[int | None, int | None]:
+        """Insert ``data`` as the supersessor of ``target_id``'s head, atomically.
+
+        SQLite parity for PgMemoryStore.supersede_atomic. One transaction on the
+        single connection inserts the new row (supersedes_id = the walked head)
+        and stamps that head's ``superseded_by_id`` — a compare-and-set that
+        lands only while the head is still open. On a lost CAS the transaction
+        rolls back (the insert, its FTS and vec rows all undone — no orphan is
+        ever committed) and we rebase onto the moved head, bounded by
+        _SUPERSEDE_REBASE_ATTEMPTS.
+
+        Returns ``(new_id, head_id)`` on success (``head_id`` == ``target_id``
+        unless a race rebased us), ``(None, last_head_id)`` when the bounded
+        rebase exhausts, or ``(None, None)`` when the target vanished.
+        """
+        last_head: int | None = None
+        for _ in range(_SUPERSEDE_REBASE_ATTEMPTS):
+            head_id = self._current_chain_head(target_id)
+            if head_id is None:
+                return None, None
+            last_head = head_id
+            data["supersedes_id"] = head_id
+            try:
+                new_id = self._insert_memory_rows(data)
+                rowcount = self._conn.execute(
+                    "UPDATE memories SET superseded_by_id = ? "
+                    "WHERE id = ? AND superseded_by_id IS NULL",
+                    (new_id, head_id),
+                ).rowcount
+            except Exception:
+                self._conn.rollback()
+                raise
+            if rowcount != 1:
+                self._conn.rollback()
+                continue
+            self._conn.commit()
+            return new_id, head_id
+        return None, last_head
 
     def get_memory(self, memory_id: int) -> dict[str, Any] | None:
         row = self._conn.execute(

--- a/mcp_server/infrastructure/sqlite_store_mood.py
+++ b/mcp_server/infrastructure/sqlite_store_mood.py
@@ -128,26 +128,33 @@ class SqliteMoodMixin:
 
     # ── Memory supersession ───────────────────────────────────────────
 
-    def set_superseded_by(self, old_id: int, new_id: int) -> None:
+    def set_superseded_by(self, old_id: int, new_id: int) -> bool:
         """Mark ``old_id`` as superseded by ``new_id`` (back-pointer edge).
 
         Precondition: old_id and new_id are valid memory IDs.
         Postcondition: memories.superseded_by_id = new_id for the row with
-          id = old_id; the forward edge (new.supersedes_id = old) is written
-          by insert_memory when data["supersedes_id"] is supplied.
+          id = old_id, only if it was NULL before (compare-and-set); the
+          forward edge (new.supersedes_id = old) is written by insert_memory
+          when data["supersedes_id"] is supplied.
 
-        Idempotent — re-running with the same args is a no-op overwrite.
+        Returns True when the edge was posted, False on conflict — the
+        target already carries a superseded_by_id (including re-runs with
+        the same args) or the column is absent (pre-migration DB). Either
+        way the edge was NOT posted; reporting False instead of pretending
+        success is the point of the CAS contract.
         Mirrors PgMemoryStore.set_superseded_by.
         """
         try:
-            self._conn.execute(
-                "UPDATE memories SET superseded_by_id = ? WHERE id = ?",
+            cur = self._conn.execute(
+                "UPDATE memories SET superseded_by_id = ? "
+                "WHERE id = ? AND superseded_by_id IS NULL",
                 (new_id, old_id),
             )
             self._conn.commit()
+            return cur.rowcount == 1
         except Exception:
-            # superseded_by_id column absent (pre-migration DB) — safe no-op.
-            pass
+            # superseded_by_id column absent (pre-migration DB).
+            return False
 
     # ── Bulk embedding fetch ──────────────────────────────────────────
 

--- a/mcp_server/infrastructure/sqlite_store_mood.py
+++ b/mcp_server/infrastructure/sqlite_store_mood.py
@@ -1,13 +1,15 @@
 """User mood and memory supersession mixin for SqliteMemoryStore.
 
-Implements the five methods that exist in PgMemoryStore but had no SQLite
+Implements methods that exist in PgMemoryStore but had no SQLite
 equivalent, causing silent no-ops under the advertised fallback backend:
 
     get_user_mood(user_id) -> float | None
     get_user_mood_state(user_id) -> dict | None
     set_user_mood(valence, arousal, user_id) -> None
-    set_superseded_by(old_id, new_id) -> None
     get_embeddings_for_memories(memory_ids) -> dict[int, bytes]
+
+The supersession write path lives in SqliteMemoryStore.supersede_atomic (the
+atomic insert+edge primitive), mirroring PgMemoryStore.
 
 All signatures mirror PgMemoryStore exactly (duck-type compatibility).
 """
@@ -125,36 +127,6 @@ class SqliteMoodMixin:
         except Exception:
             # user_mood table absent (pre-migration DB) — safe no-op.
             pass
-
-    # ── Memory supersession ───────────────────────────────────────────
-
-    def set_superseded_by(self, old_id: int, new_id: int) -> bool:
-        """Mark ``old_id`` as superseded by ``new_id`` (back-pointer edge).
-
-        Precondition: old_id and new_id are valid memory IDs.
-        Postcondition: memories.superseded_by_id = new_id for the row with
-          id = old_id, only if it was NULL before (compare-and-set); the
-          forward edge (new.supersedes_id = old) is written by insert_memory
-          when data["supersedes_id"] is supplied.
-
-        Returns True when the edge was posted, False on conflict — the
-        target already carries a superseded_by_id (including re-runs with
-        the same args) or the column is absent (pre-migration DB). Either
-        way the edge was NOT posted; reporting False instead of pretending
-        success is the point of the CAS contract.
-        Mirrors PgMemoryStore.set_superseded_by.
-        """
-        try:
-            cur = self._conn.execute(
-                "UPDATE memories SET superseded_by_id = ? "
-                "WHERE id = ? AND superseded_by_id IS NULL",
-                (new_id, old_id),
-            )
-            self._conn.commit()
-            return cur.rowcount == 1
-        except Exception:
-            # superseded_by_id column absent (pre-migration DB).
-            return False
 
     # ── Bulk embedding fetch ──────────────────────────────────────────
 

--- a/mcp_server/validation/schemas.py
+++ b/mcp_server/validation/schemas.py
@@ -100,6 +100,9 @@ SCHEMAS: dict[str, dict] = {
             "importance": {"type": "number"},
             "created_at": {"type": "string", "maxLength": 64},
             "initial_heat": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+            # Bounds + target existence are enforced by the handler
+            # (validate_supersede_target) — this layer only type-checks.
+            "supersedes_id": {"type": "number"},
         },
         "required": ["content"],
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,10 @@ hypermnesia-mcp = "mcp_server.__main__:main"
 postgresql = [
     "psycopg[binary]>=3.1",
     "psycopg-pool>=3.2",
-    "pgvector>=0.3",
+    # >=0.4: top-level pgvector.Vector import; <0.6: 0.5.0 changed psycopg
+    # loaders to return Vector (handled in pg_store._vector_to_bytes) — guard
+    # against the next breaking minor. source: pgvector-python CHANGELOG.
+    "pgvector>=0.4,<0.6",
 ]
 sqlite = [
     "sqlite-vec>=0.1.1",
@@ -97,7 +100,7 @@ benchmarks = [
     "flashrank>=0.2.0",          # cross-encoder reranking (ms-marco-MiniLM-L-12-v2)
     "psycopg[binary]>=3.1",      # PostgreSQL driver
     "psycopg-pool>=3.2",         # pg_store.py imports ConnectionPool at module level
-    "pgvector>=0.3",             # vector similarity in PostgreSQL
+    "pgvector>=0.4,<0.6",        # vector similarity in PostgreSQL (bounds: see [postgresql])
     "pymupdf>=1.24.0",           # PDF parsing for some benchmark sources
 ]
 dev = [

--- a/tests_py/handlers/test_recall_include_related.py
+++ b/tests_py/handlers/test_recall_include_related.py
@@ -66,14 +66,10 @@ def _seed(store: PgMemoryStore) -> dict:
     old_id = store.insert_memory(
         {**common, "content": "deploy target is staging alpha relation walk"}
     )
-    new_id = store.insert_memory(
-        {
-            **common,
-            "content": "deploy target is staging alpha relation walk",
-            "supersedes_id": old_id,
-        }
+    # Atomic insert + supersession edge (both directions) in one call.
+    new_id, _ = store.supersede_atomic(
+        {**common, "content": "deploy target is staging alpha relation walk"}, old_id
     )
-    store.set_superseded_by(old_id, new_id)
 
     e_deploy = store.insert_entity(
         {"name": "deploy-alpha", "type": "concept", "domain": _DOMAIN}

--- a/tests_py/handlers/test_remember_supersede.py
+++ b/tests_py/handlers/test_remember_supersede.py
@@ -2,14 +2,16 @@
 
 Item ① — ``remember(supersedes_id)``: append-only human correction through
 the handler; ``force`` composes with it (sovereign correction bypasses the
-write gate but still posts the edge). Item ② — the CAS conflict path in
-``insert_and_post_process``: a lost race rolls the fresh insert back and
-reports the conflict, never forks a chain, never loses a row silently.
+write gate but still posts the edge). Item ② — the atomic supersession path in
+``insert_and_post_process``: ``store.supersede_atomic`` inserts the new row and
+the edge as one transaction, so an exhausted reconsolidation rebase rolls the
+insert back and reports a conflict — never forks a chain, never leaves an
+orphaned, disconnected row.
 
 Handler tests run against the shared store wired by conftest (live PG when
-available). The conflict-path tests use duck-typed fakes because the race
-window — target superseded between validation and edge-posting — cannot be
-opened deterministically through the public handler.
+available). The conflict-path test uses a duck-typed fake because the race
+window — the chain head moving under the compare-and-set — cannot be opened
+deterministically through the public handler.
 """
 
 import asyncio
@@ -132,27 +134,19 @@ class TestRememberSupersedes:
 
 
 class _ConflictStore:
-    """Duck-typed store opening the lost-race window: the CAS refuses the
-    edge as if another writer superseded the target after validation."""
+    """Duck-typed store whose atomic supersession never converges: the bounded
+    reconsolidation rebase exhausts and returns (None, current_head), the
+    signal that nothing was committed (the transaction rolled back each try)."""
 
-    def __init__(self, delete_succeeds: bool = True) -> None:
-        self.delete_succeeds = delete_succeeds
-        self.deleted: list[int] = []
-        self.inserted: list[dict] = []
+    def __init__(self, current_head: int = 555) -> None:
+        self.current_head = current_head
+        self.calls: list[tuple[dict, int]] = []
 
-    def insert_memory(self, record: dict) -> int:
-        self.inserted.append(record)
-        return 777
-
-    def set_superseded_by(self, old_id: int, new_id: int) -> bool:
-        return False
-
-    def get_memory(self, mem_id: int) -> dict:
-        return {"id": mem_id, "superseded_by_id": 555}
-
-    def delete_memory(self, mem_id: int) -> bool:
-        self.deleted.append(mem_id)
-        return self.delete_succeeds
+    def supersede_atomic(
+        self, data: dict, target_id: int
+    ) -> tuple[int | None, int | None]:
+        self.calls.append((dict(data), target_id))
+        return None, self.current_head
 
 
 class _NoopEngine:
@@ -197,27 +191,20 @@ def _run_conflict(store: _ConflictStore) -> dict:
 
 
 class TestSupersedeConflict:
-    """Item ② — conflict propagation: rollback-over-orphan, never silent."""
+    """Item ② — conflict propagation: atomic rollback, never an orphan."""
 
-    def test_cas_conflict_rolls_back_insert(self):
-        store = _ConflictStore()
+    def test_exhausted_rebase_reports_conflict_no_orphan(self):
+        store = _ConflictStore(current_head=555)
         result = _run_conflict(store)
         assert result["stored"] is False
         assert result["action"] == "superseded_conflict"
-        assert result["reason"] == "supersede_target_no_longer_head"
+        assert result["reason"] == "supersede_chain_head_moving"
         assert result["supersede_target_id"] == 42
-        assert result["current_superseded_by_id"] == 555
-        assert store.deleted == [777], "the fresh insert must be rolled back"
+        assert result["current_head_id"] == 555
+        # The atomic insert+edge rolls back on a lost race, so there is never a
+        # committed row to delete or leave orphaned — the concept is gone.
         assert "orphan_memory_id" not in result
-
-    def test_cas_conflict_delete_failure_reports_orphan(self):
-        store = _ConflictStore(delete_succeeds=False)
-        result = _run_conflict(store)
-        assert result["stored"] is False
-        assert result["action"] == "superseded_conflict"
-        assert result["orphan_memory_id"] == 777, (
-            "a failed rollback must name the orphan, never stay silent"
-        )
+        assert store.calls and store.calls[0][1] == 42
 
 
 class _HeadStore:

--- a/tests_py/handlers/test_remember_supersede.py
+++ b/tests_py/handlers/test_remember_supersede.py
@@ -72,9 +72,7 @@ class TestRememberSupersedes:
         assert base["stored"] is True
         old_id = base["memory_id"]
 
-        fix = _remember(
-            {"content": content, "supersedes_id": old_id, "force": True}
-        )
+        fix = _remember({"content": content, "supersedes_id": old_id, "force": True})
         assert fix["stored"] is True, fix
         assert fix["action"] == "superseded"
         assert _store().get_memory(old_id)["superseded_by_id"] == fix["memory_id"]

--- a/tests_py/handlers/test_remember_supersede.py
+++ b/tests_py/handlers/test_remember_supersede.py
@@ -1,0 +1,257 @@
+"""Tests for the explicit supersession write path (PRD dual-access increment 1).
+
+Item ① — ``remember(supersedes_id)``: append-only human correction through
+the handler; ``force`` composes with it (sovereign correction bypasses the
+write gate but still posts the edge). Item ② — the CAS conflict path in
+``insert_and_post_process``: a lost race rolls the fresh insert back and
+reports the conflict, never forks a chain, never loses a row silently.
+
+Handler tests run against the shared store wired by conftest (live PG when
+available). The conflict-path tests use duck-typed fakes because the race
+window — target superseded between validation and edge-posting — cannot be
+opened deterministically through the public handler.
+"""
+
+import asyncio
+
+from mcp_server.handlers.remember import handler
+from mcp_server.handlers.remember_helpers import (
+    insert_and_post_process,
+    validate_supersede_target,
+)
+from mcp_server.infrastructure.memory_config import get_memory_settings
+from mcp_server.infrastructure.memory_store import get_shared_store
+
+
+def _store():
+    s = get_memory_settings()
+    return get_shared_store(s.DB_PATH, s.EMBEDDING_DIM)
+
+
+def _remember(payload: dict) -> dict:
+    return asyncio.run(handler(payload))
+
+
+class TestRememberSupersedes:
+    """Item ① acceptance — the handler-level supersession contract."""
+
+    def test_supersede_creates_chain(self):
+        base = _remember(
+            {
+                "content": "Supersede-chain base fact: gateway timeout is 30s",
+                "force": True,
+            }
+        )
+        assert base["stored"] is True
+        old_id = base["memory_id"]
+
+        fix = _remember(
+            {
+                "content": "Supersede-chain corrected fact: gateway timeout is 60s",
+                "supersedes_id": old_id,
+                "force": True,
+            }
+        )
+        assert fix["stored"] is True
+        assert fix["action"] == "superseded"
+        assert fix["superseded_id"] == old_id
+        new_id = fix["memory_id"]
+
+        store = _store()
+        assert store.get_memory(old_id)["superseded_by_id"] == new_id
+        assert store.get_memory(new_id)["supersedes_id"] == old_id
+
+    def test_human_edit_never_lost_forced_duplicate(self):
+        """Acceptance « une édition humaine ne se perd jamais » : force +
+        supersedes_id lands even when the gate would reject the content as
+        redundant (identical text = lowest possible novelty)."""
+        content = "Team retro cadence is every second Thursday morning"
+        base = _remember({"content": content, "force": True})
+        assert base["stored"] is True
+        old_id = base["memory_id"]
+
+        fix = _remember(
+            {"content": content, "supersedes_id": old_id, "force": True}
+        )
+        assert fix["stored"] is True, fix
+        assert fix["action"] == "superseded"
+        assert _store().get_memory(old_id)["superseded_by_id"] == fix["memory_id"]
+
+    def test_target_not_found_rejected(self):
+        result = _remember(
+            {
+                "content": "Correction pointing at a ghost target",
+                "supersedes_id": 2_000_000_000,
+                "force": True,
+            }
+        )
+        assert result["stored"] is False
+        assert result["action"] == "rejected"
+        assert result["reason"] == "supersede_target_not_found"
+        assert result["supersede_target_id"] == 2_000_000_000
+
+    def test_already_superseded_target_rejected_no_fork(self):
+        base = _remember(
+            {"content": "Chain-fork base: build runs on runner A", "force": True}
+        )
+        old_id = base["memory_id"]
+        first = _remember(
+            {
+                "content": "Chain-fork head: build runs on runner B",
+                "supersedes_id": old_id,
+                "force": True,
+            }
+        )
+        assert first["action"] == "superseded"
+
+        second = _remember(
+            {
+                "content": "Chain-fork attempt: build runs on runner C",
+                "supersedes_id": old_id,
+                "force": True,
+            }
+        )
+        assert second["stored"] is False
+        assert second["action"] == "rejected"
+        assert second["reason"] == "supersede_target_already_superseded"
+        assert second["current_superseded_by_id"] == first["memory_id"]
+        # No silent fork: the head is still the first correction.
+        assert _store().get_memory(old_id)["superseded_by_id"] == first["memory_id"]
+
+    def test_invalid_supersedes_id_rejected(self):
+        for bad in (0, -3, "not-an-id"):
+            result = _remember(
+                {
+                    "content": "Correction with a malformed target id",
+                    "supersedes_id": bad,
+                    "force": True,
+                }
+            )
+            assert result["stored"] is False, bad
+            assert result["reason"] == "invalid_supersedes_id", bad
+
+
+class _ConflictStore:
+    """Duck-typed store opening the lost-race window: the CAS refuses the
+    edge as if another writer superseded the target after validation."""
+
+    def __init__(self, delete_succeeds: bool = True) -> None:
+        self.delete_succeeds = delete_succeeds
+        self.deleted: list[int] = []
+        self.inserted: list[dict] = []
+
+    def insert_memory(self, record: dict) -> int:
+        self.inserted.append(record)
+        return 777
+
+    def set_superseded_by(self, old_id: int, new_id: int) -> bool:
+        return False
+
+    def get_memory(self, mem_id: int) -> dict:
+        return {"id": mem_id, "superseded_by_id": 555}
+
+    def delete_memory(self, mem_id: int) -> bool:
+        self.deleted.append(mem_id)
+        return self.delete_succeeds
+
+
+class _NoopEngine:
+    def encode(self, _text):
+        return None
+
+    def similarity(self, _a, _b) -> float:
+        return 0.0
+
+
+_MOD = {
+    "heat": 0.5,
+    "importance": 0.5,
+    "valence": 0.0,
+    "theta": 0.0,
+    "enc_mod": 1.0,
+    "schema_match": 0.0,
+    "schema_id": None,
+    "emotional_tag": None,
+}
+
+
+def _run_conflict(store: _ConflictStore) -> dict:
+    return insert_and_post_process(
+        content="corrected fact after a lost race",
+        embedding=None,
+        tags=[],
+        source="user",
+        domain="unit-test",
+        directory="",
+        action="supersede",
+        merged_id=42,
+        sims=[],
+        vec_hits=[],
+        ent_names=[],
+        extracted=[],
+        mod=_MOD,
+        novelty_score=0.5,
+        store=store,
+        emb_engine=_NoopEngine(),
+    )
+
+
+class TestSupersedeConflict:
+    """Item ② — conflict propagation: rollback-over-orphan, never silent."""
+
+    def test_cas_conflict_rolls_back_insert(self):
+        store = _ConflictStore()
+        result = _run_conflict(store)
+        assert result["stored"] is False
+        assert result["action"] == "superseded_conflict"
+        assert result["reason"] == "supersede_target_no_longer_head"
+        assert result["supersede_target_id"] == 42
+        assert result["current_superseded_by_id"] == 555
+        assert store.deleted == [777], "the fresh insert must be rolled back"
+        assert "orphan_memory_id" not in result
+
+    def test_cas_conflict_delete_failure_reports_orphan(self):
+        store = _ConflictStore(delete_succeeds=False)
+        result = _run_conflict(store)
+        assert result["stored"] is False
+        assert result["action"] == "superseded_conflict"
+        assert result["orphan_memory_id"] == 777, (
+            "a failed rollback must name the orphan, never stay silent"
+        )
+
+
+class _HeadStore:
+    """Minimal get_memory-only store for target validation tests."""
+
+    def __init__(self, rows: dict) -> None:
+        self._rows = rows
+
+    def get_memory(self, mem_id: int):
+        return self._rows.get(mem_id)
+
+
+class TestValidateSupersedeTarget:
+    def test_none_passes_through(self):
+        assert validate_supersede_target(None, _HeadStore({})) == (None, None)
+
+    def test_valid_head_resolves(self):
+        store = _HeadStore({7: {"id": 7, "superseded_by_id": None}})
+        assert validate_supersede_target(7, store) == (7, None)
+
+    def test_missing_target_rejected(self):
+        sid, rejection = validate_supersede_target(9, _HeadStore({}))
+        assert sid is None
+        assert rejection["reason"] == "supersede_target_not_found"
+
+    def test_already_superseded_rejected_with_head(self):
+        store = _HeadStore({7: {"id": 7, "superseded_by_id": 11}})
+        sid, rejection = validate_supersede_target(7, store)
+        assert sid is None
+        assert rejection["reason"] == "supersede_target_already_superseded"
+        assert rejection["current_superseded_by_id"] == 11
+
+    def test_malformed_rejected(self):
+        for bad in (0, -1, "xyz"):
+            sid, rejection = validate_supersede_target(bad, _HeadStore({}))
+            assert sid is None, bad
+            assert rejection["reason"] == "invalid_supersedes_id", bad

--- a/tests_py/infrastructure/test_pg_supersession.py
+++ b/tests_py/infrastructure/test_pg_supersession.py
@@ -152,9 +152,44 @@ def test_set_superseded_by_closes_chain(store):
     new_id = store.insert_memory(
         {**common, "content": "deploy target one alpha", "supersedes_id": old_id}
     )
-    store.set_superseded_by(old_id, new_id)
+    assert store.set_superseded_by(old_id, new_id) is True
 
     assert store.get_memory(old_id)["superseded_by_id"] == new_id
     results = _recall(store, "deploy target one alpha")
     ids = [r["memory_id"] for r in results]
     assert ids.index(new_id) < ids.index(old_id)
+
+
+def test_set_superseded_by_cas_two_writers(store):
+    """Item ② acceptance (PRD dual-access increment 1): two concurrent
+    correctors — the loser gets the conflict flag and the winner's edge is
+    never overwritten."""
+    common = {"embedding": _emb(), "source": "user", "domain": _DOMAIN, "heat": 0.5}
+    old_id = store.insert_memory({**common, "content": "shared correction target"})
+    a_id = store.insert_memory(
+        {**common, "content": "correction from writer A", "supersedes_id": old_id}
+    )
+    b_id = store.insert_memory(
+        {**common, "content": "correction from writer B", "supersedes_id": old_id}
+    )
+
+    assert store.set_superseded_by(old_id, a_id) is True
+    assert store.set_superseded_by(old_id, b_id) is False, (
+        "second writer must observe the conflict, not overwrite the edge"
+    )
+    assert store.get_memory(old_id)["superseded_by_id"] == a_id
+
+
+def test_set_superseded_by_rerun_is_conflict(store):
+    """The former docstring promised an idempotent no-op overwrite; the CAS
+    predicate replaces that with a detected conflict on any second write,
+    including a re-run with identical args."""
+    common = {"embedding": _emb(), "source": "user", "domain": _DOMAIN, "heat": 0.5}
+    old_id = store.insert_memory({**common, "content": "rerun target fact"})
+    new_id = store.insert_memory(
+        {**common, "content": "rerun corrected fact", "supersedes_id": old_id}
+    )
+
+    assert store.set_superseded_by(old_id, new_id) is True
+    assert store.set_superseded_by(old_id, new_id) is False
+    assert store.get_memory(old_id)["superseded_by_id"] == new_id

--- a/tests_py/infrastructure/test_pg_supersession.py
+++ b/tests_py/infrastructure/test_pg_supersession.py
@@ -144,52 +144,103 @@ def test_insert_persists_supersedes_id(store):
     assert row["supersedes_id"] == old_id
 
 
-def test_set_superseded_by_closes_chain(store):
-    """Phase 2: set_superseded_by stamps the old row's back-pointer and the
-    head-of-chain demotion then ranks the current version first."""
+def _open_heads(store: PgMemoryStore) -> list[int]:
+    """Ids of the domain's open chain heads (superseded_by_id IS NULL)."""
+    rows = store._execute(
+        "SELECT id FROM memories WHERE domain = %s AND superseded_by_id IS NULL",
+        (_DOMAIN,),
+    ).fetchall()
+    return [r["id"] for r in rows]
+
+
+def test_supersede_atomic_forms_chain(store):
+    """supersede_atomic inserts the new row AND stamps the head's back-pointer
+    as one unit; the head-of-chain demotion then ranks the current version
+    first, and exactly one open head remains."""
     common = {"embedding": _emb(), "source": "user", "domain": _DOMAIN, "heat": 0.5}
     old_id = store.insert_memory({**common, "content": "deploy target one alpha"})
-    new_id = store.insert_memory(
-        {**common, "content": "deploy target one alpha", "supersedes_id": old_id}
-    )
-    assert store.set_superseded_by(old_id, new_id) is True
 
+    new_id, head = store.supersede_atomic(
+        {**common, "content": "deploy target one alpha"}, old_id
+    )
+    assert head == old_id, "target was still the head → no rebase"
     assert store.get_memory(old_id)["superseded_by_id"] == new_id
+    assert store.get_memory(new_id)["supersedes_id"] == old_id
+    assert _open_heads(store) == [new_id], "exactly one open head after supersession"
+
     results = _recall(store, "deploy target one alpha")
     ids = [r["memory_id"] for r in results]
     assert ids.index(new_id) < ids.index(old_id)
 
 
-def test_set_superseded_by_cas_two_writers(store):
-    """Item ② acceptance (PRD dual-access increment 1): two concurrent
-    correctors — the loser gets the conflict flag and the winner's edge is
-    never overwritten."""
+def test_supersede_atomic_rebases_onto_moved_head(store):
+    """Reconsolidation: correcting a fact whose chain already moved rebases the
+    new row onto the CURRENT head (never forks, never disconnects). Walking
+    from the original target follows superseded_by_id to the live head."""
     common = {"embedding": _emb(), "source": "user", "domain": _DOMAIN, "heat": 0.5}
-    old_id = store.insert_memory({**common, "content": "shared correction target"})
-    a_id = store.insert_memory(
-        {**common, "content": "correction from writer A", "supersedes_id": old_id}
-    )
-    b_id = store.insert_memory(
-        {**common, "content": "correction from writer B", "supersedes_id": old_id}
-    )
+    old_id = store.insert_memory({**common, "content": "runner is host A"})
+    mid_id, _ = store.supersede_atomic({**common, "content": "runner is host B"}, old_id)
 
-    assert store.set_superseded_by(old_id, a_id) is True
-    assert store.set_superseded_by(old_id, b_id) is False, (
-        "second writer must observe the conflict, not overwrite the edge"
+    # Supersede pointing at the ORIGINAL target, now mid-chain, not the head.
+    new_id, head = store.supersede_atomic(
+        {**common, "content": "runner is host C"}, old_id
     )
-    assert store.get_memory(old_id)["superseded_by_id"] == a_id
+    assert head == mid_id, "rebase must land on the current head, not the stale target"
+    assert store.get_memory(mid_id)["superseded_by_id"] == new_id
+    assert store.get_memory(new_id)["supersedes_id"] == mid_id
+    # old → mid → new, a single linear chain with one open head.
+    assert store.get_memory(old_id)["superseded_by_id"] == mid_id
+    assert _open_heads(store) == [new_id]
 
 
-def test_set_superseded_by_rerun_is_conflict(store):
-    """The former docstring promised an idempotent no-op overwrite; the CAS
-    predicate replaces that with a detected conflict on any second write,
-    including a re-run with identical args."""
+def test_supersede_atomic_conflict_rolls_back_no_orphan(store, monkeypatch):
+    """Under relentless contention the bounded rebase exhausts, but because each
+    attempt runs insert+edge in ONE transaction, a lost compare-and-set rolls
+    the insert back: the correction is NEVER committed (no orphan) and the chain
+    keeps exactly one open head. This is the core biomimetic invariant — a
+    memory is never left physically disconnected."""
     common = {"embedding": _emb(), "source": "user", "domain": _DOMAIN, "heat": 0.5}
-    old_id = store.insert_memory({**common, "content": "rerun target fact"})
-    new_id = store.insert_memory(
-        {**common, "content": "rerun corrected fact", "supersedes_id": old_id}
+    target = store.insert_memory({**common, "content": "conflict target fact"})
+
+    real_head = store._current_chain_head
+    rivals: list[int] = []
+
+    def racing_head(conn, tid):
+        # A concurrent writer supersedes the head we just found — committed on
+        # a separate pooled connection — so our upcoming CAS on it will miss.
+        head = real_head(conn, tid)
+        if head is not None:
+            rival = store.insert_memory(
+                {**common, "content": f"rival {len(rivals)}", "supersedes_id": head}
+            )
+            store._execute(
+                "UPDATE memories SET superseded_by_id = %s "
+                "WHERE id = %s AND superseded_by_id IS NULL",
+                (rival, head),
+            )
+            store._conn.commit()
+            rivals.append(rival)
+        return head
+
+    monkeypatch.setattr(store, "_current_chain_head", racing_head)
+    new_id, head = store.supersede_atomic(
+        {**common, "content": "correction that keeps losing"}, target
     )
 
-    assert store.set_superseded_by(old_id, new_id) is True
-    assert store.set_superseded_by(old_id, new_id) is False
-    assert store.get_memory(old_id)["superseded_by_id"] == new_id
+    assert new_id is None, "bounded rebase must exhaust under relentless contention"
+    assert head is not None
+    lost = store._execute(
+        "SELECT id FROM memories WHERE domain = %s AND content = %s",
+        (_DOMAIN, "correction that keeps losing"),
+    ).fetchall()
+    assert lost == [], "a lost supersession must leave NO committed row (no orphan)"
+    assert len(_open_heads(store)) == 1, "the chain keeps exactly one open head"
+
+
+def test_supersede_atomic_target_vanished(store):
+    """A target that no longer exists yields (None, None) — nothing is
+    committed, the caller learns the write did not land."""
+    assert store.supersede_atomic({"content": "orphan correction"}, 2_000_000_000) == (
+        None,
+        None,
+    )

--- a/tests_py/infrastructure/test_pg_supersession.py
+++ b/tests_py/infrastructure/test_pg_supersession.py
@@ -179,7 +179,9 @@ def test_supersede_atomic_rebases_onto_moved_head(store):
     from the original target follows superseded_by_id to the live head."""
     common = {"embedding": _emb(), "source": "user", "domain": _DOMAIN, "heat": 0.5}
     old_id = store.insert_memory({**common, "content": "runner is host A"})
-    mid_id, _ = store.supersede_atomic({**common, "content": "runner is host B"}, old_id)
+    mid_id, _ = store.supersede_atomic(
+        {**common, "content": "runner is host B"}, old_id
+    )
 
     # Supersede pointing at the ORIGINAL target, now mid-chain, not the head.
     new_id, head = store.supersede_atomic(

--- a/tests_py/invariants/test_I2_canonical_writer.py
+++ b/tests_py/invariants/test_I2_canonical_writer.py
@@ -33,17 +33,18 @@ _MCP_ROOT = _REPO_ROOT / "mcp_server"
 # OR be added here with a source-commented ADR justification.
 _ALLOWED_WRITERS: set[tuple[str, int]] = {
     # Canonical single-row writer (all callers route through this).
-    # bump_heat_raw — UPDATE at line 581 (shifted 576→581 by the v4.0
-    # active-forgetting merge + ruff format); still the one canonical site.
-    ("infrastructure/pg_store.py", 581),
+    # bump_heat_raw — UPDATE at line 692 (shifted 581→692 by the PR #82
+    # supersession write-path refactor + ruff format); still the one
+    # canonical site.
+    ("infrastructure/pg_store.py", 692),
     # A3 batched writer (homeostatic cohort branch + any other batch consumer).
-    # update_memories_heat_batch — SET line at 641 (shifted 636→641 likewise).
-    ("infrastructure/pg_store.py", 641),
-    # SQLite parity (shifted 297→301, 341→345 by the v4.0 active-forgetting
-    # merge + ruff format; both sites remain the canonical bump_heat_raw /
+    # update_memories_heat_batch — SET line at 752 (shifted 641→752 likewise).
+    ("infrastructure/pg_store.py", 752),
+    # SQLite parity (shifted 301→382, 345→426 by the PR #82 supersession
+    # write-path refactor; both sites remain the canonical bump_heat_raw /
     # update_memories_heat_batch writers).
-    ("infrastructure/sqlite_store.py", 301),
-    ("infrastructure/sqlite_store.py", 345),
+    ("infrastructure/sqlite_store.py", 382),
+    ("infrastructure/sqlite_store.py", 426),
     # Homeostatic fold (amortized ~once/month per domain). Shifted 292→317
     # when the bounded-I/O slim-projection helpers were added above it.
     ("handlers/consolidation/homeostatic.py", 317),


### PR DESCRIPTION
## Résumé

PR n°1 de l'incrément « layer d'accès dual » : le write-path de supersession. Deux commits :

1. **d8d6637c** — `remember(supersedes_id)` : l'appelant peut déclarer qu'une mémoire en remplace une autre ; pose de l'arête `superseded_by_id` avec CAS.
2. **ed9fe1df** — refonte atomique (reconsolidation biomimétique) : `set_superseded_by` (commit séparé après insert → fenêtre d'orphelin sur CAS raté) est remplacé par `supersede_atomic` sur les deux stores :
   - **pg_store** : walk-tête de chaîne (CTE récursive), insert et CAS `superseded_by_id` dans **une seule transaction** ; un CAS raté provoque un rollback total puis un rebase sur la tête courante, borné à `_SUPERSEDE_REBASE_ATTEMPTS=5`.
   - **sqlite_store** : parité de contrat (`_insert_memory_rows` + `supersede_atomic` + `_current_chain_head`).
   - **remember_helpers** : réponse de conflit rollback-based (`superseded_conflict`, zéro orphelin, `reason=supersede_chain_head_moving`) ; `superseded_id` rebase-aware.

## Décision de conception (validée avec Clément, 2026-07-07)

Le fallback microglial d'archivage d'orphelins n'est **délibérément pas implémenté** : avec l'atomicité transactionnelle, un CAS raté ne commite rien — aucun orphelin ne peut exister, la branche serait du code mort. Le rollback-conflit tient l'invariant « jamais perdu (contenu renvoyé à l'appelant) et jamais déconnecté (rien de commité) », garantie plus forte que l'archival.

## Vérification

- 1024 tests infra+handlers verts ; 65 tests supersession/sqlite/recall verts.
- 3 guards `benchmarks/supersession_gate/` PASS (session 0/78, chunk 0/78, atomic 0/12).
- `insert_memory` prouvé byte-identique à HEAD (SQL et params inchangés).
- mypy --strict : 0 erreur sur les nouvelles méthodes (280 = baseline pré-existante de la façade).
- **Benchmark LongMemEval-s n=50 `--with-consolidation`** (DB `cortex_bench`) : **R@10 98.0 % / MRR 0.866** vs baseline **94.0 % / 0.854** — aucune régression (+4.0 pts R@10, +0.012 MRR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDnEVUwnz2ubZpiGAgrXrC