### PR TITLE
chore(deps): sync uv.lock to pyproject 4.1.0 + pgvector>=0.4,<0.6

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1234,7 +1234,7 @@ wheels = [
 
 [[package]]
 name = "hypermnesia-mcp"
-version = "4.0.0"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -1311,8 +1311,8 @@ requires-dist = [
     { name = "networkx", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "pandas", marker = "extra == 'viz-tile'", specifier = ">=2.2" },
-    { name = "pgvector", marker = "extra == 'benchmarks'", specifier = ">=0.3" },
-    { name = "pgvector", marker = "extra == 'postgresql'", specifier = ">=0.3" },
+    { name = "pgvector", marker = "extra == 'benchmarks'", specifier = ">=0.4,<0.6" },
+    { name = "pgvector", marker = "extra == 'postgresql'", specifier = ">=0.4,<0.6" },
     { name = "pillow", marker = "extra == 'viz-tile'", specifier = ">=10.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'benchmarks'", specifier = ">=3.1" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgresql'", specifier = ">=3.1" },


### PR DESCRIPTION
## Problème

`pyproject.toml` est déjà à `version = "4.1.0"` avec `pgvector>=0.4,<0.6` (commité), mais `uv.lock` était resté à `4.0.0` / `pgvector>=0.3`. Un lockfile désynchronisé du manifeste est un bug de résolution latent.

## Correctif

Régénération du lockfile pour qu'il corresponde au `pyproject.toml` commité. Aucun changement de code, aucun lien avec CLS-B (PR #87).

Diff : `uv.lock` seul, 3 insertions / 3 suppressions (bump version + bornes pgvector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)