### PR TITLE
ci(lint): pin ruff to 0.15.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install ruff
-        run: pip install ruff
+        # Pinned: ruff's formatter output changes across minor versions
+        # (0.15.6 vs 0.15.20 divergence broke Lint on PR #83). The repo is
+        # formatted with 0.15.20; bump this pin and reformat together.
+        run: pip install ruff==0.15.20
 
       - name: Check formatting
         run: ruff format --check .


### PR DESCRIPTION
## Problème

Le job Lint installe ruff sans épinglage (`pip install ruff`), donc la CI suit silencieusement la dernière release pendant que les environnements locaux restent en retard. Le formateur de ruff change entre versions mineures : la PR #83 a subi une divergence 0.15.6 (local) vs 0.15.20 (CI) — 8 fichiers « would reformat » côté CI alors qu'ils étaient propres localement (run 28870334xxx, corrigé par fce5ea67).

## Correctif

Épinglage de l'installation CI à `ruff==0.15.20`, la version avec laquelle le repo est actuellement formaté.

**Vérification** : `uvx ruff@0.15.20 format --check .` → 769 fichiers déjà formatés ; `uvx ruff@0.15.20 check .` → All checks passed (sur ce même commit).

## Protocole de mise à jour

Monter le pin et reformater dans le même commit (documenté en commentaire dans le workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NkxreafqWnvPCwrL6KJEs