### PR TITLE
feat(memory): injection receipts + blame path (T1+T2+T3, decision 4255039)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ Handlers are the **composition roots**: they wire infrastructure (I/O) to core (
 - `artifact_store.py` — Content-addressed raw-output artifacts (`~/.claude/methodology/artifacts/<yyyy-mm>/<sha256[:16]>.md`) backing gist+pointer memories
 - `agent_config.py` — Agent configuration and topic scoping
 
-**handlers/** — Composition roots (44 standalone tools + 3 upstream-integration tools conditionally registered = 47 total + helpers, one per tool)
+**handlers/** — Composition roots (45 standalone tools + 3 upstream-integration tools conditionally registered = 48 total + helpers, one per tool)
 
 **validation/** — `schemas.py` — Per-tool argument validation
 
@@ -252,7 +252,7 @@ stack (galaxy/trace/wiki/knowledge/board UI) was extracted to the standalone
 | `unified_search` | Unified retrieval across memories, wiki, and code graph | <200ms |
 | `get_telemetry` | Retrieval and memory-system telemetry metrics | <50ms |
 
-### Tier 2 — Navigation & Exploration (6 tools)
+### Tier 2 — Navigation & Exploration (7 tools)
 
 | Tool | Purpose | Target Latency |
 |---|---|---|
@@ -262,6 +262,7 @@ stack (galaxy/trace/wiki/knowledge/board UI) was extracted to the standalone
 | `get_causal_chain` | Trace entity relationships through knowledge graph | <200ms |
 | `detect_gaps` | Identify isolated entities, sparse domains, temporal drift | <500ms |
 | `recall_skills` | Recall learned procedural skills by situation | <200ms |
+| `why` | Resolve ⟦rcpt:id⟧ injection receipts into presence-in-context evidence (blame path, decision 4255039) | <100ms |
 
 ### Tier 3 — Automation & Intelligence (8 tools)
 
@@ -291,9 +292,9 @@ stack (galaxy/trace/wiki/knowledge/board UI) was extracted to the standalone
 | `wiki_purge` | Permanently delete a wiki page | <50ms |
 
 **Upstream-integration tools (3, conditionally registered)** — these register
-only when their upstream MCP server is configured, bringing the total to 47:
+only when their upstream MCP server is configured, bringing the total to 48:
 `ingest_codebase` + `change_impact` (automatised-pipeline) and `ingest_prd`
-(prd-spec-generator). With no upstream present, exactly the **44 standalone
+(prd-spec-generator). With no upstream present, exactly the **45 standalone
 tools** above register. Driving the ai-architect pipeline end-to-end
 (formerly `run_pipeline`) is **not** part of this server — it lives in the
 automatised-pipeline MCP.
@@ -301,6 +302,7 @@ automatised-pipeline MCP.
 ## Slash Commands
 
 - `/methodology` — View cognitive methodology profile
+- `/why` — Deterministic blame-path entry point: resolve the ⟦rcpt:id⟧ markers in context via the `why` tool (decision 4255039 correction 6)
 
 ## Data Flow
 

--- a/commands/why.md
+++ b/commands/why.md
@@ -1,0 +1,18 @@
+---
+name: why
+description: Resolve the ⟦rcpt:id⟧ injection markers in context into presence-in-context evidence (blame path)
+---
+
+Deterministic entry point for the blame path (decision 4255039, correction 6 — natural-language routing to the tool is not guaranteed; this command is).
+
+1. Scan the conversation context for `⟦rcpt:N⟧` markers. They sit in the header line of every memory injection block (session-start banner, auto-recall block, agent briefing, recall responses' `receipt_id` field).
+2. **Exclude the marker that arrived with THIS prompt's own memory-injection block** (the auto-recall block directly attached to the current user message). That receipt records what was injected for the current question — including it would blame the question's own context (self-pollution guard, correction 4).
+3. If the user is questioning a specific earlier answer, keep only markers that were already in context **before** that answer was produced.
+4. Call the `why` tool with the collected ids: `why(receipt_ids=[...])`.
+5. Present the evidence with the locked lexicon:
+   - Say the memories were **present in context** ("présence-en-contexte") at the recorded instants and ranks. **Never** say a memory *caused* the answer — the receipts are Pearl-rung-1 evidence of presence, nothing more.
+   - Order as returned (emitted_at DESC, receipt id DESC as deterministic tiebreak, then persisted rank) — recorded facts only.
+   - Flag rows where `superseded_by_id` is set (already corrected) and rows with `memory_missing: true` (hard-forgotten after injection; the receipt remains valid presence evidence).
+6. If the user identifies a wrong memory among the evidence, offer to store a correcting memory with `remember` (the write path supersedes near-duplicates; the explicit atomic correction flow lands in tranche 4).
+
+If no `⟦rcpt:N⟧` marker is visible in context, say so honestly: no receipt in scope means no presence evidence to resolve — do not guess or reconstruct ids.

--- a/mcp_server/handlers/injection_receipts.py
+++ b/mcp_server/handlers/injection_receipts.py
@@ -1,18 +1,88 @@
 """Injection-receipt emission for context-injecting channels.
 
-Blame path T1 (decision Cortex 4255039): every channel that injects
+Blame path T1/T2 (decision Cortex 4255039): every channel that injects
 memory content into a context emits an append-only receipt at injection
 time — the presence-in-context evidence the blame path resolves against.
-T1 wires the recall channel only; the hook channels (session_start,
-agent_briefing) follow in T2.
+T1 wired the recall channel; T2 wires the hook channels (session_start,
+auto_recall, agent_briefing) and hardens the channel enum.
 """
 
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
+from mcp_server.infrastructure.pg_store_receipts import (
+    insert_receipt_on_connection,
+)
+
 logger = logging.getLogger(__name__)
+
+# Hardened channel enum (T2, decision 4255039 correction 3): the four
+# channels that inject memory content into a context. agent_briefing
+# (SubagentStart) was the forgotten fourth channel flagged by the jury.
+# The DDL CHECK constraints in pg_schema.py / sqlite_schema.py mirror
+# these values — parity is asserted by test, not by convention.
+INJECTION_CHANNELS: frozenset[str] = frozenset(
+    {"recall", "session_start", "auto_recall", "agent_briefing"}
+)
+
+
+def receipt_marker(receipt_id: int) -> str:
+    """Render the in-context receipt marker (correction 2).
+
+    The marker travels INSIDE the injected text so the model can later
+    pass the receipt id back to ``cortex:why(receipt_ids=[...])`` — the
+    receipt-based primary path; server-side session-temporal resolution
+    does not exist in MCP.
+    """
+    return f"⟦rcpt:{receipt_id}⟧"
+
+
+def session_id_from_transcript(transcript_path: object) -> str | None:
+    """Derive the session identity from the transcript file name.
+
+    Decision 4255039 correction 7: the hook event's ``session_id`` field
+    diverges from the transcript identity across resume/clear chains
+    (verified 148/200 lines on fixture 7374abf5). The transcript file
+    basename is the stable identity; when no transcript_path is present
+    the honest value is None (session_id is NULLable by design).
+
+    The hook event is EXTERNAL input (system boundary) — a malformed
+    transcript_path of any non-string type degrades to None rather than
+    raising into the hook's primary injection path.
+    """
+    if not isinstance(transcript_path, str) or not transcript_path:
+        return None
+    return Path(transcript_path).stem or None
+
+
+def _build_items(memories: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Map an injected payload to receipt items, rank = injection order.
+
+    Internal contract, trusted here: every injected entry carries an
+    int-coercible ``memory_id``. A missing id is an upstream programming
+    bug and MUST raise loudly: swallowing it would silently drop
+    receipts in production and hide the regression.
+    """
+    return [
+        {
+            "memory_id": int(m["memory_id"]),
+            "rank": rank,
+            "score": None if m.get("score") is None else float(m["score"]),
+        }
+        for rank, m in enumerate(memories)
+    ]
+
+
+def _check_channel(channel: str) -> None:
+    """Reject unknown channels loudly — a wrong channel is a coding bug."""
+    if channel not in INJECTION_CHANNELS:
+        raise ValueError(
+            f"unknown injection channel {channel!r}; "
+            f"expected one of {sorted(INJECTION_CHANNELS)}"
+        )
 
 
 def emit_injection_receipt(
@@ -32,30 +102,49 @@ def emit_injection_receipt(
 
     Returns None — without failing the recall read path — when nothing
     was injected or when the receipt write fails (I/O is the only named
-    degradation mode).
-
-    Internal contract, trusted here: every bound-payload entry carries an
-    int-coercible ``memory_id`` — pg_recall projects it on every candidate
-    (typed injection gated by ``if mid:``), inject_triggered_memories
-    builds items from a just-fetched ``mid``, and bound_payload preserves
-    ids on truncation. A missing id is an upstream programming bug and
-    MUST raise here, loudly: swallowing it would silently drop receipts
-    in production and hide the regression.
+    degradation mode). Contract violations (unknown channel, missing
+    memory_id) raise before any I/O is attempted.
     """
+    _check_channel(channel)
     if not memories:
         return None
-    items = [
-        {
-            "memory_id": int(m["memory_id"]),
-            "rank": rank,
-            "score": None if m.get("score") is None else float(m["score"]),
-        }
-        for rank, m in enumerate(memories)
-    ]
+    items = _build_items(memories)
     try:
         return store.insert_injection_receipt(
             channel=channel, items=items, session_id=session_id
         )
     except Exception:
         logger.warning("injection receipt emission failed", exc_info=True)
+        return None
+
+
+def emit_hook_receipt(
+    conn: Any,
+    memories: list[dict[str, Any]],
+    *,
+    channel: str,
+    session_id: str | None,
+) -> int | None:
+    """Persist a receipt from a hook channel (T2); return receipt_id.
+
+    Hooks own a short-lived psycopg connection and no store instance.
+    Same parity invariant as ``emit_injection_receipt``: call with
+    exactly the memories that will be printed to stdout — entries
+    dropped by an injection budget were never in context; entries
+    printed truncated keep their id and ARE in context.
+
+    Same degradation contract: None on empty payload or receipt-write
+    I/O failure (the hook keeps injecting its banner either way); loud
+    raise on contract violations.
+    """
+    _check_channel(channel)
+    if not memories:
+        return None
+    items = _build_items(memories)
+    try:
+        return insert_receipt_on_connection(
+            conn, channel=channel, items=items, session_id=session_id
+        )
+    except Exception:
+        logger.warning("hook receipt emission failed", exc_info=True)
         return None

--- a/mcp_server/handlers/injection_receipts.py
+++ b/mcp_server/handlers/injection_receipts.py
@@ -1,0 +1,61 @@
+"""Injection-receipt emission for context-injecting channels.
+
+Blame path T1 (decision Cortex 4255039): every channel that injects
+memory content into a context emits an append-only receipt at injection
+time — the presence-in-context evidence the blame path resolves against.
+T1 wires the recall channel only; the hook channels (session_start,
+agent_briefing) follow in T2.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def emit_injection_receipt(
+    store: Any,
+    memories: list[dict[str, Any]],
+    *,
+    channel: str = "recall",
+    session_id: str | None = None,
+) -> int | None:
+    """Persist a receipt mirroring the bound payload; return receipt_id.
+
+    Must be called AFTER bound_payload (transcript↔DB parity invariant,
+    decision 4255039): entries dropped by the response budget were never
+    injected; truncated entries keep their id and ARE in context.
+    ``rank`` = index in the injected payload (0 = top result), persisted
+    verbatim — blame ordering replays recorded facts only.
+
+    Returns None — without failing the recall read path — when nothing
+    was injected or when the receipt write fails (I/O is the only named
+    degradation mode).
+
+    Internal contract, trusted here: every bound-payload entry carries an
+    int-coercible ``memory_id`` — pg_recall projects it on every candidate
+    (typed injection gated by ``if mid:``), inject_triggered_memories
+    builds items from a just-fetched ``mid``, and bound_payload preserves
+    ids on truncation. A missing id is an upstream programming bug and
+    MUST raise here, loudly: swallowing it would silently drop receipts
+    in production and hide the regression.
+    """
+    if not memories:
+        return None
+    items = [
+        {
+            "memory_id": int(m["memory_id"]),
+            "rank": rank,
+            "score": None if m.get("score") is None else float(m["score"]),
+        }
+        for rank, m in enumerate(memories)
+    ]
+    try:
+        return store.insert_injection_receipt(
+            channel=channel, items=items, session_id=session_id
+        )
+    except Exception:
+        logger.warning("injection receipt emission failed", exc_info=True)
+        return None

--- a/mcp_server/handlers/recall.py
+++ b/mcp_server/handlers/recall.py
@@ -18,6 +18,7 @@ from mcp_server.core.pg_recall import recall as pg_recall
 from mcp_server.core.query_intent import QueryIntent, classify_query_intent
 from mcp_server.core.response_budget import ListTarget, bound_payload
 from mcp_server.handlers._tool_meta import READ_ONLY
+from mcp_server.handlers.injection_receipts import emit_injection_receipt
 from mcp_server.handlers.recall_helpers import (
     annotate_source_attribution,
     build_enhancements,
@@ -99,6 +100,15 @@ schema = {
                 "description": "Classified query intent that drove the signal-weight profile.",
             },
             "count": {"type": "integer", "description": "Number of memories returned."},
+            "receipt_id": {
+                "type": "integer",
+                "description": (
+                    "Append-only injection receipt recording exactly the "
+                    "memories in this response (blame path, decision "
+                    "4255039). Absent when no memory was injected or the "
+                    "receipt write failed."
+                ),
+            },
         },
     },
     "description": (
@@ -489,6 +499,14 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
         resp, [ListTarget("memories", weight_key="score")], settings.MAX_RESPONSE_CHARS
     )
     resp["count"] = len(resp["memories"])
+    # Blame path T1 (decision 4255039): the receipt is emitted AFTER
+    # bound_payload so it mirrors exactly what enters the context
+    # (transcript↔DB parity invariant) — entries dropped by the response
+    # budget were never injected. session_id stays NULL until the hook
+    # channels land (T2); this handler has no session identity in scope.
+    receipt_id = emit_injection_receipt(store, resp["memories"])
+    if receipt_id is not None:
+        resp["receipt_id"] = receipt_id
     return resp
 
 

--- a/mcp_server/handlers/why.py
+++ b/mcp_server/handlers/why.py
@@ -1,0 +1,304 @@
+"""Handler: why -- resolve injection receipts into presence evidence.
+
+Blame path T3 (decision Cortex 4255039): the receipt-based primary
+path. The model reads the ⟦rcpt:id⟧ markers present in its own context
+(correction 2 — server-side session-temporal resolution does not exist
+in MCP) and hands the ids back here; this handler resolves them against
+the append-only receipt trail into presence-in-context evidence: which
+memories each channel put in front of the model, when, at which
+persisted rank and score.
+
+Locked lexicon: this is evidence of PRESENCE IN CONTEXT — Pearl's
+ladder rung 1, recorded associations only — never a causal claim about
+what produced an answer.
+
+Anti-self-pollution (correction 4): the receipt injected alongside the
+CURRENT prompt (its auto_recall block) must not enter the blame. Only
+the model can identify that marker — it is the one attached to the
+prompt asking the question — so the exclusion is enforced at the
+instruction layer (this schema + the /why command); the response keeps
+it auditable by carrying channel + emitted_at on every row.
+
+Anti-flooding bound (correction 5): the response passes through
+``bound_payload`` — the same measured budget as recall — so a long
+session's receipts cannot drown the context; truncated rows keep their
+ids for fetch-by-id.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_server.core.response_budget import ListTarget, bound_payload
+from mcp_server.handlers._tool_meta import READ_ONLY
+from mcp_server.handlers.injection_receipts import INJECTION_CHANNELS
+from mcp_server.infrastructure.memory_config import get_memory_settings
+from mcp_server.infrastructure.memory_store import get_shared_store
+
+schema = {
+    "title": "Why (injection blame: presence-in-context)",
+    "annotations": READ_ONLY,
+    "outputSchema": {
+        "type": "object",
+        "required": ["evidence", "count", "semantics"],
+        "properties": {
+            "evidence": {
+                "type": "array",
+                "description": (
+                    "Flat presence-in-context evidence, one row per "
+                    "(receipt, injected memory) pair. Ordered by recorded "
+                    "facts only: emitted_at DESC, receipt id DESC, then the "
+                    "injection rank persisted at emission time."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "receipt_id": {"type": "integer"},
+                        "channel": {
+                            "type": "string",
+                            "enum": sorted(INJECTION_CHANNELS),
+                            "description": "Injection channel that emitted the receipt.",
+                        },
+                        "session_id": {
+                            "type": ["string", "null"],
+                            "description": (
+                                "Transcript-derived session identity; null for "
+                                "receipts emitted by the MCP recall handler "
+                                "(no session in scope, decision 4255039 "
+                                "correction 1)."
+                            ),
+                        },
+                        "emitted_at": {
+                            "type": "string",
+                            "description": "Injection instant (ISO 8601).",
+                        },
+                        "memory_id": {"type": "integer"},
+                        "rank": {
+                            "type": "integer",
+                            "description": (
+                                "0-based position in the injected payload, "
+                                "persisted at emission — replayed, never "
+                                "recomputed."
+                            ),
+                        },
+                        "score": {
+                            "type": ["number", "null"],
+                            "description": (
+                                "Retrieval score at injection time; null for "
+                                "channels that do not score (e.g. the "
+                                "session_start banner)."
+                            ),
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": (
+                                "Memory body as stored NOW (the receipt "
+                                "proves presence, not the byte-exact text "
+                                "injected then). Absent when the memory was "
+                                "hard-forgotten. Truncated rows keep their "
+                                "memory_id — fetch the full body via recall's "
+                                "memory_id argument."
+                            ),
+                        },
+                        "memory_missing": {
+                            "type": "boolean",
+                            "description": (
+                                "True when the memory row no longer exists "
+                                "(hard-forget after injection). The receipt "
+                                "remains valid presence evidence — that is "
+                                "why receipt items carry no FK."
+                            ),
+                        },
+                        "superseded_by_id": {
+                            "type": ["integer", "null"],
+                            "description": (
+                                "Set when this memory has already been "
+                                "corrected by a superseding memory. Surfaced, "
+                                "never filtered: the receipt is historical "
+                                "evidence of what was in context."
+                            ),
+                        },
+                        "memory_created_at": {"type": ["string", "null"]},
+                        "memory_source": {"type": ["string", "null"]},
+                        "memory_domain": {"type": ["string", "null"]},
+                        "truncated": {
+                            "type": "boolean",
+                            "description": (
+                                "Present and true when content was cut to fit "
+                                "the response budget."
+                            ),
+                        },
+                        "content_length": {
+                            "type": "integer",
+                            "description": "Original content size (set when truncated).",
+                        },
+                    },
+                },
+            },
+            "count": {
+                "type": "integer",
+                "description": "Number of evidence rows returned.",
+            },
+            "receipts_resolved": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "Requested receipt ids found in the store.",
+            },
+            "receipts_unknown": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": (
+                    "Requested receipt ids with no stored receipt — a typo'd "
+                    "marker or a receipt from another store."
+                ),
+            },
+            "semantics": {
+                "type": "string",
+                "enum": ["presence-in-context"],
+                "description": (
+                    "Locked lexicon (decision 4255039): this response proves "
+                    "what was PRESENT in the context, never what CAUSED an "
+                    "answer (Pearl's ladder, rung 1)."
+                ),
+            },
+        },
+    },
+    "description": (
+        "Blame path resolver (decision 4255039): turn the ⟦rcpt:N⟧ markers "
+        "visible in the current context into presence-in-context evidence — "
+        "which memories each injection channel (recall, session_start, "
+        "auto_recall, agent_briefing) put into the context, when, at which "
+        "persisted rank and score. This is evidence of PRESENCE, never "
+        "causality. Protocol: collect the ⟦rcpt:N⟧ markers that were in "
+        "context BEFORE the answer being questioned; EXCLUDE the marker "
+        "injected alongside the current prompt's own memory block "
+        "(self-pollution guard) — then pass the ids here. To correct a wrong "
+        "memory surfaced by the evidence, store a superseding memory with "
+        "remember. Deterministic entry point: the /why slash command. "
+        "Distinct from `get_causal_chain` (entity-graph traversal over "
+        "inferred relations) and `recall` (similarity retrieval): why "
+        "replays RECORDED injection receipts only."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "required": ["receipt_ids"],
+        "properties": {
+            "receipt_ids": {
+                "type": "array",
+                "items": {"type": "integer", "minimum": 1, "maximum": 2147483647},
+                "minItems": 1,
+                "maxItems": 999,
+                "description": (
+                    "Receipt ids read from ⟦rcpt:N⟧ markers in the current "
+                    "context (at most 999 per call — bounded envelope, "
+                    "ADR-0045 R2). Pass the markers present before the "
+                    "answer being questioned; exclude the one attached to "
+                    "the current prompt (decision 4255039 correction 4)."
+                ),
+                "examples": [[412], [412, 415, 431]],
+            },
+        },
+    },
+}
+
+
+# Bounded envelope on the id list (ADR-0045 R2). 999 is the lowest
+# documented hard limit on the fetch path: SQLite's default
+# SQLITE_MAX_VARIABLE_NUMBER (sqlite.org/limits.html §9, releases before
+# 3.32.0) and the SQLite fallback binds one parameter per id. It also
+# keeps a worst-case all-unknown response (~7 JSON chars/id) far under
+# MAX_RESPONSE_CHARS, which bound_payload cannot shrink (non-ListTarget).
+_MAX_RECEIPT_IDS = 999
+# Receipt ids are int4 (SERIAL); the PG path casts ::int[], so a larger
+# value is unrepresentable — reject it instead of leaking a backend-
+# specific NumericValueOutOfRange (PG) vs silent-unknown (SQLite) split.
+_INT4_MAX = 2_147_483_647
+
+
+def _parse_receipt_ids(raw: Any) -> list[int]:
+    """Coerce the argument into a deduplicated, ordered id list — loudly.
+
+    A malformed id list is a caller bug, not a degradation mode: raise
+    with the exact offender instead of silently dropping it. bool is
+    rejected explicitly (it is an int subclass and ``True`` would
+    silently resolve receipt 1).
+    """
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("receipt_ids requires a non-empty list of receipt ids")
+    if len(raw) > _MAX_RECEIPT_IDS:
+        raise ValueError(
+            f"receipt_ids accepts at most {_MAX_RECEIPT_IDS} ids per call, "
+            f"got {len(raw)}"
+        )
+    ids: list[int] = []
+    seen: set[int] = set()
+    for value in raw:
+        if isinstance(value, bool) or not isinstance(value, (int, str)):
+            raise ValueError(f"receipt_ids entries must be integers, got {value!r}")
+        try:
+            rid = int(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"receipt_ids entries must be integers, got {value!r}"
+            ) from exc
+        if rid < 1:
+            raise ValueError(f"receipt ids are positive (SERIAL), got {rid}")
+        if rid > _INT4_MAX:
+            raise ValueError(f"receipt ids fit int4 (SERIAL), got {rid}")
+        if rid not in seen:
+            seen.add(rid)
+            ids.append(rid)
+    return ids
+
+
+def _iso(value: Any) -> str | None:
+    """ISO-8601 string for datetime-ish values; None passes through."""
+    if value is None:
+        return None
+    return value.isoformat() if hasattr(value, "isoformat") else str(value)
+
+
+def _evidence_item(row: dict[str, Any]) -> dict[str, Any]:
+    """Map one store row to one evidence row (recorded facts only)."""
+    item: dict[str, Any] = {
+        "receipt_id": int(row["receipt_id"]),
+        "channel": row["channel"],
+        "session_id": row["session_id"],
+        "emitted_at": _iso(row["emitted_at"]),
+        "memory_id": int(row["memory_id"]),
+        "rank": int(row["rank"]),
+        "score": None if row["score"] is None else float(row["score"]),
+        "memory_missing": row["memory_row_id"] is None,
+    }
+    if row["memory_row_id"] is not None:
+        item["content"] = row["content"]
+        item["superseded_by_id"] = row["superseded_by_id"]
+        item["memory_created_at"] = _iso(row["memory_created_at"])
+        item["memory_source"] = row["memory_source"]
+        item["memory_domain"] = row["memory_domain"]
+    return item
+
+
+async def handler(args: dict[str, Any]) -> dict[str, Any]:
+    """Resolve receipt ids into bounded presence-in-context evidence."""
+    receipt_ids = _parse_receipt_ids(args.get("receipt_ids"))
+    store = get_shared_store()
+    rows = store.fetch_injection_receipts(receipt_ids)
+    evidence = [_evidence_item(r) for r in rows]
+    resolved_ids = {e["receipt_id"] for e in evidence}
+    resp: dict[str, Any] = {
+        "evidence": evidence,
+        "count": len(evidence),
+        "receipts_resolved": sorted(resolved_ids),
+        "receipts_unknown": [r for r in receipt_ids if r not in resolved_ids],
+        "semantics": "presence-in-context",
+    }
+    # Anti-flooding bound (correction 5): same measured budget as recall;
+    # water-filling keeps the highest-scored rows fullest and every
+    # truncated row keeps its memory_id for fetch-by-id.
+    settings = get_memory_settings()
+    resp = bound_payload(
+        resp, [ListTarget("evidence", weight_key="score")], settings.MAX_RESPONSE_CHARS
+    )
+    resp["count"] = len(resp["evidence"])
+    return resp

--- a/mcp_server/hooks/agent_briefing.py
+++ b/mcp_server/hooks/agent_briefing.py
@@ -83,6 +83,12 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from mcp_server.handlers.injection_receipts import (
+    emit_hook_receipt,
+    receipt_marker,
+    session_id_from_transcript,
+)
+
 _LOG_PREFIX = "[cortex-agent-briefing]"
 _DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://localhost:5432/cortex")
 _MAX_MEMORIES = 3
@@ -240,7 +246,20 @@ def _extract_task_keywords(prompt: str) -> list[str]:
     return unique[:8]
 
 
-def _fetch_agent_context(agent_name: str, keywords: list[str]) -> list[dict]:
+def _connect():
+    """Open the briefing's PG connection; None when PG is unreachable."""
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError:
+        return None
+    try:
+        return psycopg.connect(_DATABASE_URL, row_factory=dict_row, autocommit=True)
+    except Exception:
+        return None
+
+
+def _fetch_agent_context(conn, agent_name: str, keywords: list[str]) -> list[dict]:
     """Fetch relevant memories for agent briefing.
 
     Two-pass query:
@@ -248,18 +267,9 @@ def _fetch_agent_context(agent_name: str, keywords: list[str]) -> list[dict]:
     2. Team decisions (is_protected + is_global) — cross-agent knowledge (TMS directory)
 
     Uses FTS plainto_tsquery for speed (no embedding model needed).
+    Each result keeps the memory ``id`` — the injection receipt (T2)
+    records exactly which memories entered the agent's context.
     """
-    try:
-        import psycopg
-        from psycopg.rows import dict_row
-    except ImportError:
-        return []
-
-    try:
-        conn = psycopg.connect(_DATABASE_URL, row_factory=dict_row, autocommit=True)
-    except Exception:
-        return []
-
     results = []
 
     # Pass 1: Agent-scoped memories matching keywords
@@ -278,6 +288,9 @@ def _fetch_agent_context(agent_name: str, keywords: list[str]) -> list[dict]:
                 WHERE m.agent_context = %s
                   AND effective_heat(m, NOW()) >= %s
                   AND NOT m.is_benchmark
+                  -- Never brief an agent with a corrected (superseded)
+                  -- fact — decision 4255039 correction 8.
+                  AND m.superseded_by_id IS NULL
                   AND m.content_tsv @@ plainto_tsquery('english', %s)
                 ORDER BY effective_heat(m, NOW()) DESC
                 LIMIT %s
@@ -287,6 +300,7 @@ def _fetch_agent_context(agent_name: str, keywords: list[str]) -> list[dict]:
             for r in rows:
                 results.append(
                     {
+                        "id": r["id"],
                         "content": r.get("content", "")[:300],
                         "heat": r.get("heat", 0),
                         "source": "agent-prior",
@@ -309,6 +323,9 @@ def _fetch_agent_context(agent_name: str, keywords: list[str]) -> list[dict]:
                   AND m.is_global = TRUE
                   AND m.agent_context != %s
                   AND NOT m.is_benchmark
+                  -- Superseded decisions are corrected facts — never
+                  -- re-inject (decision 4255039 correction 8).
+                  AND m.superseded_by_id IS NULL
                 ORDER BY effective_heat(m, NOW()) DESC
                 LIMIT %s
                 """,
@@ -317,6 +334,7 @@ def _fetch_agent_context(agent_name: str, keywords: list[str]) -> list[dict]:
             for r in rows:
                 results.append(
                     {
+                        "id": r["id"],
                         "content": r.get("content", "")[:300],
                         "heat": r.get("heat", 0),
                         "source": f"team:{r.get('agent_context', '')}",
@@ -325,7 +343,6 @@ def _fetch_agent_context(agent_name: str, keywords: list[str]) -> list[dict]:
         except Exception as exc:
             _log(f"team decisions query failed: {exc}")
 
-    conn.close()
     return results
 
 
@@ -347,13 +364,36 @@ def process_event(event: dict[str, Any]) -> None:
         _log("skip: no keywords extracted")
         sys.exit(0)
 
-    memories = _fetch_agent_context(agent_name, keywords)
-    if not memories:
-        _log(f"skip: no relevant memories for {agent_name}")
+    conn = _connect()
+    if conn is None:
+        _log("skip: PostgreSQL unavailable")
         sys.exit(0)
 
+    try:
+        memories = _fetch_agent_context(conn, agent_name, keywords)
+        if not memories:
+            _log(f"skip: no relevant memories for {agent_name}")
+            sys.exit(0)
+
+        # Receipt for exactly the memories entering the agent's context
+        # (blame path T2, decision 4255039 correction 3 — SubagentStart
+        # is the fourth injecting channel). Emitted before rendering so
+        # the header can carry the ⟦rcpt:id⟧ marker (correction 2); a
+        # failed write degrades to a marker-less briefing.
+        receipt_id = emit_hook_receipt(
+            conn,
+            [{"memory_id": m["id"]} for m in memories],
+            channel="agent_briefing",
+            session_id=session_id_from_transcript(event.get("transcript_path")),
+        )
+    finally:
+        conn.close()
+
     # Build injection
-    lines = [f"## Cortex Briefing ({agent_name})\n"]
+    header = f"## Cortex Briefing ({agent_name})"
+    if receipt_id is not None:
+        header += f" {receipt_marker(receipt_id)}"
+    lines = [header + "\n"]
     for m in memories:
         source = m.get("source", "")
         prefix = f"[{source}] " if source else ""

--- a/mcp_server/hooks/auto_recall.py
+++ b/mcp_server/hooks/auto_recall.py
@@ -68,6 +68,12 @@ import re
 import sys
 from typing import Any
 
+from mcp_server.handlers.injection_receipts import (
+    emit_hook_receipt,
+    receipt_marker,
+    session_id_from_transcript,
+)
+
 _LOG_PREFIX = "[cortex-auto-recall]"
 _DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://localhost:5432/cortex")
 _MAX_MEMORIES = 3
@@ -118,27 +124,29 @@ def _should_skip(query: str) -> bool:
     return False
 
 
-def _recall_memories(query: str) -> list[dict]:
+def _connect():
+    """Open the hook's PG connection; None when PG is unreachable."""
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError:
+        return None
+    try:
+        return psycopg.connect(_DATABASE_URL, row_factory=dict_row, autocommit=True)
+    except Exception:
+        return None
+
+
+def _recall_memories(conn, query: str) -> list[dict]:
     """Fast FTS-based recall against PG. No embedding model needed.
 
     Uses plainto_tsquery for natural language matching against the
     content_tsv tsvector column. Combined with heat filter to surface
     important memories.
 
-    Falls back to ILIKE if FTS returns nothing (handles short queries
-    that don't tokenize well).
+    Each result keeps the memory ``id`` — the injection receipt (T2)
+    records exactly which memories entered the context.
     """
-    try:
-        import psycopg
-        from psycopg.rows import dict_row
-    except ImportError:
-        return []
-
-    try:
-        conn = psycopg.connect(_DATABASE_URL, row_factory=dict_row, autocommit=True)
-    except Exception:
-        return []
-
     results = []
 
     # Pass 1: FTS match with heat filter.
@@ -162,6 +170,9 @@ def _recall_memories(query: str) -> list[dict]:
             WHERE m.content_tsv @@ q
               AND effective_heat(m, NOW()) >= %s
               AND NOT m.is_benchmark
+              -- Never re-inject a corrected (superseded) fact —
+              -- decision 4255039 correction 8.
+              AND m.superseded_by_id IS NULL
             ORDER BY m.is_protected DESC, rank DESC, effective_heat(m, NOW()) DESC
             LIMIT %s
             """,
@@ -171,6 +182,7 @@ def _recall_memories(query: str) -> list[dict]:
         for r in rows:
             results.append(
                 {
+                    "id": r["id"],
                     "content": r.get("content", ""),
                     "heat": r.get("heat", 0),
                     "domain": r.get("domain", ""),
@@ -181,18 +193,22 @@ def _recall_memories(query: str) -> list[dict]:
     except Exception as exc:
         _log(f"FTS query failed: {exc}")
 
-    conn.close()
     return results[:_MAX_MEMORIES]
 
 
-def _format_injection(memories: list[dict]) -> str:
+def _format_injection(memories: list[dict]) -> tuple[str, list[dict]]:
     """Format memories as a compact context block for injection.
 
-    Keeps total injection under _MAX_INJECTION_CHARS to avoid
-    flooding the context window.
+    Keeps total injection under _MAX_INJECTION_CHARS to avoid flooding
+    the context window. Returns the block AND the memories that actually
+    fit — the injection receipt must mirror what is printed, never what
+    was fetched (parity invariant, decision 4255039 correction 11):
+    entries dropped by the budget were never in context; entries printed
+    truncated keep their id and ARE in context.
     """
     lines = ["**Cortex context:**"]
     total_chars = len(lines[0])
+    included: list[dict] = []
 
     for m in memories:
         content = m["content"].replace("\n", " ").strip()
@@ -211,11 +227,12 @@ def _format_injection(memories: list[dict]) -> str:
 
         lines.append(line)
         total_chars += len(line)
+        included.append(m)
 
     if len(lines) == 1:
-        return ""  # No memories fit
+        return "", []  # No memories fit
 
-    return "\n".join(lines)
+    return "\n".join(lines), included
 
 
 def process_event(event: dict[str, Any]) -> None:
@@ -228,19 +245,41 @@ def process_event(event: dict[str, Any]) -> None:
     if _should_skip(query):
         sys.exit(0)
 
-    memories = _recall_memories(query)
-
-    if not memories:
+    conn = _connect()
+    if conn is None:
         sys.exit(0)
 
-    injection = _format_injection(memories)
+    try:
+        memories = _recall_memories(conn, query)
+        if not memories:
+            sys.exit(0)
 
-    if not injection:
-        sys.exit(0)
+        injection, included = _format_injection(memories)
+        if not injection:
+            sys.exit(0)
+
+        # Receipt for exactly the memories that fit the injection budget
+        # (blame path T2, decision 4255039). Emitted before printing so
+        # the header line can carry the ⟦rcpt:id⟧ marker (correction 2);
+        # a failed write degrades to a marker-less injection.
+        receipt_id = emit_hook_receipt(
+            conn,
+            [{"memory_id": m["id"]} for m in included],
+            channel="auto_recall",
+            session_id=session_id_from_transcript(event.get("transcript_path")),
+        )
+    finally:
+        conn.close()
+
+    if receipt_id is not None:
+        first, _, rest = injection.partition("\n")
+        injection = f"{first} {receipt_marker(receipt_id)}"
+        if rest:
+            injection += "\n" + rest
 
     # Exit 0 + stdout → injected into Claude's context
     print(injection)
-    _log(f"injected {len(memories)} memories for query: {query[:50]}...")
+    _log(f"injected {len(included)} memories for query: {query[:50]}...")
     sys.exit(0)
 
 

--- a/mcp_server/hooks/session_start.py
+++ b/mcp_server/hooks/session_start.py
@@ -24,6 +24,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+from mcp_server.handlers.injection_receipts import (
+    emit_hook_receipt,
+    receipt_marker,
+    session_id_from_transcript,
+)
+
 # ── Config ────────────────────────────────────────────────────────────────
 
 _DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://127.0.0.1:5432/cortex")
@@ -35,6 +41,23 @@ _PLUGIN_ROOT = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
 
 def _log(msg: str) -> None:
     print(f"[session-start-hook] {msg}", file=sys.stderr)
+
+
+def _read_event() -> dict:
+    """Read the SessionStart hook event from stdin, tolerantly.
+
+    Claude Code pipes the event JSON ({"session_id", "transcript_path",
+    "cwd", ...}) to every hook. A manual/tty run, an empty pipe, or
+    malformed JSON all degrade to {} — the banner never depends on the
+    event; only the receipt's session identity does (correction 7).
+    """
+    if sys.stdin.isatty():
+        return {}
+    try:
+        raw = sys.stdin.read().strip()
+        return json.loads(raw) if raw else {}
+    except Exception:
+        return {}
 
 
 def _has_sentence_transformers() -> bool:
@@ -118,6 +141,9 @@ def _fetch_anchors(conn) -> list[dict]:
             # be protected, but guard against misconfiguration).
             # contract: zetetic-team-subagents memory/contract.md §8b
             "AND NOT (m.tags @> '[\"auto-captured\"]'::jsonb) "
+            # Never inject a corrected (superseded) fact into the banner —
+            # decision 4255039 correction 8.
+            "AND m.superseded_by_id IS NULL "
             "ORDER BY effective_heat(m, NOW()) DESC LIMIT %s",
             (int(_ANCHOR_LIMIT),),
         ).fetchall()
@@ -165,6 +191,9 @@ def _fetch_team_decisions(conn, exclude_ids: set) -> list[dict]:
             "effective_heat(m, NOW()) AS heat FROM memories m "
             "WHERE m.is_protected = TRUE AND m.is_global = TRUE "
             "AND m.agent_context != '' "
+            # Superseded decisions are corrected facts — never re-inject
+            # (decision 4255039 correction 8).
+            "AND m.superseded_by_id IS NULL "
             "ORDER BY effective_heat(m, NOW()) DESC LIMIT 5",
         ).fetchall()
     except Exception:
@@ -203,6 +232,9 @@ def _fetch_hot_memories(conn, exclude_ids: set) -> list[dict]:
             # contract: zetetic-team-subagents memory/contract.md §8b
             "AND NOT (tags @> '[\"auto-captured\"]'::jsonb "
             "         OR tags @> '[\"memory-replica\"]'::jsonb) "
+            # Never re-inject a corrected (superseded) fact —
+            # decision 4255039 correction 8.
+            "AND superseded_by_id IS NULL "
             "ORDER BY heat_base DESC LIMIT %s",
             (float(_MIN_HEAT), int(_HOT_LIMIT + len(exclude_ids))),
         ).fetchall()
@@ -444,14 +476,43 @@ def _format_checkpoint_section(checkpoint: dict) -> list[str]:
     return lines
 
 
+def _emit_banner_receipt(
+    conn, event: dict, anchors: list[dict], team_decisions: list[dict], hot: list[dict]
+) -> int | None:
+    """Emit the session_start injection receipt for the banner (T2).
+
+    Payload order mirrors the banner exactly: anchors, then team
+    decisions, then hot memories — rank = position in the injected
+    context. Banner lines are printed truncated (_short) but the memory
+    IS in context, so truncation never drops an item (same parity stance
+    as recall's bound_payload, decision 4255039 correction 11).
+    """
+    payload = [
+        {"memory_id": m["id"]} for m in (*anchors, *team_decisions, *hot)
+    ]
+    return emit_hook_receipt(
+        conn,
+        payload,
+        channel="session_start",
+        session_id=session_id_from_transcript(event.get("transcript_path")),
+    )
+
+
 def _build_context(
     anchors: list[dict],
     hot: list[dict],
     checkpoint: dict | None,
     team_decisions: list[dict] | None = None,
     pending_curations: int = 0,
+    receipt_id: int | None = None,
 ) -> str:
-    """Build the Markdown context block injected into the session."""
+    """Build the Markdown context block injected into the session.
+
+    ``receipt_id`` stamps the banner header with the ⟦rcpt:id⟧ marker
+    (decision 4255039 correction 2) so the model can hand the id back
+    to ``cortex:why(receipt_ids=[...])`` — the receipt travels in-context
+    because server-side session-temporal resolution does not exist.
+    """
     if (
         not anchors
         and not hot
@@ -461,7 +522,10 @@ def _build_context(
     ):
         return ""
 
-    lines = ["## Cortex Memory Context\n"]
+    header = "## Cortex Memory Context"
+    if receipt_id is not None:
+        header += f" {receipt_marker(receipt_id)}"
+    lines = [header + "\n"]
 
     if checkpoint and checkpoint.get("current_task"):
         lines.extend(_format_checkpoint_section(checkpoint))
@@ -813,6 +877,10 @@ def _lookup_cached_graph_path(project_root: str) -> str | None:
 def main() -> None:
     """Entry point — print context block to stdout."""
 
+    # Hook event first: stdin carries transcript_path, the stable session
+    # identity for the injection receipt (decision 4255039 correction 7).
+    event = _read_event()
+
     # Auto-discovery runs before the PG path so users see it work even
     # on a fresh machine without a DB set up yet.
     _auto_wire_pipeline()
@@ -880,6 +948,10 @@ def main() -> None:
     team_decisions = _fetch_team_decisions(conn, anchor_ids)
     checkpoint = _fetch_checkpoint(conn)
     pending_curations = _count_pending_curations(conn)
+    # Receipt BEFORE rendering: the banner header carries the ⟦rcpt:id⟧
+    # marker, so the id must exist when the context is built. A failed
+    # write degrades to a marker-less banner (read path intact).
+    receipt_id = _emit_banner_receipt(conn, event, anchors, team_decisions, hot)
     conn.close()
 
     context = _build_context(
@@ -888,6 +960,7 @@ def main() -> None:
         checkpoint,
         team_decisions,
         pending_curations=pending_curations,
+        receipt_id=receipt_id,
     )
 
     if context:

--- a/mcp_server/hooks/session_start.py
+++ b/mcp_server/hooks/session_start.py
@@ -487,9 +487,7 @@ def _emit_banner_receipt(
     IS in context, so truncation never drops an item (same parity stance
     as recall's bound_payload, decision 4255039 correction 11).
     """
-    payload = [
-        {"memory_id": m["id"]} for m in (*anchors, *team_decisions, *hot)
-    ]
+    payload = [{"memory_id": m["id"]} for m in (*anchors, *team_decisions, *hot)]
     return emit_hook_receipt(
         conn,
         payload,

--- a/mcp_server/infrastructure/pg_schema.py
+++ b/mcp_server/infrastructure/pg_schema.py
@@ -462,18 +462,23 @@ CREATE INDEX IF NOT EXISTS idx_stage_transitions_memory
 CREATE INDEX IF NOT EXISTS idx_stage_transitions_time
     ON stage_transitions (transitioned_at);
 
--- Injection receipts (blame path T1 — decision Cortex 4255039). Every
+-- Injection receipts (blame path T1/T2 — decision Cortex 4255039). Every
 -- channel that injects memory content into a context emits, at injection
 -- time, an append-only receipt capturing {memory_id, rank, score} for
 -- exactly the bound payload (emitted AFTER bound_payload: transcript↔DB
 -- parity invariant). Presence-in-context evidence only, never causality
 -- (Pearl ladder). session_id is NULLable: the mcp recall handler has no
--- session identity in scope until the hook channels land (T2). channel
--- stays free TEXT until the channel enum hardens in T2.
+-- session identity in scope; hook channels derive it from the transcript
+-- file basename (correction 7). channel is enum-hardened (T2): the four
+-- values mirror handlers/injection_receipts.py INJECTION_CHANNELS —
+-- parity asserted by test_injection_receipts_store.py.
 CREATE TABLE IF NOT EXISTS injection_receipts (
     id                  SERIAL PRIMARY KEY,
     session_id          TEXT,
-    channel             TEXT NOT NULL,
+    channel             TEXT NOT NULL
+        CONSTRAINT injection_receipts_channel_enum CHECK (
+            channel IN ('recall', 'session_start', 'auto_recall', 'agent_briefing')
+        ),
     emitted_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_injection_receipts_session
@@ -1864,6 +1869,24 @@ DO $$ BEGIN
                               'type','constant','variable')
            OR name LIKE '%/%'
            OR (length(name) - length(replace(name, '.', ''))) >= 2;
+    END IF;
+END $$;
+
+-- Migration: harden the injection-receipts channel enum (blame path T2,
+-- decision 4255039 correction 3). Tables created by the T1 DDL carry a
+-- free-TEXT channel; the CHECK added here mirrors the CREATE TABLE
+-- constraint above and handlers/injection_receipts.py INJECTION_CHANNELS.
+-- T1 only ever wrote 'recall', a member of the enum, so validating
+-- existing rows is safe.
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'injection_receipts_channel_enum'
+    ) THEN
+        ALTER TABLE injection_receipts
+            ADD CONSTRAINT injection_receipts_channel_enum CHECK (
+                channel IN ('recall', 'session_start', 'auto_recall', 'agent_briefing')
+            );
     END IF;
 END $$;
 """

--- a/mcp_server/infrastructure/pg_schema.py
+++ b/mcp_server/infrastructure/pg_schema.py
@@ -462,6 +462,41 @@ CREATE INDEX IF NOT EXISTS idx_stage_transitions_memory
 CREATE INDEX IF NOT EXISTS idx_stage_transitions_time
     ON stage_transitions (transitioned_at);
 
+-- Injection receipts (blame path T1 — decision Cortex 4255039). Every
+-- channel that injects memory content into a context emits, at injection
+-- time, an append-only receipt capturing {memory_id, rank, score} for
+-- exactly the bound payload (emitted AFTER bound_payload: transcript↔DB
+-- parity invariant). Presence-in-context evidence only, never causality
+-- (Pearl ladder). session_id is NULLable: the mcp recall handler has no
+-- session identity in scope until the hook channels land (T2). channel
+-- stays free TEXT until the channel enum hardens in T2.
+CREATE TABLE IF NOT EXISTS injection_receipts (
+    id                  SERIAL PRIMARY KEY,
+    session_id          TEXT,
+    channel             TEXT NOT NULL,
+    emitted_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_injection_receipts_session
+    ON injection_receipts (session_id);
+CREATE INDEX IF NOT EXISTS idx_injection_receipts_time
+    ON injection_receipts (emitted_at);
+
+-- memory_id carries NO FK on purpose: receipts are an append-only audit
+-- trail — a later hard-forget of the memory must not rewrite the evidence
+-- of what was in context (unlike stage_transitions, whose rows lose all
+-- value once the memory is gone).
+CREATE TABLE IF NOT EXISTS injection_receipt_items (
+    id                  SERIAL PRIMARY KEY,
+    receipt_id          INTEGER NOT NULL REFERENCES injection_receipts(id) ON DELETE CASCADE,
+    memory_id           INTEGER NOT NULL,
+    rank                INTEGER NOT NULL,
+    score               REAL
+);
+CREATE INDEX IF NOT EXISTS idx_injection_receipt_items_receipt
+    ON injection_receipt_items (receipt_id);
+CREATE INDEX IF NOT EXISTS idx_injection_receipt_items_memory
+    ON injection_receipt_items (memory_id);
+
 CREATE TABLE IF NOT EXISTS engram_slots (
     slot_index          INTEGER PRIMARY KEY,
     excitability        REAL DEFAULT 0.5,

--- a/mcp_server/infrastructure/pg_store.py
+++ b/mcp_server/infrastructure/pg_store.py
@@ -36,6 +36,7 @@ from mcp_server.infrastructure.pg_store_auxiliary import PgAuxiliaryMixin
 from mcp_server.infrastructure.pg_store_entities import PgEntityMixin
 from mcp_server.infrastructure.pg_store_entity_merge import PgEntityMergeMixin
 from mcp_server.infrastructure.pg_store_queries import PgQueryMixin
+from mcp_server.infrastructure.pg_store_receipts import PgReceiptsMixin
 from mcp_server.infrastructure.pg_store_relationships import PgRelationshipMixin
 from mcp_server.infrastructure.pg_store_rules import PgRuleMixin
 from mcp_server.infrastructure.pg_store_stats import PgStatsMixin
@@ -133,6 +134,7 @@ class PgMemoryStore(
     PgEntityMergeMixin,
     PgRelationshipMixin,
     PgQueryMixin,
+    PgReceiptsMixin,
     PgRuleMixin,
     PgStatsMixin,
     PgAuxiliaryMixin,

--- a/mcp_server/infrastructure/pg_store_receipts.py
+++ b/mcp_server/infrastructure/pg_store_receipts.py
@@ -1,8 +1,10 @@
 """Injection-receipt persistence, PostgreSQL backend.
 
-Blame path T1/T2 (decision Cortex 4255039): receipts are an append-only
-record of what a channel injected into a context — there is no update
-or delete surface by design.
+Blame path T1/T2/T3 (decision Cortex 4255039): receipts are an
+append-only record of what a channel injected into a context — there is
+no update or delete surface by design. T3 adds the read path: resolving
+receipt ids (handed back by the model from ⟦rcpt:id⟧ context markers)
+into presence-in-context evidence.
 
 Two write paths share the single-statement SQL below:
 
@@ -66,6 +68,29 @@ def insert_receipt_on_connection(
     return int(row["receipt_id"] if isinstance(row, dict) else row[0])
 
 
+# Read path (T3). LEFT JOIN on purpose: memory_id carries no FK — a
+# memory hard-forgotten after injection must NOT erase the evidence that
+# it WAS in context; such rows come back with every m.* column NULL.
+# superseded_by_id is surfaced, never filtered: a receipt is historical
+# evidence, and a superseded memory that was injected stays part of the
+# record — the caller sees the correction state instead. Ordering is
+# recorded facts only (decision 4255039): emitted_at DESC, receipt id
+# DESC as the deterministic tiebreak, then the persisted injection rank.
+_FETCH_RECEIPTS_SQL = (
+    "SELECT r.id AS receipt_id, r.session_id, r.channel, r.emitted_at,"
+    "       i.memory_id, i.rank, i.score,"
+    "       m.id AS memory_row_id, m.content,"
+    "       m.created_at AS memory_created_at,"
+    "       m.source AS memory_source, m.domain AS memory_domain,"
+    "       m.superseded_by_id "
+    "FROM injection_receipts r "
+    "JOIN injection_receipt_items i ON i.receipt_id = r.id "
+    "LEFT JOIN memories m ON m.id = i.memory_id "
+    "WHERE r.id = ANY(%s::int[]) "
+    "ORDER BY r.emitted_at DESC, r.id DESC, i.rank ASC"
+)
+
+
 class PgReceiptsMixin:
     """Append-only injection receipts (blame path T1)."""
 
@@ -81,3 +106,21 @@ class PgReceiptsMixin:
         ).fetchone()
         self._conn.commit()
         return int(row["receipt_id"])
+
+    def fetch_injection_receipts(
+        self, receipt_ids: list[int]
+    ) -> list[dict]:
+        """Resolve receipt ids into flat (receipt × item × memory) rows.
+
+        One row per injected memory, ordered by recorded facts only
+        (emitted_at DESC, receipt id DESC, persisted rank ASC). Unknown
+        ids simply yield no rows — the handler reports them; an empty
+        input reads as an empty result (the loud non-empty contract
+        lives at the tool boundary, not here).
+        """
+        if not receipt_ids:
+            return []
+        rows = self._execute(
+            _FETCH_RECEIPTS_SQL, ([int(r) for r in receipt_ids],)
+        ).fetchall()
+        return [dict(r) for r in rows]

--- a/mcp_server/infrastructure/pg_store_receipts.py
+++ b/mcp_server/infrastructure/pg_store_receipts.py
@@ -1,11 +1,69 @@
 """Injection-receipt persistence, PostgreSQL backend.
 
-Blame path T1 (decision Cortex 4255039): receipts are an append-only
+Blame path T1/T2 (decision Cortex 4255039): receipts are an append-only
 record of what a channel injected into a context — there is no update
 or delete surface by design.
+
+Two write paths share the single-statement SQL below:
+
+* ``PgReceiptsMixin.insert_injection_receipt`` — the store path used by
+  the MCP recall handler (pooled connections via ``_execute``).
+* ``insert_receipt_on_connection`` — the hook path (T2): SessionStart /
+  UserPromptSubmit / SubagentStart hooks own a short-lived psycopg
+  connection and no store instance.
 """
 
 from __future__ import annotations
+
+# Single data-modifying-CTE statement on purpose: the store's
+# ``_execute`` borrows a pool connection per call, so two separate
+# INSERTs could land on two connections and lose header/items atomicity.
+_INSERT_RECEIPT_SQL = (
+    "WITH r AS ("
+    "  INSERT INTO injection_receipts (session_id, channel)"
+    "  VALUES (%s, %s) RETURNING id"
+    ") "
+    "INSERT INTO injection_receipt_items"
+    "  (receipt_id, memory_id, rank, score) "
+    "SELECT r.id, t.memory_id, t.rank, t.score "
+    "FROM r, UNNEST(%s::int[], %s::int[], %s::real[])"
+    "  AS t(memory_id, rank, score) "
+    "RETURNING receipt_id"
+)
+
+
+def _receipt_params(
+    channel: str, items: list[dict], session_id: str | None
+) -> tuple:
+    """Coerce items into the (session_id, channel, ids, ranks, scores) tuple."""
+    if not items:
+        raise ValueError("injection receipt requires at least one item")
+    memory_ids = [int(i["memory_id"]) for i in items]
+    ranks = [int(i["rank"]) for i in items]
+    scores = [
+        None if i.get("score") is None else float(i["score"]) for i in items
+    ]
+    return (session_id, channel, memory_ids, ranks, scores)
+
+
+def insert_receipt_on_connection(
+    conn,
+    channel: str,
+    items: list[dict],
+    session_id: str | None = None,
+) -> int:
+    """Insert one receipt atomically on a caller-owned psycopg connection.
+
+    Hook channels (T2) own their connection lifecycle — dict_row or
+    tuple rows both work. Commit is a no-op under autocommit (the hook
+    default); otherwise the receipt commits here.
+    """
+    row = conn.execute(
+        _INSERT_RECEIPT_SQL, _receipt_params(channel, items, session_id)
+    ).fetchone()
+    if not getattr(conn, "autocommit", False):
+        conn.commit()
+    return int(row["receipt_id"] if isinstance(row, dict) else row[0])
 
 
 class PgReceiptsMixin:
@@ -17,31 +75,9 @@ class PgReceiptsMixin:
         items: list[dict],
         session_id: str | None = None,
     ) -> int:
-        """Insert one receipt header + its items atomically; return receipt_id.
-
-        Single data-modifying-CTE statement on purpose: ``_execute``
-        borrows a pool connection per call, so two separate INSERTs
-        could land on two connections and lose header/items atomicity.
-        """
-        if not items:
-            raise ValueError("injection receipt requires at least one item")
-        memory_ids = [int(i["memory_id"]) for i in items]
-        ranks = [int(i["rank"]) for i in items]
-        scores = [
-            None if i.get("score") is None else float(i["score"]) for i in items
-        ]
+        """Insert one receipt header + its items atomically; return receipt_id."""
         row = self._execute(
-            "WITH r AS ("
-            "  INSERT INTO injection_receipts (session_id, channel)"
-            "  VALUES (%s, %s) RETURNING id"
-            ") "
-            "INSERT INTO injection_receipt_items"
-            "  (receipt_id, memory_id, rank, score) "
-            "SELECT r.id, t.memory_id, t.rank, t.score "
-            "FROM r, UNNEST(%s::int[], %s::int[], %s::real[])"
-            "  AS t(memory_id, rank, score) "
-            "RETURNING receipt_id",
-            (session_id, channel, memory_ids, ranks, scores),
+            _INSERT_RECEIPT_SQL, _receipt_params(channel, items, session_id)
         ).fetchone()
         self._conn.commit()
         return int(row["receipt_id"])

--- a/mcp_server/infrastructure/pg_store_receipts.py
+++ b/mcp_server/infrastructure/pg_store_receipts.py
@@ -1,0 +1,47 @@
+"""Injection-receipt persistence, PostgreSQL backend.
+
+Blame path T1 (decision Cortex 4255039): receipts are an append-only
+record of what a channel injected into a context — there is no update
+or delete surface by design.
+"""
+
+from __future__ import annotations
+
+
+class PgReceiptsMixin:
+    """Append-only injection receipts (blame path T1)."""
+
+    def insert_injection_receipt(
+        self,
+        channel: str,
+        items: list[dict],
+        session_id: str | None = None,
+    ) -> int:
+        """Insert one receipt header + its items atomically; return receipt_id.
+
+        Single data-modifying-CTE statement on purpose: ``_execute``
+        borrows a pool connection per call, so two separate INSERTs
+        could land on two connections and lose header/items atomicity.
+        """
+        if not items:
+            raise ValueError("injection receipt requires at least one item")
+        memory_ids = [int(i["memory_id"]) for i in items]
+        ranks = [int(i["rank"]) for i in items]
+        scores = [
+            None if i.get("score") is None else float(i["score"]) for i in items
+        ]
+        row = self._execute(
+            "WITH r AS ("
+            "  INSERT INTO injection_receipts (session_id, channel)"
+            "  VALUES (%s, %s) RETURNING id"
+            ") "
+            "INSERT INTO injection_receipt_items"
+            "  (receipt_id, memory_id, rank, score) "
+            "SELECT r.id, t.memory_id, t.rank, t.score "
+            "FROM r, UNNEST(%s::int[], %s::int[], %s::real[])"
+            "  AS t(memory_id, rank, score) "
+            "RETURNING receipt_id",
+            (session_id, channel, memory_ids, ranks, scores),
+        ).fetchone()
+        self._conn.commit()
+        return int(row["receipt_id"])

--- a/mcp_server/infrastructure/pg_store_receipts.py
+++ b/mcp_server/infrastructure/pg_store_receipts.py
@@ -34,17 +34,13 @@ _INSERT_RECEIPT_SQL = (
 )
 
 
-def _receipt_params(
-    channel: str, items: list[dict], session_id: str | None
-) -> tuple:
+def _receipt_params(channel: str, items: list[dict], session_id: str | None) -> tuple:
     """Coerce items into the (session_id, channel, ids, ranks, scores) tuple."""
     if not items:
         raise ValueError("injection receipt requires at least one item")
     memory_ids = [int(i["memory_id"]) for i in items]
     ranks = [int(i["rank"]) for i in items]
-    scores = [
-        None if i.get("score") is None else float(i["score"]) for i in items
-    ]
+    scores = [None if i.get("score") is None else float(i["score"]) for i in items]
     return (session_id, channel, memory_ids, ranks, scores)
 
 
@@ -107,9 +103,7 @@ class PgReceiptsMixin:
         self._conn.commit()
         return int(row["receipt_id"])
 
-    def fetch_injection_receipts(
-        self, receipt_ids: list[int]
-    ) -> list[dict]:
+    def fetch_injection_receipts(self, receipt_ids: list[int]) -> list[dict]:
         """Resolve receipt ids into flat (receipt × item × memory) rows.
 
         One row per injected memory, ordered by recorded facts only

--- a/mcp_server/infrastructure/sqlite_schema.py
+++ b/mcp_server/infrastructure/sqlite_schema.py
@@ -132,6 +132,30 @@ CREATE TABLE IF NOT EXISTS stage_transitions (
 );
 """
 
+# Injection receipts (blame path T1 — decision Cortex 4255039): append-only
+# proof of presence-in-context per injecting channel. PG parity with
+# pg_schema.py; session_id NULLable (the recall handler has no session
+# identity until the hook channels land in T2). memory_id has no FK: a
+# hard-forget must not rewrite the audit trail.
+INJECTION_RECEIPTS_DDL = """
+CREATE TABLE IF NOT EXISTS injection_receipts (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  TEXT,
+    channel     TEXT NOT NULL,
+    emitted_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"""
+
+INJECTION_RECEIPT_ITEMS_DDL = """
+CREATE TABLE IF NOT EXISTS injection_receipt_items (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    receipt_id  INTEGER NOT NULL REFERENCES injection_receipts(id) ON DELETE CASCADE,
+    memory_id   INTEGER NOT NULL,
+    rank        INTEGER NOT NULL,
+    score       REAL
+);
+"""
+
 MEMORY_ENTITIES_DDL = """
 CREATE TABLE IF NOT EXISTS memory_entities (
     memory_id   INTEGER NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
@@ -309,6 +333,8 @@ def get_all_ddl() -> list[str]:
         RELATIONSHIPS_DDL,
         MEMORY_ENTITIES_DDL,
         STAGE_TRANSITIONS_DDL,
+        INJECTION_RECEIPTS_DDL,
+        INJECTION_RECEIPT_ITEMS_DDL,
         PROSPECTIVE_MEMORIES_DDL,
         CHECKPOINTS_DDL,
         MEMORY_ARCHIVES_DDL,

--- a/mcp_server/infrastructure/sqlite_schema.py
+++ b/mcp_server/infrastructure/sqlite_schema.py
@@ -132,16 +132,23 @@ CREATE TABLE IF NOT EXISTS stage_transitions (
 );
 """
 
-# Injection receipts (blame path T1 — decision Cortex 4255039): append-only
-# proof of presence-in-context per injecting channel. PG parity with
-# pg_schema.py; session_id NULLable (the recall handler has no session
-# identity until the hook channels land in T2). memory_id has no FK: a
-# hard-forget must not rewrite the audit trail.
+# Injection receipts (blame path T1/T2 — decision Cortex 4255039):
+# append-only proof of presence-in-context per injecting channel. PG parity
+# with pg_schema.py; session_id NULLable (the recall handler has no session
+# identity; hooks derive it from the transcript basename). memory_id has no
+# FK: a hard-forget must not rewrite the audit trail. The channel CHECK
+# mirrors handlers/injection_receipts.py INJECTION_CHANNELS (parity asserted
+# by test); tables created by the T1 DDL keep free TEXT — SQLite cannot add
+# a CHECK without a table rebuild (same stance as the non-enforced FK
+# migrations above), so the emitter-level validation is the enforcement
+# point there.
 INJECTION_RECEIPTS_DDL = """
 CREATE TABLE IF NOT EXISTS injection_receipts (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id  TEXT,
-    channel     TEXT NOT NULL,
+    channel     TEXT NOT NULL CHECK (
+        channel IN ('recall', 'session_start', 'auto_recall', 'agent_briefing')
+    ),
     emitted_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 """

--- a/mcp_server/infrastructure/sqlite_store.py
+++ b/mcp_server/infrastructure/sqlite_store.py
@@ -31,6 +31,7 @@ from mcp_server.infrastructure.sqlite_store_entity_merge import (
 )
 from mcp_server.infrastructure.sqlite_store_mood import SqliteMoodMixin
 from mcp_server.infrastructure.sqlite_store_queries import SqliteQueryMixin
+from mcp_server.infrastructure.sqlite_store_receipts import SqliteReceiptsMixin
 from mcp_server.infrastructure.sqlite_store_relationships import (
     SqliteRelationshipMixin,
 )
@@ -57,6 +58,7 @@ class SqliteMemoryStore(
     SqliteEntityMergeMixin,
     SqliteRelationshipMixin,
     SqliteQueryMixin,
+    SqliteReceiptsMixin,
     SqliteRuleMixin,
     SqliteStatsMixin,
     SqliteAuxiliaryMixin,

--- a/mcp_server/infrastructure/sqlite_store_receipts.py
+++ b/mcp_server/infrastructure/sqlite_store_receipts.py
@@ -1,0 +1,41 @@
+"""Injection-receipt persistence, SQLite backend.
+
+Blame path T1 (decision Cortex 4255039): append-only record of what a
+channel injected into a context. PG parity with pg_store_receipts.py.
+"""
+
+from __future__ import annotations
+
+
+class SqliteReceiptsMixin:
+    """Append-only injection receipts (blame path T1)."""
+
+    def insert_injection_receipt(
+        self,
+        channel: str,
+        items: list[dict],
+        session_id: str | None = None,
+    ) -> int:
+        """Insert one receipt header + its items; return receipt_id."""
+        if not items:
+            raise ValueError("injection receipt requires at least one item")
+        cur = self._raw_conn.execute(
+            "INSERT INTO injection_receipts (session_id, channel) VALUES (?, ?)",
+            (session_id, channel),
+        )
+        receipt_id = int(cur.lastrowid)
+        self._raw_conn.executemany(
+            "INSERT INTO injection_receipt_items"
+            " (receipt_id, memory_id, rank, score) VALUES (?, ?, ?, ?)",
+            [
+                (
+                    receipt_id,
+                    int(i["memory_id"]),
+                    int(i["rank"]),
+                    None if i.get("score") is None else float(i["score"]),
+                )
+                for i in items
+            ],
+        )
+        self._conn.commit()
+        return receipt_id

--- a/mcp_server/infrastructure/sqlite_store_receipts.py
+++ b/mcp_server/infrastructure/sqlite_store_receipts.py
@@ -1,7 +1,9 @@
 """Injection-receipt persistence, SQLite backend.
 
-Blame path T1 (decision Cortex 4255039): append-only record of what a
-channel injected into a context. PG parity with pg_store_receipts.py.
+Blame path T1/T3 (decision Cortex 4255039): append-only record of what
+a channel injected into a context, plus the T3 read path resolving
+receipt ids into presence-in-context evidence. PG parity with
+pg_store_receipts.py.
 """
 
 from __future__ import annotations
@@ -39,3 +41,33 @@ class SqliteReceiptsMixin:
         )
         self._conn.commit()
         return receipt_id
+
+    def fetch_injection_receipts(self, receipt_ids: list[int]) -> list[dict]:
+        """Resolve receipt ids into flat (receipt × item × memory) rows.
+
+        PG parity with ``PgReceiptsMixin.fetch_injection_receipts``:
+        LEFT JOIN keeps evidence rows whose memory was hard-forgotten
+        after injection (every m.* column NULL); superseded memories are
+        surfaced with their correction state, never filtered; ordering
+        replays recorded facts only (emitted_at is ISO text, so DESC is
+        chronological). Empty input reads as empty output — the loud
+        non-empty contract lives at the tool boundary.
+        """
+        if not receipt_ids:
+            return []
+        placeholders = ",".join("?" for _ in receipt_ids)
+        rows = self._conn.execute(
+            "SELECT r.id AS receipt_id, r.session_id, r.channel, r.emitted_at,"
+            "       i.memory_id, i.rank, i.score,"
+            "       m.id AS memory_row_id, m.content,"
+            "       m.created_at AS memory_created_at,"
+            "       m.source AS memory_source, m.domain AS memory_domain,"
+            "       m.superseded_by_id "
+            "FROM injection_receipts r "
+            "JOIN injection_receipt_items i ON i.receipt_id = r.id "
+            "LEFT JOIN memories m ON m.id = i.memory_id "
+            f"WHERE r.id IN ({placeholders}) "
+            "ORDER BY r.emitted_at DESC, r.id DESC, i.rank ASC",
+            tuple(int(r) for r in receipt_ids),
+        ).fetchall()
+        return [dict(r) for r in rows]

--- a/mcp_server/tool_registry_nav.py
+++ b/mcp_server/tool_registry_nav.py
@@ -1,6 +1,7 @@
-"""Tool registration: Tier 2 navigation tools (5 tools).
+"""Tool registration: Tier 2 navigation tools (7 tools).
 
-Registers fractal navigation and knowledge graph traversal tools.
+Registers fractal navigation, knowledge graph traversal, and injection
+provenance (blame path) tools.
 Tier 3 advanced tools are in tool_registry_advanced.py.
 """
 
@@ -15,6 +16,7 @@ from mcp_server.handlers import (
     navigate_memory,
     recall_hierarchical,
     recall_skills,
+    why,
 )
 from mcp_server.tool_error_handler import safe_handler
 from mcp_server.handlers._tool_meta import tool_kwargs
@@ -29,6 +31,7 @@ SCHEMAS: dict[str, dict] = {
     "navigate_memory": navigate_memory.schema,
     "recall_hierarchical": recall_hierarchical.schema,
     "recall_skills": recall_skills.schema,
+    "why": why.schema,
 }
 
 
@@ -40,6 +43,7 @@ def register(mcp: FastMCP) -> None:
     _register_get_causal_chain(mcp)
     _register_detect_gaps(mcp)
     _register_recall_skills(mcp)
+    _register_why(mcp)
 
 
 def _register_recall_hierarchical(mcp: FastMCP) -> None:
@@ -189,4 +193,18 @@ def _register_recall_skills(mcp: FastMCP) -> None:
                 "min_proficiency": min_proficiency,
             },
             tool_name="recall_skills",
+        )
+
+
+def _register_why(mcp: FastMCP) -> None:
+    @mcp.tool(
+        name="why",
+        **tool_kwargs(why.schema),
+    )
+    async def tool_why(receipt_ids: list[int]) -> dict:
+        """Resolve ⟦rcpt:id⟧ injection receipts into presence-in-context evidence."""
+        return await safe_handler(
+            why.handler,
+            {"receipt_ids": receipt_ids},
+            tool_name="why",
         )

--- a/mcp_server/validation/schemas.py
+++ b/mcp_server/validation/schemas.py
@@ -116,6 +116,18 @@ SCHEMAS: dict[str, dict] = {
         },
         "required": ["query"],
     },
+    "why": {
+        "properties": {
+            # maxItems mirrors handlers/why.py _MAX_RECEIPT_IDS (bounded
+            # envelope, ADR-0045 R2; SQLITE_MAX_VARIABLE_NUMBER floor).
+            "receipt_ids": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "maxItems": 999,
+            },
+        },
+        "required": ["receipt_ids"],
+    },
     "wiki_write": {
         "properties": {
             "path": {"type": "string", "maxLength": 500},

--- a/scripts/test-agent-briefing.py
+++ b/scripts/test-agent-briefing.py
@@ -104,6 +104,9 @@ class TestAgentBriefing(unittest.TestCase):
         """
         stub_rows = [
             {
+                # T2 row contract: _fetch_agent_context projects r["id"]
+                # on every row (injection receipts, decision 4255039).
+                "id": 4242,
                 "content": "feynman past lesson: always verify sources",
                 "heat": 0.8,
                 "agent_context": "feynman",

--- a/tests_py/conftest.py
+++ b/tests_py/conftest.py
@@ -124,6 +124,11 @@ _TABLES_TO_CLEAN = [
     "engram_slots",
     "oscillatory_state",
     "schemas",
+    # Receipts before memories: items cascade from receipts, and the hook
+    # subprocess tests (test_auto_recall, test_hook_receipts) emit receipts
+    # that would otherwise accumulate across runs.
+    "injection_receipt_items",
+    "injection_receipts",
     "memories",
 ]
 

--- a/tests_py/handlers/test_injection_receipts_emitter.py
+++ b/tests_py/handlers/test_injection_receipts_emitter.py
@@ -111,17 +111,14 @@ def test_hook_receipt_records_channel_session_and_ranks() -> None:
         session_id="7374abf5-9c12",
     )
     assert rid == 57
-    (_, params), = conn.calls
+    ((_, params),) = conn.calls
     # (session_id, channel, memory_ids, ranks, scores)
     assert params == ("7374abf5-9c12", "session_start", [11, 7], [0, 1], [None, None])
 
 
 def test_hook_receipt_empty_payload_emits_nothing() -> None:
     conn = _Conn()
-    assert (
-        emit_hook_receipt(conn, [], channel="session_start", session_id=None)
-        is None
-    )
+    assert emit_hook_receipt(conn, [], channel="session_start", session_id=None) is None
     assert conn.calls == []
 
 

--- a/tests_py/handlers/test_injection_receipts_emitter.py
+++ b/tests_py/handlers/test_injection_receipts_emitter.py
@@ -1,10 +1,9 @@
-"""Tests for emit_injection_receipt — blame path T1 emitter.
+"""Tests for the injection-receipt emitters — blame path T1/T2.
 
-The emitter maps the BOUND response payload to receipt items. Named
-degradation modes only: no injection → no receipt; store write failure
-(I/O) → degrade to None. A payload entry without memory_id is an
-upstream contract violation and must RAISE — pg_recall and
-inject_triggered_memories guarantee the id by construction, so
+The emitters map the BOUND injected payload to receipt items. Named
+degradation modes only: no injection → no receipt; store/DB write
+failure (I/O) → degrade to None. A payload entry without memory_id or
+an unknown channel is an upstream contract violation and must RAISE —
 swallowing it would hide a regression as silently-missing receipts.
 """
 
@@ -12,7 +11,13 @@ from __future__ import annotations
 
 import pytest
 
-from mcp_server.handlers.injection_receipts import emit_injection_receipt
+from mcp_server.handlers.injection_receipts import (
+    INJECTION_CHANNELS,
+    emit_hook_receipt,
+    emit_injection_receipt,
+    receipt_marker,
+    session_id_from_transcript,
+)
 
 
 class _Store:
@@ -65,3 +70,130 @@ def test_missing_memory_id_is_a_loud_contract_violation() -> None:
 
 def test_store_failure_degrades_to_none() -> None:
     assert emit_injection_receipt(_Store(fail=True), _mems()) is None
+
+
+def test_unknown_channel_is_a_loud_contract_violation() -> None:
+    # T2 channel enum hardening (decision 4255039 correction 3): a
+    # channel outside the enum is a coding bug, not a degradation mode.
+    store = _Store()
+    with pytest.raises(ValueError):
+        emit_injection_receipt(store, _mems(), channel="banner")
+    assert store.calls == []
+
+
+# ── T2 hook emitter (caller-owned psycopg connection) ────────────────────
+
+
+class _Conn:
+    """Fake psycopg connection capturing the single-statement insert."""
+
+    def __init__(self, fail: bool = False) -> None:
+        self.calls: list[tuple[str, tuple]] = []
+        self.fail = fail
+        self.autocommit = True
+
+    def execute(self, sql: str, params: tuple):
+        if self.fail:
+            raise RuntimeError("db down")
+        self.calls.append((sql, params))
+        return self
+
+    def fetchone(self) -> dict:
+        return {"receipt_id": 57}
+
+
+def test_hook_receipt_records_channel_session_and_ranks() -> None:
+    conn = _Conn()
+    rid = emit_hook_receipt(
+        conn,
+        [{"memory_id": 11}, {"memory_id": 7}],
+        channel="session_start",
+        session_id="7374abf5-9c12",
+    )
+    assert rid == 57
+    (_, params), = conn.calls
+    # (session_id, channel, memory_ids, ranks, scores)
+    assert params == ("7374abf5-9c12", "session_start", [11, 7], [0, 1], [None, None])
+
+
+def test_hook_receipt_empty_payload_emits_nothing() -> None:
+    conn = _Conn()
+    assert (
+        emit_hook_receipt(conn, [], channel="session_start", session_id=None)
+        is None
+    )
+    assert conn.calls == []
+
+
+def test_hook_receipt_write_failure_degrades_to_none() -> None:
+    # I/O is the only named degradation mode — the hook keeps printing
+    # its (marker-less) banner.
+    assert (
+        emit_hook_receipt(
+            _Conn(fail=True),
+            [{"memory_id": 1}],
+            channel="agent_briefing",
+            session_id=None,
+        )
+        is None
+    )
+
+
+def test_hook_receipt_unknown_channel_raises_before_io() -> None:
+    conn = _Conn()
+    with pytest.raises(ValueError):
+        emit_hook_receipt(
+            conn, [{"memory_id": 1}], channel="preemptive", session_id=None
+        )
+    assert conn.calls == []
+
+
+def test_hook_receipt_missing_memory_id_raises() -> None:
+    conn = _Conn()
+    with pytest.raises(KeyError):
+        emit_hook_receipt(
+            conn, [{"content": "x"}], channel="auto_recall", session_id=None
+        )
+    assert conn.calls == []
+
+
+# ── Correction 7: session identity = transcript basename ─────────────────
+
+
+def test_session_id_is_transcript_stem() -> None:
+    # The event's session_id field diverges from the transcript identity
+    # across resume/clear chains (148/200 lines on fixture 7374abf5) —
+    # the file basename is the stable identity.
+    assert (
+        session_id_from_transcript("/x/y/7374abf5-9c12-4d18.jsonl")
+        == "7374abf5-9c12-4d18"
+    )
+
+
+def test_session_id_none_without_transcript() -> None:
+    assert session_id_from_transcript(None) is None
+    assert session_id_from_transcript("") is None
+
+
+def test_session_id_none_for_non_string_boundary_input() -> None:
+    # The hook event is external input — a malformed transcript_path must
+    # degrade to None, never raise into the hook's primary injection.
+    for garbage in (42, 3.14, True, ["a.jsonl"], {"path": "x"}):
+        assert session_id_from_transcript(garbage) is None
+
+
+# ── Correction 2: in-context receipt marker ───────────────────────────────
+
+
+def test_receipt_marker_format() -> None:
+    assert receipt_marker(57) == "⟦rcpt:57⟧"
+
+
+def test_enum_members_are_the_four_decided_channels() -> None:
+    # Decision 4255039 correction 3 fixed the enum at exactly these four.
+    assert INJECTION_CHANNELS == {
+        "recall",
+        "session_start",
+        "auto_recall",
+        "agent_briefing",
+    }

--- a/tests_py/handlers/test_injection_receipts_emitter.py
+++ b/tests_py/handlers/test_injection_receipts_emitter.py
@@ -1,0 +1,67 @@
+"""Tests for emit_injection_receipt — blame path T1 emitter.
+
+The emitter maps the BOUND response payload to receipt items. Named
+degradation modes only: no injection → no receipt; store write failure
+(I/O) → degrade to None. A payload entry without memory_id is an
+upstream contract violation and must RAISE — pg_recall and
+inject_triggered_memories guarantee the id by construction, so
+swallowing it would hide a regression as silently-missing receipts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.handlers.injection_receipts import emit_injection_receipt
+
+
+class _Store:
+    def __init__(self, fail: bool = False) -> None:
+        self.calls: list[dict] = []
+        self.fail = fail
+
+    def insert_injection_receipt(
+        self, channel: str, items: list[dict], session_id: str | None = None
+    ) -> int:
+        if self.fail:
+            raise RuntimeError("db down")
+        self.calls.append(
+            {"channel": channel, "items": items, "session_id": session_id}
+        )
+        return 42
+
+
+def _mems() -> list[dict]:
+    return [
+        {"memory_id": 11, "score": 0.9, "content": "a"},
+        {"memory_id": 7, "score": None, "content": "b"},
+    ]
+
+
+def test_items_mirror_bound_payload() -> None:
+    store = _Store()
+    rid = emit_injection_receipt(store, _mems())
+    assert rid == 42
+    assert store.calls[0]["items"] == [
+        {"memory_id": 11, "rank": 0, "score": 0.9},
+        {"memory_id": 7, "rank": 1, "score": None},
+    ]
+    assert store.calls[0]["channel"] == "recall"
+    assert store.calls[0]["session_id"] is None
+
+
+def test_empty_payload_emits_nothing() -> None:
+    store = _Store()
+    assert emit_injection_receipt(store, []) is None
+    assert store.calls == []
+
+
+def test_missing_memory_id_is_a_loud_contract_violation() -> None:
+    store = _Store()
+    with pytest.raises(KeyError):
+        emit_injection_receipt(store, [{"content": "x", "score": 1.0}])
+    assert store.calls == []
+
+
+def test_store_failure_degrades_to_none() -> None:
+    assert emit_injection_receipt(_Store(fail=True), _mems()) is None

--- a/tests_py/handlers/test_why.py
+++ b/tests_py/handlers/test_why.py
@@ -1,0 +1,222 @@
+"""Unit tests for the why handler (blame path T3, decision 4255039).
+
+Falsifiable T3 criteria at the handler boundary:
+
+* evidence rows replay the store rows verbatim, in store order —
+  recorded facts only, nothing recomputed or reordered client-side;
+* unknown receipt ids are reported, never silently dropped;
+* superseded and hard-forgotten memories are SURFACED with their state,
+  never filtered — receipts are historical evidence;
+* the response passes through the same measured budget as recall
+  (anti-flooding, correction 5) — truncated rows keep their memory_id;
+* malformed receipt_ids raise loudly — a bad id list is a caller bug,
+  not a degradation mode.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from mcp_server.core.response_budget import serialized_length
+from mcp_server.handlers import why
+
+
+class _FakeStore:
+    def __init__(self, rows: list[dict]):
+        self.rows = rows
+        self.calls: list[list[int]] = []
+
+    def fetch_injection_receipts(self, receipt_ids: list[int]) -> list[dict]:
+        self.calls.append(list(receipt_ids))
+        return self.rows
+
+
+def _row(**overrides) -> dict:
+    row = {
+        "receipt_id": 1,
+        "channel": "recall",
+        "session_id": None,
+        "emitted_at": "2026-07-07T10:00:00+00:00",
+        "memory_id": 11,
+        "rank": 0,
+        "score": 0.9,
+        "memory_row_id": 11,
+        "content": "alpha",
+        "memory_created_at": "2026-07-01T00:00:00+00:00",
+        "memory_source": "lesson",
+        "memory_domain": "cortex",
+        "superseded_by_id": None,
+    }
+    row.update(overrides)
+    if row["memory_row_id"] is None:
+        # LEFT JOIN miss: every m.* column reads NULL.
+        for key in (
+            "content",
+            "memory_created_at",
+            "memory_source",
+            "memory_domain",
+            "superseded_by_id",
+        ):
+            row[key] = None
+    return row
+
+
+def _patch(monkeypatch, rows: list[dict], budget: int = 75_000) -> _FakeStore:
+    store = _FakeStore(rows)
+    monkeypatch.setattr(why, "get_shared_store", lambda: store)
+    monkeypatch.setattr(
+        why,
+        "get_memory_settings",
+        lambda: SimpleNamespace(MAX_RESPONSE_CHARS=budget),
+    )
+    return store
+
+
+@pytest.mark.asyncio
+async def test_evidence_replays_store_rows_in_store_order(monkeypatch) -> None:
+    rows = [
+        _row(receipt_id=9, channel="auto_recall", session_id="s-1",
+             emitted_at="2026-07-07T11:00:00+00:00", memory_id=42, rank=0,
+             score=None, memory_row_id=42, content="beta"),
+        _row(receipt_id=4, memory_id=11, rank=0),
+        _row(receipt_id=4, memory_id=7, rank=1, score=0.5,
+             memory_row_id=7, content="gamma"),
+    ]
+    _patch(monkeypatch, rows)
+    resp = await why.handler({"receipt_ids": [9, 4]})
+    assert [e["receipt_id"] for e in resp["evidence"]] == [9, 4, 4]
+    assert [e["memory_id"] for e in resp["evidence"]] == [42, 11, 7]
+    assert [e["rank"] for e in resp["evidence"]] == [0, 0, 1]
+    first = resp["evidence"][0]
+    assert first["channel"] == "auto_recall"
+    assert first["session_id"] == "s-1"
+    assert first["score"] is None
+    assert first["content"] == "beta"
+    assert first["memory_missing"] is False
+    assert resp["count"] == 3
+    assert resp["receipts_resolved"] == [4, 9]
+    assert resp["receipts_unknown"] == []
+
+
+@pytest.mark.asyncio
+async def test_semantics_is_locked_lexicon(monkeypatch) -> None:
+    _patch(monkeypatch, [_row()])
+    resp = await why.handler({"receipt_ids": [1]})
+    assert resp["semantics"] == "presence-in-context"
+
+
+@pytest.mark.asyncio
+async def test_unknown_ids_reported_not_dropped(monkeypatch) -> None:
+    _patch(monkeypatch, [_row(receipt_id=5)])
+    resp = await why.handler({"receipt_ids": [5, 9, 2]})
+    assert resp["receipts_resolved"] == [5]
+    assert resp["receipts_unknown"] == [9, 2]
+
+
+@pytest.mark.asyncio
+async def test_input_ids_deduplicated_order_preserved(monkeypatch) -> None:
+    store = _patch(monkeypatch, [])
+    await why.handler({"receipt_ids": [7, 3, 7, "3"]})
+    assert store.calls == [[7, 3]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw",
+    [[], None, "7", [True], ["x"], [0], [-2], [1.5]],
+)
+async def test_malformed_receipt_ids_raise_loudly(monkeypatch, raw) -> None:
+    store = _patch(monkeypatch, [_row()])
+    with pytest.raises(ValueError):
+        await why.handler({"receipt_ids": raw})
+    # The contract violation must raise BEFORE any store I/O.
+    assert store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_receipt_ids_bounded_envelope(monkeypatch) -> None:
+    """> _MAX_RECEIPT_IDS raises before any store I/O (ADR-0045 R2).
+
+    The bound is the SQLite fallback's documented parameter ceiling
+    (SQLITE_MAX_VARIABLE_NUMBER default, sqlite.org/limits.html §9) —
+    one bound parameter per id on that path.
+    """
+    store = _patch(monkeypatch, [_row()])
+    at_bound = list(range(1, why._MAX_RECEIPT_IDS + 1))
+    await why.handler({"receipt_ids": at_bound})
+    assert store.calls == [at_bound]
+    with pytest.raises(ValueError, match="at most"):
+        await why.handler({"receipt_ids": at_bound + [len(at_bound) + 1]})
+    assert len(store.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_receipt_ids_over_int4_rejected_uniformly(monkeypatch) -> None:
+    """ids above int4 raise the same ValueError on every backend.
+
+    Receipt ids are SERIAL (int4); the PG path casts ``::int[]`` and
+    would leak NumericValueOutOfRange while SQLite (int64) would return
+    receipts_unknown — the parse layer rejects first so the degradation
+    mode cannot diverge between backends.
+    """
+    store = _patch(monkeypatch, [_row()])
+    with pytest.raises(ValueError, match="int4"):
+        await why.handler({"receipt_ids": [why._INT4_MAX + 1]})
+    assert store.calls == []
+    await why.handler({"receipt_ids": [why._INT4_MAX]})
+    assert store.calls == [[why._INT4_MAX]]
+
+
+@pytest.mark.asyncio
+async def test_hard_forgotten_memory_flagged_not_hidden(monkeypatch) -> None:
+    _patch(monkeypatch, [_row(memory_row_id=None)])
+    resp = await why.handler({"receipt_ids": [1]})
+    item = resp["evidence"][0]
+    assert item["memory_missing"] is True
+    assert item["memory_id"] == 11
+    assert "content" not in item
+    assert "superseded_by_id" not in item
+
+
+@pytest.mark.asyncio
+async def test_superseded_memory_surfaced_not_filtered(monkeypatch) -> None:
+    _patch(monkeypatch, [_row(superseded_by_id=99)])
+    resp = await why.handler({"receipt_ids": [1]})
+    assert resp["count"] == 1
+    assert resp["evidence"][0]["superseded_by_id"] == 99
+
+
+@pytest.mark.asyncio
+async def test_budget_bounds_response_and_keeps_ids(monkeypatch) -> None:
+    # Anti-flooding proof (correction 5): a mutant that skips
+    # bound_payload ships ~20k chars against a 1.2k budget and fails.
+    rows = [
+        _row(receipt_id=2, memory_id=21, content="x" * 10_000),
+        _row(receipt_id=1, memory_id=22, rank=0, score=0.2,
+             memory_row_id=22, content="y" * 10_000),
+    ]
+    budget = 1_200
+    _patch(monkeypatch, rows, budget=budget)
+    resp = await why.handler({"receipt_ids": [2, 1]})
+    assert serialized_length(resp) <= budget
+    for item in resp["evidence"]:
+        assert item["memory_id"] in (21, 22)
+        assert item.get("truncated") is True
+    assert resp["count"] == len(resp["evidence"])
+
+
+@pytest.mark.asyncio
+async def test_datetime_values_serialized_iso(monkeypatch) -> None:
+    emitted = datetime(2026, 7, 7, 9, 30, 0, tzinfo=timezone.utc)
+    created = datetime(2026, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+    _patch(
+        monkeypatch,
+        [_row(emitted_at=emitted, memory_created_at=created)],
+    )
+    resp = await why.handler({"receipt_ids": [1]})
+    item = resp["evidence"][0]
+    assert item["emitted_at"] == "2026-07-07T09:30:00+00:00"
+    assert item["memory_created_at"] == "2026-07-01T00:00:00+00:00"

--- a/tests_py/handlers/test_why.py
+++ b/tests_py/handlers/test_why.py
@@ -78,12 +78,26 @@ def _patch(monkeypatch, rows: list[dict], budget: int = 75_000) -> _FakeStore:
 @pytest.mark.asyncio
 async def test_evidence_replays_store_rows_in_store_order(monkeypatch) -> None:
     rows = [
-        _row(receipt_id=9, channel="auto_recall", session_id="s-1",
-             emitted_at="2026-07-07T11:00:00+00:00", memory_id=42, rank=0,
-             score=None, memory_row_id=42, content="beta"),
+        _row(
+            receipt_id=9,
+            channel="auto_recall",
+            session_id="s-1",
+            emitted_at="2026-07-07T11:00:00+00:00",
+            memory_id=42,
+            rank=0,
+            score=None,
+            memory_row_id=42,
+            content="beta",
+        ),
         _row(receipt_id=4, memory_id=11, rank=0),
-        _row(receipt_id=4, memory_id=7, rank=1, score=0.5,
-             memory_row_id=7, content="gamma"),
+        _row(
+            receipt_id=4,
+            memory_id=7,
+            rank=1,
+            score=0.5,
+            memory_row_id=7,
+            content="gamma",
+        ),
     ]
     _patch(monkeypatch, rows)
     resp = await why.handler({"receipt_ids": [9, 4]})
@@ -195,8 +209,14 @@ async def test_budget_bounds_response_and_keeps_ids(monkeypatch) -> None:
     # bound_payload ships ~20k chars against a 1.2k budget and fails.
     rows = [
         _row(receipt_id=2, memory_id=21, content="x" * 10_000),
-        _row(receipt_id=1, memory_id=22, rank=0, score=0.2,
-             memory_row_id=22, content="y" * 10_000),
+        _row(
+            receipt_id=1,
+            memory_id=22,
+            rank=0,
+            score=0.2,
+            memory_row_id=22,
+            content="y" * 10_000,
+        ),
     ]
     budget = 1_200
     _patch(monkeypatch, rows, budget=budget)

--- a/tests_py/hooks/test_hook_receipts.py
+++ b/tests_py/hooks/test_hook_receipts.py
@@ -1,0 +1,393 @@
+"""PG-gated tests for the T2 hook receipt channels (decision 4255039).
+
+Falsifiable T2 criteria, per channel:
+
+* the injected stdout carries the ⟦rcpt:id⟧ marker (correction 2);
+* the persisted receipt records channel + session_id derived from the
+  transcript file basename, NOT the event's divergent session_id field
+  (correction 7);
+* receipt items mirror exactly the injected payload, in injection order;
+* superseded memories never enter the banner/briefing (correction 8).
+
+session_start is exercised in-process (its main() spawns detached
+background workers — pipeline reanalyze, consolidate — that a subprocess
+test would fire on the host machine). agent_briefing and auto_recall are
+exercised end-to-end as subprocesses, mirroring test_auto_recall.py.
+
+Skipped automatically when PG is not reachable (CI without pgvector).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from tests_py.conftest import _USE_PG, _TEST_DB_URL  # type: ignore
+
+pytestmark = pytest.mark.skipif(
+    not _USE_PG, reason="PostgreSQL not available — hook receipts need PG schema"
+)
+
+# The event's session_id field diverges from the transcript identity
+# across resume/clear chains (148/200 lines on fixture 7374abf5) — the
+# receipt must record the file basename.
+_TRANSCRIPT = "/tmp/claude/projects/x/sess-t2-fixture.jsonl"
+_EXPECTED_SESSION = "sess-t2-fixture"
+_DIVERGENT_EVENT_SESSION = "divergent-event-session-id"
+
+
+def _cleanup(conn) -> None:
+    conn.execute(
+        "DELETE FROM injection_receipts WHERE session_id = %s",
+        (_EXPECTED_SESSION,),
+    )
+    conn.execute("DELETE FROM memories WHERE content LIKE %s", ("HOOKRCPT_TEST%",))
+
+
+@pytest.fixture()
+def _db():
+    """Schema (DDL + migrations, incl. the channel-enum CHECK) + clean slate."""
+    from mcp_server.infrastructure.pg_store import PgMemoryStore
+
+    store = PgMemoryStore(database_url=_TEST_DB_URL)
+
+    import psycopg
+    from psycopg.rows import dict_row
+
+    conn = psycopg.connect(_TEST_DB_URL, row_factory=dict_row, autocommit=True)
+    _cleanup(conn)
+
+    yield conn
+
+    _cleanup(conn)
+    conn.close()
+    try:
+        store._conn.close()
+    except Exception:
+        pass
+
+
+def _seed(
+    conn,
+    content: str,
+    *,
+    heat: float = 0.9,
+    protected: bool = False,
+    is_global: bool = False,
+    agent: str = "",
+    tags: str = "[]",
+    superseded_by: int | None = None,
+) -> int:
+    row = conn.execute(
+        "INSERT INTO memories (content, heat_base, heat_base_set_at, "
+        "is_benchmark, plasticity, no_decay, is_protected, is_global, "
+        "agent_context, tags, superseded_by_id) "
+        "VALUES (%s, %s, NOW(), FALSE, 1.0, FALSE, %s, %s, %s, %s::jsonb, %s) "
+        "RETURNING id",
+        (content, heat, protected, is_global, agent, tags, superseded_by),
+    ).fetchone()
+    return int(row["id"])
+
+
+def _receipt(conn, receipt_id: int) -> tuple[dict, list[dict]]:
+    header = conn.execute(
+        "SELECT session_id, channel FROM injection_receipts WHERE id = %s",
+        (receipt_id,),
+    ).fetchone()
+    items = conn.execute(
+        "SELECT memory_id, rank FROM injection_receipt_items "
+        "WHERE receipt_id = %s ORDER BY rank",
+        (receipt_id,),
+    ).fetchall()
+    return header, items
+
+
+def _run_hook(module: str, event: dict) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = _TEST_DB_URL
+    repo_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    return subprocess.run(
+        [sys.executable, "-m", module],
+        input=json.dumps(event),
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=repo_root,
+        timeout=10,
+    )
+
+
+# ── session_start (in-process) ────────────────────────────────────────────
+
+
+def test_session_start_banner_receipt_roundtrip(_db) -> None:
+    from mcp_server.hooks import session_start as ss
+
+    anchor_id = _seed(
+        _db,
+        "HOOKRCPT_TEST anchored critical fact",
+        protected=True,
+        tags='["_anchor"]',
+    )
+    hot_id = _seed(_db, "HOOKRCPT_TEST hot memory fact", heat=0.95)
+    stale_id = _seed(
+        _db,
+        "HOOKRCPT_TEST superseded stale fact",
+        heat=0.99,
+        superseded_by=hot_id,
+    )
+
+    anchors = ss._fetch_anchors(_db)
+    anchor_ids = {a["id"] for a in anchors}
+    hot = ss._fetch_hot_memories(_db, anchor_ids)
+    team = ss._fetch_team_decisions(_db, anchor_ids)
+
+    assert anchor_id in anchor_ids
+    hot_ids = [m["id"] for m in hot]
+    assert hot_id in hot_ids
+    # Correction 8: a corrected (superseded) fact never enters the banner,
+    # regardless of heat.
+    assert stale_id not in hot_ids
+    assert stale_id not in anchor_ids
+
+    event = {
+        "transcript_path": _TRANSCRIPT,
+        "session_id": _DIVERGENT_EVENT_SESSION,
+    }
+    receipt_id = ss._emit_banner_receipt(_db, event, anchors, team, hot)
+    assert receipt_id is not None
+
+    # Correction 2: the banner header carries the in-context marker.
+    context = ss._build_context(anchors, hot, None, team, receipt_id=receipt_id)
+    assert f"⟦rcpt:{receipt_id}⟧" in context.splitlines()[0]
+
+    header, items = _receipt(_db, receipt_id)
+    assert header["channel"] == "session_start"
+    # Correction 7: transcript basename, not the divergent event field.
+    assert header["session_id"] == _EXPECTED_SESSION
+
+    expected = [m["id"] for m in (*anchors, *team, *hot)]
+    assert [r["memory_id"] for r in items] == expected
+    assert [r["rank"] for r in items] == list(range(len(expected)))
+
+    # Rank order anchored to the RENDERED banner, not to the payload
+    # tuple the code builds (which would be tautological): the anchored
+    # fact prints before the hot fact, and their receipt ranks must
+    # follow that same visible order.
+    lines = context.splitlines()
+    anchor_line = next(i for i, l in enumerate(lines) if "anchored critical fact" in l)
+    hot_line = next(i for i, l in enumerate(lines) if "hot memory fact" in l)
+    assert anchor_line < hot_line
+    rank_by_id = {r["memory_id"]: r["rank"] for r in items}
+    assert rank_by_id[anchor_id] < rank_by_id[hot_id]
+
+
+def test_session_start_read_event_tolerates_garbage(monkeypatch) -> None:
+    import io
+
+    from mcp_server.hooks import session_start as ss
+
+    monkeypatch.setattr("sys.stdin", io.StringIO("not json at all"))
+    assert ss._read_event() == {}
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    assert ss._read_event() == {}
+
+
+def test_session_start_empty_banner_emits_no_receipt(_db) -> None:
+    from mcp_server.hooks import session_start as ss
+
+    before = _db.execute(
+        "SELECT COUNT(*) AS c FROM injection_receipts"
+    ).fetchone()["c"]
+    assert ss._emit_banner_receipt(_db, {}, [], [], []) is None
+    after = _db.execute(
+        "SELECT COUNT(*) AS c FROM injection_receipts"
+    ).fetchone()["c"]
+    assert after == before
+
+
+# ── auto_recall (subprocess, end-to-end) ──────────────────────────────────
+
+
+def test_auto_recall_emits_receipt_with_marker(_db) -> None:
+    mid = _seed(_db, "HOOKRCPT_TEST velvetine mirandol cartography atlas")
+
+    result = _run_hook(
+        "mcp_server.hooks.auto_recall",
+        {
+            "prompt": "velvetine mirandol cartography atlas",
+            "transcript_path": _TRANSCRIPT,
+            "session_id": _DIVERGENT_EVENT_SESSION,
+        },
+    )
+
+    assert result.returncode == 0
+    assert "velvetine" in result.stdout.lower(), (
+        f"expected injection, stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+    row = _db.execute(
+        "SELECT id FROM injection_receipts "
+        "WHERE channel = 'auto_recall' AND session_id = %s "
+        "ORDER BY id DESC LIMIT 1",
+        (_EXPECTED_SESSION,),
+    ).fetchone()
+    assert row is not None, "auto_recall receipt was not persisted"
+
+    # Marker in stdout matches the persisted receipt (correction 2).
+    assert f"⟦rcpt:{row['id']}⟧" in result.stdout.splitlines()[0]
+
+    _, items = _receipt(_db, row["id"])
+    assert mid in [r["memory_id"] for r in items]
+
+
+# ── agent_briefing (subprocess, end-to-end) ───────────────────────────────
+
+
+def test_agent_briefing_emits_receipt_with_marker(_db) -> None:
+    mid = _seed(
+        _db,
+        "HOOKRCPT_TEST zephyrine quantalum brokerage reconciliation ledger",
+        agent="engineer",
+    )
+    # Pass 2 (TMS directory layer): a protected global decision from
+    # ANOTHER agent enters the briefing regardless of keywords — it must
+    # be attested by the same receipt, ranked after the agent-scoped pass.
+    team_id = _seed(
+        _db,
+        "HOOKRCPT_TEST team decision on rollout gates",
+        protected=True,
+        is_global=True,
+        agent="architect",
+    )
+
+    result = _run_hook(
+        "mcp_server.hooks.agent_briefing",
+        {
+            "agent_name": "engineer",
+            "agent_type": "custom",
+            "prompt": (
+                "zephyrine quantalum brokerage reconciliation ledger "
+                "please review carefully"
+            ),
+            "cwd": "/tmp",
+            "transcript_path": _TRANSCRIPT,
+            "session_id": _DIVERGENT_EVENT_SESSION,
+        },
+    )
+
+    assert result.returncode == 0
+    assert "zephyrine" in result.stdout.lower(), (
+        f"expected briefing, stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+    row = _db.execute(
+        "SELECT id FROM injection_receipts "
+        "WHERE channel = 'agent_briefing' AND session_id = %s "
+        "ORDER BY id DESC LIMIT 1",
+        (_EXPECTED_SESSION,),
+    ).fetchone()
+    assert row is not None, "agent_briefing receipt was not persisted"
+
+    assert f"⟦rcpt:{row['id']}⟧" in result.stdout.splitlines()[0]
+
+    _, items = _receipt(_db, row["id"])
+    injected = [r["memory_id"] for r in items]
+    assert mid in injected
+    # Pass 2 attested by the same receipt, after the agent-scoped memory.
+    assert team_id in injected
+    assert injected.index(mid) < injected.index(team_id)
+    assert "team:architect" in result.stdout
+
+
+# ── channel enum on live PG (decision 4255039 correction 3) ──────────────
+
+
+def test_pg_rejects_unknown_channel_live(_db) -> None:
+    # The DDL CHECK is behavior, not text: an out-of-band writer with an
+    # out-of-enum channel must be rejected by the database itself.
+    import psycopg
+
+    with pytest.raises(psycopg.errors.CheckViolation):
+        _db.execute(
+            "INSERT INTO injection_receipts (session_id, channel) "
+            "VALUES (%s, 'banner')",
+            (_EXPECTED_SESSION,),
+        )
+
+
+def test_channel_enum_migration_restores_dropped_constraint(_db) -> None:
+    # Exercise the real T1→T2 path: on a T1 database the table exists with
+    # free-TEXT channel AND schema_meta records the T1 DDL hash — which
+    # differs from the T2 hash, so _init_schema replays the DDL and the
+    # MIGRATIONS_DDL DO block adds the CHECK. Simulate that state by
+    # dropping the constraint and invalidating the recorded revision
+    # (schema init is hash-gated; without this it correctly no-ops).
+    _db.execute(
+        "ALTER TABLE injection_receipts "
+        "DROP CONSTRAINT IF EXISTS injection_receipts_channel_enum"
+    )
+    _db.execute("DELETE FROM schema_meta WHERE id = 1")
+    from mcp_server.infrastructure.pg_store import PgMemoryStore
+
+    store = PgMemoryStore(database_url=_TEST_DB_URL)
+    try:
+        row = _db.execute(
+            "SELECT 1 FROM pg_constraint "
+            "WHERE conname = 'injection_receipts_channel_enum'"
+        ).fetchone()
+        assert row is not None, "migration did not restore the channel CHECK"
+    finally:
+        try:
+            store._conn.close()
+        except Exception:
+            pass
+
+
+def test_agent_briefing_skips_superseded_prior_work(_db) -> None:
+    # Correction 8 on the briefing path: the agent-scoped pass must not
+    # brief with a corrected fact.
+    current = _seed(
+        _db,
+        "HOOKRCPT_TEST ombrelline daguerre synthesis current",
+        agent="engineer",
+    )
+    stale = _seed(
+        _db,
+        "HOOKRCPT_TEST ombrelline daguerre synthesis stale",
+        agent="engineer",
+        superseded_by=current,
+    )
+
+    result = _run_hook(
+        "mcp_server.hooks.agent_briefing",
+        {
+            "agent_name": "engineer",
+            "agent_type": "custom",
+            # "work"/"please"/"ensure" are briefing stopwords — the FTS
+            # AND-query reduces to the three words both memories share.
+            "prompt": "ombrelline daguerre synthesis work please ensure",
+            "cwd": "/tmp",
+            "transcript_path": _TRANSCRIPT,
+            "session_id": _DIVERGENT_EVENT_SESSION,
+        },
+    )
+
+    assert result.returncode == 0
+    row = _db.execute(
+        "SELECT id FROM injection_receipts "
+        "WHERE channel = 'agent_briefing' AND session_id = %s "
+        "ORDER BY id DESC LIMIT 1",
+        (_EXPECTED_SESSION,),
+    ).fetchone()
+    assert row is not None
+    _, items = _receipt(_db, row["id"])
+    injected = [r["memory_id"] for r in items]
+    assert current in injected
+    assert stale not in injected

--- a/tests_py/hooks/test_hook_receipts.py
+++ b/tests_py/hooks/test_hook_receipts.py
@@ -181,8 +181,10 @@ def test_session_start_banner_receipt_roundtrip(_db) -> None:
     # fact prints before the hot fact, and their receipt ranks must
     # follow that same visible order.
     lines = context.splitlines()
-    anchor_line = next(i for i, l in enumerate(lines) if "anchored critical fact" in l)
-    hot_line = next(i for i, l in enumerate(lines) if "hot memory fact" in l)
+    anchor_line = next(
+        i for i, text in enumerate(lines) if "anchored critical fact" in text
+    )
+    hot_line = next(i for i, text in enumerate(lines) if "hot memory fact" in text)
     assert anchor_line < hot_line
     rank_by_id = {r["memory_id"]: r["rank"] for r in items}
     assert rank_by_id[anchor_id] < rank_by_id[hot_id]
@@ -202,13 +204,9 @@ def test_session_start_read_event_tolerates_garbage(monkeypatch) -> None:
 def test_session_start_empty_banner_emits_no_receipt(_db) -> None:
     from mcp_server.hooks import session_start as ss
 
-    before = _db.execute(
-        "SELECT COUNT(*) AS c FROM injection_receipts"
-    ).fetchone()["c"]
+    before = _db.execute("SELECT COUNT(*) AS c FROM injection_receipts").fetchone()["c"]
     assert ss._emit_banner_receipt(_db, {}, [], [], []) is None
-    after = _db.execute(
-        "SELECT COUNT(*) AS c FROM injection_receipts"
-    ).fetchone()["c"]
+    after = _db.execute("SELECT COUNT(*) AS c FROM injection_receipts").fetchone()["c"]
     assert after == before
 
 

--- a/tests_py/hooks/test_hook_receipts_unit.py
+++ b/tests_py/hooks/test_hook_receipts_unit.py
@@ -34,7 +34,11 @@ def test_budget_dropped_memory_is_excluded_from_included() -> None:
     # Each line renders as "- [<agent>] <200-char content>" ≈ 265 chars
     # with a 60-char agent prefix; the third line crosses the 800-char
     # budget and must be dropped from BOTH the text and the receipt list.
-    memories = [_mem(1, agent="x" * 60), _mem(2, agent="x" * 60), _mem(3, agent="x" * 60)]
+    memories = [
+        _mem(1, agent="x" * 60),
+        _mem(2, agent="x" * 60),
+        _mem(3, agent="x" * 60),
+    ]
     text, included = _format_injection(memories)
 
     assert len(text) <= _MAX_INJECTION_CHARS

--- a/tests_py/hooks/test_hook_receipts_unit.py
+++ b/tests_py/hooks/test_hook_receipts_unit.py
@@ -1,0 +1,69 @@
+"""DB-free unit tests for the T2 hook receipt plumbing (decision 4255039).
+
+Complements the PG-gated end-to-end tests in test_hook_receipts.py with
+the branches those tests cannot reach deterministically:
+
+* auto_recall's injection-budget drop — the parity invariant's teeth:
+  a memory dropped by _MAX_INJECTION_CHARS was never in context and must
+  not be attested by the receipt (correction 11). Killed mutants: moving
+  ``included.append`` above the budget break, or returning the fetched
+  list instead of the included one.
+* the marker-less degradation rendering — a failed receipt write yields
+  receipt_id=None and the banner must render WITHOUT a marker (I/O is
+  the only named degradation mode; the injection itself never breaks).
+"""
+
+from __future__ import annotations
+
+from mcp_server.hooks.auto_recall import _MAX_INJECTION_CHARS, _format_injection
+from mcp_server.hooks.session_start import _build_context
+
+
+def _mem(mid: int, *, agent: str = "", content_len: int = 250) -> dict:
+    return {
+        "id": mid,
+        "content": "y" * content_len,
+        "heat": 0.9,
+        "domain": "",
+        "agent": agent,
+        "protected": False,
+    }
+
+
+def test_budget_dropped_memory_is_excluded_from_included() -> None:
+    # Each line renders as "- [<agent>] <200-char content>" ≈ 265 chars
+    # with a 60-char agent prefix; the third line crosses the 800-char
+    # budget and must be dropped from BOTH the text and the receipt list.
+    memories = [_mem(1, agent="x" * 60), _mem(2, agent="x" * 60), _mem(3, agent="x" * 60)]
+    text, included = _format_injection(memories)
+
+    assert len(text) <= _MAX_INJECTION_CHARS
+    assert [m["id"] for m in included] == [1, 2]
+    # Exactly the included entries are printed: header + one line each.
+    assert len(text.splitlines()) == 1 + len(included)
+
+
+def test_all_fitting_memories_are_included() -> None:
+    memories = [_mem(1), _mem(2), _mem(3)]
+    text, included = _format_injection(memories)
+    assert [m["id"] for m in included] == [1, 2, 3]
+    assert len(text.splitlines()) == 4
+
+
+def test_nothing_fits_returns_empty_and_no_items() -> None:
+    # A single line already over budget → no injection, no receipt items.
+    text, included = _format_injection([_mem(1, agent="x" * 900)])
+    assert text == ""
+    assert included == []
+
+
+def test_banner_renders_marker_only_with_receipt() -> None:
+    anchors = [{"id": 1, "content": "a fact", "domain": "", "is_global": False}]
+
+    with_receipt = _build_context(anchors, [], None, receipt_id=57)
+    assert "⟦rcpt:57⟧" in with_receipt.splitlines()[0]
+
+    # Failed receipt write (None) → marker-less banner, injection intact.
+    without = _build_context(anchors, [], None, receipt_id=None)
+    assert "⟦rcpt:" not in without
+    assert "a fact" in without

--- a/tests_py/infrastructure/test_injection_receipts_fetch_pg.py
+++ b/tests_py/infrastructure/test_injection_receipts_fetch_pg.py
@@ -22,12 +22,8 @@ _SESSION = "sess-why-t3-fixture"
 
 
 def _cleanup(conn) -> None:
-    conn.execute(
-        "DELETE FROM injection_receipts WHERE session_id = %s", (_SESSION,)
-    )
-    conn.execute(
-        "DELETE FROM memories WHERE content LIKE %s", ("WHYFETCH_TEST%",)
-    )
+    conn.execute("DELETE FROM injection_receipts WHERE session_id = %s", (_SESSION,))
+    conn.execute("DELETE FROM memories WHERE content LIKE %s", ("WHYFETCH_TEST%",))
 
 
 @pytest.fixture()

--- a/tests_py/infrastructure/test_injection_receipts_fetch_pg.py
+++ b/tests_py/infrastructure/test_injection_receipts_fetch_pg.py
@@ -1,0 +1,115 @@
+"""PG-gated read-path tests for injection receipts (blame path T3).
+
+Exercises the PG-specific SQL of ``fetch_injection_receipts`` that the
+SQLite parity suite cannot: ``ANY(%s::int[])`` id resolution, the LEFT
+JOIN surviving a hard-forgotten memory, and recorded-facts ordering
+(emitted_at DESC, id DESC, rank ASC) under real timestamptz values.
+
+Skipped automatically when PG is not reachable (CI without pgvector).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests_py.conftest import _USE_PG, _TEST_DB_URL  # type: ignore
+
+pytestmark = pytest.mark.skipif(
+    not _USE_PG, reason="PostgreSQL not available — fetch path needs PG schema"
+)
+
+_SESSION = "sess-why-t3-fixture"
+
+
+def _cleanup(conn) -> None:
+    conn.execute(
+        "DELETE FROM injection_receipts WHERE session_id = %s", (_SESSION,)
+    )
+    conn.execute(
+        "DELETE FROM memories WHERE content LIKE %s", ("WHYFETCH_TEST%",)
+    )
+
+
+@pytest.fixture()
+def _env():
+    """Provisioned store + autocommit conn + clean slate, torn down after."""
+    from mcp_server.infrastructure.pg_store import PgMemoryStore
+
+    store = PgMemoryStore(database_url=_TEST_DB_URL)
+
+    import psycopg
+    from psycopg.rows import dict_row
+
+    conn = psycopg.connect(_TEST_DB_URL, row_factory=dict_row, autocommit=True)
+    _cleanup(conn)
+
+    yield store, conn
+
+    _cleanup(conn)
+    conn.close()
+    try:
+        store._conn.close()
+    except Exception:
+        pass
+
+
+def _seed(conn, content: str, superseded_by: int | None = None) -> int:
+    row = conn.execute(
+        "INSERT INTO memories (content, heat_base, heat_base_set_at, "
+        "is_benchmark, plasticity, no_decay, is_protected, is_global, "
+        "agent_context, tags, superseded_by_id) "
+        "VALUES (%s, 0.9, NOW(), FALSE, 1.0, FALSE, FALSE, FALSE, '', "
+        "'[]'::jsonb, %s) RETURNING id",
+        (content, superseded_by),
+    ).fetchone()
+    return int(row["id"])
+
+
+def test_fetch_pg_resolves_joins_and_orders_by_recorded_facts(_env) -> None:
+    store, conn = _env
+    corrected = _seed(conn, "WHYFETCH_TEST corrected")
+    wrong = _seed(conn, "WHYFETCH_TEST wrong", superseded_by=corrected)
+
+    older = store.insert_injection_receipt(
+        "recall",
+        [
+            {"memory_id": wrong, "rank": 0, "score": 0.9},
+            # Hard-forgotten memory: no row behind this id — the LEFT
+            # JOIN must keep the evidence with m.* NULL.
+            {"memory_id": 2_000_000_000, "rank": 1, "score": None},
+        ],
+        session_id=_SESSION,
+    )
+    newer = store.insert_injection_receipt(
+        "auto_recall",
+        [{"memory_id": corrected, "rank": 0, "score": 0.7}],
+        session_id=_SESSION,
+    )
+    # Force a strict emitted_at gap so the ordering test cannot pass by
+    # id-tiebreak accident.
+    conn.execute(
+        "UPDATE injection_receipts SET emitted_at = NOW() - INTERVAL '1 hour' "
+        "WHERE id = %s",
+        (older,),
+    )
+
+    rows = store.fetch_injection_receipts([older, newer, 1_999_999_999])
+
+    assert [r["receipt_id"] for r in rows] == [newer, older, older]
+    assert [r["rank"] for r in rows] == [0, 0, 1]
+    assert rows[0]["channel"] == "auto_recall"
+    assert rows[0]["content"] == "WHYFETCH_TEST corrected"
+    assert rows[0]["session_id"] == _SESSION
+    # Superseded state surfaced, never filtered (historical evidence).
+    assert rows[1]["superseded_by_id"] == corrected
+    assert rows[1]["content"] == "WHYFETCH_TEST wrong"
+    # LEFT JOIN survival for the hard-forgotten id.
+    assert rows[2]["memory_row_id"] is None
+    assert rows[2]["content"] is None
+    assert rows[2]["memory_id"] == 2_000_000_000
+
+
+def test_fetch_pg_unknown_and_empty_inputs(_env) -> None:
+    store, _conn = _env
+    assert store.fetch_injection_receipts([1_888_888_888]) == []
+    assert store.fetch_injection_receipts([]) == []

--- a/tests_py/infrastructure/test_injection_receipts_store.py
+++ b/tests_py/infrastructure/test_injection_receipts_store.py
@@ -1,0 +1,81 @@
+"""Parity roundtrip for injection receipts (blame path T1, decision 4255039).
+
+Falsifiable T1 criterion: the persisted receipt items mirror the bound
+payload exactly — same memory_ids, same order (rank), same scores.
+Runs against the SQLite backend; the PG mixin shares the same contract
+(PG parity asserted by the shared insert signature and DDL parity).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
+
+
+def _store() -> SqliteMemoryStore:
+    return SqliteMemoryStore(db_path=":memory:")
+
+
+def _payload() -> list[dict]:
+    return [
+        {"memory_id": 11, "rank": 0, "score": 0.9},
+        {"memory_id": 7, "rank": 1, "score": 0.5},
+        {"memory_id": 3, "rank": 2, "score": None},
+    ]
+
+
+def test_roundtrip_items_mirror_payload() -> None:
+    s = _store()
+    rid = s.insert_injection_receipt("recall", _payload())
+    rows = s._conn.execute(
+        "SELECT memory_id, rank, score FROM injection_receipt_items "
+        "WHERE receipt_id = ? ORDER BY rank",
+        (rid,),
+    ).fetchall()
+    assert [(r["memory_id"], r["rank"], r["score"]) for r in rows] == [
+        (11, 0, 0.9),
+        (7, 1, 0.5),
+        (3, 2, None),
+    ]
+
+
+def test_header_records_channel_and_timestamp() -> None:
+    s = _store()
+    rid = s.insert_injection_receipt("recall", _payload(), session_id="s-1")
+    row = s._conn.execute(
+        "SELECT session_id, channel, emitted_at FROM injection_receipts "
+        "WHERE id = ?",
+        (rid,),
+    ).fetchone()
+    assert row["session_id"] == "s-1"
+    assert row["channel"] == "recall"
+    assert row["emitted_at"]
+
+
+def test_session_id_nullable() -> None:
+    # Decision 4255039 correction 1: the mcp recall handler has no
+    # session identity in scope — NOT NULL would be unexecutable DDL.
+    s = _store()
+    rid = s.insert_injection_receipt("recall", _payload())
+    row = s._conn.execute(
+        "SELECT session_id FROM injection_receipts WHERE id = ?", (rid,)
+    ).fetchone()
+    assert row["session_id"] is None
+
+
+def test_receipts_are_distinct_appends() -> None:
+    s = _store()
+    a = s.insert_injection_receipt("recall", _payload())
+    b = s.insert_injection_receipt("recall", _payload())
+    assert a != b
+    count = s._conn.execute(
+        "SELECT COUNT(*) AS c FROM injection_receipt_items"
+    ).fetchone()["c"]
+    assert count == 6
+
+
+def test_empty_items_rejected() -> None:
+    s = _store()
+    with pytest.raises(ValueError):
+        s.insert_injection_receipt("recall", [])

--- a/tests_py/infrastructure/test_injection_receipts_store.py
+++ b/tests_py/infrastructure/test_injection_receipts_store.py
@@ -126,3 +126,81 @@ def test_all_enum_channels_accepted_by_fresh_sqlite_table() -> None:
     s = _store()
     for channel in sorted(INJECTION_CHANNELS):
         assert s.insert_injection_receipt(channel, _payload()) > 0
+
+
+# ── T3: read path — fetch_injection_receipts (decision 4255039) ──────────
+
+
+def test_fetch_joins_items_to_memories_in_rank_order() -> None:
+    s = _store()
+    m1 = s.insert_memory({"content": "alpha memory"})
+    m2 = s.insert_memory({"content": "beta memory"})
+    rid = s.insert_injection_receipt(
+        "recall",
+        [
+            {"memory_id": m2, "rank": 0, "score": 0.9},
+            {"memory_id": m1, "rank": 1, "score": None},
+        ],
+        session_id="s-t3",
+    )
+    rows = s.fetch_injection_receipts([rid])
+    assert [(r["memory_id"], r["rank"], r["content"]) for r in rows] == [
+        (m2, 0, "beta memory"),
+        (m1, 1, "alpha memory"),
+    ]
+    assert all(r["receipt_id"] == rid for r in rows)
+    assert all(r["session_id"] == "s-t3" for r in rows)
+    assert all(r["channel"] == "recall" for r in rows)
+    assert all(r["emitted_at"] for r in rows)
+
+
+def test_fetch_left_join_survives_hard_forgotten_memory() -> None:
+    # memory_id carries no FK on purpose: the receipt outlives a
+    # hard-forget — the evidence row comes back with m.* all NULL.
+    s = _store()
+    rid = s.insert_injection_receipt(
+        "recall", [{"memory_id": 424242, "rank": 0, "score": 0.4}]
+    )
+    rows = s.fetch_injection_receipts([rid])
+    assert len(rows) == 1
+    assert rows[0]["memory_id"] == 424242
+    assert rows[0]["memory_row_id"] is None
+    assert rows[0]["content"] is None
+
+
+def test_fetch_orders_by_emitted_at_desc_then_id_desc() -> None:
+    s = _store()
+    a = s.insert_injection_receipt("recall", _payload()[:1])
+    b = s.insert_injection_receipt("recall", _payload()[:1])
+    # Same-second inserts: the deterministic tiebreak is id DESC.
+    rows = s.fetch_injection_receipts([a, b])
+    assert [r["receipt_id"] for r in rows] == [b, a]
+    # Age receipt b below a: emitted_at DESC must now dominate the ids.
+    s._conn.execute(
+        "UPDATE injection_receipts SET emitted_at = '2000-01-01T00:00:00' "
+        "WHERE id = ?",
+        (b,),
+    )
+    rows = s.fetch_injection_receipts([a, b])
+    assert [r["receipt_id"] for r in rows] == [a, b]
+
+
+def test_fetch_surfaces_superseded_state_never_filters() -> None:
+    s = _store()
+    m1 = s.insert_memory({"content": "wrong fact"})
+    m2 = s.insert_memory({"content": "corrected fact"})
+    s._conn.execute(
+        "UPDATE memories SET superseded_by_id = ? WHERE id = ?", (m2, m1)
+    )
+    rid = s.insert_injection_receipt(
+        "recall", [{"memory_id": m1, "rank": 0, "score": 0.8}]
+    )
+    rows = s.fetch_injection_receipts([rid])
+    assert len(rows) == 1
+    assert rows[0]["superseded_by_id"] == m2
+
+
+def test_fetch_unknown_and_empty_inputs() -> None:
+    s = _store()
+    assert s.fetch_injection_receipts([987654]) == []
+    assert s.fetch_injection_receipts([]) == []

--- a/tests_py/infrastructure/test_injection_receipts_store.py
+++ b/tests_py/infrastructure/test_injection_receipts_store.py
@@ -44,8 +44,7 @@ def test_header_records_channel_and_timestamp() -> None:
     s = _store()
     rid = s.insert_injection_receipt("recall", _payload(), session_id="s-1")
     row = s._conn.execute(
-        "SELECT session_id, channel, emitted_at FROM injection_receipts "
-        "WHERE id = ?",
+        "SELECT session_id, channel, emitted_at FROM injection_receipts WHERE id = ?",
         (rid,),
     ).fetchone()
     assert row["session_id"] == "s-1"
@@ -177,8 +176,7 @@ def test_fetch_orders_by_emitted_at_desc_then_id_desc() -> None:
     assert [r["receipt_id"] for r in rows] == [b, a]
     # Age receipt b below a: emitted_at DESC must now dominate the ids.
     s._conn.execute(
-        "UPDATE injection_receipts SET emitted_at = '2000-01-01T00:00:00' "
-        "WHERE id = ?",
+        "UPDATE injection_receipts SET emitted_at = '2000-01-01T00:00:00' WHERE id = ?",
         (b,),
     )
     rows = s.fetch_injection_receipts([a, b])
@@ -189,9 +187,7 @@ def test_fetch_surfaces_superseded_state_never_filters() -> None:
     s = _store()
     m1 = s.insert_memory({"content": "wrong fact"})
     m2 = s.insert_memory({"content": "corrected fact"})
-    s._conn.execute(
-        "UPDATE memories SET superseded_by_id = ? WHERE id = ?", (m2, m1)
-    )
+    s._conn.execute("UPDATE memories SET superseded_by_id = ? WHERE id = ?", (m2, m1))
     rid = s.insert_injection_receipt(
         "recall", [{"memory_id": m1, "rank": 0, "score": 0.8}]
     )

--- a/tests_py/infrastructure/test_injection_receipts_store.py
+++ b/tests_py/infrastructure/test_injection_receipts_store.py
@@ -79,3 +79,50 @@ def test_empty_items_rejected() -> None:
     s = _store()
     with pytest.raises(ValueError):
         s.insert_injection_receipt("recall", [])
+
+
+# ── T2: channel enum hardening (decision 4255039 correction 3) ───────────
+
+
+def _ddl_check_members(ddl: str) -> set[str]:
+    """Extract the channel CHECK members from a DDL string."""
+    import re
+
+    m = re.search(r"channel IN \(([^)]*)\)", ddl)
+    assert m, "channel CHECK constraint not found in DDL"
+    return {v.strip().strip("'") for v in m.group(1).split(",")}
+
+
+def test_channel_enum_parity_sqlite_ddl() -> None:
+    from mcp_server.handlers.injection_receipts import INJECTION_CHANNELS
+    from mcp_server.infrastructure.sqlite_schema import INJECTION_RECEIPTS_DDL
+
+    assert _ddl_check_members(INJECTION_RECEIPTS_DDL) == set(INJECTION_CHANNELS)
+
+
+def test_channel_enum_parity_pg_ddl_and_migration() -> None:
+    from mcp_server.handlers.injection_receipts import INJECTION_CHANNELS
+    from mcp_server.infrastructure import pg_schema
+
+    ddl = pg_schema.SUPPORT_TABLES_DDL
+    assert _ddl_check_members(ddl) == set(INJECTION_CHANNELS)
+    # The migration that hardens T1-created tables must carry the same enum.
+    assert _ddl_check_members(pg_schema.MIGRATIONS_DDL) == set(INJECTION_CHANNELS)
+
+
+def test_fresh_sqlite_table_rejects_unknown_channel() -> None:
+    # Fresh tables carry the CHECK; pre-T2 tables keep free TEXT and rely
+    # on the emitter-level validation (documented DDL deviation).
+    import sqlite3
+
+    s = _store()
+    with pytest.raises(sqlite3.IntegrityError):
+        s.insert_injection_receipt("banner", _payload())
+
+
+def test_all_enum_channels_accepted_by_fresh_sqlite_table() -> None:
+    from mcp_server.handlers.injection_receipts import INJECTION_CHANNELS
+
+    s = _store()
+    for channel in sorted(INJECTION_CHANNELS):
+        assert s.insert_injection_receipt(channel, _payload()) > 0

--- a/tests_py/invariants/test_I2_canonical_writer.py
+++ b/tests_py/invariants/test_I2_canonical_writer.py
@@ -33,18 +33,18 @@ _MCP_ROOT = _REPO_ROOT / "mcp_server"
 # OR be added here with a source-commented ADR justification.
 _ALLOWED_WRITERS: set[tuple[str, int]] = {
     # Canonical single-row writer (all callers route through this).
-    # bump_heat_raw — UPDATE at line 692 (shifted 581→692 by the PR #82
-    # supersession write-path refactor + ruff format); still the one
-    # canonical site.
-    ("infrastructure/pg_store.py", 692),
+    # bump_heat_raw — UPDATE at line 694 (581→692 by the PR #82 supersession
+    # write-path refactor + ruff format, then 692→694 by the blame-path T1
+    # receipts mixin wiring, decision 4255039); still the one canonical site.
+    ("infrastructure/pg_store.py", 694),
     # A3 batched writer (homeostatic cohort branch + any other batch consumer).
-    # update_memories_heat_batch — SET line at 752 (shifted 641→752 likewise).
-    ("infrastructure/pg_store.py", 752),
-    # SQLite parity (shifted 301→382, 345→426 by the PR #82 supersession
-    # write-path refactor; both sites remain the canonical bump_heat_raw /
+    # update_memories_heat_batch — SET line at 754 (641→752→754 likewise).
+    ("infrastructure/pg_store.py", 754),
+    # SQLite parity (301→382→384, 345→426→428 by the same two landings;
+    # both sites remain the canonical bump_heat_raw /
     # update_memories_heat_batch writers).
-    ("infrastructure/sqlite_store.py", 382),
-    ("infrastructure/sqlite_store.py", 426),
+    ("infrastructure/sqlite_store.py", 384),
+    ("infrastructure/sqlite_store.py", 428),
     # Homeostatic fold (amortized ~once/month per domain). Shifted 292→317
     # when the bounded-I/O slim-projection helpers were added above it.
     ("handlers/consolidation/homeostatic.py", 317),

--- a/tests_py/test_main.py
+++ b/tests_py/test_main.py
@@ -46,12 +46,14 @@ class TestMain:
             # Should call mcp.run with stdio transport
             mock_run.assert_called_once_with(transport="stdio")
 
-    def test_standalone_baseline_is_44_tools(self):
-        """With no upstream available, exactly the 44 standalone tools register.
+    def test_standalone_baseline_is_45_tools(self):
+        """With no upstream available, exactly the 45 standalone tools register.
 
-        The 3 upstream-integration tools (ingest_codebase, change_impact,
-        ingest_prd) MUST NOT be advertised — every advertised tool then works
-        out of the box. source: MCP Directory submission decision 2026-06-19.
+        45 = the 44 pre-blame-path tools + `why` (blame path T3, decision
+        4255039). The 3 upstream-integration tools (ingest_codebase,
+        change_impact, ingest_prd) MUST NOT be advertised — every advertised
+        tool then works out of the box. source: MCP Directory submission
+        decision 2026-06-19.
         """
         names = _tool_names(codebase=False, prd=False)
         # Core memory / profiling / wiki tools are always present.
@@ -78,22 +80,24 @@ class TestMain:
         assert "get_methodology_graph" not in names
         assert "open_visualization" not in names
         assert "query_workflow_graph" not in names
+        # Blame path T3: the receipt resolver is a standalone tool.
+        assert "why" in names
         # The upstream-integration tools are gated OFF.
         assert names.isdisjoint(_UPSTREAM_TOOLS)
-        assert len(names) == 44
+        assert len(names) == 45
 
-    def test_with_upstreams_registers_47_tools(self):
+    def test_with_upstreams_registers_48_tools(self):
         """When both upstreams are available, the 3 integration tools register."""
         names = _tool_names(codebase=True, prd=True)
         assert _UPSTREAM_TOOLS <= names
-        assert len(names) == 47
+        assert len(names) == 48
 
     def test_codebase_only_adds_two_tools(self):
         """codebase upstream gates ingest_codebase + change_impact together."""
         names = _tool_names(codebase=True, prd=False)
         assert {"ingest_codebase", "change_impact"} <= names
         assert "ingest_prd" not in names
-        assert len(names) == 46
+        assert len(names) == 47
 
     def test_mcp_server_name_and_version(self):
         assert mcp.name == "methodology-agent"


### PR DESCRIPTION
## Summary

Implements the **blame path** (decision 4255039) in three slices, rebased on `main` post-PR82 (`bf7872e8`, supersede-write-path) — receipts and supersession cohabit cleanly.

- **T1 — injection receipts, write path** (`2e13baf9`): every memory injected into context carries a `⟦rcpt:N⟧` receipt recording what was injected, where, and why.
- **T2 — hook channels** (`6079b513`): receipts wired through the injection hook channels.
- **T3 — why tool resolves receipts** (`63380af6`): the `why` tool resolves `⟦rcpt:N⟧` markers back to their originating memories, closing the blame loop.
- **I2 invariant refresh** (`152865f3`): heat-writers allow-list line numbers recomputed deterministically against the rebased tree via the test's own `_scan_heat_writers()` (`pg_store.py` 694/754, `sqlite_store.py` 384/428).

## Verification

- Full suite post-rebase: **4136 passed, 0 failed** (6:16). Pre-rebase reference: 4122 passed — the +14 tests come from main/PR82; no receipts test regressed.
- Targeted post-rebase: 44 receipts/why/test_main tests green + 28 PR82 supersession tests green (cohabitation verified).
- 39 I2 invariants green after allow-list recomputation.
- 13 review findings applied across the change set.

## Notes

- Single rebase conflict (I2 allow-list, double re-pin vs main `9d204a04`) resolved by deterministic recomputation — neither `ours` nor `theirs` was correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NkxreafqWnvPCwrL6KJEs