### PR TITLE
docs(design): restyle banner + diagrams to AI Architect design system

### DIFF
--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,39 +1,68 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 340" width="820" height="340">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 340" width="820" height="340" role="img" aria-label="cortex — the memory that learns, forgets, and proves what it keeps">
   <defs>
     <style>
-      @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&amp;display=swap');
-      .mono { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace; }
+      @import url('https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,wght@0,400;0,500;1,400&amp;display=swap');
+      .mono  { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace; }
+      .serif { font-family: 'Newsreader', 'Iowan Old Style', Georgia, 'Times New Roman', serif; }
+      .sans  { font-family: 'Inter Tight', system-ui, -apple-system, 'Segoe UI', sans-serif; }
     </style>
+    <!-- ============================================================================
+         COLOUR LEGEND — every literal below traces to an AI Architect DS token
+         (the CSS custom properties, written here without their leading dashes so
+         this XML comment stays well-formed). Paper surface. oklch->sRGB values are
+         SCRIPTED (CSS Color 4 math, scratchpad/oklch2srgb.py), never eyeballed.
+           #f1eee7  DS colors.css  paper-0        cream desk ground         scripted oklch->srgb
+           #f8f7f2  DS colors.css  sheet          whiter sheet, mark fill   scripted oklch->srgb
+           #261d17  DS colors.css  pfg-0          primary warm ink          scripted oklch->srgb
+           #61554e  DS colors.css  pfg-2          muted labels              scripted oklch->srgb
+           #a53e00  DS colors.css  accent-deep    terracotta ink on paper   scripted oklch->srgb
+           #3b3129  DS colors.css  paper-line base (ruled hairlines)        scripted oklch->srgb
+         Data-only stage palette (paper re-inked, DS surfaces.css data-surface=paper):
+           #006894 stage-labile · #006a66 stage-early · #0a693c stage-late ·
+           #7d6700 stage-cons  · #753e81 stage-recon   (all scripted oklch->srgb)
+         ============================================================================ -->
   </defs>
 
-  <!-- Background -->
-  <rect width="820" height="340" rx="8" fill="#0d1117"/>
+  <!-- Cream desk ground : DS colors.css paper-0 (scripted oklch->srgb) -->
+  <rect width="820" height="340" rx="8" fill="#f1eee7"/>
+  <!-- Dossier frame: quiet hairline, no glow : DS paper-line base #3b3129 (scripted oklch->srgb) -->
+  <rect x="16" y="16" width="788" height="308" rx="6" fill="none" stroke="#3b3129" stroke-opacity="0.28" stroke-width="1"/>
 
-  <!-- ASCII art title -->
-  <text class="mono" x="32" y="52" fill="#7fbbb3" font-size="13" font-weight="700" xml:space="preserve"> ██████╗ ██████╗ ██████╗ ████████╗███████╗██╗  ██╗</text>
-  <text class="mono" x="32" y="70" fill="#7fbbb3" font-size="13" font-weight="700" xml:space="preserve">██╔════╝██╔═══██╗██╔══██╗╚══██╔══╝██╔════╝╚██╗██╔╝</text>
-  <text class="mono" x="32" y="88" fill="#7fbbb3" font-size="13" font-weight="700" xml:space="preserve">██║     ██║   ██║██████╔╝   ██║   █████╗   ╚███╔╝</text>
-  <text class="mono" x="32" y="106" fill="#7fbbb3" font-size="13" font-weight="700" xml:space="preserve">██║     ██║   ██║██╔══██╗   ██║   ██╔══╝   ██╔██╗</text>
-  <text class="mono" x="32" y="124" fill="#7fbbb3" font-size="13" font-weight="700" xml:space="preserve">╚██████╗╚██████╔╝██║  ██║   ██║   ███████╗██╔╝ ██╗</text>
-  <text class="mono" x="32" y="142" fill="#7fbbb3" font-size="13" font-weight="700" xml:space="preserve"> ╚═════╝ ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚══════╝╚═╝  ╚═╝</text>
+  <!-- Header corners (chrome micro-caps, mono) : DS pfg-2 #61554e (scripted oklch->srgb) -->
+  <text class="mono" x="30" y="35" fill="#61554e" font-size="9.5" letter-spacing="1.4">PYTHON 3.10+  ·  MIT  ·  v4.0.0</text>
+  <text class="mono" x="790" y="35" fill="#61554e" font-size="9.5" letter-spacing="1.4" text-anchor="end">ai-architect.tools</text>
 
-  <!-- Subtitle -->
-  <text class="mono" x="32" y="174" fill="#e0e0e0" font-size="14" font-weight="700">persistent memory for Claude Code</text>
+  <!-- Brand mark: terracotta diamond-in-square with centre node -->
+  <rect x="388" y="44" width="44" height="44" rx="6" fill="#f8f7f2" stroke="#3b3129" stroke-opacity="0.34" stroke-width="1"/>
+  <!-- diamond + node : DS accent-deep #a53e00 (scripted oklch->srgb) -->
+  <path d="M410 50 L426 66 L410 82 L394 66 Z" fill="none" stroke="#a53e00" stroke-width="1.6" stroke-linejoin="round"/>
+  <circle cx="410" cy="66" r="3" fill="#a53e00"/>
 
-  <!-- Stats -->
-  <text class="mono" x="32" y="208" fill="#e0e0e0" font-size="12">44 MCP tools  ·  36 bio mechanisms  ·  9 hooks  ·  3000+ tests  ·  97 citations</text>
+  <!-- Appellation lockup : over-line -->
+  <text class="mono" x="410" y="121" fill="#61554e" font-size="10.5" letter-spacing="2.0" text-anchor="middle">PERSISTENT MEMORY  ·  COGNITIVE PROFILING</text>
 
-  <!-- Benchmarks -->
-  <text class="mono" x="32" y="244" fill="#bec3be" font-size="11">98.2% R@10 LongMemEval  ·  91.5% R@10 LoCoMo  ·  +33.4% BEAM-10M</text>
+  <!-- Repo name : lowercase mono identifier (DS brand card B-02), DS pfg-0 #261d17 -->
+  <text class="mono" x="410" y="164" fill="#261d17" font-size="46" font-weight="700" letter-spacing="-1" text-anchor="middle">cortex</text>
 
-  <!-- Mechanism chain -->
-  <text class="mono" x="32" y="272" fill="#96a09b" font-size="11">encode ── consolidate ── decay ── retrieve ── reconstruct</text>
-  <text class="mono" x="32" y="288" fill="#96a09b" font-size="11">thermodynamic memory that learns, forgets, and surfaces what matters</text>
+  <!-- Ruled line with terracotta diamond at centre -->
+  <line x1="286" y1="186" x2="398" y2="186" stroke="#3b3129" stroke-opacity="0.5" stroke-width="1"/>
+  <line x1="422" y1="186" x2="534" y2="186" stroke="#3b3129" stroke-opacity="0.5" stroke-width="1"/>
+  <path d="M410 180 L416 186 L410 192 L404 186 Z" fill="#a53e00"/>
 
-  <!-- Principles -->
-  <text class="mono" x="32" y="320" fill="#bec3be" font-size="10">built on neuroscience research, not guesswork  ·  runs entirely on your machine</text>
+  <!-- The record: the product's claim, in the serif voice (Newsreader) -->
+  <text class="serif" x="410" y="222" fill="#261d17" font-size="21" text-anchor="middle">The memory that learns, forgets, and <tspan font-style="italic" fill="#a53e00">proves</tspan> what it keeps.</text>
 
-  <!-- Ecosystem brand -->
-  <text class="mono" x="788" y="308" fill="#7fbbb3" font-size="10" opacity="0.6" text-anchor="end">powered by</text>
-  <text class="mono" x="788" y="322" fill="#7fbbb3" font-size="10" opacity="0.6" text-anchor="end">ai-architect.tools</text>
+  <!-- Sub-line descriptors (mono micro-caps) -->
+  <text class="mono" x="410" y="254" fill="#61554e" font-size="10" letter-spacing="1.9" text-anchor="middle">MEASURED  ·  SOURCED  ·  LOCAL-FIRST</text>
+
+  <!-- Tiny data glyphs: consolidation lifecycle (labile to reconsolidating), stage palette -->
+  <line x1="356" y1="283" x2="464" y2="283" stroke="#3b3129" stroke-opacity="0.3" stroke-width="1"/>
+  <circle cx="356" cy="283" r="3.4" fill="#006894"/>
+  <circle cx="383" cy="283" r="3.4" fill="#006a66"/>
+  <circle cx="410" cy="283" r="3.4" fill="#0a693c"/>
+  <circle cx="437" cy="283" r="3.4" fill="#7d6700"/>
+  <circle cx="464" cy="283" r="3.4" fill="#753e81"/>
+
+  <!-- Measured ledger line (mono) : DS pfg-2 #61554e -->
+  <text class="mono" x="410" y="309" fill="#61554e" font-size="9.5" letter-spacing="0.8" text-anchor="middle">44 MCP TOOLS  ·  36 MECHANISMS  ·  97 CITATIONS  ·  98.2% R@10 LONGMEMEVAL</text>
 </svg>

--- a/docs/diagram-architecture.svg
+++ b/docs/diagram-architecture.svg
@@ -1,99 +1,143 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 620" font-family="Inter, -apple-system, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 620" font-family="'Inter Tight', -apple-system, system-ui, sans-serif">
+<!-- =====================================================================
+  RE-INKED to the AI Architect Design System (paper doctrine). Geometry,
+  layout and text content are unchanged; only colour + font-family voices
+  were remapped. Scripted oklch->sRGB (CSS Color 4 math) from DS tokens
+  (colors.css + surfaces.css paper block). Tokens named WITHOUT their
+  leading double-hyphen (XML-comment safe); prefix each with it in CSS.
+  ONE mapping, applied identically across all nine diagrams.
+
+  CHROME (warm-neutral greyscale):
+    #0f172a canvas          -> paper-0        #f1eee7
+    #1e293b box fill        -> sheet          #f8f7f2
+    #292524 #0a1d10 #172554 #1a2e05 #2a1a00 #1d1408 #1e3a5f
+            inner/callout/layer/pill fills -> paper-1  #e6e1d7
+    #44403c inner stroke    -> paper-line     rgba(59,49,41,0.26)
+    #475569 #334155 box stroke -> paper-line-2 rgba(59,49,41,0.42)
+    #64748b arrows/tertiary -> pfg-2          #61554e
+    #a3a3a3 faint hint      -> pfg-2          #61554e
+    #94a3b8 secondary label -> pfg-1          #4b4038
+    #e2e8f0 #cbd5e1 #d4d4d8 primary text -> pfg-0  #261d17
+    #fff reversed on data node -> paper-0     #f1eee7
+
+  DATA (deep re-inked palette, L<=52pct, legible on cream; each source
+  meaning kept distinct, never merged):
+    red    #ef4444 #fca5a5           new/emotion/reject -> danger-deep  #a52a24
+    orange #f97316 #fdba74           surprise momentum  -> emo-frustr   #a05000
+    amber  #f59e0b #fbbf24 #fcd34d #92400e
+                                     active/handlers/encoding/reviewer/directory -> warn-deep #845b00
+    gold   #daa520                   wiki/consolidated  -> stage-cons   #7d6700
+    green  #22c55e #86efac #10b981 #6ee7b7 #166534 #4ade80
+                                     core/retrieval/novel/coordination  -> ok-deep #0a693c
+    cyan   #06b6d4 #67e8f9           infrastructure/storage -> stage-early #006a66
+    blue   #3b82f6 #60a5fa #93c5fd #1e40af
+                                     query/results/compressed/specialization/sleep -> info-deep #006185
+    purple #8b5cf6 #a855f7 #c4b5fd   neuromodulation/plasticity/intent -> emo-conflct #784d96
+    pink   #ec4899 #f9a8d4 #d946ef #e879f9
+                                     hooks/emotional-tagging/intent -> stage-recon #753e81
+
+  Note: amber(80) and gold(95) stay distinct; green ink is single in the DS
+  paper palette so green+emerald share ok-deep (same 'valid/positive' meaning);
+  category-tinted panel fills neutralised to paper-1 with the category kept in
+  their stroke+text data ink. Fonts: labels -> Inter Tight, identifiers ->
+  JetBrains Mono. Gradients/glow: none used; the unused blur filter was removed.
+===================================================================== -->
+
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+      <path d="M0,0 L8,3 L0,6" fill="#61554e"/>
     </marker>
     <marker id="arr-pink" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#ec4899"/>
+      <path d="M0,0 L8,3 L0,6" fill="#753e81"/>
     </marker>
     <marker id="arr-gold" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#daa520"/>
+      <path d="M0,0 L8,3 L0,6" fill="#7d6700"/>
     </marker>
   </defs>
 
-  <rect width="780" height="620" rx="12" fill="#0f172a"/>
+  <rect width="780" height="620" rx="12" fill="#f1eee7"/>
 
   <!-- Title -->
-  <text x="390" y="28" text-anchor="middle" fill="#e2e8f0" font-size="14" font-weight="600">Cortex Clean Architecture — 3.17.0</text>
-  <text x="390" y="46" text-anchor="middle" fill="#64748b" font-size="10">Inner layers never import outer layers · handlers compose core + infrastructure</text>
+  <text x="390" y="28" text-anchor="middle" fill="#261d17" font-size="14" font-weight="600">Cortex Clean Architecture — 3.17.0</text>
+  <text x="390" y="46" text-anchor="middle" fill="#61554e" font-size="10">Inner layers never import outer layers · handlers compose core + infrastructure</text>
 
   <!-- ── Row 1: server/ ── -->
-  <rect x="300" y="64" width="180" height="44" rx="5" fill="#1e293b" stroke="#94a3b8" stroke-width="1"/>
-  <text x="390" y="83" text-anchor="middle" fill="#cbd5e1" font-size="13" font-weight="600">server/</text>
-  <text x="390" y="99" text-anchor="middle" fill="#64748b" font-size="9">HTTP standalone · wiki API · viz · 4 modules</text>
+  <rect x="300" y="64" width="180" height="44" rx="5" fill="#f8f7f2" stroke="#4b4038" stroke-width="1"/>
+  <text x="390" y="83" text-anchor="middle" fill="#261d17" font-size="13" font-weight="600">server/</text>
+  <text x="390" y="99" text-anchor="middle" fill="#61554e" font-size="9">HTTP standalone · wiki API · viz · 4 modules</text>
 
-  <line x1="390" y1="108" x2="390" y2="132" stroke="#64748b" stroke-width="1.4" marker-end="url(#arr)"/>
-  <text x="412" y="124" fill="#64748b" font-size="8">dispatch</text>
+  <line x1="390" y1="108" x2="390" y2="132" stroke="#61554e" stroke-width="1.4" marker-end="url(#arr)"/>
+  <text x="412" y="124" fill="#61554e" font-size="8">dispatch</text>
 
   <!-- ── Row 2: handlers/ ── -->
-  <rect x="270" y="136" width="240" height="48" rx="5" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="390" y="158" text-anchor="middle" fill="#fbbf24" font-size="13" font-weight="600">handlers/ (composition roots)</text>
-  <text x="390" y="174" text-anchor="middle" fill="#64748b" font-size="9">91+ tool / cycle handlers · 49 MCP-exposed</text>
+  <rect x="270" y="136" width="240" height="48" rx="5" fill="#f8f7f2" stroke="#845b00" stroke-width="1.5"/>
+  <text x="390" y="158" text-anchor="middle" fill="#845b00" font-size="13" font-weight="600">handlers/ (composition roots)</text>
+  <text x="390" y="174" text-anchor="middle" fill="#61554e" font-size="9">91+ tool / cycle handlers · 49 MCP-exposed</text>
 
   <!-- handlers → core (left) -->
-  <line x1="310" y1="184" x2="200" y2="226" stroke="#64748b" stroke-width="1.4" marker-end="url(#arr)"/>
-  <text x="220" y="211" fill="#64748b" font-size="8">compose pure logic</text>
+  <line x1="310" y1="184" x2="200" y2="226" stroke="#61554e" stroke-width="1.4" marker-end="url(#arr)"/>
+  <text x="220" y="211" fill="#61554e" font-size="8">compose pure logic</text>
 
   <!-- handlers → infrastructure (right) -->
-  <line x1="470" y1="184" x2="580" y2="226" stroke="#64748b" stroke-width="1.4" marker-end="url(#arr)"/>
-  <text x="495" y="211" fill="#64748b" font-size="8">wire I/O adapters</text>
+  <line x1="470" y1="184" x2="580" y2="226" stroke="#61554e" stroke-width="1.4" marker-end="url(#arr)"/>
+  <text x="495" y="211" fill="#61554e" font-size="8">wire I/O adapters</text>
 
   <!-- ── Row 3: core/ | infrastructure/ ── -->
-  <rect x="60" y="230" width="280" height="60" rx="5" fill="#1e293b" stroke="#22c55e" stroke-width="1.6"/>
-  <text x="200" y="252" text-anchor="middle" fill="#86efac" font-size="13" font-weight="600">core/</text>
-  <text x="200" y="268" text-anchor="middle" fill="#64748b" font-size="9">neuroscience · retrieval · wiki curation</text>
-  <text x="200" y="282" text-anchor="middle" fill="#86efac" font-size="10" font-weight="500">175+ modules · pure logic · zero I/O</text>
+  <rect x="60" y="230" width="280" height="60" rx="5" fill="#f8f7f2" stroke="#0a693c" stroke-width="1.6"/>
+  <text x="200" y="252" text-anchor="middle" fill="#0a693c" font-size="13" font-weight="600">core/</text>
+  <text x="200" y="268" text-anchor="middle" fill="#61554e" font-size="9">neuroscience · retrieval · wiki curation</text>
+  <text x="200" y="282" text-anchor="middle" fill="#0a693c" font-size="10" font-weight="500">175+ modules · pure logic · zero I/O</text>
 
-  <rect x="440" y="230" width="280" height="60" rx="5" fill="#1e293b" stroke="#06b6d4" stroke-width="1.6"/>
-  <text x="580" y="252" text-anchor="middle" fill="#67e8f9" font-size="13" font-weight="600">infrastructure/</text>
-  <text x="580" y="268" text-anchor="middle" fill="#64748b" font-size="9">PostgreSQL · pgvector · embeddings · MCP client</text>
-  <text x="580" y="282" text-anchor="middle" fill="#67e8f9" font-size="10" font-weight="500">33 modules · all I/O</text>
+  <rect x="440" y="230" width="280" height="60" rx="5" fill="#f8f7f2" stroke="#006a66" stroke-width="1.6"/>
+  <text x="580" y="252" text-anchor="middle" fill="#006a66" font-size="13" font-weight="600">infrastructure/</text>
+  <text x="580" y="268" text-anchor="middle" fill="#61554e" font-size="9">PostgreSQL · pgvector · embeddings · MCP client</text>
+  <text x="580" y="282" text-anchor="middle" fill="#006a66" font-size="10" font-weight="500">33 modules · all I/O</text>
 
   <!-- ── Wiki curation subsystem callout (centered below core/infra) ── -->
-  <rect x="160" y="306" width="460" height="88" rx="5" fill="#0a1d10" stroke="#daa520" stroke-width="1.4" stroke-dasharray="4,3"/>
-  <text x="390" y="324" text-anchor="middle" fill="#daa520" font-size="11" font-weight="700">Wiki curation subsystem (3.17.0) — inside core/</text>
-  <text x="390" y="342" text-anchor="middle" fill="#94a3b8" font-size="9">wiki_coverage · wiki_curation_gaps · wiki_drift · wiki_file_doc_skeleton</text>
-  <text x="390" y="356" text-anchor="middle" fill="#94a3b8" font-size="9">wiki_coverage_dashboard · auto_task_record · wiki_stub_detector · auto_curator</text>
-  <text x="390" y="378" text-anchor="middle" fill="#daa520" font-size="9" font-weight="600">42 canonical scopes · 14 file-doc sections per file</text>
+  <rect x="160" y="306" width="460" height="88" rx="5" fill="#e6e1d7" stroke="#7d6700" stroke-width="1.4" stroke-dasharray="4,3"/>
+  <text x="390" y="324" text-anchor="middle" fill="#7d6700" font-size="11" font-weight="700">Wiki curation subsystem (3.17.0) — inside core/</text>
+  <text x="390" y="342" text-anchor="middle" fill="#4b4038" font-size="9">wiki_coverage · wiki_curation_gaps · wiki_drift · wiki_file_doc_skeleton</text>
+  <text x="390" y="356" text-anchor="middle" fill="#4b4038" font-size="9">wiki_coverage_dashboard · auto_task_record · wiki_stub_detector · auto_curator</text>
+  <text x="390" y="378" text-anchor="middle" fill="#7d6700" font-size="9" font-weight="600">42 canonical scopes · 14 file-doc sections per file</text>
 
   <!-- ── Row 4: shared/ | errors/validation/ ── -->
-  <rect x="155" y="412" width="200" height="46" rx="5" fill="#1e293b" stroke="#64748b" stroke-width="1"/>
-  <text x="255" y="431" text-anchor="middle" fill="#cbd5e1" font-size="12" font-weight="600">shared/</text>
-  <text x="255" y="446" text-anchor="middle" fill="#64748b" font-size="9">11 modules · Python stdlib only</text>
+  <rect x="155" y="412" width="200" height="46" rx="5" fill="#f8f7f2" stroke="#61554e" stroke-width="1"/>
+  <text x="255" y="431" text-anchor="middle" fill="#261d17" font-size="12" font-weight="600">shared/</text>
+  <text x="255" y="446" text-anchor="middle" fill="#61554e" font-size="9">11 modules · Python stdlib only</text>
 
-  <rect x="425" y="412" width="200" height="46" rx="5" fill="#1e293b" stroke="#64748b" stroke-width="1"/>
-  <text x="525" y="431" text-anchor="middle" fill="#cbd5e1" font-size="12" font-weight="600">errors/ · validation/</text>
-  <text x="525" y="446" text-anchor="middle" fill="#64748b" font-size="9">exception types · arg schemas</text>
+  <rect x="425" y="412" width="200" height="46" rx="5" fill="#f8f7f2" stroke="#61554e" stroke-width="1"/>
+  <text x="525" y="431" text-anchor="middle" fill="#261d17" font-size="12" font-weight="600">errors/ · validation/</text>
+  <text x="525" y="446" text-anchor="middle" fill="#61554e" font-size="9">exception types · arg schemas</text>
 
   <!-- core → shared (down arrow) -->
-  <line x1="200" y1="290" x2="220" y2="412" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
+  <line x1="200" y1="290" x2="220" y2="412" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
   <!-- infrastructure → shared (down arrow) -->
-  <line x1="580" y1="290" x2="560" y2="412" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
+  <line x1="580" y1="290" x2="560" y2="412" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
 
   <!-- ── Row 5: hooks/ ↔ consolidate_background (autonomous loop row) ── -->
-  <rect x="60" y="490" width="200" height="50" rx="5" fill="#1e293b" stroke="#ec4899" stroke-width="1.5"/>
-  <text x="160" y="510" text-anchor="middle" fill="#f9a8d4" font-size="12" font-weight="700">hooks/</text>
-  <text x="160" y="526" text-anchor="middle" fill="#94a3b8" font-size="9">9 hooks · SessionStart-driven spawn</text>
+  <rect x="60" y="490" width="200" height="50" rx="5" fill="#f8f7f2" stroke="#753e81" stroke-width="1.5"/>
+  <text x="160" y="510" text-anchor="middle" fill="#753e81" font-size="12" font-weight="700">hooks/</text>
+  <text x="160" y="526" text-anchor="middle" fill="#4b4038" font-size="9">9 hooks · SessionStart-driven spawn</text>
 
-  <rect x="520" y="490" width="200" height="50" rx="5" fill="#1e293b" stroke="#daa520" stroke-width="1.5"/>
-  <text x="620" y="510" text-anchor="middle" fill="#daa520" font-size="12" font-weight="700">consolidate_background</text>
-  <text x="620" y="526" text-anchor="middle" fill="#94a3b8" font-size="9">every 6h · drains wiki gap queue</text>
+  <rect x="520" y="490" width="200" height="50" rx="5" fill="#f8f7f2" stroke="#7d6700" stroke-width="1.5"/>
+  <text x="620" y="510" text-anchor="middle" fill="#7d6700" font-size="12" font-weight="700">consolidate_background</text>
+  <text x="620" y="526" text-anchor="middle" fill="#4b4038" font-size="9">every 6h · drains wiki gap queue</text>
 
   <!-- Gold dashed arrow: hooks → consolidate_background (straight horizontal, below everything else) -->
-  <line x1="260" y1="515" x2="520" y2="515" stroke="#daa520" stroke-width="1.4" stroke-dasharray="5,3" marker-end="url(#arr-gold)"/>
-  <text x="390" y="508" text-anchor="middle" fill="#daa520" font-size="9" font-weight="500">stamp-gated spawn (TTL = 6h)</text>
+  <line x1="260" y1="515" x2="520" y2="515" stroke="#7d6700" stroke-width="1.4" stroke-dasharray="5,3" marker-end="url(#arr-gold)"/>
+  <text x="390" y="508" text-anchor="middle" fill="#7d6700" font-size="9" font-weight="500">stamp-gated spawn (TTL = 6h)</text>
 
   <!-- Pink curved arrows: hooks → core (up + over left edge, away from wiki box) -->
-  <path d="M 80 490 Q 30 380 60 290" stroke="#ec4899" stroke-width="1" stroke-dasharray="3,3" fill="none" marker-end="url(#arr-pink)"/>
-  <text x="20" y="395" fill="#ec4899" font-size="8" transform="rotate(-90 20 395)">imports core</text>
+  <path d="M 80 490 Q 30 380 60 290" stroke="#753e81" stroke-width="1" stroke-dasharray="3,3" fill="none" marker-end="url(#arr-pink)"/>
+  <text x="20" y="395" fill="#753e81" font-size="8" transform="rotate(-90 20 395)">imports core</text>
 
   <!-- Pink curved arrow: consolidate → infrastructure (up + over right edge) -->
-  <path d="M 700 490 Q 750 380 720 290" stroke="#ec4899" stroke-width="1" stroke-dasharray="3,3" fill="none" marker-end="url(#arr-pink)"/>
-  <text x="755" y="395" fill="#ec4899" font-size="8" transform="rotate(90 755 395)">imports infra</text>
+  <path d="M 700 490 Q 750 380 720 290" stroke="#753e81" stroke-width="1" stroke-dasharray="3,3" fill="none" marker-end="url(#arr-pink)"/>
+  <text x="755" y="395" fill="#753e81" font-size="8" transform="rotate(90 755 395)">imports infra</text>
 
   <!-- ── Footer: dependency rule ── -->
-  <text x="390" y="568" text-anchor="middle" fill="#94a3b8" font-size="10" font-weight="600">Dependency rule (enforced by code-reviewer + CI)</text>
-  <text x="390" y="584" text-anchor="middle" fill="#64748b" font-size="9">shared → stdlib only · core → shared · infrastructure → shared · validation → shared+errors</text>
-  <text x="390" y="598" text-anchor="middle" fill="#64748b" font-size="9">handlers → core + infrastructure + shared + validation + errors · server → handlers + errors · hooks → infra + core + shared</text>
-  <text x="390" y="612" text-anchor="middle" fill="#94a3b8" font-size="9" font-style="italic">Violations block PR · exceptions require ADR with human approval</text>
+  <text x="390" y="568" text-anchor="middle" fill="#4b4038" font-size="10" font-weight="600">Dependency rule (enforced by code-reviewer + CI)</text>
+  <text x="390" y="584" text-anchor="middle" fill="#61554e" font-size="9">shared → stdlib only · core → shared · infrastructure → shared · validation → shared+errors</text>
+  <text x="390" y="598" text-anchor="middle" fill="#61554e" font-size="9">handlers → core + infrastructure + shared + validation + errors · server → handlers + errors · hooks → infra + core + shared</text>
+  <text x="390" y="612" text-anchor="middle" fill="#4b4038" font-size="9" font-style="italic">Violations block PR · exceptions require ADR with human approval</text>
 </svg>

--- a/docs/diagram-big-picture.svg
+++ b/docs/diagram-big-picture.svg
@@ -1,58 +1,98 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 400" font-family="Inter, -apple-system, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 400" font-family="'Inter Tight', -apple-system, system-ui, sans-serif">
+<!-- =====================================================================
+  RE-INKED to the AI Architect Design System (paper doctrine). Geometry,
+  layout and text content are unchanged; only colour + font-family voices
+  were remapped. Scripted oklch->sRGB (CSS Color 4 math) from DS tokens
+  (colors.css + surfaces.css paper block). Tokens named WITHOUT their
+  leading double-hyphen (XML-comment safe); prefix each with it in CSS.
+  ONE mapping, applied identically across all nine diagrams.
+
+  CHROME (warm-neutral greyscale):
+    #0f172a canvas          -> paper-0        #f1eee7
+    #1e293b box fill        -> sheet          #f8f7f2
+    #292524 #0a1d10 #172554 #1a2e05 #2a1a00 #1d1408 #1e3a5f
+            inner/callout/layer/pill fills -> paper-1  #e6e1d7
+    #44403c inner stroke    -> paper-line     rgba(59,49,41,0.26)
+    #475569 #334155 box stroke -> paper-line-2 rgba(59,49,41,0.42)
+    #64748b arrows/tertiary -> pfg-2          #61554e
+    #a3a3a3 faint hint      -> pfg-2          #61554e
+    #94a3b8 secondary label -> pfg-1          #4b4038
+    #e2e8f0 #cbd5e1 #d4d4d8 primary text -> pfg-0  #261d17
+    #fff reversed on data node -> paper-0     #f1eee7
+
+  DATA (deep re-inked palette, L<=52pct, legible on cream; each source
+  meaning kept distinct, never merged):
+    red    #ef4444 #fca5a5           new/emotion/reject -> danger-deep  #a52a24
+    orange #f97316 #fdba74           surprise momentum  -> emo-frustr   #a05000
+    amber  #f59e0b #fbbf24 #fcd34d #92400e
+                                     active/handlers/encoding/reviewer/directory -> warn-deep #845b00
+    gold   #daa520                   wiki/consolidated  -> stage-cons   #7d6700
+    green  #22c55e #86efac #10b981 #6ee7b7 #166534 #4ade80
+                                     core/retrieval/novel/coordination  -> ok-deep #0a693c
+    cyan   #06b6d4 #67e8f9           infrastructure/storage -> stage-early #006a66
+    blue   #3b82f6 #60a5fa #93c5fd #1e40af
+                                     query/results/compressed/specialization/sleep -> info-deep #006185
+    purple #8b5cf6 #a855f7 #c4b5fd   neuromodulation/plasticity/intent -> emo-conflct #784d96
+    pink   #ec4899 #f9a8d4 #d946ef #e879f9
+                                     hooks/emotional-tagging/intent -> stage-recon #753e81
+
+  Note: amber(80) and gold(95) stay distinct; green ink is single in the DS
+  paper palette so green+emerald share ok-deep (same 'valid/positive' meaning);
+  category-tinted panel fills neutralised to paper-1 with the category kept in
+  their stroke+text data ink. Fonts: labels -> Inter Tight, identifiers ->
+  JetBrains Mono. Gradients/glow: none used; the unused blur filter was removed.
+===================================================================== -->
+
   <defs>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="2" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+      <path d="M0,0 L8,3 L0,6" fill="#61554e"/>
     </marker>
   </defs>
 
-  <rect width="900" height="400" rx="12" fill="#0f172a"/>
+  <rect width="900" height="400" rx="12" fill="#f1eee7"/>
 
   <!-- Claude Code node -->
-  <rect x="30" y="155" width="140" height="50" rx="25" fill="#3b82f6" stroke="#60a5fa" stroke-width="1.5"/>
-  <text x="100" y="185" text-anchor="middle" fill="#fff" font-size="13" font-weight="600">Claude Code</text>
+  <rect x="30" y="155" width="140" height="50" rx="25" fill="#006185" stroke="#006185" stroke-width="1.5"/>
+  <text x="100" y="185" text-anchor="middle" fill="#f1eee7" font-size="13" font-weight="600">Claude Code</text>
 
   <!-- Cortex Plugin box -->
-  <rect x="220" y="20" width="220" height="200" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5" opacity="0.9"/>
-  <text x="330" y="44" text-anchor="middle" fill="#f59e0b" font-size="11" font-weight="700" letter-spacing="0.5">CORTEX PLUGIN</text>
-  <rect x="240" y="56" width="180" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="330" y="75" text-anchor="middle" fill="#fbbf24" font-size="11">MCP Server - 34 tools</text>
-  <rect x="240" y="92" width="180" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="330" y="111" text-anchor="middle" fill="#d4d4d8" font-size="10">SessionStart - inject context</text>
-  <rect x="240" y="128" width="180" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="330" y="147" text-anchor="middle" fill="#d4d4d8" font-size="10">PostToolUse - auto-capture</text>
-  <rect x="240" y="164" width="180" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="330" y="183" text-anchor="middle" fill="#d4d4d8" font-size="10">SessionEnd - update profile</text>
+  <rect x="220" y="20" width="220" height="200" rx="8" fill="#f8f7f2" stroke="#845b00" stroke-width="1.5" opacity="0.9"/>
+  <text x="330" y="44" text-anchor="middle" fill="#845b00" font-size="11" font-weight="700" letter-spacing="0.5">CORTEX PLUGIN</text>
+  <rect x="240" y="56" width="180" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="330" y="75" text-anchor="middle" fill="#845b00" font-size="11">MCP Server - 34 tools</text>
+  <rect x="240" y="92" width="180" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="330" y="111" text-anchor="middle" fill="#261d17" font-size="10">SessionStart - inject context</text>
+  <rect x="240" y="128" width="180" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="330" y="147" text-anchor="middle" fill="#261d17" font-size="10">PostToolUse - auto-capture</text>
+  <rect x="240" y="164" width="180" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="330" y="183" text-anchor="middle" fill="#261d17" font-size="10">SessionEnd - update profile</text>
 
   <!-- 10 Skills box -->
-  <rect x="220" y="240" width="220" height="140" rx="8" fill="#1e293b" stroke="#22c55e" stroke-width="1.5" opacity="0.9"/>
-  <text x="330" y="264" text-anchor="middle" fill="#22c55e" font-size="11" font-weight="700" letter-spacing="0.5">10 SKILLS</text>
-  <text x="330" y="290" text-anchor="middle" fill="#86efac" font-size="11" font-family="monospace">/cortex-remember</text>
-  <text x="330" y="310" text-anchor="middle" fill="#86efac" font-size="11" font-family="monospace">/cortex-recall</text>
-  <text x="330" y="330" text-anchor="middle" fill="#86efac" font-size="11" font-family="monospace">/cortex-profile</text>
-  <text x="330" y="350" text-anchor="middle" fill="#86efac" font-size="11" font-family="monospace">/cortex-visualize</text>
-  <text x="330" y="370" text-anchor="middle" fill="#64748b" font-size="10">+ 6 more</text>
+  <rect x="220" y="240" width="220" height="140" rx="8" fill="#f8f7f2" stroke="#0a693c" stroke-width="1.5" opacity="0.9"/>
+  <text x="330" y="264" text-anchor="middle" fill="#0a693c" font-size="11" font-weight="700" letter-spacing="0.5">10 SKILLS</text>
+  <text x="330" y="290" text-anchor="middle" fill="#0a693c" font-size="11" font-family="'JetBrains Mono', ui-monospace, monospace">/cortex-remember</text>
+  <text x="330" y="310" text-anchor="middle" fill="#0a693c" font-size="11" font-family="'JetBrains Mono', ui-monospace, monospace">/cortex-recall</text>
+  <text x="330" y="330" text-anchor="middle" fill="#0a693c" font-size="11" font-family="'JetBrains Mono', ui-monospace, monospace">/cortex-profile</text>
+  <text x="330" y="350" text-anchor="middle" fill="#0a693c" font-size="11" font-family="'JetBrains Mono', ui-monospace, monospace">/cortex-visualize</text>
+  <text x="330" y="370" text-anchor="middle" fill="#61554e" font-size="10">+ 6 more</text>
 
   <!-- PostgreSQL box -->
-  <rect x="520" y="60" width="240" height="160" rx="8" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5" opacity="0.9"/>
-  <text x="640" y="84" text-anchor="middle" fill="#06b6d4" font-size="11" font-weight="700" letter-spacing="0.5">POSTGRESQL + PGVECTOR</text>
-  <rect x="540" y="96" width="200" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="640" y="115" text-anchor="middle" fill="#67e8f9" font-size="11">Memories + Embeddings</text>
-  <rect x="540" y="132" width="200" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="640" y="151" text-anchor="middle" fill="#67e8f9" font-size="11">Entity Knowledge Graph</text>
-  <rect x="540" y="168" width="200" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="640" y="187" text-anchor="middle" fill="#67e8f9" font-size="11">WRRF Stored Procedures</text>
+  <rect x="520" y="60" width="240" height="160" rx="8" fill="#f8f7f2" stroke="#006a66" stroke-width="1.5" opacity="0.9"/>
+  <text x="640" y="84" text-anchor="middle" fill="#006a66" font-size="11" font-weight="700" letter-spacing="0.5">POSTGRESQL + PGVECTOR</text>
+  <rect x="540" y="96" width="200" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="640" y="115" text-anchor="middle" fill="#006a66" font-size="11">Memories + Embeddings</text>
+  <rect x="540" y="132" width="200" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="640" y="151" text-anchor="middle" fill="#006a66" font-size="11">Entity Knowledge Graph</text>
+  <rect x="540" y="168" width="200" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="640" y="187" text-anchor="middle" fill="#006a66" font-size="11">WRRF Stored Procedures</text>
 
   <!-- Arrows -->
-  <line x1="170" y1="170" x2="215" y2="120" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <line x1="170" y1="190" x2="215" y2="300" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <line x1="440" y1="140" x2="515" y2="140" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <line x1="440" y1="310" x2="465" y2="310" stroke="#64748b" stroke-width="1" stroke-dasharray="4,3"/>
-  <path d="M465,310 Q490,310 490,220 L490,120 L515,120" fill="none" stroke="#64748b" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+  <line x1="170" y1="170" x2="215" y2="120" stroke="#61554e" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="170" y1="190" x2="215" y2="300" stroke="#61554e" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="440" y1="140" x2="515" y2="140" stroke="#61554e" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="440" y1="310" x2="465" y2="310" stroke="#61554e" stroke-width="1" stroke-dasharray="4,3"/>
+  <path d="M465,310 Q490,310 490,220 L490,120 L515,120" fill="none" stroke="#61554e" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
 
   <!-- Arrow labels -->
-  <text x="475" y="105" text-anchor="middle" fill="#94a3b8" font-size="9">via plugin</text>
+  <text x="475" y="105" text-anchor="middle" fill="#4b4038" font-size="9">via plugin</text>
 </svg>

--- a/docs/diagram-lifecycle.svg
+++ b/docs/diagram-lifecycle.svg
@@ -1,48 +1,92 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 120" font-family="Inter, -apple-system, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 120" font-family="'Inter Tight', -apple-system, system-ui, sans-serif">
+<!-- =====================================================================
+  RE-INKED to the AI Architect Design System (paper doctrine). Geometry,
+  layout and text content are unchanged; only colour + font-family voices
+  were remapped. Scripted oklch->sRGB (CSS Color 4 math) from DS tokens
+  (colors.css + surfaces.css paper block). Tokens named WITHOUT their
+  leading double-hyphen (XML-comment safe); prefix each with it in CSS.
+  ONE mapping, applied identically across all nine diagrams.
+
+  CHROME (warm-neutral greyscale):
+    #0f172a canvas          -> paper-0        #f1eee7
+    #1e293b box fill        -> sheet          #f8f7f2
+    #292524 #0a1d10 #172554 #1a2e05 #2a1a00 #1d1408 #1e3a5f
+            inner/callout/layer/pill fills -> paper-1  #e6e1d7
+    #44403c inner stroke    -> paper-line     rgba(59,49,41,0.26)
+    #475569 #334155 box stroke -> paper-line-2 rgba(59,49,41,0.42)
+    #64748b arrows/tertiary -> pfg-2          #61554e
+    #a3a3a3 faint hint      -> pfg-2          #61554e
+    #94a3b8 secondary label -> pfg-1          #4b4038
+    #e2e8f0 #cbd5e1 #d4d4d8 primary text -> pfg-0  #261d17
+    #fff reversed on data node -> paper-0     #f1eee7
+
+  DATA (deep re-inked palette, L<=52pct, legible on cream; each source
+  meaning kept distinct, never merged):
+    red    #ef4444 #fca5a5           new/emotion/reject -> danger-deep  #a52a24
+    orange #f97316 #fdba74           surprise momentum  -> emo-frustr   #a05000
+    amber  #f59e0b #fbbf24 #fcd34d #92400e
+                                     active/handlers/encoding/reviewer/directory -> warn-deep #845b00
+    gold   #daa520                   wiki/consolidated  -> stage-cons   #7d6700
+    green  #22c55e #86efac #10b981 #6ee7b7 #166534 #4ade80
+                                     core/retrieval/novel/coordination  -> ok-deep #0a693c
+    cyan   #06b6d4 #67e8f9           infrastructure/storage -> stage-early #006a66
+    blue   #3b82f6 #60a5fa #93c5fd #1e40af
+                                     query/results/compressed/specialization/sleep -> info-deep #006185
+    purple #8b5cf6 #a855f7 #c4b5fd   neuromodulation/plasticity/intent -> emo-conflct #784d96
+    pink   #ec4899 #f9a8d4 #d946ef #e879f9
+                                     hooks/emotional-tagging/intent -> stage-recon #753e81
+
+  Note: amber(80) and gold(95) stay distinct; green ink is single in the DS
+  paper palette so green+emerald share ok-deep (same 'valid/positive' meaning);
+  category-tinted panel fills neutralised to paper-1 with the category kept in
+  their stroke+text data ink. Fonts: labels -> Inter Tight, identifiers ->
+  JetBrains Mono. Gradients/glow: none used; the unused blur filter was removed.
+===================================================================== -->
+
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+      <path d="M0,0 L8,3 L0,6" fill="#61554e"/>
     </marker>
     <marker id="arr-up" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#f59e0b"/>
+      <path d="M0,0 L8,3 L0,6" fill="#845b00"/>
     </marker>
   </defs>
 
-  <rect width="750" height="120" rx="12" fill="#0f172a"/>
+  <rect width="750" height="120" rx="12" fill="#f1eee7"/>
 
   <!-- New -->
-  <rect x="20" y="35" width="120" height="42" rx="21" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
-  <text x="80" y="55" text-anchor="middle" fill="#fca5a5" font-size="12" font-weight="600">New</text>
-  <text x="80" y="70" text-anchor="middle" fill="#a3a3a3" font-size="9">heat = 1.0</text>
+  <rect x="20" y="35" width="120" height="42" rx="21" fill="#f8f7f2" stroke="#a52a24" stroke-width="1.5"/>
+  <text x="80" y="55" text-anchor="middle" fill="#a52a24" font-size="12" font-weight="600">New</text>
+  <text x="80" y="70" text-anchor="middle" fill="#61554e" font-size="9">heat = 1.0</text>
 
-  <line x1="140" y1="56" x2="170" y2="56" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="140" y1="56" x2="170" y2="56" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Active -->
-  <rect x="175" y="35" width="110" height="42" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="230" y="61" text-anchor="middle" fill="#fbbf24" font-size="12" font-weight="600">Active</text>
+  <rect x="175" y="35" width="110" height="42" rx="6" fill="#f8f7f2" stroke="#845b00" stroke-width="1.5"/>
+  <text x="230" y="61" text-anchor="middle" fill="#845b00" font-size="12" font-weight="600">Active</text>
 
-  <line x1="285" y1="56" x2="320" y2="56" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="285" y1="56" x2="320" y2="56" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Cooling -->
-  <rect x="325" y="35" width="110" height="42" rx="6" fill="#1e293b" stroke="#64748b" stroke-width="1.5"/>
-  <text x="380" y="61" text-anchor="middle" fill="#94a3b8" font-size="12" font-weight="600">Cooling</text>
+  <rect x="325" y="35" width="110" height="42" rx="6" fill="#f8f7f2" stroke="#61554e" stroke-width="1.5"/>
+  <text x="380" y="61" text-anchor="middle" fill="#4b4038" font-size="12" font-weight="600">Cooling</text>
 
-  <line x1="435" y1="56" x2="470" y2="56" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="435" y1="56" x2="470" y2="56" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Compressed -->
-  <rect x="475" y="35" width="120" height="42" rx="6" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="535" y="61" text-anchor="middle" fill="#93c5fd" font-size="12" font-weight="600">Compressed</text>
+  <rect x="475" y="35" width="120" height="42" rx="6" fill="#f8f7f2" stroke="#006185" stroke-width="1.5"/>
+  <text x="535" y="61" text-anchor="middle" fill="#006185" font-size="12" font-weight="600">Compressed</text>
 
-  <line x1="595" y1="56" x2="625" y2="56" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="595" y1="56" x2="625" y2="56" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Consolidated -->
-  <rect x="630" y="35" width="110" height="42" rx="21" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="685" y="61" text-anchor="middle" fill="#86efac" font-size="12" font-weight="600">Consolidated</text>
+  <rect x="630" y="35" width="110" height="42" rx="21" fill="#f8f7f2" stroke="#0a693c" stroke-width="1.5"/>
+  <text x="685" y="61" text-anchor="middle" fill="#0a693c" font-size="12" font-weight="600">Consolidated</text>
 
   <!-- Recalled loops -->
-  <path d="M230,35 Q230,10 305,10 Q380,10 380,35" fill="none" stroke="#f59e0b" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr-up)"/>
-  <text x="305" y="8" text-anchor="middle" fill="#f59e0b" font-size="9">recalled</text>
+  <path d="M230,35 Q230,10 305,10 Q380,10 380,35" fill="none" stroke="#845b00" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr-up)"/>
+  <text x="305" y="8" text-anchor="middle" fill="#845b00" font-size="9">recalled</text>
 
-  <path d="M380,77 Q380,105 305,105 Q230,105 230,77" fill="none" stroke="#f59e0b" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr-up)"/>
-  <text x="305" y="115" text-anchor="middle" fill="#f59e0b" font-size="9">recalled</text>
+  <path d="M380,77 Q380,105 305,105 Q230,105 230,77" fill="none" stroke="#845b00" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr-up)"/>
+  <text x="305" y="115" text-anchor="middle" fill="#845b00" font-size="9">recalled</text>
 </svg>

--- a/docs/diagram-mechanisms.svg
+++ b/docs/diagram-mechanisms.svg
@@ -1,79 +1,123 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 280" font-family="Inter, -apple-system, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 280" font-family="'Inter Tight', -apple-system, system-ui, sans-serif">
+<!-- =====================================================================
+  RE-INKED to the AI Architect Design System (paper doctrine). Geometry,
+  layout and text content are unchanged; only colour + font-family voices
+  were remapped. Scripted oklch->sRGB (CSS Color 4 math) from DS tokens
+  (colors.css + surfaces.css paper block). Tokens named WITHOUT their
+  leading double-hyphen (XML-comment safe); prefix each with it in CSS.
+  ONE mapping, applied identically across all nine diagrams.
+
+  CHROME (warm-neutral greyscale):
+    #0f172a canvas          -> paper-0        #f1eee7
+    #1e293b box fill        -> sheet          #f8f7f2
+    #292524 #0a1d10 #172554 #1a2e05 #2a1a00 #1d1408 #1e3a5f
+            inner/callout/layer/pill fills -> paper-1  #e6e1d7
+    #44403c inner stroke    -> paper-line     rgba(59,49,41,0.26)
+    #475569 #334155 box stroke -> paper-line-2 rgba(59,49,41,0.42)
+    #64748b arrows/tertiary -> pfg-2          #61554e
+    #a3a3a3 faint hint      -> pfg-2          #61554e
+    #94a3b8 secondary label -> pfg-1          #4b4038
+    #e2e8f0 #cbd5e1 #d4d4d8 primary text -> pfg-0  #261d17
+    #fff reversed on data node -> paper-0     #f1eee7
+
+  DATA (deep re-inked palette, L<=52pct, legible on cream; each source
+  meaning kept distinct, never merged):
+    red    #ef4444 #fca5a5           new/emotion/reject -> danger-deep  #a52a24
+    orange #f97316 #fdba74           surprise momentum  -> emo-frustr   #a05000
+    amber  #f59e0b #fbbf24 #fcd34d #92400e
+                                     active/handlers/encoding/reviewer/directory -> warn-deep #845b00
+    gold   #daa520                   wiki/consolidated  -> stage-cons   #7d6700
+    green  #22c55e #86efac #10b981 #6ee7b7 #166534 #4ade80
+                                     core/retrieval/novel/coordination  -> ok-deep #0a693c
+    cyan   #06b6d4 #67e8f9           infrastructure/storage -> stage-early #006a66
+    blue   #3b82f6 #60a5fa #93c5fd #1e40af
+                                     query/results/compressed/specialization/sleep -> info-deep #006185
+    purple #8b5cf6 #a855f7 #c4b5fd   neuromodulation/plasticity/intent -> emo-conflct #784d96
+    pink   #ec4899 #f9a8d4 #d946ef #e879f9
+                                     hooks/emotional-tagging/intent -> stage-recon #753e81
+
+  Note: amber(80) and gold(95) stay distinct; green ink is single in the DS
+  paper palette so green+emerald share ok-deep (same 'valid/positive' meaning);
+  category-tinted panel fills neutralised to paper-1 with the category kept in
+  their stroke+text data ink. Fonts: labels -> Inter Tight, identifiers ->
+  JetBrains Mono. Gradients/glow: none used; the unused blur filter was removed.
+===================================================================== -->
+
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+      <path d="M0,0 L8,3 L0,6" fill="#61554e"/>
     </marker>
     <marker id="arr-purple" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#a855f7"/>
+      <path d="M0,0 L8,3 L0,6" fill="#784d96"/>
     </marker>
   </defs>
 
-  <rect width="900" height="280" rx="12" fill="#0f172a"/>
+  <rect width="900" height="280" rx="12" fill="#f1eee7"/>
 
   <!-- Encoding -->
-  <rect x="16" y="16" width="190" height="248" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="111" y="38" text-anchor="middle" fill="#f59e0b" font-size="11" font-weight="700" letter-spacing="0.5">ENCODING</text>
-  <rect x="30" y="50" width="162" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="111" y="69" text-anchor="middle" fill="#d4d4d8" font-size="10">Oscillatory Clock</text>
-  <rect x="30" y="86" width="162" height="28" rx="4" fill="#292524" stroke="#f59e0b" stroke-width="0.8"/>
-  <text x="111" y="105" text-anchor="middle" fill="#fbbf24" font-size="10" font-weight="500">Predictive Coding</text>
-  <rect x="30" y="122" width="162" height="28" rx="4" fill="#292524" stroke="#8b5cf6" stroke-width="0.8"/>
-  <text x="111" y="141" text-anchor="middle" fill="#c4b5fd" font-size="10" font-weight="500">Neuromodulation</text>
-  <rect x="30" y="158" width="162" height="28" rx="4" fill="#292524" stroke="#ef4444" stroke-width="0.8"/>
-  <text x="111" y="177" text-anchor="middle" fill="#fca5a5" font-size="10" font-weight="500">Emotional Tagging</text>
-  <rect x="30" y="194" width="162" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="111" y="213" text-anchor="middle" fill="#d4d4d8" font-size="10">Pattern Separation</text>
-  <text x="111" y="248" text-anchor="middle" fill="#64748b" font-size="8" font-style="italic">Hasselmo, Friston, Doya, Wang</text>
+  <rect x="16" y="16" width="190" height="248" rx="8" fill="#f8f7f2" stroke="#845b00" stroke-width="1.5"/>
+  <text x="111" y="38" text-anchor="middle" fill="#845b00" font-size="11" font-weight="700" letter-spacing="0.5">ENCODING</text>
+  <rect x="30" y="50" width="162" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="111" y="69" text-anchor="middle" fill="#261d17" font-size="10">Oscillatory Clock</text>
+  <rect x="30" y="86" width="162" height="28" rx="4" fill="#e6e1d7" stroke="#845b00" stroke-width="0.8"/>
+  <text x="111" y="105" text-anchor="middle" fill="#845b00" font-size="10" font-weight="500">Predictive Coding</text>
+  <rect x="30" y="122" width="162" height="28" rx="4" fill="#e6e1d7" stroke="#784d96" stroke-width="0.8"/>
+  <text x="111" y="141" text-anchor="middle" fill="#784d96" font-size="10" font-weight="500">Neuromodulation</text>
+  <rect x="30" y="158" width="162" height="28" rx="4" fill="#e6e1d7" stroke="#a52a24" stroke-width="0.8"/>
+  <text x="111" y="177" text-anchor="middle" fill="#a52a24" font-size="10" font-weight="500">Emotional Tagging</text>
+  <rect x="30" y="194" width="162" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="111" y="213" text-anchor="middle" fill="#261d17" font-size="10">Pattern Separation</text>
+  <text x="111" y="248" text-anchor="middle" fill="#61554e" font-size="8" font-style="italic">Hasselmo, Friston, Doya, Wang</text>
 
   <!-- Arrow Encoding -> Maintenance -->
-  <line x1="206" y1="140" x2="232" y2="140" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="206" y1="140" x2="232" y2="140" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Storage & Maintenance -->
-  <rect x="238" y="16" width="190" height="248" rx="8" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5"/>
-  <text x="333" y="38" text-anchor="middle" fill="#06b6d4" font-size="11" font-weight="700" letter-spacing="0.5">STORAGE</text>
-  <rect x="252" y="50" width="162" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="333" y="69" text-anchor="middle" fill="#d4d4d8" font-size="10">Engram Competition</text>
-  <rect x="252" y="86" width="162" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="333" y="105" text-anchor="middle" fill="#d4d4d8" font-size="10">Thermodynamics</text>
-  <rect x="252" y="122" width="162" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="333" y="141" text-anchor="middle" fill="#d4d4d8" font-size="10">Homeostatic Plasticity</text>
-  <rect x="252" y="158" width="162" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="333" y="177" text-anchor="middle" fill="#d4d4d8" font-size="10">Consolidation Cascade</text>
-  <text x="333" y="248" text-anchor="middle" fill="#64748b" font-size="8" font-style="italic">Josselyn, Ebbinghaus, Turrigiano, Kandel</text>
+  <rect x="238" y="16" width="190" height="248" rx="8" fill="#f8f7f2" stroke="#006a66" stroke-width="1.5"/>
+  <text x="333" y="38" text-anchor="middle" fill="#006a66" font-size="11" font-weight="700" letter-spacing="0.5">STORAGE</text>
+  <rect x="252" y="50" width="162" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="333" y="69" text-anchor="middle" fill="#261d17" font-size="10">Engram Competition</text>
+  <rect x="252" y="86" width="162" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="333" y="105" text-anchor="middle" fill="#261d17" font-size="10">Thermodynamics</text>
+  <rect x="252" y="122" width="162" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="333" y="141" text-anchor="middle" fill="#261d17" font-size="10">Homeostatic Plasticity</text>
+  <rect x="252" y="158" width="162" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="333" y="177" text-anchor="middle" fill="#261d17" font-size="10">Consolidation Cascade</text>
+  <text x="333" y="248" text-anchor="middle" fill="#61554e" font-size="8" font-style="italic">Josselyn, Ebbinghaus, Turrigiano, Kandel</text>
 
   <!-- Arrow Maintenance -> Retrieval -->
-  <line x1="428" y1="140" x2="454" y2="140" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="428" y1="140" x2="454" y2="140" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Retrieval -->
-  <rect x="460" y="16" width="190" height="248" rx="8" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="555" y="38" text-anchor="middle" fill="#22c55e" font-size="11" font-weight="700" letter-spacing="0.5">RETRIEVAL</text>
-  <rect x="474" y="50" width="162" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="555" y="69" text-anchor="middle" fill="#d4d4d8" font-size="10">Hopfield Network</text>
-  <rect x="474" y="86" width="162" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="555" y="105" text-anchor="middle" fill="#d4d4d8" font-size="10">Spreading Activation</text>
-  <rect x="474" y="122" width="162" height="28" rx="4" fill="#292524" stroke="#f97316" stroke-width="0.8"/>
-  <text x="555" y="141" text-anchor="middle" fill="#fdba74" font-size="10" font-weight="500">Surprise Momentum</text>
-  <rect x="474" y="158" width="162" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="555" y="177" text-anchor="middle" fill="#d4d4d8" font-size="10">Co-Activation</text>
-  <text x="555" y="248" text-anchor="middle" fill="#64748b" font-size="8" font-style="italic">Ramsauer, Collins, Behrouz, Kosowski</text>
+  <rect x="460" y="16" width="190" height="248" rx="8" fill="#f8f7f2" stroke="#0a693c" stroke-width="1.5"/>
+  <text x="555" y="38" text-anchor="middle" fill="#0a693c" font-size="11" font-weight="700" letter-spacing="0.5">RETRIEVAL</text>
+  <rect x="474" y="50" width="162" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="555" y="69" text-anchor="middle" fill="#261d17" font-size="10">Hopfield Network</text>
+  <rect x="474" y="86" width="162" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="555" y="105" text-anchor="middle" fill="#261d17" font-size="10">Spreading Activation</text>
+  <rect x="474" y="122" width="162" height="28" rx="4" fill="#e6e1d7" stroke="#a05000" stroke-width="0.8"/>
+  <text x="555" y="141" text-anchor="middle" fill="#a05000" font-size="10" font-weight="500">Surprise Momentum</text>
+  <rect x="474" y="158" width="162" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="555" y="177" text-anchor="middle" fill="#261d17" font-size="10">Co-Activation</text>
+  <text x="555" y="248" text-anchor="middle" fill="#61554e" font-size="8" font-style="italic">Ramsauer, Collins, Behrouz, Kosowski</text>
 
   <!-- Arrow Retrieval -> Plasticity -->
-  <line x1="650" y1="140" x2="676" y2="140" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="650" y1="140" x2="676" y2="140" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Plasticity & Pruning -->
-  <rect x="682" y="16" width="200" height="248" rx="8" fill="#1e293b" stroke="#a855f7" stroke-width="1.5"/>
-  <text x="782" y="38" text-anchor="middle" fill="#a855f7" font-size="11" font-weight="700" letter-spacing="0.5">PLASTICITY</text>
-  <rect x="696" y="50" width="172" height="28" rx="4" fill="#292524" stroke="#22c55e" stroke-width="0.8"/>
-  <text x="782" y="69" text-anchor="middle" fill="#86efac" font-size="10" font-weight="500">LTP/LTD + STDP</text>
-  <rect x="696" y="86" width="172" height="28" rx="4" fill="#292524" stroke="#ef4444" stroke-width="0.8"/>
-  <text x="782" y="105" text-anchor="middle" fill="#fca5a5" font-size="10" font-weight="500">Microglial Pruning</text>
-  <rect x="696" y="122" width="172" height="28" rx="4" fill="#292524" stroke="#1e40af" stroke-width="0.8"/>
-  <text x="782" y="141" text-anchor="middle" fill="#93c5fd" font-size="10" font-weight="500">Sleep Compute</text>
-  <rect x="696" y="158" width="172" height="28" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="782" y="177" text-anchor="middle" fill="#d4d4d8" font-size="10">Interference Mgmt</text>
-  <text x="782" y="248" text-anchor="middle" fill="#64748b" font-size="8" font-style="italic">Hebb, Bi &amp; Poo, Wang, McClelland</text>
+  <rect x="682" y="16" width="200" height="248" rx="8" fill="#f8f7f2" stroke="#784d96" stroke-width="1.5"/>
+  <text x="782" y="38" text-anchor="middle" fill="#784d96" font-size="11" font-weight="700" letter-spacing="0.5">PLASTICITY</text>
+  <rect x="696" y="50" width="172" height="28" rx="4" fill="#e6e1d7" stroke="#0a693c" stroke-width="0.8"/>
+  <text x="782" y="69" text-anchor="middle" fill="#0a693c" font-size="10" font-weight="500">LTP/LTD + STDP</text>
+  <rect x="696" y="86" width="172" height="28" rx="4" fill="#e6e1d7" stroke="#a52a24" stroke-width="0.8"/>
+  <text x="782" y="105" text-anchor="middle" fill="#a52a24" font-size="10" font-weight="500">Microglial Pruning</text>
+  <rect x="696" y="122" width="172" height="28" rx="4" fill="#e6e1d7" stroke="#006185" stroke-width="0.8"/>
+  <text x="782" y="141" text-anchor="middle" fill="#006185" font-size="10" font-weight="500">Sleep Compute</text>
+  <rect x="696" y="158" width="172" height="28" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="782" y="177" text-anchor="middle" fill="#261d17" font-size="10">Interference Mgmt</text>
+  <text x="782" y="248" text-anchor="middle" fill="#61554e" font-size="8" font-style="italic">Hebb, Bi &amp; Poo, Wang, McClelland</text>
 
   <!-- Feedback loop: Plasticity -> Maintenance (bottom arc) -->
-  <path d="M782,264 Q782,275 555,275 Q333,275 333,264" fill="none" stroke="#a855f7" stroke-width="1.2" stroke-dasharray="5,3" marker-end="url(#arr-purple)"/>
-  <text x="555" y="274" text-anchor="middle" fill="#a855f7" font-size="9" font-weight="500" dy="-3">strengthen / weaken</text>
+  <path d="M782,264 Q782,275 555,275 Q333,275 333,264" fill="none" stroke="#784d96" stroke-width="1.2" stroke-dasharray="5,3" marker-end="url(#arr-purple)"/>
+  <text x="555" y="274" text-anchor="middle" fill="#784d96" font-size="9" font-weight="500" dy="-3">strengthen / weaken</text>
 </svg>

--- a/docs/diagram-profiling.svg
+++ b/docs/diagram-profiling.svg
@@ -1,54 +1,98 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300" font-family="Inter, -apple-system, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300" font-family="'Inter Tight', -apple-system, system-ui, sans-serif">
+<!-- =====================================================================
+  RE-INKED to the AI Architect Design System (paper doctrine). Geometry,
+  layout and text content are unchanged; only colour + font-family voices
+  were remapped. Scripted oklch->sRGB (CSS Color 4 math) from DS tokens
+  (colors.css + surfaces.css paper block). Tokens named WITHOUT their
+  leading double-hyphen (XML-comment safe); prefix each with it in CSS.
+  ONE mapping, applied identically across all nine diagrams.
+
+  CHROME (warm-neutral greyscale):
+    #0f172a canvas          -> paper-0        #f1eee7
+    #1e293b box fill        -> sheet          #f8f7f2
+    #292524 #0a1d10 #172554 #1a2e05 #2a1a00 #1d1408 #1e3a5f
+            inner/callout/layer/pill fills -> paper-1  #e6e1d7
+    #44403c inner stroke    -> paper-line     rgba(59,49,41,0.26)
+    #475569 #334155 box stroke -> paper-line-2 rgba(59,49,41,0.42)
+    #64748b arrows/tertiary -> pfg-2          #61554e
+    #a3a3a3 faint hint      -> pfg-2          #61554e
+    #94a3b8 secondary label -> pfg-1          #4b4038
+    #e2e8f0 #cbd5e1 #d4d4d8 primary text -> pfg-0  #261d17
+    #fff reversed on data node -> paper-0     #f1eee7
+
+  DATA (deep re-inked palette, L<=52pct, legible on cream; each source
+  meaning kept distinct, never merged):
+    red    #ef4444 #fca5a5           new/emotion/reject -> danger-deep  #a52a24
+    orange #f97316 #fdba74           surprise momentum  -> emo-frustr   #a05000
+    amber  #f59e0b #fbbf24 #fcd34d #92400e
+                                     active/handlers/encoding/reviewer/directory -> warn-deep #845b00
+    gold   #daa520                   wiki/consolidated  -> stage-cons   #7d6700
+    green  #22c55e #86efac #10b981 #6ee7b7 #166534 #4ade80
+                                     core/retrieval/novel/coordination  -> ok-deep #0a693c
+    cyan   #06b6d4 #67e8f9           infrastructure/storage -> stage-early #006a66
+    blue   #3b82f6 #60a5fa #93c5fd #1e40af
+                                     query/results/compressed/specialization/sleep -> info-deep #006185
+    purple #8b5cf6 #a855f7 #c4b5fd   neuromodulation/plasticity/intent -> emo-conflct #784d96
+    pink   #ec4899 #f9a8d4 #d946ef #e879f9
+                                     hooks/emotional-tagging/intent -> stage-recon #753e81
+
+  Note: amber(80) and gold(95) stay distinct; green ink is single in the DS
+  paper palette so green+emerald share ok-deep (same 'valid/positive' meaning);
+  category-tinted panel fills neutralised to paper-1 with the category kept in
+  their stroke+text data ink. Fonts: labels -> Inter Tight, identifiers ->
+  JetBrains Mono. Gradients/glow: none used; the unused blur filter was removed.
+===================================================================== -->
+
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+      <path d="M0,0 L8,3 L0,6" fill="#61554e"/>
     </marker>
   </defs>
 
-  <rect width="600" height="300" rx="12" fill="#0f172a"/>
+  <rect width="600" height="300" rx="12" fill="#f1eee7"/>
 
   <!-- Session History -->
-  <rect x="200" y="14" width="200" height="40" rx="20" fill="#1e293b" stroke="#64748b" stroke-width="1.2"/>
-  <text x="300" y="33" text-anchor="middle" fill="#94a3b8" font-size="12" font-weight="500">Session History</text>
-  <text x="300" y="47" text-anchor="middle" fill="#64748b" font-size="9" font-family="monospace">~/.claude/projects/</text>
+  <rect x="200" y="14" width="200" height="40" rx="20" fill="#f8f7f2" stroke="#61554e" stroke-width="1.2"/>
+  <text x="300" y="33" text-anchor="middle" fill="#4b4038" font-size="12" font-weight="500">Session History</text>
+  <text x="300" y="47" text-anchor="middle" fill="#61554e" font-size="9" font-family="'JetBrains Mono', ui-monospace, monospace">~/.claude/projects/</text>
 
-  <line x1="300" y1="54" x2="300" y2="76" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="300" y1="54" x2="300" y2="76" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Pattern Extraction -->
-  <rect x="210" y="80" width="180" height="34" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="300" y="101" text-anchor="middle" fill="#d4d4d8" font-size="12">Pattern Extraction</text>
+  <rect x="210" y="80" width="180" height="34" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="300" y="101" text-anchor="middle" fill="#261d17" font-size="12">Pattern Extraction</text>
 
   <!-- Four branches -->
-  <line x1="210" y1="114" x2="90" y2="155" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
-  <line x1="260" y1="114" x2="230" y2="155" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
-  <line x1="340" y1="114" x2="370" y2="155" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
-  <line x1="390" y1="114" x2="510" y2="155" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
+  <line x1="210" y1="114" x2="90" y2="155" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
+  <line x1="260" y1="114" x2="230" y2="155" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
+  <line x1="340" y1="114" x2="370" y2="155" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
+  <line x1="390" y1="114" x2="510" y2="155" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
 
   <!-- Cognitive Style -->
-  <rect x="18" y="158" width="150" height="38" rx="4" fill="#1e293b" stroke="#a855f7" stroke-width="1.2"/>
-  <text x="93" y="175" text-anchor="middle" fill="#c4b5fd" font-size="11" font-weight="500">Cognitive Style</text>
-  <text x="93" y="189" text-anchor="middle" fill="#64748b" font-size="9">Felder-Silverman 4D</text>
+  <rect x="18" y="158" width="150" height="38" rx="4" fill="#f8f7f2" stroke="#784d96" stroke-width="1.2"/>
+  <text x="93" y="175" text-anchor="middle" fill="#784d96" font-size="11" font-weight="500">Cognitive Style</text>
+  <text x="93" y="189" text-anchor="middle" fill="#61554e" font-size="9">Felder-Silverman 4D</text>
 
   <!-- Entry Patterns -->
-  <rect x="180" y="158" width="110" height="38" rx="4" fill="#1e293b" stroke="#475569" stroke-width="1"/>
-  <text x="235" y="181" text-anchor="middle" fill="#d4d4d8" font-size="11">Entry Patterns</text>
+  <rect x="180" y="158" width="110" height="38" rx="4" fill="#f8f7f2" stroke="rgba(59,49,41,0.42)" stroke-width="1"/>
+  <text x="235" y="181" text-anchor="middle" fill="#261d17" font-size="11">Entry Patterns</text>
 
   <!-- Blind Spots -->
-  <rect x="310" y="158" width="110" height="38" rx="4" fill="#1e293b" stroke="#475569" stroke-width="1"/>
-  <text x="365" y="181" text-anchor="middle" fill="#d4d4d8" font-size="11">Blind Spots</text>
+  <rect x="310" y="158" width="110" height="38" rx="4" fill="#f8f7f2" stroke="rgba(59,49,41,0.42)" stroke-width="1"/>
+  <text x="365" y="181" text-anchor="middle" fill="#261d17" font-size="11">Blind Spots</text>
 
   <!-- Cross-Domain Bridges -->
-  <rect x="438" y="158" width="148" height="38" rx="4" fill="#1e293b" stroke="#475569" stroke-width="1"/>
-  <text x="512" y="181" text-anchor="middle" fill="#d4d4d8" font-size="11">Cross-Domain Bridges</text>
+  <rect x="438" y="158" width="148" height="38" rx="4" fill="#f8f7f2" stroke="rgba(59,49,41,0.42)" stroke-width="1"/>
+  <text x="512" y="181" text-anchor="middle" fill="#261d17" font-size="11">Cross-Domain Bridges</text>
 
   <!-- All converge -->
-  <line x1="93" y1="196" x2="300" y2="240" stroke="#64748b" stroke-width="1" marker-end="url(#arr)"/>
-  <line x1="235" y1="196" x2="300" y2="240" stroke="#64748b" stroke-width="1" marker-end="url(#arr)"/>
-  <line x1="365" y1="196" x2="300" y2="240" stroke="#64748b" stroke-width="1" marker-end="url(#arr)"/>
-  <line x1="512" y1="196" x2="300" y2="240" stroke="#64748b" stroke-width="1" marker-end="url(#arr)"/>
+  <line x1="93" y1="196" x2="300" y2="240" stroke="#61554e" stroke-width="1" marker-end="url(#arr)"/>
+  <line x1="235" y1="196" x2="300" y2="240" stroke="#61554e" stroke-width="1" marker-end="url(#arr)"/>
+  <line x1="365" y1="196" x2="300" y2="240" stroke="#61554e" stroke-width="1" marker-end="url(#arr)"/>
+  <line x1="512" y1="196" x2="300" y2="240" stroke="#61554e" stroke-width="1" marker-end="url(#arr)"/>
 
   <!-- Cognitive Profile -->
-  <rect x="180" y="245" width="240" height="40" rx="20" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="300" y="264" text-anchor="middle" fill="#fbbf24" font-size="12" font-weight="600">Cognitive Profile</text>
-  <text x="300" y="278" text-anchor="middle" fill="#a3a3a3" font-size="9">injected at session start</text>
+  <rect x="180" y="245" width="240" height="40" rx="20" fill="#f8f7f2" stroke="#845b00" stroke-width="1.5"/>
+  <text x="300" y="264" text-anchor="middle" fill="#845b00" font-size="12" font-weight="600">Cognitive Profile</text>
+  <text x="300" y="278" text-anchor="middle" fill="#61554e" font-size="9">injected at session start</text>
 </svg>

--- a/docs/diagram-read-path.svg
+++ b/docs/diagram-read-path.svg
@@ -1,78 +1,122 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 400" font-family="Inter, -apple-system, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 400" font-family="'Inter Tight', -apple-system, system-ui, sans-serif">
+<!-- =====================================================================
+  RE-INKED to the AI Architect Design System (paper doctrine). Geometry,
+  layout and text content are unchanged; only colour + font-family voices
+  were remapped. Scripted oklch->sRGB (CSS Color 4 math) from DS tokens
+  (colors.css + surfaces.css paper block). Tokens named WITHOUT their
+  leading double-hyphen (XML-comment safe); prefix each with it in CSS.
+  ONE mapping, applied identically across all nine diagrams.
+
+  CHROME (warm-neutral greyscale):
+    #0f172a canvas          -> paper-0        #f1eee7
+    #1e293b box fill        -> sheet          #f8f7f2
+    #292524 #0a1d10 #172554 #1a2e05 #2a1a00 #1d1408 #1e3a5f
+            inner/callout/layer/pill fills -> paper-1  #e6e1d7
+    #44403c inner stroke    -> paper-line     rgba(59,49,41,0.26)
+    #475569 #334155 box stroke -> paper-line-2 rgba(59,49,41,0.42)
+    #64748b arrows/tertiary -> pfg-2          #61554e
+    #a3a3a3 faint hint      -> pfg-2          #61554e
+    #94a3b8 secondary label -> pfg-1          #4b4038
+    #e2e8f0 #cbd5e1 #d4d4d8 primary text -> pfg-0  #261d17
+    #fff reversed on data node -> paper-0     #f1eee7
+
+  DATA (deep re-inked palette, L<=52pct, legible on cream; each source
+  meaning kept distinct, never merged):
+    red    #ef4444 #fca5a5           new/emotion/reject -> danger-deep  #a52a24
+    orange #f97316 #fdba74           surprise momentum  -> emo-frustr   #a05000
+    amber  #f59e0b #fbbf24 #fcd34d #92400e
+                                     active/handlers/encoding/reviewer/directory -> warn-deep #845b00
+    gold   #daa520                   wiki/consolidated  -> stage-cons   #7d6700
+    green  #22c55e #86efac #10b981 #6ee7b7 #166534 #4ade80
+                                     core/retrieval/novel/coordination  -> ok-deep #0a693c
+    cyan   #06b6d4 #67e8f9           infrastructure/storage -> stage-early #006a66
+    blue   #3b82f6 #60a5fa #93c5fd #1e40af
+                                     query/results/compressed/specialization/sleep -> info-deep #006185
+    purple #8b5cf6 #a855f7 #c4b5fd   neuromodulation/plasticity/intent -> emo-conflct #784d96
+    pink   #ec4899 #f9a8d4 #d946ef #e879f9
+                                     hooks/emotional-tagging/intent -> stage-recon #753e81
+
+  Note: amber(80) and gold(95) stay distinct; green ink is single in the DS
+  paper palette so green+emerald share ok-deep (same 'valid/positive' meaning);
+  category-tinted panel fills neutralised to paper-1 with the category kept in
+  their stroke+text data ink. Fonts: labels -> Inter Tight, identifiers ->
+  JetBrains Mono. Gradients/glow: none used; the unused blur filter was removed.
+===================================================================== -->
+
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+      <path d="M0,0 L8,3 L0,6" fill="#61554e"/>
     </marker>
   </defs>
 
-  <rect width="750" height="400" rx="12" fill="#0f172a"/>
+  <rect width="750" height="400" rx="12" fill="#f1eee7"/>
 
   <!-- Query input -->
-  <rect x="290" y="14" width="160" height="36" rx="18" fill="#1e293b" stroke="#94a3b8" stroke-width="1"/>
-  <text x="370" y="37" text-anchor="middle" fill="#e2e8f0" font-size="13" font-weight="500">recall query</text>
+  <rect x="290" y="14" width="160" height="36" rx="18" fill="#f8f7f2" stroke="#4b4038" stroke-width="1"/>
+  <text x="370" y="37" text-anchor="middle" fill="#261d17" font-size="13" font-weight="500">recall query</text>
 
-  <line x1="370" y1="50" x2="370" y2="68" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="370" y1="50" x2="370" y2="68" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Intent Classification -->
-  <rect x="270" y="72" width="200" height="36" rx="6" fill="#1e293b" stroke="#d946ef" stroke-width="1.5"/>
-  <text x="370" y="95" text-anchor="middle" fill="#e879f9" font-size="12" font-weight="500">Intent Classification</text>
+  <rect x="270" y="72" width="200" height="36" rx="6" fill="#f8f7f2" stroke="#753e81" stroke-width="1.5"/>
+  <text x="370" y="95" text-anchor="middle" fill="#753e81" font-size="12" font-weight="500">Intent Classification</text>
 
-  <line x1="370" y1="108" x2="370" y2="126" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="370" y1="108" x2="370" y2="126" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Intent-Aware Weights -->
-  <rect x="270" y="130" width="200" height="32" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="370" y="151" text-anchor="middle" fill="#d4d4d8" font-size="11">Intent-Aware Weights</text>
+  <rect x="270" y="130" width="200" height="32" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="370" y="151" text-anchor="middle" fill="#261d17" font-size="11">Intent-Aware Weights</text>
 
-  <line x1="370" y1="162" x2="370" y2="180" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="370" y1="162" x2="370" y2="180" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- PL/pgSQL -->
-  <rect x="245" y="184" width="250" height="36" rx="6" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5"/>
-  <text x="370" y="207" text-anchor="middle" fill="#67e8f9" font-size="12" font-weight="500">PL/pgSQL recall_memories()</text>
+  <rect x="245" y="184" width="250" height="36" rx="6" fill="#f8f7f2" stroke="#006a66" stroke-width="1.5"/>
+  <text x="370" y="207" text-anchor="middle" fill="#006a66" font-size="12" font-weight="500">PL/pgSQL recall_memories()</text>
 
-  <line x1="370" y1="220" x2="370" y2="238" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="370" y1="220" x2="370" y2="238" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Server-Side Fusion box -->
-  <rect x="60" y="242" width="620" height="52" rx="6" fill="#1e293b" stroke="#475569" stroke-width="1"/>
-  <text x="370" y="258" text-anchor="middle" fill="#94a3b8" font-size="9" font-weight="600" letter-spacing="1">SERVER-SIDE FUSION</text>
+  <rect x="60" y="242" width="620" height="52" rx="6" fill="#f8f7f2" stroke="rgba(59,49,41,0.42)" stroke-width="1"/>
+  <text x="370" y="258" text-anchor="middle" fill="#4b4038" font-size="9" font-weight="600" letter-spacing="1">SERVER-SIDE FUSION</text>
 
   <!-- 5 signal pills -->
-  <rect x="80" y="264" width="100" height="24" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="130" y="280" text-anchor="middle" fill="#67e8f9" font-size="10">Vector HNSW</text>
+  <rect x="80" y="264" width="100" height="24" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="130" y="280" text-anchor="middle" fill="#006a66" font-size="10">Vector HNSW</text>
 
-  <rect x="195" y="264" width="100" height="24" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="245" y="280" text-anchor="middle" fill="#67e8f9" font-size="10">Full-Text FTS</text>
+  <rect x="195" y="264" width="100" height="24" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="245" y="280" text-anchor="middle" fill="#006a66" font-size="10">Full-Text FTS</text>
 
-  <rect x="310" y="264" width="110" height="24" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="365" y="280" text-anchor="middle" fill="#67e8f9" font-size="10">Trigram pg_trgm</text>
+  <rect x="310" y="264" width="110" height="24" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="365" y="280" text-anchor="middle" fill="#006a66" font-size="10">Trigram pg_trgm</text>
 
-  <rect x="435" y="264" width="70" height="24" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="470" y="280" text-anchor="middle" fill="#67e8f9" font-size="10">Heat</text>
+  <rect x="435" y="264" width="70" height="24" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="470" y="280" text-anchor="middle" fill="#006a66" font-size="10">Heat</text>
 
-  <rect x="520" y="264" width="80" height="24" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="560" y="280" text-anchor="middle" fill="#67e8f9" font-size="10">Recency</text>
+  <rect x="520" y="264" width="80" height="24" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="560" y="280" text-anchor="middle" fill="#006a66" font-size="10">Recency</text>
 
-  <line x1="370" y1="294" x2="370" y2="310" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="370" y1="294" x2="370" y2="310" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- WRRF Fusion -->
-  <rect x="220" y="314" width="300" height="32" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="370" y="335" text-anchor="middle" fill="#fbbf24" font-size="11">WRRF Fusion  score = weight / (K + rank)</text>
+  <rect x="220" y="314" width="300" height="32" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="370" y="335" text-anchor="middle" fill="#845b00" font-size="11">WRRF Fusion  score = weight / (K + rank)</text>
 
-  <line x1="370" y1="346" x2="370" y2="360" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="370" y1="346" x2="370" y2="360" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Bottom row: FlashRank -> Surprise -> Results -->
-  <rect x="80" y="362" width="170" height="30" rx="4" fill="#1e293b" stroke="#22c55e" stroke-width="1.2"/>
-  <text x="165" y="382" text-anchor="middle" fill="#86efac" font-size="11">FlashRank Reranking</text>
+  <rect x="80" y="362" width="170" height="30" rx="4" fill="#f8f7f2" stroke="#0a693c" stroke-width="1.2"/>
+  <text x="165" y="382" text-anchor="middle" fill="#0a693c" font-size="11">FlashRank Reranking</text>
 
-  <line x1="250" y1="377" x2="290" y2="377" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
+  <line x1="250" y1="377" x2="290" y2="377" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
 
-  <rect x="295" y="362" width="180" height="30" rx="4" fill="#1e293b" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="385" y="382" text-anchor="middle" fill="#fbbf24" font-size="11">Surprise Momentum</text>
+  <rect x="295" y="362" width="180" height="30" rx="4" fill="#f8f7f2" stroke="#845b00" stroke-width="1.2"/>
+  <text x="385" y="382" text-anchor="middle" fill="#845b00" font-size="11">Surprise Momentum</text>
 
-  <line x1="475" y1="377" x2="515" y2="377" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
+  <line x1="475" y1="377" x2="515" y2="377" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
 
-  <rect x="520" y="362" width="140" height="30" rx="18" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="590" y="382" text-anchor="middle" fill="#93c5fd" font-size="12" font-weight="500">Top 10 Results</text>
+  <rect x="520" y="362" width="140" height="30" rx="18" fill="#f8f7f2" stroke="#006185" stroke-width="1.5"/>
+  <text x="590" y="382" text-anchor="middle" fill="#006185" font-size="12" font-weight="500">Top 10 Results</text>
 
   <!-- Vertical connector from WRRF to FlashRank -->
-  <path d="M370,346 L370,355 L165,355 L165,360" fill="none" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
+  <path d="M370,346 L370,355 L165,355 L165,360" fill="none" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
 </svg>

--- a/docs/diagram-retrieval-pipeline.svg
+++ b/docs/diagram-retrieval-pipeline.svg
@@ -1,66 +1,110 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 320" font-family="Inter, -apple-system, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 320" font-family="'Inter Tight', -apple-system, system-ui, sans-serif">
+<!-- =====================================================================
+  RE-INKED to the AI Architect Design System (paper doctrine). Geometry,
+  layout and text content are unchanged; only colour + font-family voices
+  were remapped. Scripted oklch->sRGB (CSS Color 4 math) from DS tokens
+  (colors.css + surfaces.css paper block). Tokens named WITHOUT their
+  leading double-hyphen (XML-comment safe); prefix each with it in CSS.
+  ONE mapping, applied identically across all nine diagrams.
+
+  CHROME (warm-neutral greyscale):
+    #0f172a canvas          -> paper-0        #f1eee7
+    #1e293b box fill        -> sheet          #f8f7f2
+    #292524 #0a1d10 #172554 #1a2e05 #2a1a00 #1d1408 #1e3a5f
+            inner/callout/layer/pill fills -> paper-1  #e6e1d7
+    #44403c inner stroke    -> paper-line     rgba(59,49,41,0.26)
+    #475569 #334155 box stroke -> paper-line-2 rgba(59,49,41,0.42)
+    #64748b arrows/tertiary -> pfg-2          #61554e
+    #a3a3a3 faint hint      -> pfg-2          #61554e
+    #94a3b8 secondary label -> pfg-1          #4b4038
+    #e2e8f0 #cbd5e1 #d4d4d8 primary text -> pfg-0  #261d17
+    #fff reversed on data node -> paper-0     #f1eee7
+
+  DATA (deep re-inked palette, L<=52pct, legible on cream; each source
+  meaning kept distinct, never merged):
+    red    #ef4444 #fca5a5           new/emotion/reject -> danger-deep  #a52a24
+    orange #f97316 #fdba74           surprise momentum  -> emo-frustr   #a05000
+    amber  #f59e0b #fbbf24 #fcd34d #92400e
+                                     active/handlers/encoding/reviewer/directory -> warn-deep #845b00
+    gold   #daa520                   wiki/consolidated  -> stage-cons   #7d6700
+    green  #22c55e #86efac #10b981 #6ee7b7 #166534 #4ade80
+                                     core/retrieval/novel/coordination  -> ok-deep #0a693c
+    cyan   #06b6d4 #67e8f9           infrastructure/storage -> stage-early #006a66
+    blue   #3b82f6 #60a5fa #93c5fd #1e40af
+                                     query/results/compressed/specialization/sleep -> info-deep #006185
+    purple #8b5cf6 #a855f7 #c4b5fd   neuromodulation/plasticity/intent -> emo-conflct #784d96
+    pink   #ec4899 #f9a8d4 #d946ef #e879f9
+                                     hooks/emotional-tagging/intent -> stage-recon #753e81
+
+  Note: amber(80) and gold(95) stay distinct; green ink is single in the DS
+  paper palette so green+emerald share ok-deep (same 'valid/positive' meaning);
+  category-tinted panel fills neutralised to paper-1 with the category kept in
+  their stroke+text data ink. Fonts: labels -> Inter Tight, identifiers ->
+  JetBrains Mono. Gradients/glow: none used; the unused blur filter was removed.
+===================================================================== -->
+
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+      <path d="M0,0 L8,3 L0,6" fill="#61554e"/>
     </marker>
   </defs>
 
-  <rect width="750" height="320" rx="12" fill="#0f172a"/>
+  <rect width="750" height="320" rx="12" fill="#f1eee7"/>
 
   <!-- Title -->
-  <text x="375" y="30" text-anchor="middle" fill="#e2e8f0" font-size="14" font-weight="600">Retrieval Pipeline</text>
+  <text x="375" y="30" text-anchor="middle" fill="#261d17" font-size="14" font-weight="600">Retrieval Pipeline</text>
 
   <!-- Query -->
-  <rect x="20" y="55" width="130" height="40" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="85" y="80" text-anchor="middle" fill="#93c5fd" font-size="12" font-weight="500">Query</text>
+  <rect x="20" y="55" width="130" height="40" rx="8" fill="#f8f7f2" stroke="#006185" stroke-width="1.5"/>
+  <text x="85" y="80" text-anchor="middle" fill="#006185" font-size="12" font-weight="500">Query</text>
 
   <!-- Arrow -->
-  <line x1="150" y1="75" x2="180" y2="75" stroke="#64748b" marker-end="url(#arr)"/>
+  <line x1="150" y1="75" x2="180" y2="75" stroke="#61554e" marker-end="url(#arr)"/>
 
   <!-- Intent Classification -->
-  <rect x="185" y="55" width="150" height="40" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="1.5"/>
-  <text x="260" y="73" text-anchor="middle" fill="#c4b5fd" font-size="11" font-weight="500">Intent Classification</text>
-  <text x="260" y="87" text-anchor="middle" fill="#64748b" font-size="9">weight profiles</text>
+  <rect x="185" y="55" width="150" height="40" rx="8" fill="#f8f7f2" stroke="#784d96" stroke-width="1.5"/>
+  <text x="260" y="73" text-anchor="middle" fill="#784d96" font-size="11" font-weight="500">Intent Classification</text>
+  <text x="260" y="87" text-anchor="middle" fill="#61554e" font-size="9">weight profiles</text>
 
   <!-- Arrow -->
-  <line x1="335" y1="75" x2="365" y2="75" stroke="#64748b" marker-end="url(#arr)"/>
+  <line x1="335" y1="75" x2="365" y2="75" stroke="#61554e" marker-end="url(#arr)"/>
 
   <!-- PG recall_memories -->
-  <rect x="370" y="45" width="180" height="60" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="1.5"/>
-  <text x="460" y="68" text-anchor="middle" fill="#6ee7b7" font-size="11" font-weight="500">PG recall_memories()</text>
-  <text x="460" y="83" text-anchor="middle" fill="#64748b" font-size="9">5-signal TMM fusion</text>
-  <text x="460" y="95" text-anchor="middle" fill="#64748b" font-size="9">Bruch et al. 2023</text>
+  <rect x="370" y="45" width="180" height="60" rx="8" fill="#f8f7f2" stroke="#0a693c" stroke-width="1.5"/>
+  <text x="460" y="68" text-anchor="middle" fill="#0a693c" font-size="11" font-weight="500">PG recall_memories()</text>
+  <text x="460" y="83" text-anchor="middle" fill="#61554e" font-size="9">5-signal TMM fusion</text>
+  <text x="460" y="95" text-anchor="middle" fill="#61554e" font-size="9">Bruch et al. 2023</text>
 
   <!-- Arrow down -->
-  <line x1="460" y1="105" x2="460" y2="135" stroke="#64748b" marker-end="url(#arr)"/>
+  <line x1="460" y1="105" x2="460" y2="135" stroke="#61554e" marker-end="url(#arr)"/>
 
   <!-- 5 signals box -->
-  <rect x="50" y="140" width="650" height="55" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="375" y="160" text-anchor="middle" fill="#94a3b8" font-size="10" font-weight="500">TMM Fusion Signals</text>
+  <rect x="50" y="140" width="650" height="55" rx="8" fill="#f8f7f2" stroke="rgba(59,49,41,0.42)" stroke-width="1"/>
+  <text x="375" y="160" text-anchor="middle" fill="#4b4038" font-size="10" font-weight="500">TMM Fusion Signals</text>
   <!-- Signal pills -->
-  <rect x="75" y="167" width="100" height="20" rx="10" fill="#1e3a5f"/>
-  <text x="125" y="181" text-anchor="middle" fill="#60a5fa" font-size="9">Vector (pgvector)</text>
-  <rect x="185" y="167" width="100" height="20" rx="10" fill="#1e3a5f"/>
-  <text x="235" y="181" text-anchor="middle" fill="#60a5fa" font-size="9">FTS (tsvector)</text>
-  <rect x="295" y="167" width="100" height="20" rx="10" fill="#1e3a5f"/>
-  <text x="345" y="181" text-anchor="middle" fill="#60a5fa" font-size="9">Trigram (pg_trgm)</text>
-  <rect x="405" y="167" width="100" height="20" rx="10" fill="#1e3a5f"/>
-  <text x="455" y="181" text-anchor="middle" fill="#60a5fa" font-size="9">Heat (Ebbinghaus)</text>
-  <rect x="515" y="167" width="100" height="20" rx="10" fill="#1e3a5f"/>
-  <text x="565" y="181" text-anchor="middle" fill="#60a5fa" font-size="9">Recency (decay)</text>
+  <rect x="75" y="167" width="100" height="20" rx="10" fill="#e6e1d7"/>
+  <text x="125" y="181" text-anchor="middle" fill="#006185" font-size="9">Vector (pgvector)</text>
+  <rect x="185" y="167" width="100" height="20" rx="10" fill="#e6e1d7"/>
+  <text x="235" y="181" text-anchor="middle" fill="#006185" font-size="9">FTS (tsvector)</text>
+  <rect x="295" y="167" width="100" height="20" rx="10" fill="#e6e1d7"/>
+  <text x="345" y="181" text-anchor="middle" fill="#006185" font-size="9">Trigram (pg_trgm)</text>
+  <rect x="405" y="167" width="100" height="20" rx="10" fill="#e6e1d7"/>
+  <text x="455" y="181" text-anchor="middle" fill="#006185" font-size="9">Heat (Ebbinghaus)</text>
+  <rect x="515" y="167" width="100" height="20" rx="10" fill="#e6e1d7"/>
+  <text x="565" y="181" text-anchor="middle" fill="#006185" font-size="9">Recency (decay)</text>
 
   <!-- Arrow down -->
-  <line x1="375" y1="195" x2="375" y2="220" stroke="#64748b" marker-end="url(#arr)"/>
+  <line x1="375" y1="195" x2="375" y2="220" stroke="#61554e" marker-end="url(#arr)"/>
 
   <!-- FlashRank -->
-  <rect x="250" y="225" width="250" height="40" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="375" y="243" text-anchor="middle" fill="#fcd34d" font-size="11" font-weight="500">FlashRank CE Reranking (α=0.70)</text>
-  <text x="375" y="257" text-anchor="middle" fill="#64748b" font-size="9">Nogueira &amp; Cho 2019</text>
+  <rect x="250" y="225" width="250" height="40" rx="8" fill="#f8f7f2" stroke="#845b00" stroke-width="1.5"/>
+  <text x="375" y="243" text-anchor="middle" fill="#845b00" font-size="11" font-weight="500">FlashRank CE Reranking (α=0.70)</text>
+  <text x="375" y="257" text-anchor="middle" fill="#61554e" font-size="9">Nogueira &amp; Cho 2019</text>
 
   <!-- Arrow down -->
-  <line x1="375" y1="265" x2="375" y2="280" stroke="#64748b" marker-end="url(#arr)"/>
+  <line x1="375" y1="265" x2="375" y2="280" stroke="#61554e" marker-end="url(#arr)"/>
 
   <!-- Results -->
-  <rect x="280" y="280" width="190" height="30" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="375" y="300" text-anchor="middle" fill="#93c5fd" font-size="12" font-weight="500">Ranked Results</text>
+  <rect x="280" y="280" width="190" height="30" rx="8" fill="#f8f7f2" stroke="#006185" stroke-width="1.5"/>
+  <text x="375" y="300" text-anchor="middle" fill="#006185" font-size="12" font-weight="500">Ranked Results</text>
 </svg>

--- a/docs/diagram-team-memory.svg
+++ b/docs/diagram-team-memory.svg
@@ -1,87 +1,131 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 460" font-family="Inter, -apple-system, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 460" font-family="'Inter Tight', -apple-system, system-ui, sans-serif">
+<!-- =====================================================================
+  RE-INKED to the AI Architect Design System (paper doctrine). Geometry,
+  layout and text content are unchanged; only colour + font-family voices
+  were remapped. Scripted oklch->sRGB (CSS Color 4 math) from DS tokens
+  (colors.css + surfaces.css paper block). Tokens named WITHOUT their
+  leading double-hyphen (XML-comment safe); prefix each with it in CSS.
+  ONE mapping, applied identically across all nine diagrams.
+
+  CHROME (warm-neutral greyscale):
+    #0f172a canvas          -> paper-0        #f1eee7
+    #1e293b box fill        -> sheet          #f8f7f2
+    #292524 #0a1d10 #172554 #1a2e05 #2a1a00 #1d1408 #1e3a5f
+            inner/callout/layer/pill fills -> paper-1  #e6e1d7
+    #44403c inner stroke    -> paper-line     rgba(59,49,41,0.26)
+    #475569 #334155 box stroke -> paper-line-2 rgba(59,49,41,0.42)
+    #64748b arrows/tertiary -> pfg-2          #61554e
+    #a3a3a3 faint hint      -> pfg-2          #61554e
+    #94a3b8 secondary label -> pfg-1          #4b4038
+    #e2e8f0 #cbd5e1 #d4d4d8 primary text -> pfg-0  #261d17
+    #fff reversed on data node -> paper-0     #f1eee7
+
+  DATA (deep re-inked palette, L<=52pct, legible on cream; each source
+  meaning kept distinct, never merged):
+    red    #ef4444 #fca5a5           new/emotion/reject -> danger-deep  #a52a24
+    orange #f97316 #fdba74           surprise momentum  -> emo-frustr   #a05000
+    amber  #f59e0b #fbbf24 #fcd34d #92400e
+                                     active/handlers/encoding/reviewer/directory -> warn-deep #845b00
+    gold   #daa520                   wiki/consolidated  -> stage-cons   #7d6700
+    green  #22c55e #86efac #10b981 #6ee7b7 #166534 #4ade80
+                                     core/retrieval/novel/coordination  -> ok-deep #0a693c
+    cyan   #06b6d4 #67e8f9           infrastructure/storage -> stage-early #006a66
+    blue   #3b82f6 #60a5fa #93c5fd #1e40af
+                                     query/results/compressed/specialization/sleep -> info-deep #006185
+    purple #8b5cf6 #a855f7 #c4b5fd   neuromodulation/plasticity/intent -> emo-conflct #784d96
+    pink   #ec4899 #f9a8d4 #d946ef #e879f9
+                                     hooks/emotional-tagging/intent -> stage-recon #753e81
+
+  Note: amber(80) and gold(95) stay distinct; green ink is single in the DS
+  paper palette so green+emerald share ok-deep (same 'valid/positive' meaning);
+  category-tinted panel fills neutralised to paper-1 with the category kept in
+  their stroke+text data ink. Fonts: labels -> Inter Tight, identifiers ->
+  JetBrains Mono. Gradients/glow: none used; the unused blur filter was removed.
+===================================================================== -->
+
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+      <path d="M0,0 L8,3 L0,6" fill="#61554e"/>
     </marker>
     <marker id="arr-gold" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#daa520"/>
+      <path d="M0,0 L8,3 L0,6" fill="#7d6700"/>
     </marker>
   </defs>
 
-  <rect width="900" height="460" rx="12" fill="#0f172a"/>
+  <rect width="900" height="460" rx="12" fill="#f1eee7"/>
 
   <!-- Title -->
-  <text x="450" y="28" text-anchor="middle" fill="#e2e8f0" font-size="14" font-weight="600">Transactive Memory System — Cortex 3.17.0</text>
-  <text x="450" y="46" text-anchor="middle" fill="#64748b" font-size="10">Wegner 1987: specialised agents share critical decisions; Cortex adds an autonomous documentation agent</text>
+  <text x="450" y="28" text-anchor="middle" fill="#261d17" font-size="14" font-weight="600">Transactive Memory System — Cortex 3.17.0</text>
+  <text x="450" y="46" text-anchor="middle" fill="#61554e" font-size="10">Wegner 1987: specialised agents share critical decisions; Cortex adds an autonomous documentation agent</text>
 
   <!-- Agent boxes row 1 -->
-  <rect x="30" y="64" width="155" height="70" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="1.5"/>
-  <text x="107" y="88" text-anchor="middle" fill="#c4b5fd" font-size="12" font-weight="600">Engineer</text>
-  <text x="107" y="105" text-anchor="middle" fill="#64748b" font-size="9">topic: engineer</text>
-  <text x="107" y="120" text-anchor="middle" fill="#64748b" font-size="9">bugs · implementations</text>
+  <rect x="30" y="64" width="155" height="70" rx="8" fill="#f8f7f2" stroke="#784d96" stroke-width="1.5"/>
+  <text x="107" y="88" text-anchor="middle" fill="#784d96" font-size="12" font-weight="600">Engineer</text>
+  <text x="107" y="105" text-anchor="middle" fill="#61554e" font-size="9">topic: engineer</text>
+  <text x="107" y="120" text-anchor="middle" fill="#61554e" font-size="9">bugs · implementations</text>
 
-  <rect x="200" y="64" width="155" height="70" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="1.5"/>
-  <text x="277" y="88" text-anchor="middle" fill="#6ee7b7" font-size="12" font-weight="600">Tester</text>
-  <text x="277" y="105" text-anchor="middle" fill="#64748b" font-size="9">topic: tester</text>
-  <text x="277" y="120" text-anchor="middle" fill="#64748b" font-size="9">coverage · results</text>
+  <rect x="200" y="64" width="155" height="70" rx="8" fill="#f8f7f2" stroke="#0a693c" stroke-width="1.5"/>
+  <text x="277" y="88" text-anchor="middle" fill="#0a693c" font-size="12" font-weight="600">Tester</text>
+  <text x="277" y="105" text-anchor="middle" fill="#61554e" font-size="9">topic: tester</text>
+  <text x="277" y="120" text-anchor="middle" fill="#61554e" font-size="9">coverage · results</text>
 
-  <rect x="370" y="64" width="155" height="70" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="447" y="88" text-anchor="middle" fill="#fcd34d" font-size="12" font-weight="600">Reviewer</text>
-  <text x="447" y="105" text-anchor="middle" fill="#64748b" font-size="9">topic: reviewer</text>
-  <text x="447" y="120" text-anchor="middle" fill="#64748b" font-size="9">patterns · violations</text>
+  <rect x="370" y="64" width="155" height="70" rx="8" fill="#f8f7f2" stroke="#845b00" stroke-width="1.5"/>
+  <text x="447" y="88" text-anchor="middle" fill="#845b00" font-size="12" font-weight="600">Reviewer</text>
+  <text x="447" y="105" text-anchor="middle" fill="#61554e" font-size="9">topic: reviewer</text>
+  <text x="447" y="120" text-anchor="middle" fill="#61554e" font-size="9">patterns · violations</text>
 
-  <rect x="540" y="64" width="155" height="70" rx="8" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
-  <text x="617" y="88" text-anchor="middle" fill="#fca5a5" font-size="12" font-weight="600">Researcher</text>
-  <text x="617" y="105" text-anchor="middle" fill="#64748b" font-size="9">topic: researcher</text>
-  <text x="617" y="120" text-anchor="middle" fill="#64748b" font-size="9">papers · benchmarks</text>
+  <rect x="540" y="64" width="155" height="70" rx="8" fill="#f8f7f2" stroke="#a52a24" stroke-width="1.5"/>
+  <text x="617" y="88" text-anchor="middle" fill="#a52a24" font-size="12" font-weight="600">Researcher</text>
+  <text x="617" y="105" text-anchor="middle" fill="#61554e" font-size="9">topic: researcher</text>
+  <text x="617" y="120" text-anchor="middle" fill="#61554e" font-size="9">papers · benchmarks</text>
 
   <!-- New: Wiki worker (autonomous) -->
-  <rect x="710" y="64" width="160" height="70" rx="8" fill="#0a1d10" stroke="#daa520" stroke-width="2"/>
-  <text x="790" y="86" text-anchor="middle" fill="#daa520" font-size="12" font-weight="700">Wiki worker</text>
-  <text x="790" y="100" text-anchor="middle" fill="#94a3b8" font-size="9">topic: wiki-curation</text>
-  <text x="790" y="113" text-anchor="middle" fill="#94a3b8" font-size="9">claude -p · headless</text>
-  <text x="790" y="125" text-anchor="middle" fill="#daa520" font-size="8" font-weight="600">NEW in 3.17.0</text>
+  <rect x="710" y="64" width="160" height="70" rx="8" fill="#e6e1d7" stroke="#7d6700" stroke-width="2"/>
+  <text x="790" y="86" text-anchor="middle" fill="#7d6700" font-size="12" font-weight="700">Wiki worker</text>
+  <text x="790" y="100" text-anchor="middle" fill="#4b4038" font-size="9">topic: wiki-curation</text>
+  <text x="790" y="113" text-anchor="middle" fill="#4b4038" font-size="9">claude -p · headless</text>
+  <text x="790" y="125" text-anchor="middle" fill="#7d6700" font-size="8" font-weight="600">NEW in 3.17.0</text>
 
   <!-- Arrows down to memory -->
-  <line x1="107" y1="134" x2="107" y2="172" stroke="#8b5cf6" stroke-width="1.4" marker-end="url(#arr)"/>
-  <line x1="277" y1="134" x2="277" y2="172" stroke="#10b981" stroke-width="1.4" marker-end="url(#arr)"/>
-  <line x1="447" y1="134" x2="447" y2="172" stroke="#f59e0b" stroke-width="1.4" marker-end="url(#arr)"/>
-  <line x1="617" y1="134" x2="617" y2="172" stroke="#ef4444" stroke-width="1.4" marker-end="url(#arr)"/>
-  <line x1="790" y1="134" x2="790" y2="172" stroke="#daa520" stroke-width="1.6" marker-end="url(#arr-gold)"/>
+  <line x1="107" y1="134" x2="107" y2="172" stroke="#784d96" stroke-width="1.4" marker-end="url(#arr)"/>
+  <line x1="277" y1="134" x2="277" y2="172" stroke="#0a693c" stroke-width="1.4" marker-end="url(#arr)"/>
+  <line x1="447" y1="134" x2="447" y2="172" stroke="#845b00" stroke-width="1.4" marker-end="url(#arr)"/>
+  <line x1="617" y1="134" x2="617" y2="172" stroke="#a52a24" stroke-width="1.4" marker-end="url(#arr)"/>
+  <line x1="790" y1="134" x2="790" y2="172" stroke="#7d6700" stroke-width="1.6" marker-end="url(#arr-gold)"/>
 
   <!-- PostgreSQL box -->
-  <rect x="30" y="178" width="840" height="180" rx="10" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
-  <text x="450" y="202" text-anchor="middle" fill="#93c5fd" font-size="13" font-weight="600">Cortex Memory (PostgreSQL + pgvector) · 42-scope autonomous wiki</text>
+  <rect x="30" y="178" width="840" height="180" rx="10" fill="#f8f7f2" stroke="#006185" stroke-width="2"/>
+  <text x="450" y="202" text-anchor="middle" fill="#006185" font-size="13" font-weight="600">Cortex Memory (PostgreSQL + pgvector) · 42-scope autonomous wiki</text>
 
   <!-- Three layers -->
-  <rect x="50" y="218" width="260" height="44" rx="6" fill="#172554" stroke="#1e40af" stroke-width="1"/>
-  <text x="180" y="237" text-anchor="middle" fill="#60a5fa" font-size="11" font-weight="600">Specialization</text>
-  <text x="180" y="252" text-anchor="middle" fill="#94a3b8" font-size="9">agent_topic scoping per writer</text>
+  <rect x="50" y="218" width="260" height="44" rx="6" fill="#e6e1d7" stroke="#006185" stroke-width="1"/>
+  <text x="180" y="237" text-anchor="middle" fill="#006185" font-size="11" font-weight="600">Specialization</text>
+  <text x="180" y="252" text-anchor="middle" fill="#4b4038" font-size="9">agent_topic scoping per writer</text>
 
-  <rect x="320" y="218" width="260" height="44" rx="6" fill="#1a2e05" stroke="#166534" stroke-width="1"/>
-  <text x="450" y="237" text-anchor="middle" fill="#4ade80" font-size="11" font-weight="600">Coordination</text>
-  <text x="450" y="252" text-anchor="middle" fill="#94a3b8" font-size="9">ADRs + decisions auto-propagate</text>
+  <rect x="320" y="218" width="260" height="44" rx="6" fill="#e6e1d7" stroke="#0a693c" stroke-width="1"/>
+  <text x="450" y="237" text-anchor="middle" fill="#0a693c" font-size="11" font-weight="600">Coordination</text>
+  <text x="450" y="252" text-anchor="middle" fill="#4b4038" font-size="9">ADRs + decisions auto-propagate</text>
 
-  <rect x="590" y="218" width="260" height="44" rx="6" fill="#2a1a00" stroke="#92400e" stroke-width="1"/>
-  <text x="720" y="237" text-anchor="middle" fill="#fbbf24" font-size="11" font-weight="600">Directory</text>
-  <text x="720" y="252" text-anchor="middle" fill="#94a3b8" font-size="9">entity graph spans all topics</text>
+  <rect x="590" y="218" width="260" height="44" rx="6" fill="#e6e1d7" stroke="#845b00" stroke-width="1"/>
+  <text x="720" y="237" text-anchor="middle" fill="#845b00" font-size="11" font-weight="600">Directory</text>
+  <text x="720" y="252" text-anchor="middle" fill="#4b4038" font-size="9">entity graph spans all topics</text>
 
   <!-- New: Wiki layer -->
-  <rect x="50" y="276" width="800" height="68" rx="6" fill="#1d1408" stroke="#daa520" stroke-width="1.5"/>
-  <text x="450" y="296" text-anchor="middle" fill="#daa520" font-size="11" font-weight="700">Autonomous wiki layer — per-project knowledge base</text>
-  <text x="200" y="315" text-anchor="middle" fill="#94a3b8" font-size="9">42 canonical scopes per project</text>
-  <text x="200" y="328" text-anchor="middle" fill="#64748b" font-size="8">architecture · services · api · data-flow · …</text>
-  <text x="450" y="315" text-anchor="middle" fill="#94a3b8" font-size="9">14 sections per file-doc</text>
-  <text x="450" y="328" text-anchor="middle" fill="#64748b" font-size="8">Purpose · Public API · Callers · Sequence · Flow · Parameters · …</text>
-  <text x="710" y="315" text-anchor="middle" fill="#94a3b8" font-size="9">visible curation gaps</text>
-  <text x="710" y="328" text-anchor="middle" fill="#64748b" font-size="8">_(missing — needs: …)_ markers</text>
+  <rect x="50" y="276" width="800" height="68" rx="6" fill="#e6e1d7" stroke="#7d6700" stroke-width="1.5"/>
+  <text x="450" y="296" text-anchor="middle" fill="#7d6700" font-size="11" font-weight="700">Autonomous wiki layer — per-project knowledge base</text>
+  <text x="200" y="315" text-anchor="middle" fill="#4b4038" font-size="9">42 canonical scopes per project</text>
+  <text x="200" y="328" text-anchor="middle" fill="#61554e" font-size="8">architecture · services · api · data-flow · …</text>
+  <text x="450" y="315" text-anchor="middle" fill="#4b4038" font-size="9">14 sections per file-doc</text>
+  <text x="450" y="328" text-anchor="middle" fill="#61554e" font-size="8">Purpose · Public API · Callers · Sequence · Flow · Parameters · …</text>
+  <text x="710" y="315" text-anchor="middle" fill="#4b4038" font-size="9">visible curation gaps</text>
+  <text x="710" y="328" text-anchor="middle" fill="#61554e" font-size="8">_(missing — needs: …)_ markers</text>
 
   <!-- Autonomous loop callout -->
-  <rect x="30" y="376" width="840" height="40" rx="8" fill="#0a1d10" stroke="#daa520" stroke-width="1.2" stroke-dasharray="4,3"/>
-  <text x="450" y="396" text-anchor="middle" fill="#daa520" font-size="11" font-weight="600">SessionStart → 6h-stamp check → spawn consolidate_background → headless_authoring drains gap queue via claude -p</text>
-  <text x="450" y="410" text-anchor="middle" fill="#94a3b8" font-size="9">no cron · no daemon · no manual invocation · uses your existing Claude Code session</text>
+  <rect x="30" y="376" width="840" height="40" rx="8" fill="#e6e1d7" stroke="#7d6700" stroke-width="1.2" stroke-dasharray="4,3"/>
+  <text x="450" y="396" text-anchor="middle" fill="#7d6700" font-size="11" font-weight="600">SessionStart → 6h-stamp check → spawn consolidate_background → headless_authoring drains gap queue via claude -p</text>
+  <text x="450" y="410" text-anchor="middle" fill="#4b4038" font-size="9">no cron · no daemon · no manual invocation · uses your existing Claude Code session</text>
 
   <!-- Footer -->
-  <text x="450" y="438" text-anchor="middle" fill="#94a3b8" font-size="9">Specialisation prevents cross-agent noise; coordination shares the critical decisions; directory spans all topics</text>
-  <text x="450" y="452" text-anchor="middle" fill="#64748b" font-size="9">Sources — Wegner 1987 (transactive memory) · McGaugh 2004 (memory protection) · Friston 2010 (predictive coding write gate)</text>
+  <text x="450" y="438" text-anchor="middle" fill="#4b4038" font-size="9">Specialisation prevents cross-agent noise; coordination shares the critical decisions; directory spans all topics</text>
+  <text x="450" y="452" text-anchor="middle" fill="#61554e" font-size="9">Sources — Wegner 1987 (transactive memory) · McGaugh 2004 (memory protection) · Friston 2010 (predictive coding write gate)</text>
 </svg>

--- a/docs/diagram-write-path.svg
+++ b/docs/diagram-write-path.svg
@@ -1,84 +1,128 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 420" font-family="Inter, -apple-system, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 420" font-family="'Inter Tight', -apple-system, system-ui, sans-serif">
+<!-- =====================================================================
+  RE-INKED to the AI Architect Design System (paper doctrine). Geometry,
+  layout and text content are unchanged; only colour + font-family voices
+  were remapped. Scripted oklch->sRGB (CSS Color 4 math) from DS tokens
+  (colors.css + surfaces.css paper block). Tokens named WITHOUT their
+  leading double-hyphen (XML-comment safe); prefix each with it in CSS.
+  ONE mapping, applied identically across all nine diagrams.
+
+  CHROME (warm-neutral greyscale):
+    #0f172a canvas          -> paper-0        #f1eee7
+    #1e293b box fill        -> sheet          #f8f7f2
+    #292524 #0a1d10 #172554 #1a2e05 #2a1a00 #1d1408 #1e3a5f
+            inner/callout/layer/pill fills -> paper-1  #e6e1d7
+    #44403c inner stroke    -> paper-line     rgba(59,49,41,0.26)
+    #475569 #334155 box stroke -> paper-line-2 rgba(59,49,41,0.42)
+    #64748b arrows/tertiary -> pfg-2          #61554e
+    #a3a3a3 faint hint      -> pfg-2          #61554e
+    #94a3b8 secondary label -> pfg-1          #4b4038
+    #e2e8f0 #cbd5e1 #d4d4d8 primary text -> pfg-0  #261d17
+    #fff reversed on data node -> paper-0     #f1eee7
+
+  DATA (deep re-inked palette, L<=52pct, legible on cream; each source
+  meaning kept distinct, never merged):
+    red    #ef4444 #fca5a5           new/emotion/reject -> danger-deep  #a52a24
+    orange #f97316 #fdba74           surprise momentum  -> emo-frustr   #a05000
+    amber  #f59e0b #fbbf24 #fcd34d #92400e
+                                     active/handlers/encoding/reviewer/directory -> warn-deep #845b00
+    gold   #daa520                   wiki/consolidated  -> stage-cons   #7d6700
+    green  #22c55e #86efac #10b981 #6ee7b7 #166534 #4ade80
+                                     core/retrieval/novel/coordination  -> ok-deep #0a693c
+    cyan   #06b6d4 #67e8f9           infrastructure/storage -> stage-early #006a66
+    blue   #3b82f6 #60a5fa #93c5fd #1e40af
+                                     query/results/compressed/specialization/sleep -> info-deep #006185
+    purple #8b5cf6 #a855f7 #c4b5fd   neuromodulation/plasticity/intent -> emo-conflct #784d96
+    pink   #ec4899 #f9a8d4 #d946ef #e879f9
+                                     hooks/emotional-tagging/intent -> stage-recon #753e81
+
+  Note: amber(80) and gold(95) stay distinct; green ink is single in the DS
+  paper palette so green+emerald share ok-deep (same 'valid/positive' meaning);
+  category-tinted panel fills neutralised to paper-1 with the category kept in
+  their stroke+text data ink. Fonts: labels -> Inter Tight, identifiers ->
+  JetBrains Mono. Gradients/glow: none used; the unused blur filter was removed.
+===================================================================== -->
+
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+      <path d="M0,0 L8,3 L0,6" fill="#61554e"/>
     </marker>
     <marker id="arr-green" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#22c55e"/>
+      <path d="M0,0 L8,3 L0,6" fill="#0a693c"/>
     </marker>
     <marker id="arr-red" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#ef4444"/>
+      <path d="M0,0 L8,3 L0,6" fill="#a52a24"/>
     </marker>
   </defs>
 
-  <rect width="700" height="420" rx="12" fill="#0f172a"/>
+  <rect width="700" height="420" rx="12" fill="#f1eee7"/>
 
   <!-- remember input -->
-  <rect x="270" y="16" width="160" height="36" rx="18" fill="#1e293b" stroke="#94a3b8" stroke-width="1"/>
-  <text x="350" y="39" text-anchor="middle" fill="#e2e8f0" font-size="13" font-weight="500">remember</text>
+  <rect x="270" y="16" width="160" height="36" rx="18" fill="#f8f7f2" stroke="#4b4038" stroke-width="1"/>
+  <text x="350" y="39" text-anchor="middle" fill="#261d17" font-size="13" font-weight="500">remember</text>
 
   <!-- Arrow down -->
-  <line x1="350" y1="52" x2="350" y2="72" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="350" y1="52" x2="350" y2="72" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Predictive Coding Gate -->
-  <polygon points="350,78 460,115 350,152 240,115" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="350" y="112" text-anchor="middle" fill="#fbbf24" font-size="11" font-weight="600">Predictive Coding Gate</text>
-  <text x="350" y="126" text-anchor="middle" fill="#a3a3a3" font-size="9">Is this novel?</text>
+  <polygon points="350,78 460,115 350,152 240,115" fill="#f8f7f2" stroke="#845b00" stroke-width="1.5"/>
+  <text x="350" y="112" text-anchor="middle" fill="#845b00" font-size="11" font-weight="600">Predictive Coding Gate</text>
+  <text x="350" y="126" text-anchor="middle" fill="#61554e" font-size="9">Is this novel?</text>
 
   <!-- Novel branch (left) -->
-  <line x1="295" y1="138" x2="220" y2="170" stroke="#22c55e" stroke-width="1.5" marker-end="url(#arr-green)"/>
-  <text x="240" y="158" fill="#22c55e" font-size="10" font-weight="500">novel</text>
+  <line x1="295" y1="138" x2="220" y2="170" stroke="#0a693c" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <text x="240" y="158" fill="#0a693c" font-size="10" font-weight="500">novel</text>
 
   <!-- Redundant branch (right) -->
-  <line x1="405" y1="138" x2="520" y2="170" stroke="#ef4444" stroke-width="1.5" marker-end="url(#arr-red)"/>
-  <text x="455" y="158" fill="#ef4444" font-size="10" font-weight="500">redundant</text>
+  <line x1="405" y1="138" x2="520" y2="170" stroke="#a52a24" stroke-width="1.5" marker-end="url(#arr-red)"/>
+  <text x="455" y="158" fill="#a52a24" font-size="10" font-weight="500">redundant</text>
 
   <!-- Rejected -->
-  <rect x="490" y="175" width="120" height="32" rx="16" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
-  <text x="550" y="196" text-anchor="middle" fill="#fca5a5" font-size="12">Rejected</text>
+  <rect x="490" y="175" width="120" height="32" rx="16" fill="#f8f7f2" stroke="#a52a24" stroke-width="1.5"/>
+  <text x="550" y="196" text-anchor="middle" fill="#a52a24" font-size="12">Rejected</text>
 
   <!-- Emotional Tagging -->
-  <rect x="130" y="175" width="180" height="36" rx="6" fill="#1e293b" stroke="#ec4899" stroke-width="1.5"/>
-  <text x="220" y="198" text-anchor="middle" fill="#f9a8d4" font-size="12">Emotional Tagging</text>
+  <rect x="130" y="175" width="180" height="36" rx="6" fill="#f8f7f2" stroke="#753e81" stroke-width="1.5"/>
+  <text x="220" y="198" text-anchor="middle" fill="#753e81" font-size="12">Emotional Tagging</text>
 
   <!-- Arrow down -->
-  <line x1="220" y1="211" x2="220" y2="235" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="220" y1="211" x2="220" y2="235" stroke="#61554e" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Active Curation -->
-  <polygon points="220,240 340,270 220,300 100,270" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="220" y="274" text-anchor="middle" fill="#fbbf24" font-size="11" font-weight="600">Active Curation</text>
+  <polygon points="220,240 340,270 220,300 100,270" fill="#f8f7f2" stroke="#845b00" stroke-width="1.5"/>
+  <text x="220" y="274" text-anchor="middle" fill="#845b00" font-size="11" font-weight="600">Active Curation</text>
 
   <!-- Three branches -->
-  <line x1="140" y1="285" x2="80" y2="320" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
-  <text x="86" y="310" fill="#94a3b8" font-size="9">similar</text>
-  <line x1="220" y1="300" x2="220" y2="325" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
-  <text x="238" y="316" fill="#94a3b8" font-size="9">related</text>
-  <line x1="300" y1="285" x2="360" y2="320" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
-  <text x="345" y="310" fill="#94a3b8" font-size="9">new</text>
+  <line x1="140" y1="285" x2="80" y2="320" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
+  <text x="86" y="310" fill="#4b4038" font-size="9">similar</text>
+  <line x1="220" y1="300" x2="220" y2="325" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
+  <text x="238" y="316" fill="#4b4038" font-size="9">related</text>
+  <line x1="300" y1="285" x2="360" y2="320" stroke="#61554e" stroke-width="1.2" marker-end="url(#arr)"/>
+  <text x="345" y="310" fill="#4b4038" font-size="9">new</text>
 
   <!-- Merge -->
-  <rect x="20" y="328" width="130" height="30" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="85" y="348" text-anchor="middle" fill="#d4d4d8" font-size="11">Merge existing</text>
+  <rect x="20" y="328" width="130" height="30" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="85" y="348" text-anchor="middle" fill="#261d17" font-size="11">Merge existing</text>
 
   <!-- Link -->
-  <rect x="160" y="328" width="120" height="30" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="220" y="348" text-anchor="middle" fill="#d4d4d8" font-size="11">Link related</text>
+  <rect x="160" y="328" width="120" height="30" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="220" y="348" text-anchor="middle" fill="#261d17" font-size="11">Link related</text>
 
   <!-- Create -->
-  <rect x="300" y="328" width="130" height="30" rx="4" fill="#1e293b" stroke="#22c55e" stroke-width="1.2"/>
-  <text x="365" y="348" text-anchor="middle" fill="#86efac" font-size="11">Create new</text>
+  <rect x="300" y="328" width="130" height="30" rx="4" fill="#f8f7f2" stroke="#0a693c" stroke-width="1.2"/>
+  <text x="365" y="348" text-anchor="middle" fill="#0a693c" font-size="11">Create new</text>
 
   <!-- All converge to PostgreSQL -->
-  <line x1="85" y1="358" x2="500" y2="390" stroke="#64748b" stroke-width="1" marker-end="url(#arr)"/>
-  <line x1="220" y1="358" x2="500" y2="390" stroke="#64748b" stroke-width="1" marker-end="url(#arr)"/>
-  <line x1="365" y1="358" x2="500" y2="390" stroke="#64748b" stroke-width="1" marker-end="url(#arr)"/>
+  <line x1="85" y1="358" x2="500" y2="390" stroke="#61554e" stroke-width="1" marker-end="url(#arr)"/>
+  <line x1="220" y1="358" x2="500" y2="390" stroke="#61554e" stroke-width="1" marker-end="url(#arr)"/>
+  <line x1="365" y1="358" x2="500" y2="390" stroke="#61554e" stroke-width="1" marker-end="url(#arr)"/>
 
   <!-- PostgreSQL -->
-  <rect x="490" y="375" width="190" height="34" rx="6" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5"/>
-  <text x="585" y="397" text-anchor="middle" fill="#67e8f9" font-size="12" font-weight="500">PostgreSQL + pgvector</text>
+  <rect x="490" y="375" width="190" height="34" rx="6" fill="#f8f7f2" stroke="#006a66" stroke-width="1.5"/>
+  <text x="585" y="397" text-anchor="middle" fill="#006a66" font-size="12" font-weight="500">PostgreSQL + pgvector</text>
 
   <!-- Entity extraction arrow from Create -->
-  <line x1="430" y1="343" x2="490" y2="343" stroke="#64748b" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr)"/>
-  <rect x="490" y="328" width="170" height="30" rx="4" fill="#292524" stroke="#44403c" stroke-width="0.5"/>
-  <text x="575" y="348" text-anchor="middle" fill="#a3a3a3" font-size="10">Extract Entities to KG</text>
+  <line x1="430" y1="343" x2="490" y2="343" stroke="#61554e" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr)"/>
+  <rect x="490" y="328" width="170" height="30" rx="4" fill="#e6e1d7" stroke="rgba(59,49,41,0.26)" stroke-width="0.5"/>
+  <text x="575" y="348" text-anchor="middle" fill="#61554e" font-size="10">Extract Entities to KG</text>
 </svg>


### PR DESCRIPTION
## Contenu

Restylage du banner README et des 9 diagrammes de `docs/` vers le design system AI Architect (Proof Dossier) : surface papier (`paper-0`/`sheet`), encre chaude (`pfg-0`/`pfg-2`), accent terracotta (`accent-deep`), hairlines réglées, palette data-only pour les étapes de consolidation.

**Provenance des couleurs** : chaque littéral hexadécimal trace vers un token DS ; les conversions oklch→sRGB sont scriptées (CSS Color 4, `oklch2srgb.py`) — la légende embarquée dans chaque SVG documente le mapping token par token.

## Recouvrement connu avec PR #83

`assets/banner.svg` incorpore déjà les chiffres de benchmark corrigés (mêmes valeurs que le commit 9f902916 de la PR #83). Quelle que soit la PR mergée en premier, la résolution du conflit éventuel = prendre la version de cette branche (design + chiffres corrects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NkxreafqWnvPCwrL6KJEs