### PR TITLE
feat(wiki): page→source-file linkage (ADR-0051, STEPS 1–4)

### DIFF
--- a/docs/adr/ADR-0051-wiki-page-sources-schema.md
+++ b/docs/adr/ADR-0051-wiki-page-sources-schema.md
@@ -1,0 +1,141 @@
+# ADR-0051: Wiki Page-Source Linkage — Dual Schema Surface
+
+**Status:** Accepted
+**Date:** 2026-07-08
+**Decision-makers:** cdeust
+**Related:** wiki schema (`mcp_server/infrastructure/pg_schema.py::WIKI_SCHEMA_DDL`), cortex-viz (downstream consumer)
+
+## Context
+
+Wiki pages already record which source file(s) they document, but the
+linkage is dropped before it ever reaches the database:
+
+- `wiki_file_doc_skeleton.py` writes a `source_file_path:` frontmatter
+  key when scaffolding a file-doc page.
+- Legacy pages use `file:` (a different frontmatter key) or a
+  `file:<path>` tag inside `wiki.pages.tags`.
+- `wiki.claim_events.evidence_refs` (JSONB) already carries `kind='file'`
+  evidence references extracted per-claim during synthesis
+  (`wiki_staleness.py`, `draft_synthesizer.py`).
+
+None of these forms is queryable as a first-class DB edge. A downstream
+visualizer (cortex-viz) needs to draw wiki-page → source-file edges, and
+today that would require re-parsing every page's frontmatter and tags at
+render time — the DB has no surface for "which files does this page
+document" or its reverse, "which pages document this file."
+
+This ADR (STEP 1 of the feature) creates that surface. The writer that
+populates it from frontmatter/evidence_refs, the backfill over existing
+pages, and any consolidate-cycle wiring are separate, later steps — not
+implemented here.
+
+## Decision
+
+**Dual schema surface**, added to `WIKI_SCHEMA_DDL` and `MIGRATIONS_DDL`
+in `mcp_server/infrastructure/pg_schema.py`:
+
+1. **Edge table `wiki.page_sources`** (N:M, general case):
+   ```sql
+   CREATE TABLE IF NOT EXISTS wiki.page_sources (
+       page_id     INTEGER NOT NULL REFERENCES wiki.pages(id) ON DELETE CASCADE,
+       source_path TEXT NOT NULL,
+       symbol      TEXT,
+       link_kind   TEXT NOT NULL DEFAULT 'documents'
+                   CHECK (link_kind IN ('documents','references','derived')),
+       confidence  REAL NOT NULL DEFAULT 1.0,
+       source      TEXT NOT NULL DEFAULT 'frontmatter'
+                   CHECK (source IN ('frontmatter','claim_evidence','body','codebase_grounding')),
+       PRIMARY KEY (page_id, source_path, link_kind)
+   );
+   CREATE INDEX IF NOT EXISTS idx_wiki_page_sources_path ON wiki.page_sources (source_path);
+   ```
+   Shape mirrors `wiki.links` (src row → typed target key). `source_path`
+   is the rel path under the project source root, in canonical form (see
+   Risks below). The reverse index on `source_path` is the query the viz
+   edge-builder actually runs: file → page(s).
+
+2. **Denormalized scalar `wiki.pages.documents_primary TEXT`** (nullable,
+   1:1 fast path):
+   - Added to the `wiki.pages` `CREATE TABLE`, adjacent to `memory_id`/
+     `concept_id`.
+   - Added via an idempotent `MIGRATIONS_DDL` guard (`information_schema.
+     columns` existence check, `table_schema = 'wiki'` qualified) for
+     already-provisioned databases, following the same pattern already
+     used for `memories.heat_base_set_at` etc.
+
+Both are additive: `CREATE TABLE IF NOT EXISTS` for the new table (safe
+on fresh and existing DBs — `WIKI_SCHEMA_DDL` runs every boot), and the
+`DO $$ ... ALTER TABLE ... ADD COLUMN ... END $$` guard for the new
+column on existing installs.
+
+### Rationale for the dual surface
+
+- **The edge table is the general model.** An anchor/scope page can
+  document many files (e.g. an ADR touching five modules); rarely, one
+  file is documented by more than one page (a module overview plus a
+  deep-dive). This is consistent with how `wiki.links` and
+  `wiki.citations` already model page relationships as edge tables, not
+  scalars.
+- **The scalar column is a denormalized query index for the dominant
+  1:1 case** (most file-doc pages document exactly one file). Wiki's
+  stated design invariant is **zero joins from the recall hot path**
+  (`pg_schema.py` §"Isolated `wiki` schema"). Without
+  `documents_primary`, any recall-path query wanting "what file does
+  this page document" would have to join `wiki.page_sources` even for
+  the overwhelmingly common single-file case. The scalar keeps that
+  query join-free; `wiki.page_sources` remains the source of truth for
+  the N:M case and for the writer/backfill's authoritative history.
+
+### Alternatives rejected
+
+- **(a) Frontmatter-only.** The visualizer needs a queryable DB edge,
+  not a per-file markdown parse at render time. Frontmatter stays the
+  authored source of truth (files are canonical, per this repo's own
+  wiki design — see `wiki.pages` comment "Files remain source of
+  truth"), but the DB needs a derived index over it.
+- **(b) Single scalar column only (no edge table).** Cannot represent
+  the N:M case — an anchor page documenting multiple files, or a file
+  documented by multiple pages, would silently lose data or force an
+  arbitrary "pick one" resolution.
+- **(c) Reuse `wiki.links` with a synthetic file-slug.** `wiki.links.
+  dst_page_id` is a strict `FOREIGN KEY REFERENCES wiki.pages(id)`.
+  Source files are not wiki pages and have no `wiki.pages` row to
+  reference; forcing them through `wiki.links` would mean either
+  fabricating placeholder page rows for every source file (schema
+  abuse: files aren't pages, and it would pollute `wiki.pages` heat/
+  citation/backlink physics with non-page rows) or relaxing the FK to
+  allow dangling `dst_page_id`, which defeats the purpose of the
+  constraint for every other `wiki.links` consumer.
+
+## Consequences
+
+- Additive migration: `Type-2 reversible` (can be dropped without data
+  loss to any other table — no other table's DDL references
+  `wiki.page_sources` or `documents_primary` yet). Once cortex-viz (or
+  any other consumer) starts reading these columns, the contract
+  becomes `Type-1` — a compatibility-breaking removal, not a
+  no-op-revert.
+- No writer, backfill, or consolidate-cycle wiring is part of this ADR.
+  Both `wiki.page_sources` and `wiki.pages.documents_primary` are empty
+  on every existing row until a later step populates them from
+  frontmatter and `wiki.claim_events.evidence_refs`.
+- `source_path` normalization (rel-path canonicalization against the
+  project source root, symlink resolution, case sensitivity) is
+  deliberately deferred to the writer step — this ADR fixes the column
+  as `TEXT NOT NULL` with no format constraint yet, to avoid
+  over-specifying a contract before the writer's actual normalization
+  logic is designed.
+
+## References
+
+- `mcp_server/infrastructure/pg_schema.py::WIKI_SCHEMA_DDL`
+  (`wiki.pages`, `wiki.links`, `wiki.citations`)
+- `mcp_server/infrastructure/pg_schema.py::MIGRATIONS_DDL`
+  (idempotent `ALTER TABLE ... ADD COLUMN` guard pattern)
+- `mcp_server/core/wiki_file_doc_skeleton.py` (`source_file_path:`
+  frontmatter writer)
+- `mcp_server/core/wiki_staleness.py`,
+  `mcp_server/core/draft_synthesizer.py` (`evidence_refs` kind='file')
+- `mcp_server/handlers/consolidation/page_io.py`,
+  `candidate_scan.py`, `authoring_prompts.py` (legacy
+  `source_file_path` readers)

--- a/mcp_server/core/wiki_drift.py
+++ b/mcp_server/core/wiki_drift.py
@@ -34,6 +34,7 @@ from dataclasses import dataclass, field
 from typing import Final
 
 from mcp_server.shared.platform import to_posix
+from mcp_server.shared.wiki_source_paths import extract_document_paths
 
 
 @dataclass
@@ -54,6 +55,16 @@ class PageDrift:
 REASON_MISSING_SOURCE: Final[str] = "missing_source_file"
 REASON_STALE: Final[str] = "stale_content"
 REASON_OFF_TEMPLATE: Final[str] = "off_template"
+REASON_MISSING_LINK: Final[str] = "missing_source_link"
+
+# Page kinds whose entire purpose is to document a source file — these are
+# the kinds the STEP-3 backfill (core.wiki_source_backfill) targets, and
+# the ones REASON_MISSING_LINK applies to. Restricted to ``reference``
+# (the kind ``codebase_analyze``/rebucket route file-docs to, per
+# CHANGELOG 3.15.4 "File-documentation pages") — pages of other kinds
+# (adr, explanation, ...) don't claim to document one file, so an absent
+# link there is not drift.
+_SOURCE_DOCUMENTING_KINDS: Final[frozenset[str]] = frozenset({"reference"})
 
 # Default re-author window. Pages older than this whose body cites
 # source files trigger a re-author job — the prose may still be true,
@@ -307,6 +318,22 @@ def audit_page_drift(
         missing_sections = [s for s in required if s not in body]
         if missing_sections:
             drift.reasons.append(REASON_OFF_TEMPLATE)
+
+    # Reason 4: missing source link. A source-documenting page (kind ==
+    # "reference") that declares no documented file in its frontmatter
+    # AND has no groundable cited path in its body is a page nobody can
+    # trace to a real file — the STEP-3 backfill
+    # (core.wiki_source_backfill.derive_primary_source) either couldn't
+    # find an unambiguous candidate or hasn't run yet. Surfaced as drift
+    # so it queues as a re-authoring job. Without a source_root we can't
+    # verify any citation, so an unlinked page is flagged regardless —
+    # this only affects backlog counts, nothing is deleted.
+    if kind in _SOURCE_DOCUMENTING_KINDS and not extract_document_paths(meta):
+        groundable = source_root is not None and any(
+            _file_exists_under(source_root, c) for c in cited
+        )
+        if not groundable:
+            drift.reasons.append(REASON_MISSING_LINK)
 
     return drift if drift.reasons else None
 

--- a/mcp_server/core/wiki_source_backfill.py
+++ b/mcp_server/core/wiki_source_backfill.py
@@ -1,0 +1,153 @@
+"""Derive the primary documented source file for wiki pages that lack one
+(ADR-0051 STEP 3).
+
+``wiki_reindex`` / ``migrate_wiki`` already backfill ``documents_primary``
+for pages whose frontmatter *has* a ``documents``/``source_file_path``/
+``file`` field (``mcp_server.shared.wiki_source_paths.extract_document_paths``).
+This module closes the remaining gap: pages with no such field.
+
+Pure logic, no I/O — filesystem existence checks are injected via
+``exists_fn`` so this module stays unit-testable without touching a real
+tree, and so it can live in core/ per the Dependency Rule (core imports
+shared/ + stdlib only; no ``os``/``pathlib`` here).
+
+Derivation is a strict priority chain; each step either produces exactly
+one confident candidate or falls through — the zetetic anti-fabrication
+standard (CLAUDE.md, coding-standards.md §8) forbids guessing a "most
+likely" primary when the evidence is ambiguous:
+
+  1. **claim_evidence** — file paths cited as evidence on the page's
+     source memory's claims (``pg_store_wiki_thermo.get_claim_file_refs_for_pages``).
+     Accepted only when exactly one distinct normalized path is present;
+     several candidates with no way to rank them is refused, not guessed.
+  2. **codebase_grounding** — the wiki page's own ``rel_path`` slug,
+     reversed into a plausible source path (mirrors
+     ``scripts/wiki_rebucket_file_docs.py::_derive_target_path``'s
+     ``path.replace("/", "-")`` forward transform). Accepted only if
+     ``exists_fn`` confirms the reversed guess names a real file — the
+     guess is never trusted on its own.
+  3. **body** — a single source-file-shaped path cited in the page's
+     lead + sections (reusing ``wiki_drift._extract_cited_paths``, not
+     duplicating its regex/filter logic), accepted only if it resolves
+     via ``exists_fn`` and no other groundable candidate ties with it.
+
+Returns ``None`` when no step produces an unambiguous, real-file-backed
+candidate — the caller (``wiki_maintenance``) then leaves the page
+unlinked for the next ``wiki_drift`` REASON_MISSING_LINK pass to surface
+as a re-authoring job.
+
+Pre-condition:  ``page`` carries at least ``rel_path`` and ``domain``
+                (str); ``lead``/``sections`` are optional and default to
+                empty; ``claim_files`` entries are raw (not yet
+                normalized) path strings; ``exists_fn`` answers whether a
+                normalized, source-root-relative path names a real file.
+Post-condition: the returned path (if any) is canonical per
+                ``normalize_source_path`` and ``exists_fn`` returns True
+                for it whenever the derivation step requires grounding
+                (steps 2 and 3; step 1 is not filesystem-checked here —
+                claim evidence is already a memory-derived fact, grounded
+                at write time by the claim extractor).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Final
+
+from mcp_server.core.wiki_drift import _extract_cited_paths
+from mcp_server.shared.wiki_source_paths import normalize_source_path
+
+SOURCE_CLAIM_EVIDENCE: Final[str] = "claim_evidence"
+SOURCE_CODEBASE_GROUNDING: Final[str] = "codebase_grounding"
+SOURCE_BODY: Final[str] = "body"
+
+ExistsFn = Callable[[str], bool]
+
+
+def derive_primary_source(
+    page: dict[str, object],
+    claim_files: list[str],
+    exists_fn: ExistsFn,
+) -> tuple[str, str] | None:
+    """Derive the single best primary documented file for ``page``.
+
+    Returns ``(canonical_source_path, source_tag)`` or ``None`` when no
+    step yields an unambiguous, groundable candidate. See module
+    docstring for the priority chain and its refusal conditions.
+    """
+    candidate = _from_claim_evidence(claim_files)
+    if candidate is not None:
+        return candidate, SOURCE_CLAIM_EVIDENCE
+
+    rel_path = str(page.get("rel_path") or "")
+    candidate = _from_codebase_grounding(rel_path, exists_fn)
+    if candidate is not None:
+        return candidate, SOURCE_CODEBASE_GROUNDING
+
+    candidate = _from_body(page, exists_fn)
+    if candidate is not None:
+        return candidate, SOURCE_BODY
+
+    return None
+
+
+def _from_claim_evidence(claim_files: list[str]) -> str | None:
+    """Exactly one distinct normalized claim-cited file -> use it.
+
+    Several candidates carry no ranking signal here (no per-ref weight
+    is passed through ``get_claim_file_refs_for_pages``), so more than
+    one distinct path is a refusal, not a guess.
+    """
+    normalized: dict[str, None] = {}
+    for raw in claim_files:
+        canonical = normalize_source_path(raw)
+        if canonical:
+            normalized.setdefault(canonical, None)
+    if len(normalized) == 1:
+        return next(iter(normalized))
+    return None
+
+
+def _from_codebase_grounding(rel_path: str, exists_fn: ExistsFn) -> str | None:
+    """Reverse the wiki page's own slug into a source-path guess.
+
+    ``wiki_rebucket_file_docs._derive_target_path`` forward-transforms a
+    source path into a slug via ``path.replace("/", "-")`` then
+    ``slugify``. This reverses that specific transform (dashes back to
+    slashes) on the page's filename stem. The guess is lossy (a source
+    path containing a literal dash is indistinguishable from a directory
+    separator) so it is NEVER trusted alone — only returned when
+    ``exists_fn`` independently confirms a real file at that path.
+    """
+    if not rel_path or not rel_path.endswith(".md"):
+        return None
+    stem = rel_path.rsplit("/", 1)[-1][: -len(".md")]
+    if not stem:
+        return None
+    guess = stem.replace("-", "/")
+    canonical = normalize_source_path(guess)
+    if canonical and exists_fn(canonical):
+        return canonical
+    return None
+
+
+def _from_body(page: dict[str, object], exists_fn: ExistsFn) -> str | None:
+    """Exactly one groundable path cited in the page's lead + sections.
+
+    Reuses ``wiki_drift._extract_cited_paths`` (regex + wiki-internal /
+    technology-name filtering) rather than duplicating it. Several
+    groundable citations carry no signal for which is "primary" — a tie
+    is a refusal, matching ``_from_claim_evidence``'s discipline.
+    """
+    lead = str(page.get("lead") or "")
+    sections = page.get("sections")
+    section_text = "\n".join(str(v) for v in sections.values()) if isinstance(sections, dict) else ""
+    body = f"{lead}\n{section_text}"
+
+    grounded: dict[str, None] = {}
+    for cited in _extract_cited_paths(body):
+        canonical = normalize_source_path(cited)
+        if canonical and exists_fn(canonical):
+            grounded.setdefault(canonical, None)
+    if len(grounded) == 1:
+        return next(iter(grounded))
+    return None

--- a/mcp_server/core/wiki_source_backfill.py
+++ b/mcp_server/core/wiki_source_backfill.py
@@ -140,7 +140,11 @@ def _from_body(page: dict[str, object], exists_fn: ExistsFn) -> str | None:
     """
     lead = str(page.get("lead") or "")
     sections = page.get("sections")
-    section_text = "\n".join(str(v) for v in sections.values()) if isinstance(sections, dict) else ""
+    section_text = (
+        "\n".join(str(v) for v in sections.values())
+        if isinstance(sections, dict)
+        else ""
+    )
     body = f"{lead}\n{section_text}"
 
     grounded: dict[str, None] = {}

--- a/mcp_server/core/wiki_staleness.py
+++ b/mcp_server/core/wiki_staleness.py
@@ -11,12 +11,22 @@ I/O), and returns the decision.
 Staleness signal sources:
   - claim_events.evidence_refs where kind='file' (most reliable)
   - Inline file-pattern matches in lead/sections (best-effort)
+
+ADR-0051 STEP 4 adds ``harvest_page_refs_typed`` / ``normalize_typed_refs``:
+the staleness brake above only needs the *union* of referenced paths, but
+persisting them as ``wiki.page_sources`` rows (link_kind='references')
+needs per-path provenance (was this path cited by a claim, or only found
+by best-effort regex in the body?) so downstream consumers can weigh the
+two differently. ``harvest_page_refs`` is kept and now derives from the
+typed variant rather than duplicating the merge logic.
 """
 
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+
+from mcp_server.shared.wiki_source_paths import normalize_source_path
 
 _FILE_REF_RE = re.compile(
     r"\b([\w./-]+\.(?:py|js|ts|md|json|yaml|yml|sql|go|rs|rb|java|cpp|c|h|hpp|sh|toml))\b"
@@ -110,25 +120,90 @@ def harvest_page_refs(page: dict, claim_evidence_files: list[str]) -> list[str]:
     Combines:
       - claim-derived file refs (high signal, from extractor)
       - inline file patterns in lead + section bodies (best effort)
+
+    A thin adapter over ``harvest_page_refs_typed`` that drops the
+    per-path provenance the staleness brake doesn't need (it only cares
+    about the union of paths to existence-check).
     """
-    refs: set[str] = set(claim_evidence_files or [])
-    refs.update(extract_file_refs(page.get("lead") or ""))
+    return sorted(harvest_page_refs_typed(page, claim_evidence_files))
+
+
+# Per-path provenance tags for harvest_page_refs_typed / normalize_typed_refs.
+REF_SOURCE_CLAIM_EVIDENCE = "claim_evidence"
+REF_SOURCE_BODY = "body"
+
+
+def harvest_page_refs_typed(
+    page: dict, claim_evidence_files: list[str]
+) -> dict[str, str]:
+    """Like ``harvest_page_refs`` but keeps, per path, which signal found it.
+
+    Pre-condition:  ``claim_evidence_files`` are raw (not yet normalized)
+                    path strings, as returned by
+                    ``pg_store_wiki_thermo.get_claim_file_refs_for_pages``.
+    Post-condition: every key of the returned dict is a raw (not yet
+                    normalized — see ``normalize_typed_refs``) path
+                    string; the value is ``REF_SOURCE_CLAIM_EVIDENCE`` if
+                    that exact raw string was present in
+                    ``claim_evidence_files``, else ``REF_SOURCE_BODY``.
+                    When the same raw path is cited both ways, claim
+                    evidence wins (it is the higher-signal source).
+    """
+    origins: dict[str, str] = {}
+
+    def _collect_body(text: str) -> None:
+        for ref in extract_file_refs(text):
+            origins.setdefault(ref, REF_SOURCE_BODY)
+
+    _collect_body(page.get("lead") or "")
     sections = page.get("sections") or {}
     if isinstance(sections, dict):
         for body in sections.values():
-            refs.update(extract_file_refs(str(body)))
+            _collect_body(str(body))
     elif isinstance(sections, list):
         for s in sections:
             body = s.get("body") if isinstance(s, dict) else getattr(s, "body", "")
-            refs.update(extract_file_refs(str(body)))
-    return sorted(refs)
+            _collect_body(str(body))
+
+    for ref in claim_evidence_files or []:
+        origins[ref] = REF_SOURCE_CLAIM_EVIDENCE  # claim always wins a tie
+
+    return origins
+
+
+def normalize_typed_refs(typed_refs: dict[str, str]) -> dict[str, str]:
+    """Canonicalize a ``harvest_page_refs_typed`` result for persistence.
+
+    ``wiki.page_sources.source_path`` must share the same canonical form
+    across every link_kind (``mcp_server.shared.wiki_source_paths
+    .normalize_source_path`` — the convention ``documents`` links already
+    use) so the reverse index doesn't split one real file into two rows.
+
+    Two raw refs that normalize to the same canonical path collapse into
+    one entry. ``claim_evidence`` wins the merge regardless of iteration
+    order (mirrors ``harvest_page_refs_typed``'s own precedence): a path
+    already recorded as claim-evidence is never demoted to body, and a
+    later claim-evidence hit always promotes an existing body entry.
+    """
+    out: dict[str, str] = {}
+    for raw, origin in typed_refs.items():
+        canonical = normalize_source_path(raw)
+        if canonical is None:
+            continue
+        if canonical not in out or origin == REF_SOURCE_CLAIM_EVIDENCE:
+            out[canonical] = origin
+    return out
 
 
 __all__ = [
     "STALE_THRESHOLD",
     "MIN_FILE_REFS",
+    "REF_SOURCE_CLAIM_EVIDENCE",
+    "REF_SOURCE_BODY",
     "StalenessDecision",
     "extract_file_refs",
     "evaluate_staleness",
     "harvest_page_refs",
+    "harvest_page_refs_typed",
+    "normalize_typed_refs",
 ]

--- a/mcp_server/handlers/consolidation/wiki_backlog_pass.py
+++ b/mcp_server/handlers/consolidation/wiki_backlog_pass.py
@@ -40,7 +40,9 @@ async def run_backlog_pass(store: Any) -> dict[str, Any]:
         if hasattr(store, "iter_memories_for_decay")
         else [store.get_all_memories_for_decay()]
     )
-    out["cluster_jobs"] = count_pending_clusters_streamed(chunks, wiki_root=str(WIKI_ROOT))
+    out["cluster_jobs"] = count_pending_clusters_streamed(
+        chunks, wiki_root=str(WIKI_ROOT)
+    )
 
     coverages = audit_all_domains(str(WIKI_ROOT))
     out["coverage_gaps"] = sum(c.missing_count for c in coverages)

--- a/mcp_server/handlers/consolidation/wiki_backlog_pass.py
+++ b/mcp_server/handlers/consolidation/wiki_backlog_pass.py
@@ -1,0 +1,79 @@
+"""Curation-backlog count for ``run_wiki_maintenance``.
+
+Split out of ``wiki_maintenance.py`` to keep both files under the
+300-line cap (coding-standards.md §4.1) — no logic changed from what
+previously lived inline in that module's "Curation backlog" block.
+
+Composition root — wires ``core.auto_curator`` / ``core.wiki_coverage`` /
+``core.wiki_drift`` (pure logic) to the memory store's decay-chunk
+iterator and the filesystem wiki root.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+async def run_backlog_pass(store: Any) -> dict[str, Any]:
+    """Count pending coverage/cluster/drift jobs across the whole wiki.
+
+    Pre-condition:  ``store`` exposes ``iter_memories_for_decay`` (or,
+                    failing that, ``get_all_memories_for_decay``).
+    Post-condition: returned dict carries ``cluster_jobs``,
+                    ``coverage_gaps``, ``uncovered_files``,
+                    ``file_coverage_by_domain``, ``drifted_pages``, and
+                    ``pending_total`` (the sum of the first four count
+                    fields) — read-only, no rows written.
+    """
+    from mcp_server.core.auto_curator import count_pending_clusters_streamed
+    from mcp_server.core.wiki_coverage import (
+        _project_source_root,
+        audit_all_domains,
+        audit_all_file_coverage,
+    )
+    from mcp_server.core.wiki_drift import audit_wiki_drift
+    from mcp_server.infrastructure.config import WIKI_ROOT
+
+    out: dict[str, Any] = {}
+    chunks = (
+        store.iter_memories_for_decay()
+        if hasattr(store, "iter_memories_for_decay")
+        else [store.get_all_memories_for_decay()]
+    )
+    out["cluster_jobs"] = count_pending_clusters_streamed(chunks, wiki_root=str(WIKI_ROOT))
+
+    coverages = audit_all_domains(str(WIKI_ROOT))
+    out["coverage_gaps"] = sum(c.missing_count for c in coverages)
+
+    # File-level coverage: count files that aren't referenced anywhere
+    # in the wiki. Aggregated across every domain that has a resolvable
+    # source root. This is "nothing left uncovered" measured at the
+    # file granularity.
+    file_rolls = audit_all_file_coverage(str(WIKI_ROOT))
+    out["uncovered_files"] = sum(
+        r.source_file_count - r.covered_file_count for r in file_rolls
+    )
+    out["file_coverage_by_domain"] = [
+        {
+            "domain": r.domain,
+            "covered": r.covered_file_count,
+            "total": r.source_file_count,
+            "ratio": round(r.coverage_ratio, 3),
+        }
+        for r in file_rolls
+    ]
+
+    # Drift: existing pages out of sync with the code or off-template.
+    # Capped at 1000 entries — a wide-open drift backlog doesn't need
+    # to materialise in full here; the curate_wiki call can
+    # re-enumerate when it needs the actual job set.
+    drifts = audit_wiki_drift(str(WIKI_ROOT), _project_source_root, limit=1000)
+    out["drifted_pages"] = len(drifts)
+
+    out["pending_total"] = (
+        out["cluster_jobs"]
+        + out["coverage_gaps"]
+        + out["uncovered_files"]
+        + out["drifted_pages"]
+    )
+    return out

--- a/mcp_server/handlers/consolidation/wiki_maintenance.py
+++ b/mcp_server/handlers/consolidation/wiki_maintenance.py
@@ -127,6 +127,7 @@ async def run_wiki_maintenance(
     apply_stubs: bool = _AUTONOMOUS_STUB_APPLY_DEFAULT,
     apply_classifier_rejects: bool = _AUTONOMOUS_CLASSIFIER_APPLY_DEFAULT,
     max_purges_per_axis: int | None = MAX_PURGES_PER_CYCLE,
+    source_backfill_dry_run: bool = False,
 ) -> dict[str, Any]:
     """Purge stale wiki pages and report the curation backlog.
 
@@ -140,10 +141,17 @@ async def run_wiki_maintenance(
       * **classifier_rejects** — pages that no longer pass the current
         admission gate.
 
+    Also runs the ADR-0051 STEP 3 primary-source backfill (derives and
+    persists ``documents_primary`` for pages that lack it — see
+    ``consolidation.wiki_source_backfill_pass``). Applies by default,
+    matching the autonomous maintenance policy; ``source_backfill_dry_run``
+    switches it to derive-without-write.
+
     Returns a dict with one stanza per axis (``stub`` / ``classifier``)
     each carrying ``{applied, purged, deferred, cap_reached, ...}`` plus
     a backlog stanza (``coverage_gaps``, ``cluster_jobs``,
-    ``pending_total``).
+    ``pending_total``) and a ``source_backfill`` stanza
+    (``{pages_scanned, primaries_written, by_source, status}``).
     """
     out: dict[str, Any] = {
         "stub": {
@@ -242,57 +250,29 @@ async def run_wiki_maintenance(
         logger.debug("wiki_maintenance: dashboard render failed (non-fatal): %s", exc)
         out["dashboards"] = {"status": f"error: {type(exc).__name__}: {exc}"}
 
+    # Primary-source backfill (ADR-0051 STEP 3). Runs before the backlog
+    # count below so drifts.pending_total (REASON_MISSING_LINK included)
+    # reflects pages still unlinked *after* this cycle's backfill, not
+    # before it.
+    try:
+        from mcp_server.handlers.consolidation.wiki_source_backfill_pass import (
+            run_source_backfill_pass,
+        )
+
+        out["source_backfill"] = await run_source_backfill_pass(
+            store, apply=not source_backfill_dry_run
+        )
+    except Exception as exc:
+        logger.warning("wiki_maintenance: source backfill failed (non-fatal): %s", exc)
+        out["source_backfill"] = {"status": f"error: {type(exc).__name__}: {exc}"}
+        if out["status"] == "ok":
+            out["status"] = f"source_backfill_error: {type(exc).__name__}: {exc}"
+
     # Curation backlog.
     try:
-        from mcp_server.core.auto_curator import count_pending_clusters_streamed
-        from mcp_server.core.wiki_coverage import (
-            _project_source_root,
-            audit_all_domains,
-            audit_all_file_coverage,
-        )
-        from mcp_server.core.wiki_drift import audit_wiki_drift
-        from mcp_server.infrastructure.config import WIKI_ROOT
+        from mcp_server.handlers.consolidation.wiki_backlog_pass import run_backlog_pass
 
-        chunks = (
-            store.iter_memories_for_decay()
-            if hasattr(store, "iter_memories_for_decay")
-            else [store.get_all_memories_for_decay()]
-        )
-        out["cluster_jobs"] = count_pending_clusters_streamed(
-            chunks, wiki_root=str(WIKI_ROOT)
-        )
-        coverages = audit_all_domains(str(WIKI_ROOT))
-        out["coverage_gaps"] = sum(c.missing_count for c in coverages)
-        # File-level coverage: count files that aren't referenced
-        # anywhere in the wiki. Aggregated across every domain that has
-        # a resolvable source root. This is "nothing left uncovered"
-        # measured at the file granularity.
-        file_rolls = audit_all_file_coverage(str(WIKI_ROOT))
-        out["uncovered_files"] = sum(
-            r.source_file_count - r.covered_file_count for r in file_rolls
-        )
-        out["file_coverage_by_domain"] = [
-            {
-                "domain": r.domain,
-                "covered": r.covered_file_count,
-                "total": r.source_file_count,
-                "ratio": round(r.coverage_ratio, 3),
-            }
-            for r in file_rolls
-        ]
-        # Drift: existing pages out of sync with the code or
-        # off-template. Capped at 1000 entries — a wide-open drift
-        # backlog doesn't need to materialise in full here; the
-        # curate_wiki call can re-enumerate when it needs the actual
-        # job set.
-        drifts = audit_wiki_drift(str(WIKI_ROOT), _project_source_root, limit=1000)
-        out["drifted_pages"] = len(drifts)
-        out["pending_total"] = (
-            out["cluster_jobs"]
-            + out["coverage_gaps"]
-            + out["uncovered_files"]
-            + out["drifted_pages"]
-        )
+        out.update(await run_backlog_pass(store))
     except Exception as exc:
         logger.debug("wiki_maintenance: backlog count failed (non-fatal): %s", exc)
         if out["status"] == "ok":

--- a/mcp_server/handlers/consolidation/wiki_source_backfill_pass.py
+++ b/mcp_server/handlers/consolidation/wiki_source_backfill_pass.py
@@ -1,0 +1,113 @@
+"""Backfill pass: derive + persist primary wiki page -> source-file links
+for pages whose frontmatter never declared one (ADR-0051 STEP 3).
+
+Composition root — wires ``core.wiki_source_backfill`` (pure derivation)
+to infrastructure (DB reads/writes via ``pg_store_wiki_sources`` /
+``pg_store_wiki_thermo``, filesystem existence checks via
+``wiki_drift._file_exists_under``) under ``run_wiki_maintenance``'s
+non-fatal try/except contract. Split out of ``wiki_maintenance.py`` to
+keep both files under the 300-line cap (coding-standards.md §4.1).
+
+Scope: strictly the primary ``'documents'`` link_kind. Persisting
+``'references'`` (the per-page cited-symbol graph ``wiki_consolidate``
+already computes and discards) is Étape 4 — out of scope here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# Per-cycle scan cap — mirrors MAX_PURGES_PER_CYCLE's rationale in
+# wiki_maintenance.py: bounds one consolidate cycle's cost; pages left
+# over are picked up by the next cycle (list_pages_missing_source_link
+# only returns pages that are STILL unlinked, so nothing is skipped).
+DEFAULT_BACKFILL_LIMIT = 500
+
+
+def _build_exists_fn(source_root: str | None) -> Callable[[str], bool]:
+    if source_root is None:
+        return lambda _path: False
+    from mcp_server.core.wiki_drift import _file_exists_under
+
+    return lambda path: _file_exists_under(source_root, path)
+
+
+def _resolve_source_root(domain: str) -> str | None:
+    from mcp_server.core.wiki_coverage import _project_source_root
+
+    return _project_source_root(domain)
+
+
+def _process_one_page(
+    conn: Any, page: dict[str, Any], claim_files: list[str], *, apply: bool, out: dict[str, Any]
+) -> None:
+    """Derive one page's primary source and, if found, persist it."""
+    from mcp_server.core.wiki_source_backfill import derive_primary_source
+    from mcp_server.infrastructure.pg_store_wiki_sources import upsert_page_sources
+
+    exists_fn = _build_exists_fn(_resolve_source_root(str(page.get("domain") or "")))
+    result = derive_primary_source(page, claim_files, exists_fn)
+    if result is None:
+        return
+    path, tag = result
+    out["by_source"][tag] = out["by_source"].get(tag, 0) + 1
+    out["primaries_written"] += 1
+    if not apply:
+        return
+    upsert_page_sources(conn, page["id"], [path], link_kind="documents", source=tag)
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE wiki.pages SET documents_primary = %s WHERE id = %s",
+            (path, page["id"]),
+        )
+
+
+async def run_source_backfill_pass(
+    store: Any, *, apply: bool = True, limit: int = DEFAULT_BACKFILL_LIMIT
+) -> dict[str, Any]:
+    """Derive and persist ``documents_primary`` for pages that lack one.
+
+    Pre-condition:  ``store`` exposes ``batch_pool``
+                    (``psycopg_pool.ConnectionPool``) — the long-running
+                    writer pool, matching how ``consolidate`` already
+                    borrows connections for other maintenance sweeps.
+    Post-condition: for every scanned page where
+                    ``core.wiki_source_backfill.derive_primary_source``
+                    finds an unambiguous candidate, ``wiki.page_sources``
+                    carries one ``link_kind='documents'`` row for that
+                    page and ``wiki.pages.documents_primary`` equals that
+                    path, IFF ``apply`` is True. ``apply=False`` performs
+                    the same derivation without writing (dry run) — the
+                    returned counts are identical either way.
+    """
+    from mcp_server.infrastructure.pg_store_wiki_sources import (
+        list_pages_missing_source_link,
+    )
+    from mcp_server.infrastructure.pg_store_wiki_thermo import (
+        get_claim_file_refs_for_pages,
+    )
+
+    out: dict[str, Any] = {
+        "pages_scanned": 0,
+        "primaries_written": 0,
+        "by_source": {},
+        "status": "ok",
+    }
+    try:
+        with store.batch_pool.connection() as conn:
+            pages = list_pages_missing_source_link(conn, limit=limit)
+            out["pages_scanned"] = len(pages)
+            if not pages:
+                return out
+            claim_refs = get_claim_file_refs_for_pages(conn, [p["id"] for p in pages])
+            for page in pages:
+                _process_one_page(
+                    conn, page, claim_refs.get(page["id"], []), apply=apply, out=out
+                )
+    except Exception as exc:
+        logger.warning("wiki_source_backfill_pass failed (non-fatal): %s", exc)
+        out["status"] = f"error: {type(exc).__name__}: {exc}"
+    return out

--- a/mcp_server/handlers/consolidation/wiki_source_backfill_pass.py
+++ b/mcp_server/handlers/consolidation/wiki_source_backfill_pass.py
@@ -42,7 +42,12 @@ def _resolve_source_root(domain: str) -> str | None:
 
 
 def _process_one_page(
-    conn: Any, page: dict[str, Any], claim_files: list[str], *, apply: bool, out: dict[str, Any]
+    conn: Any,
+    page: dict[str, Any],
+    claim_files: list[str],
+    *,
+    apply: bool,
+    out: dict[str, Any],
 ) -> None:
     """Derive one page's primary source and, if found, persist it."""
     from mcp_server.core.wiki_source_backfill import derive_primary_source

--- a/mcp_server/handlers/wiki_compile.py
+++ b/mcp_server/handlers/wiki_compile.py
@@ -35,6 +35,7 @@ from mcp_server.infrastructure.pg_store_wiki import (
     upsert_page,
 )
 from mcp_server.infrastructure.wiki_store import write_page
+from mcp_server.shared.wiki_source_paths import extract_document_paths
 
 
 schema = {
@@ -133,6 +134,9 @@ def _publish_one(conn, draft: dict, *, dry_run: bool) -> dict:
     write_page(WIKI_ROOT, rel_path, markdown, mode="replace")
 
     # 2. Build the wiki.pages mirror payload
+    draft_frontmatter = draft.get("frontmatter") or {}
+    draft_tags = draft_frontmatter.get("tags", [])
+    documents = extract_document_paths(draft_frontmatter, draft_tags)
     page_row = {
         "memory_id": draft.get("memory_id"),
         "concept_id": draft.get("concept_id"),
@@ -142,9 +146,9 @@ def _publish_one(conn, draft: dict, *, dry_run: bool) -> dict:
         "title": draft.get("title", "Untitled"),
         "domain": domain,
         "domains": [domain] if domain else [],
-        "tags": (draft.get("frontmatter") or {}).get("tags", []),
-        "audience": (draft.get("frontmatter") or {}).get("audience", []),
-        "requires": (draft.get("frontmatter") or {}).get("requires", []),
+        "tags": draft_tags,
+        "audience": draft_frontmatter.get("audience", []),
+        "requires": draft_frontmatter.get("requires", []),
         "status": frontmatter.get("status", "seedling"),
         "lifecycle_state": frontmatter.get("lifecycle_state", "active"),
         "lead": (draft.get("lead") or "").strip(),
@@ -156,6 +160,8 @@ def _publish_one(conn, draft: dict, *, dry_run: bool) -> dict:
         },
         "body": markdown,
         "body_hash": body_hash(markdown),
+        "documents": documents,
+        "documents_primary": documents[0] if documents else None,
     }
     page_id, was_modified = upsert_page(conn, page_row)
 

--- a/mcp_server/handlers/wiki_consolidate.py
+++ b/mcp_server/handlers/wiki_consolidate.py
@@ -6,7 +6,10 @@ Runs three passes over wiki.pages:
      archived → active on revival).
   2. Staleness brake — pages whose file references no longer exist
      get is_stale=True; pages whose refs all came back get
-     is_stale=False (auto-recovery).
+     is_stale=False (auto-recovery). Also persists the harvested refs
+     as wiki.page_sources rows (link_kind='references', ADR-0051 STEP 4)
+     so the file <-> wiki graph exposes not just the one 'documents'
+     primary but every file a page cites.
   3. Memo every transition for the audit trail.
 
 Modes:
@@ -25,19 +28,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from mcp_server.core.wiki_staleness import (
-    StalenessDecision,
-    evaluate_staleness,
-    harvest_page_refs,
-)
 from mcp_server.core.wiki_thermodynamics import evaluate_page, summarise
+from mcp_server.handlers.wiki_consolidate_staleness import run_staleness_pass
 from mcp_server.infrastructure.config import WIKI_ROOT
 from mcp_server.infrastructure.memory_config import get_memory_settings
 from mcp_server.infrastructure.memory_store import MemoryStore, get_shared_store
 from mcp_server.infrastructure.pg_store_wiki import (
-    apply_staleness_decisions,
     apply_thermo_decisions,
-    get_claim_file_refs_for_pages,
     insert_memo,
     list_pages_for_decay,
 )
@@ -49,13 +46,13 @@ schema = {
         "lifecycle transitions (active → area → archived, archived → active "
         "on revival), and staleness checks for pages whose file references "
         "no longer exist on disk. Phase 4 of the wiki redesign pipeline; "
-        "schedule on a daily/weekly cadence. Mutates wiki.pages and writes "
-        "audit memos. Distinct from `consolidate` (which operates on "
-        "memories, not wiki pages), and from `wiki_purge` (which deletes "
-        "pages failing classifier rules). File-existence checks are sandboxed "
-        "to repo_root. Latency ~1-3s for 5000 pages. Returns "
-        "{pages_evaluated, pages_decayed, transitions, staleness, "
-        "avg_heat_before/after}."
+        "schedule on a daily/weekly cadence. Mutates wiki.pages, wiki.page_sources "
+        "(link_kind='references') and writes audit memos. Distinct from "
+        "`consolidate` (which operates on memories, not wiki pages), and from "
+        "`wiki_purge` (which deletes pages failing classifier rules). "
+        "File-existence checks are sandboxed to repo_root. Latency ~1-3s for "
+        "5000 pages. Returns {pages_evaluated, pages_decayed, transitions, "
+        "staleness (includes references_written), avg_heat_before/after}."
     ),
     "inputSchema": {
         "type": "object",
@@ -120,49 +117,13 @@ def _get_store() -> MemoryStore:
     return get_shared_store(settings.DB_PATH, settings.EMBEDDING_DIM)
 
 
-def _check_existence(refs: set[str], repo_root: Path) -> dict[str, bool]:
-    """Resolve each ref against repo_root; return existence map."""
-    out: dict[str, bool] = {}
-    for ref in refs:
-        ref = ref.strip().rstrip(".,;:")
-        if not ref:
-            continue
-        # Reject absolute paths and traversal — staleness checks must
-        # not escape the repo root (defence against poisoned page text)
-        try:
-            p = Path(ref)
-            if p.is_absolute():
-                out[ref] = False
-                continue
-            target = (repo_root / p).resolve()
-            target.relative_to(repo_root.resolve())
-            out[ref] = target.exists()
-        except (ValueError, OSError):
-            out[ref] = False
-    return out
+def _run_decay_pass(
+    conn: Any, pages: list[dict], now: datetime, *, dry_run: bool
+) -> tuple[Any, int]:
+    """Pass 1: heat decay + lifecycle transitions.
 
-
-async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
-    args = args or {}
-    limit = int(args.get("limit", 5000))
-    dry_run = bool(args.get("dry_run", False))
-    skip_staleness = bool(args.get("skip_staleness", False))
-    include_archived = bool(args.get("include_archived", False))
-    repo_root_arg = args.get("repo_root")
-    repo_root = Path(repo_root_arg) if repo_root_arg else Path.cwd()
-
-    store = _get_store()
-    conn = store._conn
-    now = datetime.now(tz=timezone.utc)
-
-    # ── Pass 1: Decay + lifecycle ─────────────────────────────────────
-    pages = list_pages_for_decay(conn, limit=limit, include_archived=include_archived)
-    if not pages:
-        return {
-            "pages_evaluated": 0,
-            "note": "no eligible pages (no active/area pages exist)",
-        }
-
+    Returns ``(thermo_stats, pages_updated)``.
+    """
     original_heats = {p["id"]: float(p.get("heat") or 0.0) for p in pages}
     decisions = [evaluate_page(p, now=now) for p in pages]
     stats = summarise(decisions, original_heats)
@@ -183,59 +144,36 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
                     confidence=0.9,
                     author="thermo",
                 )
+    return stats, pages_updated
 
-    # ── Pass 2: Staleness ─────────────────────────────────────────────
+
+async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
+    args = args or {}
+    limit = int(args.get("limit", 5000))
+    dry_run = bool(args.get("dry_run", False))
+    skip_staleness = bool(args.get("skip_staleness", False))
+    include_archived = bool(args.get("include_archived", False))
+    repo_root_arg = args.get("repo_root")
+    repo_root = Path(repo_root_arg) if repo_root_arg else Path.cwd()
+
+    store = _get_store()
+    conn = store._conn
+    now = datetime.now(tz=timezone.utc)
+
+    pages = list_pages_for_decay(conn, limit=limit, include_archived=include_archived)
+    if not pages:
+        return {
+            "pages_evaluated": 0,
+            "note": "no eligible pages (no active/area pages exist)",
+        }
+
+    stats, pages_updated = _run_decay_pass(conn, pages, now, dry_run=dry_run)
+
     stale_summary: dict[str, Any] = {"skipped": True}
     if not skip_staleness:
-        page_ids = [p["id"] for p in pages]
-        claim_refs_by_page = get_claim_file_refs_for_pages(conn, page_ids)
-        # Combine claim refs + inline refs per page
-        per_page_refs: dict[int, list[str]] = {}
-        all_refs: set[str] = set()
-        for p in pages:
-            refs = harvest_page_refs(p, claim_refs_by_page.get(p["id"], []))
-            per_page_refs[p["id"]] = refs
-            all_refs.update(refs)
-        existence = _check_existence(all_refs, repo_root)
-
-        stale_decisions: list[StalenessDecision] = []
-        for p in pages:
-            decision = evaluate_staleness(
-                page_id=p["id"],
-                is_stale_was=bool(p.get("is_stale", False)),
-                file_refs=per_page_refs[p["id"]],
-                existence=existence,
-            )
-            stale_decisions.append(decision)
-
-        stale_written = 0
-        if not dry_run:
-            stale_written = apply_staleness_decisions(conn, stale_decisions)
-            for d in stale_decisions:
-                if d.transitioned:
-                    insert_memo(
-                        conn,
-                        subject_type="page",
-                        subject_id=d.page_id,
-                        decision=(
-                            "staleness_set" if d.is_stale_now else "staleness_cleared"
-                        ),
-                        rationale=d.rationale,
-                        inputs={
-                            "missing": d.missing_refs[:10],
-                            "total_refs": len(d.file_refs),
-                        },
-                        confidence=0.8,
-                        author="staleness",
-                    )
-        stale_summary = {
-            "pages_with_refs": sum(1 for d in stale_decisions if d.file_refs),
-            "pages_now_stale": sum(1 for d in stale_decisions if d.is_stale_now),
-            "transitions_written": stale_written,
-            "files_checked": len(existence),
-            "files_missing": sum(1 for v in existence.values() if not v),
-            "skipped": False,
-        }
+        stale_summary = run_staleness_pass(
+            conn, pages, repo_root=repo_root, dry_run=dry_run
+        )
 
     if not dry_run:
         conn.commit()

--- a/mcp_server/handlers/wiki_consolidate_staleness.py
+++ b/mcp_server/handlers/wiki_consolidate_staleness.py
@@ -1,0 +1,192 @@
+"""Wiki Phase 4, Pass 2 — staleness brake + reference-link persistence.
+
+Split out of ``wiki_consolidate.py`` to keep both files under the
+300-line cap and the orchestrator's ``handler()`` under the 50-line cap
+(coding-standards.md §4.1/§4.2). Composition root — wires
+``core.wiki_staleness`` (pure derivation) against ``pg_store_wiki`` /
+``pg_store_wiki_sources`` (persistence). ``wiki_consolidate.handler``
+still owns Pass 1 (decay/lifecycle) and Pass 3 (the final response
+shape); this module owns exactly Pass 2.
+
+ADR-0051 STEP 4: alongside the pre-existing staleness verdict, this pass
+now persists every harvested file ref as a ``wiki.page_sources`` row
+(``link_kind='references'``) so the file <-> wiki graph exposes every
+file a page cites, not just its one 'documents' primary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from mcp_server.core.wiki_staleness import (
+    StalenessDecision,
+    evaluate_staleness,
+    harvest_page_refs_typed,
+    normalize_typed_refs,
+)
+from mcp_server.infrastructure.pg_store_wiki import (
+    apply_staleness_decisions,
+    get_claim_file_refs_for_pages,
+    insert_memo,
+)
+from mcp_server.infrastructure.pg_store_wiki_sources import upsert_page_sources
+
+
+def _check_existence(refs: set[str], repo_root: Path) -> dict[str, bool]:
+    """Resolve each ref against repo_root; return existence map."""
+    out: dict[str, bool] = {}
+    for ref in refs:
+        ref = ref.strip().rstrip(".,;:")
+        if not ref:
+            continue
+        # Reject absolute paths and traversal — staleness checks must
+        # not escape the repo root (defence against poisoned page text)
+        try:
+            p = Path(ref)
+            if p.is_absolute():
+                out[ref] = False
+                continue
+            target = (repo_root / p).resolve()
+            target.relative_to(repo_root.resolve())
+            out[ref] = target.exists()
+        except (ValueError, OSError):
+            out[ref] = False
+    return out
+
+
+def _persist_reference_links(
+    conn: Any, pages: list[dict], per_page_typed_refs: dict[int, dict[str, str]]
+) -> int:
+    """Persist harvested file refs as ``link_kind='references'`` rows.
+
+    One ``upsert_page_sources`` call per page (delete-then-insert scoped
+    to ``(page_id, 'references')`` — see that function's docstring for
+    why this is idempotent). Runs for every page in this cycle's batch,
+    not just pages with refs: a page whose refs dropped to zero must
+    still have its stale rows cleared, which the empty-list branch of
+    ``upsert_page_sources`` already does.
+
+    Decision (ADR-0051 STEP 4): confidence is left at the function
+    default (1.0) for every row regardless of origin (claim_evidence vs
+    body). ``wiki_source_backfill_pass.py`` sets the same uniform 1.0
+    across its own three origin tags for 'documents' — there is no
+    existing precedent or measured basis (coding-standards.md §8) for a
+    differentiated per-origin confidence, so inventing one here would be
+    an unsourced constant. ``source`` (the origin tag) is still recorded
+    per-row and is what a future differentiation would key off.
+
+    Pre-condition:  every dict in ``per_page_typed_refs`` maps a page id
+                    (present in ``pages``) to a raw (pre-normalization)
+                    path -> origin mapping, as returned by
+                    ``harvest_page_refs_typed``.
+    Post-condition: for every page, wiki.page_sources' 'references' rows
+                    equal exactly the normalized (deduplicated,
+                    claim-wins) set of that page's harvested refs; no
+                    stale 'references' row from a prior cycle survives.
+
+    Returns the total number of rows written across all pages.
+    """
+    written = 0
+    for p in pages:
+        normalized = normalize_typed_refs(per_page_typed_refs[p["id"]])
+        entries = sorted(normalized.items())
+        written += upsert_page_sources(conn, p["id"], entries, link_kind="references")
+    return written
+
+
+def _harvest_all_pages(
+    conn: Any, pages: list[dict]
+) -> tuple[dict[int, dict[str, str]], dict[int, list[str]], set[str]]:
+    """Harvest typed refs for every page; return (typed, plain, all-refs-union).
+
+    Keeping per-path provenance (the first return value) lets the caller
+    both check staleness (the plain sorted-list form) and persist
+    'references' rows (path + origin) from one harvest pass.
+    """
+    claim_refs_by_page = get_claim_file_refs_for_pages(
+        conn, [p["id"] for p in pages]
+    )
+    per_page_typed: dict[int, dict[str, str]] = {}
+    per_page_plain: dict[int, list[str]] = {}
+    all_refs: set[str] = set()
+    for p in pages:
+        typed = harvest_page_refs_typed(p, claim_refs_by_page.get(p["id"], []))
+        per_page_typed[p["id"]] = typed
+        refs = sorted(typed)
+        per_page_plain[p["id"]] = refs
+        all_refs.update(refs)
+    return per_page_typed, per_page_plain, all_refs
+
+
+def _memo_staleness_transitions(conn: Any, stale_decisions: list[StalenessDecision]) -> None:
+    """Audit-trail memo for each staleness transition (set or cleared)."""
+    for d in stale_decisions:
+        if not d.transitioned:
+            continue
+        insert_memo(
+            conn,
+            subject_type="page",
+            subject_id=d.page_id,
+            decision="staleness_set" if d.is_stale_now else "staleness_cleared",
+            rationale=d.rationale,
+            inputs={"missing": d.missing_refs[:10], "total_refs": len(d.file_refs)},
+            confidence=0.8,
+            author="staleness",
+        )
+
+
+def run_staleness_pass(
+    conn: Any,
+    pages: list[dict],
+    *,
+    repo_root: Path,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Evaluate staleness for ``pages`` and, if not ``dry_run``, persist it.
+
+    Pre-condition:  ``pages`` is the same page batch Pass 1 evaluated
+                    this cycle (each dict carries at least id, lead,
+                    sections, is_stale).
+    Post-condition: when ``dry_run`` is False, wiki.pages.is_stale
+                    reflects each page's verdict and wiki.page_sources
+                    carries that page's current 'references' rows;
+                    when True, no row is written and the returned
+                    summary still reflects what *would* be written.
+
+    Returns the ``staleness`` summary dict for the handler's response.
+    """
+    per_page_typed_refs, per_page_refs, all_refs = _harvest_all_pages(conn, pages)
+    existence = _check_existence(all_refs, repo_root)
+
+    stale_decisions: list[StalenessDecision] = [
+        evaluate_staleness(
+            page_id=p["id"],
+            is_stale_was=bool(p.get("is_stale", False)),
+            file_refs=per_page_refs[p["id"]],
+            existence=existence,
+        )
+        for p in pages
+    ]
+
+    stale_written = 0
+    references_written = 0
+    if not dry_run:
+        stale_written = apply_staleness_decisions(conn, stale_decisions)
+        _memo_staleness_transitions(conn, stale_decisions)
+        references_written = _persist_reference_links(
+            conn, pages, per_page_typed_refs
+        )
+
+    return {
+        "pages_with_refs": sum(1 for d in stale_decisions if d.file_refs),
+        "pages_now_stale": sum(1 for d in stale_decisions if d.is_stale_now),
+        "transitions_written": stale_written,
+        "references_written": references_written,
+        "files_checked": len(existence),
+        "files_missing": sum(1 for v in existence.values() if not v),
+        "skipped": False,
+    }
+
+
+__all__ = ["run_staleness_pass"]

--- a/mcp_server/handlers/wiki_consolidate_staleness.py
+++ b/mcp_server/handlers/wiki_consolidate_staleness.py
@@ -104,9 +104,7 @@ def _harvest_all_pages(
     both check staleness (the plain sorted-list form) and persist
     'references' rows (path + origin) from one harvest pass.
     """
-    claim_refs_by_page = get_claim_file_refs_for_pages(
-        conn, [p["id"] for p in pages]
-    )
+    claim_refs_by_page = get_claim_file_refs_for_pages(conn, [p["id"] for p in pages])
     per_page_typed: dict[int, dict[str, str]] = {}
     per_page_plain: dict[int, list[str]] = {}
     all_refs: set[str] = set()
@@ -119,7 +117,9 @@ def _harvest_all_pages(
     return per_page_typed, per_page_plain, all_refs
 
 
-def _memo_staleness_transitions(conn: Any, stale_decisions: list[StalenessDecision]) -> None:
+def _memo_staleness_transitions(
+    conn: Any, stale_decisions: list[StalenessDecision]
+) -> None:
     """Audit-trail memo for each staleness transition (set or cleared)."""
     for d in stale_decisions:
         if not d.transitioned:
@@ -174,9 +174,7 @@ def run_staleness_pass(
     if not dry_run:
         stale_written = apply_staleness_decisions(conn, stale_decisions)
         _memo_staleness_transitions(conn, stale_decisions)
-        references_written = _persist_reference_links(
-            conn, pages, per_page_typed_refs
-        )
+        references_written = _persist_reference_links(conn, pages, per_page_typed_refs)
 
     return {
         "pages_with_refs": sum(1 for d in stale_decisions if d.file_refs),

--- a/mcp_server/handlers/wiki_migrate.py
+++ b/mcp_server/handlers/wiki_migrate.py
@@ -25,6 +25,7 @@ from mcp_server.infrastructure.pg_store_wiki import (
     upsert_page,
 )
 from mcp_server.infrastructure.wiki_store import list_pages, read_page
+from mcp_server.shared.wiki_source_paths import extract_document_paths
 
 # Wiki-link syntax: [[slug]] or [[slug|display text]]
 _WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
@@ -82,6 +83,11 @@ def _page_row_from_md(
     if isinstance(tags, str):
         tags = [tags]
 
+    # ADR-0051 STEP 2: extract every legacy documented-file form
+    # (documents:/source_file_path:/file:/file:<path> tag) into the
+    # canonical list. documents_primary is the 1:1 fast-path scalar.
+    documents = extract_document_paths(fm, tags)
+
     return {
         "memory_id": memory_id,
         "rel_path": rel_path,
@@ -102,6 +108,8 @@ def _page_row_from_md(
         "sections": sections,
         "body": body,
         "body_hash": body_hash(body),
+        "documents": documents,
+        "documents_primary": documents[0] if documents else None,
     }
 
 

--- a/mcp_server/infrastructure/pg_schema.py
+++ b/mcp_server/infrastructure/pg_schema.py
@@ -235,6 +235,12 @@ CREATE TABLE IF NOT EXISTS wiki.pages (
     id              SERIAL PRIMARY KEY,
     memory_id       INTEGER UNIQUE REFERENCES memories(id) ON DELETE SET NULL,
     concept_id      BIGINT REFERENCES wiki.concepts(id) ON DELETE SET NULL,
+    -- Denormalized 1:1 fast-path mirror of wiki.page_sources for the
+    -- dominant single-file-doc case: keeps the recall hot path join-free
+    -- (see "ZERO joins from recall hot path" invariant above). NULL for
+    -- pages that document zero or many files; wiki.page_sources is the
+    -- source of truth for the N:M case. ADR-0051.
+    documents_primary TEXT,
     rel_path        TEXT UNIQUE NOT NULL,
     slug            TEXT NOT NULL,
     kind            TEXT NOT NULL,
@@ -294,6 +300,29 @@ CREATE TABLE IF NOT EXISTS wiki.citations (
     cited_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- page_sources: N:M edge from a wiki page to the source file(s) it
+-- documents. General model — an anchor/scope page can document many
+-- files, and (rarely) a file can be documented by more than one page
+-- (e.g. a module overview plus a deep-dive). Populated from frontmatter
+-- (`documents:`/legacy `source_file_path`/`file`/`file:` tag) and from
+-- wiki.claim_events.evidence_refs (kind='file'). Mirrors wiki.links'
+-- shape (src table row -> target key, typed by link_kind).
+-- Downstream consumer: cortex-viz wiki-page -> source-file edges.
+-- ADR-0051.
+CREATE TABLE IF NOT EXISTS wiki.page_sources (
+    page_id         INTEGER NOT NULL REFERENCES wiki.pages(id) ON DELETE CASCADE,
+    source_path     TEXT NOT NULL,
+    symbol          TEXT,
+    link_kind       TEXT NOT NULL DEFAULT 'documents'
+                    CHECK (link_kind IN ('documents','references','derived')),
+    confidence      REAL NOT NULL DEFAULT 1.0,
+    source          TEXT NOT NULL DEFAULT 'frontmatter'
+                    CHECK (source IN (
+                      'frontmatter','claim_evidence','body','codebase_grounding'
+                    )),
+    PRIMARY KEY (page_id, source_path, link_kind)
+);
+
 -- memos: the grounded-theory audit trail. Every curation decision
 -- (merge, split, promote, abandon, reclassify) writes one row with
 -- its inputs, rationale, alternatives considered, and confidence.
@@ -349,6 +378,11 @@ CREATE INDEX IF NOT EXISTS idx_wiki_links_dst
     ON wiki.links (dst_page_id) WHERE dst_page_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_wiki_links_dst_slug
     ON wiki.links (dst_slug);
+
+-- Reverse index: file -> page(s) documenting it. The query the viz
+-- edge-builder actually runs.
+CREATE INDEX IF NOT EXISTS idx_wiki_page_sources_path
+    ON wiki.page_sources (source_path);
 
 CREATE INDEX IF NOT EXISTS idx_wiki_citations_page_time
     ON wiki.citations (page_id, cited_at DESC);
@@ -1915,6 +1949,22 @@ DO $$ BEGIN
             ADD CONSTRAINT injection_receipts_channel_enum CHECK (
                 channel IN ('recall', 'session_start', 'auto_recall', 'agent_briefing')
             );
+    END IF;
+END $$;
+
+-- Migration: add wiki.pages.documents_primary for DBs provisioned before
+-- ADR-0051 (wiki.page_sources is created fresh via CREATE TABLE IF NOT
+-- EXISTS above and needs no guard; this column was added to an
+-- already-existing table). table_schema qualifies the lookup since
+-- information_schema.columns is not schema-scoped by default.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'wiki' AND table_name = 'pages'
+          AND column_name = 'documents_primary'
+    ) THEN
+        ALTER TABLE wiki.pages ADD COLUMN documents_primary TEXT;
     END IF;
 END $$;
 """

--- a/mcp_server/infrastructure/pg_store_wiki.py
+++ b/mcp_server/infrastructure/pg_store_wiki.py
@@ -9,882 +9,100 @@ or body_hash). Triggers on wiki.links and wiki.citations maintain the
 denormalised counters on wiki.pages.
 
 Pure infrastructure — no core imports, no handler imports.
+
+This module is now a thin re-export facade: the implementation was split
+across sibling ``pg_store_wiki_*`` modules (pages / links / claims /
+thermo / concepts / drafts / notes / common) to satisfy the 300-line
+file limit (CLAUDE.md "Code Quality Rules") — originally 890 lines.
+Every name below is re-exported verbatim so existing importers
+(``from mcp_server.infrastructure.pg_store_wiki import X``) keep working
+unchanged. No logic changed.
 """
 
 from __future__ import annotations
 
-import hashlib
-import json
-from typing import Any
-
-from psycopg import Connection
-from psycopg.rows import dict_row
-
+from mcp_server.infrastructure.pg_store_wiki_claims import (
+    delete_claims_for_memory,
+    get_claims_by_entity,
+    get_claims_for_memory,
+    get_entities_by_memory,
+    get_entity_name_index,
+    insert_claim_events,
+    update_claim_entities,
+    update_claim_supersedes,
+)
+from mcp_server.infrastructure.pg_store_wiki_common import body_hash
+from mcp_server.infrastructure.pg_store_wiki_concepts import (
+    get_concepts_by_entity_overlap,
+    insert_concept,
+    list_concepts,
+    update_concept,
+)
+from mcp_server.infrastructure.pg_store_wiki_drafts import (
+    find_draft_for_source,
+    get_draft,
+    insert_draft,
+    list_drafts,
+    update_draft,
+    update_draft_status,
+)
+from mcp_server.infrastructure.pg_store_wiki_links import (
+    delete_links_from,
+    get_backlinks,
+    resolve_unresolved_links,
+    upsert_link,
+)
+from mcp_server.infrastructure.pg_store_wiki_notes import (
+    insert_citation,
+    insert_memo,
+    wiki_stats,
+)
+from mcp_server.infrastructure.pg_store_wiki_pages import (
+    get_page_by_rel_path,
+    get_page_by_slug,
+    upsert_page,
+)
 from mcp_server.infrastructure.pg_store_wiki_sources import upsert_page_sources
-
-
-# ── Hashing helper ─────────────────────────────────────────────────────
-
-
-def body_hash(body: str) -> str:
-    """Deterministic hash of a page body — drives idempotent upserts."""
-    return hashlib.sha256(body.encode("utf-8")).hexdigest()
-
-
-def _returning_id(row: dict[str, Any] | tuple[Any, ...] | None) -> int:
-    """Extract the id from an ``INSERT ... RETURNING id`` fetchone() result.
-
-    A default psycopg cursor yields tuple rows; a ``dict_row`` cursor yields
-    dict rows — hence the isinstance split. An INSERT ... RETURNING always
-    produces exactly one row, so a None here is a broken query (or a silently
-    rolled-back transaction), not a normal path — surface it loudly.
-    """
-    if row is None:
-        raise RuntimeError("INSERT ... RETURNING id produced no row")
-    return row["id"] if isinstance(row, dict) else row[0]
-
-
-# ── wiki.pages ─────────────────────────────────────────────────────────
-
-
-def upsert_page(conn: Connection, page: dict[str, Any]) -> tuple[int, bool]:
-    """Upsert a page row by rel_path.
-
-    Returns ``(page_id, was_modified)`` where ``was_modified`` is True
-    when the row was inserted or actually updated, False when the
-    body_hash matched and nothing changed.
-
-    Required fields: rel_path, slug, kind, title.
-    Optional: all other columns, including ``documents`` (list of
-    canonical source-file paths — ADR-0051) and ``documents_primary``
-    (defaults to the first entry of ``documents`` when omitted).
-    ``wiki.page_sources`` is refreshed unconditionally (even on a
-    body_hash no-op) so a frontmatter-only edit still lands, matching
-    how ``wiki.links`` is refreshed independently of body_hash in
-    ``wiki_migrate.migrate_wiki``.
-    """
-    required = ("rel_path", "slug", "kind", "title")
-    for k in required:
-        if k not in page:
-            raise ValueError(f"upsert_page missing required field: {k}")
-
-    body = page.get("body", "")
-    bh = page.get("body_hash") or body_hash(body)
-    documents = page.get("documents") or []
-    documents_primary = page.get("documents_primary") or (
-        documents[0] if documents else None
-    )
-
-    # Use xmax=0 (Postgres trick) to detect INSERT vs UPDATE: xmax is 0
-    # only on a fresh INSERT. We also OR in body_hash equality to detect
-    # no-op updates that the WHERE clause filtered out.
-    sql = """
-    INSERT INTO wiki.pages (
-        memory_id, concept_id, rel_path, slug, kind, title, domain, domains,
-        tags, audience, requires, status, lifecycle_state, supersedes,
-        superseded_by, verified, lead, sections, body_hash, documents_primary
-    ) VALUES (
-        %(memory_id)s, %(concept_id)s, %(rel_path)s, %(slug)s, %(kind)s,
-        %(title)s, %(domain)s, %(domains)s::jsonb, %(tags)s::jsonb,
-        %(audience)s::jsonb, %(requires)s::jsonb, %(status)s,
-        %(lifecycle_state)s, %(supersedes)s, %(superseded_by)s, %(verified)s,
-        %(lead)s, %(sections)s::jsonb, %(body_hash)s, %(documents_primary)s
-    )
-    ON CONFLICT (rel_path) DO UPDATE SET
-        memory_id = EXCLUDED.memory_id,
-        concept_id = EXCLUDED.concept_id,
-        slug = EXCLUDED.slug,
-        kind = EXCLUDED.kind,
-        title = EXCLUDED.title,
-        domain = EXCLUDED.domain,
-        domains = EXCLUDED.domains,
-        tags = EXCLUDED.tags,
-        audience = EXCLUDED.audience,
-        requires = EXCLUDED.requires,
-        status = EXCLUDED.status,
-        lifecycle_state = EXCLUDED.lifecycle_state,
-        supersedes = EXCLUDED.supersedes,
-        superseded_by = EXCLUDED.superseded_by,
-        verified = EXCLUDED.verified,
-        lead = EXCLUDED.lead,
-        sections = EXCLUDED.sections,
-        body_hash = EXCLUDED.body_hash,
-        documents_primary = EXCLUDED.documents_primary,
-        tended = NOW()
-    WHERE wiki.pages.body_hash <> EXCLUDED.body_hash
-       OR wiki.pages.documents_primary IS DISTINCT FROM EXCLUDED.documents_primary
-    RETURNING id, (xmax = 0) AS inserted;
-    """
-    params = {
-        "memory_id": page.get("memory_id"),
-        "concept_id": page.get("concept_id"),
-        "rel_path": page["rel_path"],
-        "slug": page["slug"],
-        "kind": page["kind"],
-        "title": page["title"],
-        "domain": page.get("domain", ""),
-        "domains": json.dumps(page.get("domains", [])),
-        "tags": json.dumps(page.get("tags", [])),
-        "audience": json.dumps(page.get("audience", [])),
-        "requires": json.dumps(page.get("requires", [])),
-        "status": page.get("status", "seedling"),
-        "lifecycle_state": page.get("lifecycle_state", "active"),
-        "supersedes": page.get("supersedes"),
-        "superseded_by": page.get("superseded_by"),
-        "verified": page.get("verified"),
-        "lead": page.get("lead", ""),
-        "sections": json.dumps(page.get("sections", {})),
-        "body_hash": bh,
-        "documents_primary": documents_primary,
-    }
-    with conn.cursor() as cur:
-        cur.execute(sql, params)
-        row = cur.fetchone()
-        if row is not None:
-            # Row was inserted or actually updated.
-            page_id = row["id"] if isinstance(row, dict) else row[0]
-            upsert_page_sources(conn, page_id, documents)
-            return page_id, True
-        # WHERE clause filtered the UPDATE out → body_hash matched, no-op.
-        cur.execute(
-            "SELECT id FROM wiki.pages WHERE rel_path = %s", (page["rel_path"],)
-        )
-        existing = cur.fetchone()
-        if existing is None:
-            return -1, False
-        existing_id = existing["id"] if isinstance(existing, dict) else existing[0]
-        upsert_page_sources(conn, existing_id, documents)
-        return existing_id, False
-
-
-def get_page_by_slug(conn: Connection, slug: str) -> dict | None:
-    """Return a page row by slug, or None."""
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute("SELECT * FROM wiki.pages WHERE slug = %s LIMIT 1", (slug,))
-        return cur.fetchone()
-
-
-def get_page_by_rel_path(conn: Connection, rel_path: str) -> dict | None:
-    """Return a page row by rel_path, or None."""
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute("SELECT * FROM wiki.pages WHERE rel_path = %s LIMIT 1", (rel_path,))
-        return cur.fetchone()
-
-
-# ── wiki.links ─────────────────────────────────────────────────────────
-
-
-def upsert_link(
-    conn: Connection,
-    src_page_id: int,
-    dst_slug: str,
-    link_kind: str = "see-also",
-    dst_page_id: int | None = None,
-) -> None:
-    """Insert a link, resolving dst_page_id by slug if not provided.
-
-    ON CONFLICT DO UPDATE lets a stale dst_page_id be refreshed when
-    the target page appears later.
-    """
-    if dst_page_id is None:
-        p = get_page_by_slug(conn, dst_slug)
-        dst_page_id = p["id"] if p else None
-
-    sql = """
-    INSERT INTO wiki.links (src_page_id, dst_slug, dst_page_id, link_kind)
-    VALUES (%s, %s, %s, %s)
-    ON CONFLICT (src_page_id, dst_slug, link_kind) DO UPDATE SET
-        dst_page_id = EXCLUDED.dst_page_id
-    WHERE wiki.links.dst_page_id IS DISTINCT FROM EXCLUDED.dst_page_id;
-    """
-    with conn.cursor() as cur:
-        cur.execute(sql, (src_page_id, dst_slug, dst_page_id, link_kind))
-
-
-def delete_links_from(conn: Connection, src_page_id: int) -> int:
-    """Remove all outgoing links from a page (used before re-indexing)."""
-    with conn.cursor() as cur:
-        cur.execute("DELETE FROM wiki.links WHERE src_page_id = %s", (src_page_id,))
-        return cur.rowcount
-
-
-def get_backlinks(conn: Connection, dst_page_id: int) -> list[dict]:
-    """Return rows linking TO this page."""
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(
-            """
-            SELECT l.*, p.title AS src_title, p.rel_path AS src_rel_path
-              FROM wiki.links l
-              JOIN wiki.pages p ON p.id = l.src_page_id
-             WHERE l.dst_page_id = %s
-            """,
-            (dst_page_id,),
-        )
-        return list(cur.fetchall())
-
-
-def resolve_unresolved_links(conn: Connection) -> int:
-    """Second-pass link resolution: fill in dst_page_id for links whose
-    target didn't exist at insert time. Returns rows updated."""
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            UPDATE wiki.links l
-               SET dst_page_id = p.id
-              FROM wiki.pages p
-             WHERE p.slug = l.dst_slug
-               AND l.dst_page_id IS NULL
-            """
-        )
-        return cur.rowcount
-
-
-# ── wiki.claim_events ──────────────────────────────────────────────────
-
-
-def insert_claim_events(conn: Connection, claims: list[dict]) -> list[int]:
-    """Bulk insert ClaimEvent rows. Returns the new ids in order.
-
-    Each ``claims`` dict requires: ``text``, ``claim_type``. Optional:
-    memory_id, session_id, entity_ids, evidence_refs, confidence,
-    supersedes, embedding (vector or None).
-
-    All inserted in one cursor cycle for throughput.
-    """
-    if not claims:
-        return []
-
-    sql = """
-    INSERT INTO wiki.claim_events (
-        memory_id, session_id, text, claim_type, entity_ids,
-        evidence_refs, confidence, supersedes
-    ) VALUES (
-        %(memory_id)s, %(session_id)s, %(text)s, %(claim_type)s,
-        %(entity_ids)s, %(evidence_refs)s::jsonb, %(confidence)s,
-        %(supersedes)s
-    ) RETURNING id;
-    """
-    out: list[int] = []
-    with conn.cursor() as cur:
-        for c in claims:
-            params = {
-                "memory_id": c.get("memory_id"),
-                "session_id": c.get("session_id", ""),
-                "text": c["text"][:1900],
-                "claim_type": c.get("claim_type", "assertion"),
-                "entity_ids": c.get("entity_ids", []),
-                "evidence_refs": json.dumps(c.get("evidence_refs", [])),
-                "confidence": c.get("confidence", 0.5),
-                "supersedes": c.get("supersedes"),
-            }
-            cur.execute(sql, params)
-            out.append(_returning_id(cur.fetchone()))
-    return out
-
-
-def delete_claims_for_memory(conn: Connection, memory_id: int) -> int:
-    """Remove all claim_events derived from a single memory.
-
-    Used before re-extraction to keep the table clean of stale claims.
-    """
-    with conn.cursor() as cur:
-        cur.execute("DELETE FROM wiki.claim_events WHERE memory_id = %s", (memory_id,))
-        return cur.rowcount
-
-
-def get_claims_for_memory(conn: Connection, memory_id: int) -> list[dict]:
-    """Return all claim_events derived from a single memory."""
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(
-            "SELECT * FROM wiki.claim_events WHERE memory_id = %s ORDER BY id",
-            (memory_id,),
-        )
-        return list(cur.fetchall())
-
-
-def get_entities_by_memory(
-    conn: Connection, memory_ids: list[int]
-) -> dict[int, list[int]]:
-    """Pre-fetch memory_id → list[entity_id] for a batch of memories."""
-    if not memory_ids:
-        return {}
-    with conn.cursor() as cur:
-        cur.execute(
-            "SELECT memory_id, entity_id FROM memory_entities "
-            "WHERE memory_id = ANY(%s)",
-            (list(memory_ids),),
-        )
-        rows = cur.fetchall()
-    out: dict[int, list[int]] = {}
-    for r in rows:
-        if isinstance(r, dict):
-            mid, eid = r["memory_id"], r["entity_id"]
-        else:
-            mid, eid = r[0], r[1]
-        out.setdefault(mid, []).append(eid)
-    return out
-
-
-def get_entity_name_index(conn: Connection, limit: int = 5000) -> dict[str, int]:
-    """Return name → entity_id map for inline-mention matching.
-
-    Limit caps the index size for in-memory matching against claim text.
-    Heat-ranked so the most frequently-touched entities win.
-    """
-    with conn.cursor() as cur:
-        cur.execute(
-            "SELECT name, id FROM entities ORDER BY heat DESC NULLS LAST LIMIT %s",
-            (limit,),
-        )
-        rows = cur.fetchall()
-    out: dict[str, int] = {}
-    for r in rows:
-        if isinstance(r, dict):
-            name, eid = r["name"], r["id"]
-        else:
-            name, eid = r[0], r[1]
-        if name and len(name) >= 3:
-            out[name] = eid
-    return out
-
-
-def get_claims_by_entity(
-    conn: Connection,
-    entity_ids: list[int],
-    exclude_claim_ids: list[int] | None = None,
-) -> dict[int, list[dict]]:
-    """For each entity_id, fetch claims that already reference it.
-
-    Used by the resolver to find supersedes / conflict candidates.
-    Excludes the claims being resolved (avoid self-matches).
-    """
-    if not entity_ids:
-        return {}
-    excl = exclude_claim_ids or []
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(
-            """
-            SELECT id, memory_id, text, claim_type, entity_ids, supersedes,
-                   extracted_at
-              FROM wiki.claim_events
-             WHERE entity_ids && %s::int[]
-               AND (%s::bigint[] IS NULL OR NOT (id = ANY(%s::bigint[])))
-            """,
-            (list(entity_ids), excl or None, excl or None),
-        )
-        rows = list(cur.fetchall())
-    out: dict[int, list[dict]] = {}
-    for r in rows:
-        # entity_ids returns as a list already (PG INT[] → Python list)
-        for eid in r.get("entity_ids") or []:
-            if eid in entity_ids:
-                out.setdefault(eid, []).append(r)
-    return out
-
-
-def update_claim_entities(
-    conn: Connection, updates: list[tuple[int, list[int]]]
-) -> int:
-    """Bulk update wiki.claim_events.entity_ids. Returns rows updated.
-
-    Idempotent: only writes when the new list differs from the current.
-    """
-    if not updates:
-        return 0
-    written = 0
-    with conn.cursor() as cur:
-        for claim_id, eids in updates:
-            cur.execute(
-                """
-                UPDATE wiki.claim_events
-                   SET entity_ids = %s::int[]
-                 WHERE id = %s
-                   AND entity_ids IS DISTINCT FROM %s::int[]
-                """,
-                (eids, claim_id, eids),
-            )
-            written += cur.rowcount
-    return written
-
-
-def update_claim_supersedes(conn: Connection, updates: list[tuple[int, int]]) -> int:
-    """Bulk update wiki.claim_events.supersedes. Returns rows updated.
-
-    ``updates`` is [(new_claim_id, superseded_claim_id), ...].
-    """
-    if not updates:
-        return 0
-    written = 0
-    with conn.cursor() as cur:
-        for new_id, sup_id in updates:
-            cur.execute(
-                """
-                UPDATE wiki.claim_events
-                   SET supersedes = %s
-                 WHERE id = %s
-                   AND (supersedes IS NULL OR supersedes <> %s)
-                """,
-                (sup_id, new_id, sup_id),
-            )
-            written += cur.rowcount
-    return written
-
-
-# ── wiki.pages — bulk thermodynamic updates ───────────────────────────
-
-
-def list_pages_for_decay(
-    conn: Connection,
-    *,
-    limit: int = 5000,
-    include_archived: bool = False,
-) -> list[dict]:
-    """Pages eligible for a thermodynamic sweep.
-
-    Skips evergreen by default (never decays) and archived unless
-    ``include_archived`` is True (only useful to detect revivals,
-    which we handle via the citation trigger anyway).
-    """
-    states = ["active", "area"]
-    if include_archived:
-        states.append("archived")
-    sql = """
-    SELECT id, heat, lifecycle_state, tended, is_stale, lead, sections
-      FROM wiki.pages
-     WHERE lifecycle_state = ANY(%s)
-     ORDER BY id LIMIT %s
-    """
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(sql, (states, limit))
-        return list(cur.fetchall())
-
-
-def apply_thermo_decisions(conn: Connection, decisions: list[Any]) -> int:
-    """Bulk apply HeatDecision rows. Returns count of pages written.
-
-    Idempotent — UPDATE only fires when at least one of (heat,
-    lifecycle_state, archived_at) differs from current.
-    """
-    if not decisions:
-        return 0
-    written = 0
-    with conn.cursor() as cur:
-        for d in decisions:
-            cur.execute(
-                """
-                UPDATE wiki.pages
-                   SET heat = %s,
-                       lifecycle_state = %s,
-                       archived_at = COALESCE(%s::timestamptz, archived_at),
-                       tended = NOW()
-                 WHERE id = %s
-                   AND (
-                     ABS(heat - %s) > 0.001
-                     OR lifecycle_state <> %s
-                     OR (%s::timestamptz IS NOT NULL AND archived_at IS NULL)
-                   )
-                """,
-                (
-                    d.new_heat,
-                    d.new_lifecycle,
-                    d.archived_at,
-                    d.page_id,
-                    d.new_heat,
-                    d.new_lifecycle,
-                    d.archived_at,
-                ),
-            )
-            written += cur.rowcount
-    return written
-
-
-def apply_staleness_decisions(conn: Connection, decisions: list[Any]) -> int:
-    """Bulk apply StalenessDecision rows. Returns transitions written."""
-    if not decisions:
-        return 0
-    written = 0
-    with conn.cursor() as cur:
-        for d in decisions:
-            if not d.transitioned:
-                continue
-            cur.execute(
-                "UPDATE wiki.pages SET is_stale = %s WHERE id = %s",
-                (d.is_stale_now, d.page_id),
-            )
-            written += cur.rowcount
-    return written
-
-
-def get_claim_file_refs_for_pages(
-    conn: Connection, page_ids: list[int]
-) -> dict[int, list[str]]:
-    """For each page, return the file paths cited by its source memory's claims.
-
-    Joins wiki.pages → memories → wiki.claim_events; pulls evidence_refs
-    of kind='file'. Returns {page_id: [file_path, ...]}.
-    """
-    if not page_ids:
-        return {}
-    sql = """
-    SELECT p.id AS page_id,
-           c.evidence_refs
-      FROM wiki.pages p
-      JOIN wiki.claim_events c ON c.memory_id = p.memory_id
-     WHERE p.id = ANY(%s)
-    """
-    out: dict[int, set[str]] = {}
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(sql, (list(page_ids),))
-        for row in cur.fetchall():
-            page_id = row["page_id"]
-            refs = row["evidence_refs"] or []
-            for ref in refs:
-                if isinstance(ref, dict) and ref.get("kind") == "file":
-                    out.setdefault(page_id, set()).add(ref["target"])
-    return {k: sorted(v) for k, v in out.items()}
-
-
-# ── wiki.concepts ──────────────────────────────────────────────────────
-
-
-def list_concepts(
-    conn: Connection,
-    *,
-    status: str | None = None,
-    limit: int = 200,
-) -> list[dict]:
-    """Return concept rows, optionally filtered by status."""
-    if status:
-        sql = "SELECT * FROM wiki.concepts WHERE status = %s ORDER BY id LIMIT %s"
-        params: tuple = (status, limit)
-    else:
-        sql = "SELECT * FROM wiki.concepts ORDER BY id LIMIT %s"
-        params = (limit,)
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(sql, params)
-        return list(cur.fetchall())
-
-
-def get_concepts_by_entity_overlap(
-    conn: Connection, entity_ids: list[int]
-) -> list[dict]:
-    """Return concepts whose entity_ids intersect the given list."""
-    if not entity_ids:
-        return []
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(
-            "SELECT * FROM wiki.concepts WHERE entity_ids && %s::int[]",
-            (list(entity_ids),),
-        )
-        return list(cur.fetchall())
-
-
-def insert_concept(conn: Connection, concept: dict[str, Any]) -> int:
-    """Insert a new concept. Returns wiki.concepts.id."""
-    sql = """
-    INSERT INTO wiki.concepts (
-        label, status, entity_ids, grounding_memory_ids,
-        grounding_claim_ids, properties, axial_slots,
-        saturation_rate, saturation_streak
-    ) VALUES (
-        %(label)s, %(status)s, %(entity_ids)s::int[],
-        %(grounding_memory_ids)s::int[], %(grounding_claim_ids)s::bigint[],
-        %(properties)s::jsonb, %(axial_slots)s::jsonb,
-        %(saturation_rate)s, %(saturation_streak)s
-    ) RETURNING id;
-    """
-    params = {
-        "label": concept["label"],
-        "status": concept.get("status", "candidate"),
-        "entity_ids": concept.get("entity_ids", []),
-        "grounding_memory_ids": concept.get("grounding_memory_ids", []),
-        "grounding_claim_ids": concept.get("grounding_claim_ids", []),
-        "properties": json.dumps(concept.get("properties", {})),
-        "axial_slots": json.dumps(concept.get("axial_slots", {})),
-        "saturation_rate": float(concept.get("saturation_rate", 1.0)),
-        "saturation_streak": int(concept.get("saturation_streak", 0)),
-    }
-    with conn.cursor() as cur:
-        cur.execute(sql, params)
-        return _returning_id(cur.fetchone())
-
-
-def update_concept(conn: Connection, concept_id: int, fields: dict[str, Any]) -> bool:
-    """Patch a concept row. Returns True if updated."""
-    if not fields:
-        return False
-    sets: list[str] = []
-    params: list = []
-    for k, v in fields.items():
-        if k in ("entity_ids", "grounding_memory_ids"):
-            sets.append(f"{k} = %s::int[]")
-            params.append(v)
-        elif k == "grounding_claim_ids":
-            sets.append(f"{k} = %s::bigint[]")
-            params.append(v)
-        elif k in ("properties", "axial_slots"):
-            sets.append(f"{k} = %s::jsonb")
-            params.append(json.dumps(v))
-        elif k == "last_property_at":
-            sets.append(f"{k} = NOW()")
-        else:
-            sets.append(f"{k} = %s")
-            params.append(v)
-    params.append(concept_id)
-    sql = f"UPDATE wiki.concepts SET {', '.join(sets)} WHERE id = %s"
-    with conn.cursor() as cur:
-        cur.execute(sql, params)
-        return cur.rowcount > 0
-
-
-# ── wiki.drafts ────────────────────────────────────────────────────────
-
-
-def insert_draft(conn: Connection, draft: dict[str, Any]) -> int:
-    """Insert a draft row. Returns the new wiki.drafts.id.
-
-    Required: title, kind. Optional: concept_id, memory_id, lead,
-    sections (list of dicts), frontmatter, provenance, synth_prompt,
-    synth_model, confidence, status.
-    """
-    sql = """
-    INSERT INTO wiki.drafts (
-        concept_id, memory_id, title, kind, lead, sections,
-        frontmatter, provenance, synth_prompt, synth_model,
-        confidence, status
-    ) VALUES (
-        %(concept_id)s, %(memory_id)s, %(title)s, %(kind)s, %(lead)s,
-        %(sections)s::jsonb, %(frontmatter)s::jsonb,
-        %(provenance)s::jsonb, %(synth_prompt)s, %(synth_model)s,
-        %(confidence)s, %(status)s
-    ) RETURNING id;
-    """
-    params = {
-        "concept_id": draft.get("concept_id"),
-        "memory_id": draft.get("memory_id"),
-        "title": draft["title"],
-        "kind": draft["kind"],
-        "lead": draft.get("lead", ""),
-        "sections": json.dumps(draft.get("sections", [])),
-        "frontmatter": json.dumps(draft.get("frontmatter", {})),
-        "provenance": json.dumps(draft.get("provenance", {})),
-        "synth_prompt": draft.get("synth_prompt"),
-        "synth_model": draft.get("synth_model"),
-        "confidence": float(draft.get("confidence", 0.5)),
-        "status": draft.get("status", "pending"),
-    }
-    with conn.cursor() as cur:
-        cur.execute(sql, params)
-        return _returning_id(cur.fetchone())
-
-
-def get_draft(conn: Connection, draft_id: int) -> dict | None:
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute("SELECT * FROM wiki.drafts WHERE id = %s", (draft_id,))
-        return cur.fetchone()
-
-
-def list_drafts(
-    conn: Connection,
-    *,
-    status: str | None = None,
-    kind: str | None = None,
-    limit: int = 50,
-) -> list[dict]:
-    where: list[str] = []
-    params: list = []
-    if status:
-        where.append("status = %s")
-        params.append(status)
-    if kind:
-        where.append("kind = %s")
-        params.append(kind)
-    where_sql = ("WHERE " + " AND ".join(where)) if where else ""
-    sql = f"""
-    SELECT * FROM wiki.drafts {where_sql}
-    ORDER BY created_at DESC LIMIT %s
-    """
-    params.append(limit)
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(sql, params)
-        return list(cur.fetchall())
-
-
-def update_draft(
-    conn: Connection,
-    draft_id: int,
-    *,
-    title: str | None = None,
-    lead: str | None = None,
-    sections: list | None = None,
-    frontmatter: dict | None = None,
-    confidence: float | None = None,
-    synth_prompt: str | None = None,
-    synth_model: str | None = None,
-) -> bool:
-    """Patch a draft's content fields. Returns True if a row was updated.
-
-    Used by Path B (LLM refinement) — Claude submits a refined draft
-    by updating the in-DB record. Status transitions go through
-    update_draft_status.
-    """
-    sets: list[str] = []
-    params: list = []
-    if title is not None:
-        sets.append("title = %s")
-        params.append(title)
-    if lead is not None:
-        sets.append("lead = %s")
-        params.append(lead)
-    if sections is not None:
-        sets.append("sections = %s::jsonb")
-        params.append(json.dumps(sections))
-    if frontmatter is not None:
-        sets.append("frontmatter = %s::jsonb")
-        params.append(json.dumps(frontmatter))
-    if confidence is not None:
-        sets.append("confidence = %s")
-        params.append(float(confidence))
-    if synth_prompt is not None:
-        sets.append("synth_prompt = %s")
-        params.append(synth_prompt)
-    if synth_model is not None:
-        sets.append("synth_model = %s")
-        params.append(synth_model)
-    if not sets:
-        return False
-    params.append(draft_id)
-    sql = f"UPDATE wiki.drafts SET {', '.join(sets)} WHERE id = %s"
-    with conn.cursor() as cur:
-        cur.execute(sql, params)
-        return cur.rowcount > 0
-
-
-def update_draft_status(
-    conn: Connection,
-    draft_id: int,
-    *,
-    status: str,
-    published_page_id: int | None = None,
-) -> bool:
-    """Transition a draft's status. Stamps reviewed_at automatically."""
-    if status not in ("pending", "approved", "rejected", "published"):
-        raise ValueError(f"invalid status: {status}")
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            UPDATE wiki.drafts
-               SET status = %s,
-                   published_page_id = COALESCE(%s, published_page_id),
-                   reviewed_at = NOW()
-             WHERE id = %s
-            """,
-            (status, published_page_id, draft_id),
-        )
-        return cur.rowcount > 0
-
-
-def find_draft_for_source(
-    conn: Connection, *, memory_id: int | None = None, concept_id: int | None = None
-) -> dict | None:
-    """Return the most recent draft for a given source, or None."""
-    if not memory_id and not concept_id:
-        return None
-    if memory_id is not None:
-        sql = (
-            "SELECT * FROM wiki.drafts WHERE memory_id = %s "
-            "ORDER BY created_at DESC LIMIT 1"
-        )
-        params: tuple = (memory_id,)
-    else:
-        sql = (
-            "SELECT * FROM wiki.drafts WHERE concept_id = %s "
-            "ORDER BY created_at DESC LIMIT 1"
-        )
-        params = (concept_id,)
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(sql, params)
-        return cur.fetchone()
-
-
-# ── wiki.citations ─────────────────────────────────────────────────────
-
-
-def insert_citation(
-    conn: Connection,
-    page_id: int,
-    session_id: str = "",
-    domain: str = "",
-    memory_id: int | None = None,
-) -> int:
-    """Record that a page was cited. Trigger bumps heat + citation_count."""
-    sql = """
-    INSERT INTO wiki.citations (page_id, session_id, domain, memory_id)
-    VALUES (%s, %s, %s, %s)
-    RETURNING id;
-    """
-    with conn.cursor() as cur:
-        cur.execute(sql, (page_id, session_id, domain, memory_id))
-        return _returning_id(cur.fetchone())
-
-
-# ── wiki.memos (grounded-theory audit trail) ──────────────────────────
-
-
-def insert_memo(
-    conn: Connection,
-    subject_type: str,
-    subject_id: int,
-    decision: str,
-    rationale: str = "",
-    alternatives: list | None = None,
-    inputs: dict | None = None,
-    confidence: float = 0.5,
-    author: str = "system",
-) -> int:
-    sql = """
-    INSERT INTO wiki.memos (
-        subject_type, subject_id, decision, rationale,
-        alternatives, inputs, confidence, author
-    )
-    VALUES (%s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s)
-    RETURNING id;
-    """
-    with conn.cursor() as cur:
-        cur.execute(
-            sql,
-            (
-                subject_type,
-                subject_id,
-                decision,
-                rationale,
-                json.dumps(alternatives or []),
-                json.dumps(inputs or {}),
-                confidence,
-                author,
-            ),
-        )
-        return _returning_id(cur.fetchone())
-
-
-# ── Diagnostics ────────────────────────────────────────────────────────
-
-
-def wiki_stats(conn: Connection) -> dict:
-    """Counts across the wiki schema."""
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(
-            """
-            SELECT
-              (SELECT COUNT(*) FROM wiki.pages) AS pages,
-              (SELECT COUNT(*) FROM wiki.pages WHERE lifecycle_state='active') AS active,
-              (SELECT COUNT(*) FROM wiki.pages WHERE lifecycle_state='archived') AS archived,
-              (SELECT COUNT(*) FROM wiki.concepts) AS concepts,
-              (SELECT COUNT(*) FROM wiki.drafts WHERE status='pending') AS pending_drafts,
-              (SELECT COUNT(*) FROM wiki.claim_events) AS claim_events,
-              (SELECT COUNT(*) FROM wiki.links) AS links,
-              (SELECT COUNT(*) FROM wiki.citations) AS citations,
-              (SELECT COUNT(*) FROM wiki.memos) AS memos
-            """
-        )
-        return cur.fetchone()
+from mcp_server.infrastructure.pg_store_wiki_thermo import (
+    apply_staleness_decisions,
+    apply_thermo_decisions,
+    get_claim_file_refs_for_pages,
+    list_pages_for_decay,
+)
+
+__all__ = [
+    "apply_staleness_decisions",
+    "apply_thermo_decisions",
+    "body_hash",
+    "delete_claims_for_memory",
+    "delete_links_from",
+    "find_draft_for_source",
+    "get_backlinks",
+    "get_claim_file_refs_for_pages",
+    "get_claims_by_entity",
+    "get_claims_for_memory",
+    "get_concepts_by_entity_overlap",
+    "get_draft",
+    "get_entities_by_memory",
+    "get_entity_name_index",
+    "get_page_by_rel_path",
+    "get_page_by_slug",
+    "insert_citation",
+    "insert_claim_events",
+    "insert_concept",
+    "insert_draft",
+    "insert_memo",
+    "list_concepts",
+    "list_drafts",
+    "list_pages_for_decay",
+    "resolve_unresolved_links",
+    "update_claim_entities",
+    "update_claim_supersedes",
+    "update_concept",
+    "update_draft",
+    "update_draft_status",
+    "upsert_link",
+    "upsert_page",
+    "upsert_page_sources",
+    "wiki_stats",
+]

--- a/mcp_server/infrastructure/pg_store_wiki.py
+++ b/mcp_server/infrastructure/pg_store_wiki.py
@@ -20,6 +20,8 @@ from typing import Any
 from psycopg import Connection
 from psycopg.rows import dict_row
 
+from mcp_server.infrastructure.pg_store_wiki_sources import upsert_page_sources
+
 
 # ── Hashing helper ─────────────────────────────────────────────────────
 
@@ -53,7 +55,13 @@ def upsert_page(conn: Connection, page: dict[str, Any]) -> tuple[int, bool]:
     body_hash matched and nothing changed.
 
     Required fields: rel_path, slug, kind, title.
-    Optional: all other columns.
+    Optional: all other columns, including ``documents`` (list of
+    canonical source-file paths — ADR-0051) and ``documents_primary``
+    (defaults to the first entry of ``documents`` when omitted).
+    ``wiki.page_sources`` is refreshed unconditionally (even on a
+    body_hash no-op) so a frontmatter-only edit still lands, matching
+    how ``wiki.links`` is refreshed independently of body_hash in
+    ``wiki_migrate.migrate_wiki``.
     """
     required = ("rel_path", "slug", "kind", "title")
     for k in required:
@@ -62,6 +70,10 @@ def upsert_page(conn: Connection, page: dict[str, Any]) -> tuple[int, bool]:
 
     body = page.get("body", "")
     bh = page.get("body_hash") or body_hash(body)
+    documents = page.get("documents") or []
+    documents_primary = page.get("documents_primary") or (
+        documents[0] if documents else None
+    )
 
     # Use xmax=0 (Postgres trick) to detect INSERT vs UPDATE: xmax is 0
     # only on a fresh INSERT. We also OR in body_hash equality to detect
@@ -70,13 +82,13 @@ def upsert_page(conn: Connection, page: dict[str, Any]) -> tuple[int, bool]:
     INSERT INTO wiki.pages (
         memory_id, concept_id, rel_path, slug, kind, title, domain, domains,
         tags, audience, requires, status, lifecycle_state, supersedes,
-        superseded_by, verified, lead, sections, body_hash
+        superseded_by, verified, lead, sections, body_hash, documents_primary
     ) VALUES (
         %(memory_id)s, %(concept_id)s, %(rel_path)s, %(slug)s, %(kind)s,
         %(title)s, %(domain)s, %(domains)s::jsonb, %(tags)s::jsonb,
         %(audience)s::jsonb, %(requires)s::jsonb, %(status)s,
         %(lifecycle_state)s, %(supersedes)s, %(superseded_by)s, %(verified)s,
-        %(lead)s, %(sections)s::jsonb, %(body_hash)s
+        %(lead)s, %(sections)s::jsonb, %(body_hash)s, %(documents_primary)s
     )
     ON CONFLICT (rel_path) DO UPDATE SET
         memory_id = EXCLUDED.memory_id,
@@ -97,8 +109,10 @@ def upsert_page(conn: Connection, page: dict[str, Any]) -> tuple[int, bool]:
         lead = EXCLUDED.lead,
         sections = EXCLUDED.sections,
         body_hash = EXCLUDED.body_hash,
+        documents_primary = EXCLUDED.documents_primary,
         tended = NOW()
     WHERE wiki.pages.body_hash <> EXCLUDED.body_hash
+       OR wiki.pages.documents_primary IS DISTINCT FROM EXCLUDED.documents_primary
     RETURNING id, (xmax = 0) AS inserted;
     """
     params = {
@@ -121,15 +135,16 @@ def upsert_page(conn: Connection, page: dict[str, Any]) -> tuple[int, bool]:
         "lead": page.get("lead", ""),
         "sections": json.dumps(page.get("sections", {})),
         "body_hash": bh,
+        "documents_primary": documents_primary,
     }
     with conn.cursor() as cur:
         cur.execute(sql, params)
         row = cur.fetchone()
         if row is not None:
             # Row was inserted or actually updated.
-            if isinstance(row, dict):
-                return row["id"], True
-            return row[0], True
+            page_id = row["id"] if isinstance(row, dict) else row[0]
+            upsert_page_sources(conn, page_id, documents)
+            return page_id, True
         # WHERE clause filtered the UPDATE out → body_hash matched, no-op.
         cur.execute(
             "SELECT id FROM wiki.pages WHERE rel_path = %s", (page["rel_path"],)
@@ -138,6 +153,7 @@ def upsert_page(conn: Connection, page: dict[str, Any]) -> tuple[int, bool]:
         if existing is None:
             return -1, False
         existing_id = existing["id"] if isinstance(existing, dict) else existing[0]
+        upsert_page_sources(conn, existing_id, documents)
         return existing_id, False
 
 

--- a/mcp_server/infrastructure/pg_store_wiki_claims.py
+++ b/mcp_server/infrastructure/pg_store_wiki_claims.py
@@ -1,0 +1,205 @@
+"""wiki.claim_events DB operations.
+
+Split out of ``pg_store_wiki.py`` (originally 890 lines, over the
+300-line file limit — CLAUDE.md "Code Quality Rules") purely for size
+compliance; no logic changed.
+
+Pure infrastructure — no core imports, no handler imports.
+"""
+
+from __future__ import annotations
+
+import json
+
+from psycopg import Connection
+from psycopg.rows import dict_row
+
+from mcp_server.infrastructure.pg_store_wiki_common import _returning_id
+
+
+def insert_claim_events(conn: Connection, claims: list[dict]) -> list[int]:
+    """Bulk insert ClaimEvent rows. Returns the new ids in order.
+
+    Each ``claims`` dict requires: ``text``, ``claim_type``. Optional:
+    memory_id, session_id, entity_ids, evidence_refs, confidence,
+    supersedes, embedding (vector or None).
+
+    All inserted in one cursor cycle for throughput.
+    """
+    if not claims:
+        return []
+
+    sql = """
+    INSERT INTO wiki.claim_events (
+        memory_id, session_id, text, claim_type, entity_ids,
+        evidence_refs, confidence, supersedes
+    ) VALUES (
+        %(memory_id)s, %(session_id)s, %(text)s, %(claim_type)s,
+        %(entity_ids)s, %(evidence_refs)s::jsonb, %(confidence)s,
+        %(supersedes)s
+    ) RETURNING id;
+    """
+    out: list[int] = []
+    with conn.cursor() as cur:
+        for c in claims:
+            params = {
+                "memory_id": c.get("memory_id"),
+                "session_id": c.get("session_id", ""),
+                "text": c["text"][:1900],
+                "claim_type": c.get("claim_type", "assertion"),
+                "entity_ids": c.get("entity_ids", []),
+                "evidence_refs": json.dumps(c.get("evidence_refs", [])),
+                "confidence": c.get("confidence", 0.5),
+                "supersedes": c.get("supersedes"),
+            }
+            cur.execute(sql, params)
+            out.append(_returning_id(cur.fetchone()))
+    return out
+
+
+def delete_claims_for_memory(conn: Connection, memory_id: int) -> int:
+    """Remove all claim_events derived from a single memory.
+
+    Used before re-extraction to keep the table clean of stale claims.
+    """
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM wiki.claim_events WHERE memory_id = %s", (memory_id,))
+        return cur.rowcount
+
+
+def get_claims_for_memory(conn: Connection, memory_id: int) -> list[dict]:
+    """Return all claim_events derived from a single memory."""
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            "SELECT * FROM wiki.claim_events WHERE memory_id = %s ORDER BY id",
+            (memory_id,),
+        )
+        return list(cur.fetchall())
+
+
+def get_entities_by_memory(
+    conn: Connection, memory_ids: list[int]
+) -> dict[int, list[int]]:
+    """Pre-fetch memory_id → list[entity_id] for a batch of memories."""
+    if not memory_ids:
+        return {}
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT memory_id, entity_id FROM memory_entities "
+            "WHERE memory_id = ANY(%s)",
+            (list(memory_ids),),
+        )
+        rows = cur.fetchall()
+    out: dict[int, list[int]] = {}
+    for r in rows:
+        if isinstance(r, dict):
+            mid, eid = r["memory_id"], r["entity_id"]
+        else:
+            mid, eid = r[0], r[1]
+        out.setdefault(mid, []).append(eid)
+    return out
+
+
+def get_entity_name_index(conn: Connection, limit: int = 5000) -> dict[str, int]:
+    """Return name → entity_id map for inline-mention matching.
+
+    Limit caps the index size for in-memory matching against claim text.
+    Heat-ranked so the most frequently-touched entities win.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT name, id FROM entities ORDER BY heat DESC NULLS LAST LIMIT %s",
+            (limit,),
+        )
+        rows = cur.fetchall()
+    out: dict[str, int] = {}
+    for r in rows:
+        if isinstance(r, dict):
+            name, eid = r["name"], r["id"]
+        else:
+            name, eid = r[0], r[1]
+        if name and len(name) >= 3:
+            out[name] = eid
+    return out
+
+
+def get_claims_by_entity(
+    conn: Connection,
+    entity_ids: list[int],
+    exclude_claim_ids: list[int] | None = None,
+) -> dict[int, list[dict]]:
+    """For each entity_id, fetch claims that already reference it.
+
+    Used by the resolver to find supersedes / conflict candidates.
+    Excludes the claims being resolved (avoid self-matches).
+    """
+    if not entity_ids:
+        return {}
+    excl = exclude_claim_ids or []
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            SELECT id, memory_id, text, claim_type, entity_ids, supersedes,
+                   extracted_at
+              FROM wiki.claim_events
+             WHERE entity_ids && %s::int[]
+               AND (%s::bigint[] IS NULL OR NOT (id = ANY(%s::bigint[])))
+            """,
+            (list(entity_ids), excl or None, excl or None),
+        )
+        rows = list(cur.fetchall())
+    out: dict[int, list[dict]] = {}
+    for r in rows:
+        # entity_ids returns as a list already (PG INT[] → Python list)
+        for eid in r.get("entity_ids") or []:
+            if eid in entity_ids:
+                out.setdefault(eid, []).append(r)
+    return out
+
+
+def update_claim_entities(
+    conn: Connection, updates: list[tuple[int, list[int]]]
+) -> int:
+    """Bulk update wiki.claim_events.entity_ids. Returns rows updated.
+
+    Idempotent: only writes when the new list differs from the current.
+    """
+    if not updates:
+        return 0
+    written = 0
+    with conn.cursor() as cur:
+        for claim_id, eids in updates:
+            cur.execute(
+                """
+                UPDATE wiki.claim_events
+                   SET entity_ids = %s::int[]
+                 WHERE id = %s
+                   AND entity_ids IS DISTINCT FROM %s::int[]
+                """,
+                (eids, claim_id, eids),
+            )
+            written += cur.rowcount
+    return written
+
+
+def update_claim_supersedes(conn: Connection, updates: list[tuple[int, int]]) -> int:
+    """Bulk update wiki.claim_events.supersedes. Returns rows updated.
+
+    ``updates`` is [(new_claim_id, superseded_claim_id), ...].
+    """
+    if not updates:
+        return 0
+    written = 0
+    with conn.cursor() as cur:
+        for new_id, sup_id in updates:
+            cur.execute(
+                """
+                UPDATE wiki.claim_events
+                   SET supersedes = %s
+                 WHERE id = %s
+                   AND (supersedes IS NULL OR supersedes <> %s)
+                """,
+                (sup_id, new_id, sup_id),
+            )
+            written += cur.rowcount
+    return written

--- a/mcp_server/infrastructure/pg_store_wiki_common.py
+++ b/mcp_server/infrastructure/pg_store_wiki_common.py
@@ -1,0 +1,32 @@
+"""Shared helpers for the wiki-schema store modules.
+
+Split out of ``pg_store_wiki.py`` (originally 890 lines, over the
+300-line file limit — CLAUDE.md "Code Quality Rules") purely for size
+compliance; no logic changed. ``body_hash`` and ``_returning_id`` are
+used across the pages/claims/concepts/drafts/citations modules.
+
+Pure infrastructure — no core imports, no handler imports.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+
+def body_hash(body: str) -> str:
+    """Deterministic hash of a page body — drives idempotent upserts."""
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _returning_id(row: dict[str, Any] | tuple[Any, ...] | None) -> int:
+    """Extract the id from an ``INSERT ... RETURNING id`` fetchone() result.
+
+    A default psycopg cursor yields tuple rows; a ``dict_row`` cursor yields
+    dict rows — hence the isinstance split. An INSERT ... RETURNING always
+    produces exactly one row, so a None here is a broken query (or a silently
+    rolled-back transaction), not a normal path — surface it loudly.
+    """
+    if row is None:
+        raise RuntimeError("INSERT ... RETURNING id produced no row")
+    return row["id"] if isinstance(row, dict) else row[0]

--- a/mcp_server/infrastructure/pg_store_wiki_concepts.py
+++ b/mcp_server/infrastructure/pg_store_wiki_concepts.py
@@ -1,0 +1,108 @@
+"""wiki.concepts DB operations.
+
+Split out of ``pg_store_wiki.py`` (originally 890 lines, over the
+300-line file limit — CLAUDE.md "Code Quality Rules") purely for size
+compliance; no logic changed.
+
+Pure infrastructure — no core imports, no handler imports.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from psycopg import Connection
+from psycopg.rows import dict_row
+
+from mcp_server.infrastructure.pg_store_wiki_common import _returning_id
+
+
+def list_concepts(
+    conn: Connection,
+    *,
+    status: str | None = None,
+    limit: int = 200,
+) -> list[dict]:
+    """Return concept rows, optionally filtered by status."""
+    if status:
+        sql = "SELECT * FROM wiki.concepts WHERE status = %s ORDER BY id LIMIT %s"
+        params: tuple = (status, limit)
+    else:
+        sql = "SELECT * FROM wiki.concepts ORDER BY id LIMIT %s"
+        params = (limit,)
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, params)
+        return list(cur.fetchall())
+
+
+def get_concepts_by_entity_overlap(
+    conn: Connection, entity_ids: list[int]
+) -> list[dict]:
+    """Return concepts whose entity_ids intersect the given list."""
+    if not entity_ids:
+        return []
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            "SELECT * FROM wiki.concepts WHERE entity_ids && %s::int[]",
+            (list(entity_ids),),
+        )
+        return list(cur.fetchall())
+
+
+def insert_concept(conn: Connection, concept: dict[str, Any]) -> int:
+    """Insert a new concept. Returns wiki.concepts.id."""
+    sql = """
+    INSERT INTO wiki.concepts (
+        label, status, entity_ids, grounding_memory_ids,
+        grounding_claim_ids, properties, axial_slots,
+        saturation_rate, saturation_streak
+    ) VALUES (
+        %(label)s, %(status)s, %(entity_ids)s::int[],
+        %(grounding_memory_ids)s::int[], %(grounding_claim_ids)s::bigint[],
+        %(properties)s::jsonb, %(axial_slots)s::jsonb,
+        %(saturation_rate)s, %(saturation_streak)s
+    ) RETURNING id;
+    """
+    params = {
+        "label": concept["label"],
+        "status": concept.get("status", "candidate"),
+        "entity_ids": concept.get("entity_ids", []),
+        "grounding_memory_ids": concept.get("grounding_memory_ids", []),
+        "grounding_claim_ids": concept.get("grounding_claim_ids", []),
+        "properties": json.dumps(concept.get("properties", {})),
+        "axial_slots": json.dumps(concept.get("axial_slots", {})),
+        "saturation_rate": float(concept.get("saturation_rate", 1.0)),
+        "saturation_streak": int(concept.get("saturation_streak", 0)),
+    }
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        return _returning_id(cur.fetchone())
+
+
+def update_concept(conn: Connection, concept_id: int, fields: dict[str, Any]) -> bool:
+    """Patch a concept row. Returns True if updated."""
+    if not fields:
+        return False
+    sets: list[str] = []
+    params: list = []
+    for k, v in fields.items():
+        if k in ("entity_ids", "grounding_memory_ids"):
+            sets.append(f"{k} = %s::int[]")
+            params.append(v)
+        elif k == "grounding_claim_ids":
+            sets.append(f"{k} = %s::bigint[]")
+            params.append(v)
+        elif k in ("properties", "axial_slots"):
+            sets.append(f"{k} = %s::jsonb")
+            params.append(json.dumps(v))
+        elif k == "last_property_at":
+            sets.append(f"{k} = NOW()")
+        else:
+            sets.append(f"{k} = %s")
+            params.append(v)
+    params.append(concept_id)
+    sql = f"UPDATE wiki.concepts SET {', '.join(sets)} WHERE id = %s"
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        return cur.rowcount > 0

--- a/mcp_server/infrastructure/pg_store_wiki_drafts.py
+++ b/mcp_server/infrastructure/pg_store_wiki_drafts.py
@@ -1,0 +1,185 @@
+"""wiki.drafts DB operations.
+
+Split out of ``pg_store_wiki.py`` (originally 890 lines, over the
+300-line file limit — CLAUDE.md "Code Quality Rules") purely for size
+compliance; no logic changed.
+
+Pure infrastructure — no core imports, no handler imports.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from psycopg import Connection
+from psycopg.rows import dict_row
+
+from mcp_server.infrastructure.pg_store_wiki_common import _returning_id
+
+
+def insert_draft(conn: Connection, draft: dict[str, Any]) -> int:
+    """Insert a draft row. Returns the new wiki.drafts.id.
+
+    Required: title, kind. Optional: concept_id, memory_id, lead,
+    sections (list of dicts), frontmatter, provenance, synth_prompt,
+    synth_model, confidence, status.
+    """
+    sql = """
+    INSERT INTO wiki.drafts (
+        concept_id, memory_id, title, kind, lead, sections,
+        frontmatter, provenance, synth_prompt, synth_model,
+        confidence, status
+    ) VALUES (
+        %(concept_id)s, %(memory_id)s, %(title)s, %(kind)s, %(lead)s,
+        %(sections)s::jsonb, %(frontmatter)s::jsonb,
+        %(provenance)s::jsonb, %(synth_prompt)s, %(synth_model)s,
+        %(confidence)s, %(status)s
+    ) RETURNING id;
+    """
+    params = {
+        "concept_id": draft.get("concept_id"),
+        "memory_id": draft.get("memory_id"),
+        "title": draft["title"],
+        "kind": draft["kind"],
+        "lead": draft.get("lead", ""),
+        "sections": json.dumps(draft.get("sections", [])),
+        "frontmatter": json.dumps(draft.get("frontmatter", {})),
+        "provenance": json.dumps(draft.get("provenance", {})),
+        "synth_prompt": draft.get("synth_prompt"),
+        "synth_model": draft.get("synth_model"),
+        "confidence": float(draft.get("confidence", 0.5)),
+        "status": draft.get("status", "pending"),
+    }
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        return _returning_id(cur.fetchone())
+
+
+def get_draft(conn: Connection, draft_id: int) -> dict | None:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute("SELECT * FROM wiki.drafts WHERE id = %s", (draft_id,))
+        return cur.fetchone()
+
+
+def list_drafts(
+    conn: Connection,
+    *,
+    status: str | None = None,
+    kind: str | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    where: list[str] = []
+    params: list = []
+    if status:
+        where.append("status = %s")
+        params.append(status)
+    if kind:
+        where.append("kind = %s")
+        params.append(kind)
+    where_sql = ("WHERE " + " AND ".join(where)) if where else ""
+    sql = f"""
+    SELECT * FROM wiki.drafts {where_sql}
+    ORDER BY created_at DESC LIMIT %s
+    """
+    params.append(limit)
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, params)
+        return list(cur.fetchall())
+
+
+def update_draft(
+    conn: Connection,
+    draft_id: int,
+    *,
+    title: str | None = None,
+    lead: str | None = None,
+    sections: list | None = None,
+    frontmatter: dict | None = None,
+    confidence: float | None = None,
+    synth_prompt: str | None = None,
+    synth_model: str | None = None,
+) -> bool:
+    """Patch a draft's content fields. Returns True if a row was updated.
+
+    Used by Path B (LLM refinement) — Claude submits a refined draft
+    by updating the in-DB record. Status transitions go through
+    update_draft_status.
+    """
+    sets: list[str] = []
+    params: list = []
+    if title is not None:
+        sets.append("title = %s")
+        params.append(title)
+    if lead is not None:
+        sets.append("lead = %s")
+        params.append(lead)
+    if sections is not None:
+        sets.append("sections = %s::jsonb")
+        params.append(json.dumps(sections))
+    if frontmatter is not None:
+        sets.append("frontmatter = %s::jsonb")
+        params.append(json.dumps(frontmatter))
+    if confidence is not None:
+        sets.append("confidence = %s")
+        params.append(float(confidence))
+    if synth_prompt is not None:
+        sets.append("synth_prompt = %s")
+        params.append(synth_prompt)
+    if synth_model is not None:
+        sets.append("synth_model = %s")
+        params.append(synth_model)
+    if not sets:
+        return False
+    params.append(draft_id)
+    sql = f"UPDATE wiki.drafts SET {', '.join(sets)} WHERE id = %s"
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        return cur.rowcount > 0
+
+
+def update_draft_status(
+    conn: Connection,
+    draft_id: int,
+    *,
+    status: str,
+    published_page_id: int | None = None,
+) -> bool:
+    """Transition a draft's status. Stamps reviewed_at automatically."""
+    if status not in ("pending", "approved", "rejected", "published"):
+        raise ValueError(f"invalid status: {status}")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE wiki.drafts
+               SET status = %s,
+                   published_page_id = COALESCE(%s, published_page_id),
+                   reviewed_at = NOW()
+             WHERE id = %s
+            """,
+            (status, published_page_id, draft_id),
+        )
+        return cur.rowcount > 0
+
+
+def find_draft_for_source(
+    conn: Connection, *, memory_id: int | None = None, concept_id: int | None = None
+) -> dict | None:
+    """Return the most recent draft for a given source, or None."""
+    if not memory_id and not concept_id:
+        return None
+    if memory_id is not None:
+        sql = (
+            "SELECT * FROM wiki.drafts WHERE memory_id = %s "
+            "ORDER BY created_at DESC LIMIT 1"
+        )
+        params: tuple = (memory_id,)
+    else:
+        sql = (
+            "SELECT * FROM wiki.drafts WHERE concept_id = %s "
+            "ORDER BY created_at DESC LIMIT 1"
+        )
+        params = (concept_id,)
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, params)
+        return cur.fetchone()

--- a/mcp_server/infrastructure/pg_store_wiki_links.py
+++ b/mcp_server/infrastructure/pg_store_wiki_links.py
@@ -1,0 +1,80 @@
+"""wiki.links DB operations.
+
+Split out of ``pg_store_wiki.py`` (originally 890 lines, over the
+300-line file limit — CLAUDE.md "Code Quality Rules") purely for size
+compliance; no logic changed.
+
+Pure infrastructure — no core imports, no handler imports.
+"""
+
+from __future__ import annotations
+
+from psycopg import Connection
+from psycopg.rows import dict_row
+
+from mcp_server.infrastructure.pg_store_wiki_pages import get_page_by_slug
+
+
+def upsert_link(
+    conn: Connection,
+    src_page_id: int,
+    dst_slug: str,
+    link_kind: str = "see-also",
+    dst_page_id: int | None = None,
+) -> None:
+    """Insert a link, resolving dst_page_id by slug if not provided.
+
+    ON CONFLICT DO UPDATE lets a stale dst_page_id be refreshed when
+    the target page appears later.
+    """
+    if dst_page_id is None:
+        p = get_page_by_slug(conn, dst_slug)
+        dst_page_id = p["id"] if p else None
+
+    sql = """
+    INSERT INTO wiki.links (src_page_id, dst_slug, dst_page_id, link_kind)
+    VALUES (%s, %s, %s, %s)
+    ON CONFLICT (src_page_id, dst_slug, link_kind) DO UPDATE SET
+        dst_page_id = EXCLUDED.dst_page_id
+    WHERE wiki.links.dst_page_id IS DISTINCT FROM EXCLUDED.dst_page_id;
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (src_page_id, dst_slug, dst_page_id, link_kind))
+
+
+def delete_links_from(conn: Connection, src_page_id: int) -> int:
+    """Remove all outgoing links from a page (used before re-indexing)."""
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM wiki.links WHERE src_page_id = %s", (src_page_id,))
+        return cur.rowcount
+
+
+def get_backlinks(conn: Connection, dst_page_id: int) -> list[dict]:
+    """Return rows linking TO this page."""
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            SELECT l.*, p.title AS src_title, p.rel_path AS src_rel_path
+              FROM wiki.links l
+              JOIN wiki.pages p ON p.id = l.src_page_id
+             WHERE l.dst_page_id = %s
+            """,
+            (dst_page_id,),
+        )
+        return list(cur.fetchall())
+
+
+def resolve_unresolved_links(conn: Connection) -> int:
+    """Second-pass link resolution: fill in dst_page_id for links whose
+    target didn't exist at insert time. Returns rows updated."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE wiki.links l
+               SET dst_page_id = p.id
+              FROM wiki.pages p
+             WHERE p.slug = l.dst_slug
+               AND l.dst_page_id IS NULL
+            """
+        )
+        return cur.rowcount

--- a/mcp_server/infrastructure/pg_store_wiki_notes.py
+++ b/mcp_server/infrastructure/pg_store_wiki_notes.py
@@ -1,0 +1,91 @@
+"""wiki.citations / wiki.memos DB operations, and wiki-schema diagnostics.
+
+Split out of ``pg_store_wiki.py`` (originally 890 lines, over the
+300-line file limit — CLAUDE.md "Code Quality Rules") purely for size
+compliance; no logic changed.
+
+Pure infrastructure — no core imports, no handler imports.
+"""
+
+from __future__ import annotations
+
+import json
+
+from psycopg import Connection
+from psycopg.rows import dict_row
+
+from mcp_server.infrastructure.pg_store_wiki_common import _returning_id
+
+
+def insert_citation(
+    conn: Connection,
+    page_id: int,
+    session_id: str = "",
+    domain: str = "",
+    memory_id: int | None = None,
+) -> int:
+    """Record that a page was cited. Trigger bumps heat + citation_count."""
+    sql = """
+    INSERT INTO wiki.citations (page_id, session_id, domain, memory_id)
+    VALUES (%s, %s, %s, %s)
+    RETURNING id;
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (page_id, session_id, domain, memory_id))
+        return _returning_id(cur.fetchone())
+
+
+def insert_memo(
+    conn: Connection,
+    subject_type: str,
+    subject_id: int,
+    decision: str,
+    rationale: str = "",
+    alternatives: list | None = None,
+    inputs: dict | None = None,
+    confidence: float = 0.5,
+    author: str = "system",
+) -> int:
+    sql = """
+    INSERT INTO wiki.memos (
+        subject_type, subject_id, decision, rationale,
+        alternatives, inputs, confidence, author
+    )
+    VALUES (%s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s)
+    RETURNING id;
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            sql,
+            (
+                subject_type,
+                subject_id,
+                decision,
+                rationale,
+                json.dumps(alternatives or []),
+                json.dumps(inputs or {}),
+                confidence,
+                author,
+            ),
+        )
+        return _returning_id(cur.fetchone())
+
+
+def wiki_stats(conn: Connection) -> dict:
+    """Counts across the wiki schema."""
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            SELECT
+              (SELECT COUNT(*) FROM wiki.pages) AS pages,
+              (SELECT COUNT(*) FROM wiki.pages WHERE lifecycle_state='active') AS active,
+              (SELECT COUNT(*) FROM wiki.pages WHERE lifecycle_state='archived') AS archived,
+              (SELECT COUNT(*) FROM wiki.concepts) AS concepts,
+              (SELECT COUNT(*) FROM wiki.drafts WHERE status='pending') AS pending_drafts,
+              (SELECT COUNT(*) FROM wiki.claim_events) AS claim_events,
+              (SELECT COUNT(*) FROM wiki.links) AS links,
+              (SELECT COUNT(*) FROM wiki.citations) AS citations,
+              (SELECT COUNT(*) FROM wiki.memos) AS memos
+            """
+        )
+        return cur.fetchone()

--- a/mcp_server/infrastructure/pg_store_wiki_pages.py
+++ b/mcp_server/infrastructure/pg_store_wiki_pages.py
@@ -1,0 +1,143 @@
+"""wiki.pages DB operations — CRUD and lookups.
+
+Split out of ``pg_store_wiki.py`` (originally 890 lines, over the
+300-line file limit — CLAUDE.md "Code Quality Rules") purely for size
+compliance; no logic changed.
+
+Pure infrastructure — no core imports, no handler imports.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from psycopg import Connection
+from psycopg.rows import dict_row
+
+from mcp_server.infrastructure.pg_store_wiki_common import body_hash
+from mcp_server.infrastructure.pg_store_wiki_sources import upsert_page_sources
+
+
+def upsert_page(conn: Connection, page: dict[str, Any]) -> tuple[int, bool]:
+    """Upsert a page row by rel_path.
+
+    Returns ``(page_id, was_modified)`` where ``was_modified`` is True
+    when the row was inserted or actually updated, False when the
+    body_hash matched and nothing changed.
+
+    Required fields: rel_path, slug, kind, title.
+    Optional: all other columns, including ``documents`` (list of
+    canonical source-file paths — ADR-0051) and ``documents_primary``
+    (defaults to the first entry of ``documents`` when omitted).
+    ``wiki.page_sources`` is refreshed unconditionally (even on a
+    body_hash no-op) so a frontmatter-only edit still lands, matching
+    how ``wiki.links`` is refreshed independently of body_hash in
+    ``wiki_migrate.migrate_wiki``.
+    """
+    required = ("rel_path", "slug", "kind", "title")
+    for k in required:
+        if k not in page:
+            raise ValueError(f"upsert_page missing required field: {k}")
+
+    body = page.get("body", "")
+    bh = page.get("body_hash") or body_hash(body)
+    documents = page.get("documents") or []
+    documents_primary = page.get("documents_primary") or (
+        documents[0] if documents else None
+    )
+
+    # Use xmax=0 (Postgres trick) to detect INSERT vs UPDATE: xmax is 0
+    # only on a fresh INSERT. We also OR in body_hash equality to detect
+    # no-op updates that the WHERE clause filtered out.
+    sql = """
+    INSERT INTO wiki.pages (
+        memory_id, concept_id, rel_path, slug, kind, title, domain, domains,
+        tags, audience, requires, status, lifecycle_state, supersedes,
+        superseded_by, verified, lead, sections, body_hash, documents_primary
+    ) VALUES (
+        %(memory_id)s, %(concept_id)s, %(rel_path)s, %(slug)s, %(kind)s,
+        %(title)s, %(domain)s, %(domains)s::jsonb, %(tags)s::jsonb,
+        %(audience)s::jsonb, %(requires)s::jsonb, %(status)s,
+        %(lifecycle_state)s, %(supersedes)s, %(superseded_by)s, %(verified)s,
+        %(lead)s, %(sections)s::jsonb, %(body_hash)s, %(documents_primary)s
+    )
+    ON CONFLICT (rel_path) DO UPDATE SET
+        memory_id = EXCLUDED.memory_id,
+        concept_id = EXCLUDED.concept_id,
+        slug = EXCLUDED.slug,
+        kind = EXCLUDED.kind,
+        title = EXCLUDED.title,
+        domain = EXCLUDED.domain,
+        domains = EXCLUDED.domains,
+        tags = EXCLUDED.tags,
+        audience = EXCLUDED.audience,
+        requires = EXCLUDED.requires,
+        status = EXCLUDED.status,
+        lifecycle_state = EXCLUDED.lifecycle_state,
+        supersedes = EXCLUDED.supersedes,
+        superseded_by = EXCLUDED.superseded_by,
+        verified = EXCLUDED.verified,
+        lead = EXCLUDED.lead,
+        sections = EXCLUDED.sections,
+        body_hash = EXCLUDED.body_hash,
+        documents_primary = EXCLUDED.documents_primary,
+        tended = NOW()
+    WHERE wiki.pages.body_hash <> EXCLUDED.body_hash
+       OR wiki.pages.documents_primary IS DISTINCT FROM EXCLUDED.documents_primary
+    RETURNING id, (xmax = 0) AS inserted;
+    """
+    params = {
+        "memory_id": page.get("memory_id"),
+        "concept_id": page.get("concept_id"),
+        "rel_path": page["rel_path"],
+        "slug": page["slug"],
+        "kind": page["kind"],
+        "title": page["title"],
+        "domain": page.get("domain", ""),
+        "domains": json.dumps(page.get("domains", [])),
+        "tags": json.dumps(page.get("tags", [])),
+        "audience": json.dumps(page.get("audience", [])),
+        "requires": json.dumps(page.get("requires", [])),
+        "status": page.get("status", "seedling"),
+        "lifecycle_state": page.get("lifecycle_state", "active"),
+        "supersedes": page.get("supersedes"),
+        "superseded_by": page.get("superseded_by"),
+        "verified": page.get("verified"),
+        "lead": page.get("lead", ""),
+        "sections": json.dumps(page.get("sections", {})),
+        "body_hash": bh,
+        "documents_primary": documents_primary,
+    }
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        row = cur.fetchone()
+        if row is not None:
+            # Row was inserted or actually updated.
+            page_id = row["id"] if isinstance(row, dict) else row[0]
+            upsert_page_sources(conn, page_id, documents)
+            return page_id, True
+        # WHERE clause filtered the UPDATE out → body_hash matched, no-op.
+        cur.execute(
+            "SELECT id FROM wiki.pages WHERE rel_path = %s", (page["rel_path"],)
+        )
+        existing = cur.fetchone()
+        if existing is None:
+            return -1, False
+        existing_id = existing["id"] if isinstance(existing, dict) else existing[0]
+        upsert_page_sources(conn, existing_id, documents)
+        return existing_id, False
+
+
+def get_page_by_slug(conn: Connection, slug: str) -> dict | None:
+    """Return a page row by slug, or None."""
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute("SELECT * FROM wiki.pages WHERE slug = %s LIMIT 1", (slug,))
+        return cur.fetchone()
+
+
+def get_page_by_rel_path(conn: Connection, rel_path: str) -> dict | None:
+    """Return a page row by rel_path, or None."""
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute("SELECT * FROM wiki.pages WHERE rel_path = %s LIMIT 1", (rel_path,))
+        return cur.fetchone()

--- a/mcp_server/infrastructure/pg_store_wiki_sources.py
+++ b/mcp_server/infrastructure/pg_store_wiki_sources.py
@@ -12,6 +12,38 @@ Pure infrastructure — no core imports, no handler imports.
 from __future__ import annotations
 
 from psycopg import Connection
+from psycopg.rows import dict_row
+
+
+def list_pages_missing_source_link(conn: Connection, *, limit: int) -> list[dict]:
+    """Pages with no primary 'documents' source link (ADR-0051 STEP 3).
+
+    Selects pages where ``documents_primary IS NULL`` (the fast-path
+    mirror is unset) AND no ``wiki.page_sources`` row exists for that
+    page with ``link_kind = 'documents'`` (the N:M source of truth is
+    also empty) — both must be absent, matching the invariant
+    ``upsert_page`` maintains between the two representations.
+
+    Pre-condition:  ``limit`` bounds the per-cycle scan so a large wiki
+                    doesn't stall one ``consolidate`` invocation.
+    Post-condition: every returned row's ``id`` refers to a page with
+                    zero 'documents' rows in wiki.page_sources and a
+                    NULL documents_primary.
+    """
+    sql = """
+    SELECT p.id, p.memory_id, p.rel_path, p.title, p.domain, p.lead, p.sections
+      FROM wiki.pages p
+     WHERE p.documents_primary IS NULL
+       AND NOT EXISTS (
+             SELECT 1 FROM wiki.page_sources s
+              WHERE s.page_id = p.id AND s.link_kind = 'documents'
+           )
+     ORDER BY p.id
+     LIMIT %s
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, (limit,))
+        return list(cur.fetchall())
 
 
 def upsert_page_sources(

--- a/mcp_server/infrastructure/pg_store_wiki_sources.py
+++ b/mcp_server/infrastructure/pg_store_wiki_sources.py
@@ -1,0 +1,62 @@
+"""wiki.page_sources DB operations (ADR-0051 STEP 2 — the writer).
+
+Split out of ``pg_store_wiki.py`` (already ~874 lines, over the 300-line
+file limit) rather than added there — coding-standards.md §4.1. Mirrors
+the shape of ``pg_store_wiki.upsert_link``: an idempotent refresh scoped
+by a key, matching how ``wiki_migrate.migrate_wiki`` already refreshes
+``wiki.links`` via ``delete_links_from`` + re-insert per page.
+
+Pure infrastructure — no core imports, no handler imports.
+"""
+
+from __future__ import annotations
+
+from psycopg import Connection
+
+
+def upsert_page_sources(
+    conn: Connection,
+    page_id: int,
+    documents: list[str],
+    *,
+    link_kind: str = "documents",
+    source: str = "frontmatter",
+    confidence: float = 1.0,
+) -> int:
+    """Idempotently replace a page's ``wiki.page_sources`` rows for one link_kind.
+
+    Delete-then-insert scoped to ``(page_id, link_kind)`` — mirrors
+    ``pg_store_wiki`` refreshing ``wiki.links`` per src page before
+    re-inserting the current set, so re-running the writer on an
+    unchanged page produces the same rows (idempotent), and a page
+    whose frontmatter dropped a file removes the stale edge instead
+    of accumulating it forever.
+
+    Pre-condition:  page_id refers to an existing wiki.pages row;
+                    documents entries are already canonical
+                    (mcp_server.shared.wiki_source_paths.normalize_source_path).
+    Post-condition: wiki.page_sources contains exactly one row per
+                    unique path in ``documents`` for this
+                    (page_id, link_kind), and no other rows for that
+                    (page_id, link_kind) survive from a prior call.
+
+    Returns the number of rows inserted.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM wiki.page_sources WHERE page_id = %s AND link_kind = %s",
+            (page_id, link_kind),
+        )
+        if not documents:
+            return 0
+        cur.executemany(
+            """
+            INSERT INTO wiki.page_sources (page_id, source_path, link_kind, confidence, source)
+            VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT (page_id, source_path, link_kind) DO UPDATE SET
+                confidence = EXCLUDED.confidence,
+                source = EXCLUDED.source
+            """,
+            [(page_id, path, link_kind, confidence, source) for path in documents],
+        )
+        return len(documents)

--- a/mcp_server/infrastructure/pg_store_wiki_sources.py
+++ b/mcp_server/infrastructure/pg_store_wiki_sources.py
@@ -46,10 +46,39 @@ def list_pages_missing_source_link(conn: Connection, *, limit: int) -> list[dict
         return list(cur.fetchall())
 
 
+SourceEntry = str | tuple[str, str] | tuple[str, str, float]
+
+
+def _entry_row(
+    entry: SourceEntry,
+    page_id: int,
+    link_kind: str,
+    *,
+    default_source: str,
+    default_confidence: float,
+) -> tuple[int, str, str, float, str]:
+    """Build one INSERT row ``(page_id, path, link_kind, confidence, source)``.
+
+    A bare ``str`` entry uses the call's ``source``/``confidence``
+    defaults (the original, still-supported shape — the ``documents``
+    link_kind callers pass a uniform origin for the whole list). A
+    ``tuple`` carries its own per-entry origin (ADR-0051 STEP 4: the
+    ``references`` link_kind mixes ``claim_evidence`` and ``body``
+    provenance in one call, which a single call-level ``source`` cannot
+    express).
+    """
+    if isinstance(entry, tuple):
+        path = entry[0]
+        entry_source = entry[1] if len(entry) > 1 else default_source
+        entry_confidence = entry[2] if len(entry) > 2 else default_confidence
+        return page_id, path, link_kind, entry_confidence, entry_source
+    return page_id, entry, link_kind, default_confidence, default_source
+
+
 def upsert_page_sources(
     conn: Connection,
     page_id: int,
-    documents: list[str],
+    documents: list[SourceEntry],
     *,
     link_kind: str = "documents",
     source: str = "frontmatter",
@@ -58,19 +87,20 @@ def upsert_page_sources(
     """Idempotently replace a page's ``wiki.page_sources`` rows for one link_kind.
 
     Delete-then-insert scoped to ``(page_id, link_kind)`` — mirrors
-    ``pg_store_wiki`` refreshing ``wiki.links`` per src page before
-    re-inserting the current set, so re-running the writer on an
-    unchanged page produces the same rows (idempotent), and a page
-    whose frontmatter dropped a file removes the stale edge instead
-    of accumulating it forever.
+    ``pg_store_wiki`` refreshing ``wiki.links``, so re-running the writer
+    on an unchanged page produces the same rows (idempotent).
 
-    Pre-condition:  page_id refers to an existing wiki.pages row;
-                    documents entries are already canonical
-                    (mcp_server.shared.wiki_source_paths.normalize_source_path).
-    Post-condition: wiki.page_sources contains exactly one row per
-                    unique path in ``documents`` for this
-                    (page_id, link_kind), and no other rows for that
-                    (page_id, link_kind) survive from a prior call.
+    ``documents`` entries: plain ``str`` uses the call's ``source``/
+    ``confidence`` for every row (original shape, unchanged); a
+    ``(path, source)`` / ``(path, source, confidence)`` tuple carries its
+    own per-entry origin (additive, ADR-0051 STEP 4 — a single call now
+    mixes provenances, e.g. 'references' mixing claim_evidence + body).
+
+    Pre-condition:  page_id exists; every path is already canonical
+                    (wiki_source_paths.normalize_source_path).
+    Post-condition: wiki.page_sources has exactly one row per unique
+                    path in ``documents`` for this (page_id, link_kind);
+                    no prior-call row for that key survives.
 
     Returns the number of rows inserted.
     """
@@ -81,6 +111,16 @@ def upsert_page_sources(
         )
         if not documents:
             return 0
+        rows = [
+            _entry_row(
+                entry,
+                page_id,
+                link_kind,
+                default_source=source,
+                default_confidence=confidence,
+            )
+            for entry in documents
+        ]
         cur.executemany(
             """
             INSERT INTO wiki.page_sources (page_id, source_path, link_kind, confidence, source)
@@ -89,6 +129,6 @@ def upsert_page_sources(
                 confidence = EXCLUDED.confidence,
                 source = EXCLUDED.source
             """,
-            [(page_id, path, link_kind, confidence, source) for path in documents],
+            rows,
         )
-        return len(documents)
+        return len(rows)

--- a/mcp_server/infrastructure/pg_store_wiki_thermo.py
+++ b/mcp_server/infrastructure/pg_store_wiki_thermo.py
@@ -1,0 +1,126 @@
+"""wiki.pages bulk thermodynamic-update DB operations.
+
+Split out of ``pg_store_wiki.py`` (originally 890 lines, over the
+300-line file limit — CLAUDE.md "Code Quality Rules") purely for size
+compliance; no logic changed.
+
+Pure infrastructure — no core imports, no handler imports.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from psycopg import Connection
+from psycopg.rows import dict_row
+
+
+def list_pages_for_decay(
+    conn: Connection,
+    *,
+    limit: int = 5000,
+    include_archived: bool = False,
+) -> list[dict]:
+    """Pages eligible for a thermodynamic sweep.
+
+    Skips evergreen by default (never decays) and archived unless
+    ``include_archived`` is True (only useful to detect revivals,
+    which we handle via the citation trigger anyway).
+    """
+    states = ["active", "area"]
+    if include_archived:
+        states.append("archived")
+    sql = """
+    SELECT id, heat, lifecycle_state, tended, is_stale, lead, sections
+      FROM wiki.pages
+     WHERE lifecycle_state = ANY(%s)
+     ORDER BY id LIMIT %s
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, (states, limit))
+        return list(cur.fetchall())
+
+
+def apply_thermo_decisions(conn: Connection, decisions: list[Any]) -> int:
+    """Bulk apply HeatDecision rows. Returns count of pages written.
+
+    Idempotent — UPDATE only fires when at least one of (heat,
+    lifecycle_state, archived_at) differs from current.
+    """
+    if not decisions:
+        return 0
+    written = 0
+    with conn.cursor() as cur:
+        for d in decisions:
+            cur.execute(
+                """
+                UPDATE wiki.pages
+                   SET heat = %s,
+                       lifecycle_state = %s,
+                       archived_at = COALESCE(%s::timestamptz, archived_at),
+                       tended = NOW()
+                 WHERE id = %s
+                   AND (
+                     ABS(heat - %s) > 0.001
+                     OR lifecycle_state <> %s
+                     OR (%s::timestamptz IS NOT NULL AND archived_at IS NULL)
+                   )
+                """,
+                (
+                    d.new_heat,
+                    d.new_lifecycle,
+                    d.archived_at,
+                    d.page_id,
+                    d.new_heat,
+                    d.new_lifecycle,
+                    d.archived_at,
+                ),
+            )
+            written += cur.rowcount
+    return written
+
+
+def apply_staleness_decisions(conn: Connection, decisions: list[Any]) -> int:
+    """Bulk apply StalenessDecision rows. Returns transitions written."""
+    if not decisions:
+        return 0
+    written = 0
+    with conn.cursor() as cur:
+        for d in decisions:
+            if not d.transitioned:
+                continue
+            cur.execute(
+                "UPDATE wiki.pages SET is_stale = %s WHERE id = %s",
+                (d.is_stale_now, d.page_id),
+            )
+            written += cur.rowcount
+    return written
+
+
+def get_claim_file_refs_for_pages(
+    conn: Connection, page_ids: list[int]
+) -> dict[int, list[str]]:
+    """For each page, return the file paths cited by its source memory's claims.
+
+    Joins wiki.pages → memories → wiki.claim_events; pulls evidence_refs
+    of kind='file'. Returns {page_id: [file_path, ...]}.
+    """
+    if not page_ids:
+        return {}
+    sql = """
+    SELECT p.id AS page_id,
+           c.evidence_refs
+      FROM wiki.pages p
+      JOIN wiki.claim_events c ON c.memory_id = p.memory_id
+     WHERE p.id = ANY(%s)
+    """
+    out: dict[int, set[str]] = {}
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, (list(page_ids),))
+        for row in cur.fetchall():
+            page_id = row["page_id"]
+            refs = row["evidence_refs"] or []
+            for ref in refs:
+                if isinstance(ref, dict) and ref.get("kind") == "file":
+                    out.setdefault(page_id, set()).add(ref["target"])
+    return {k: sorted(v) for k, v in out.items()}

--- a/mcp_server/shared/wiki_source_paths.py
+++ b/mcp_server/shared/wiki_source_paths.py
@@ -1,0 +1,95 @@
+"""Canonical form for wiki page -> source-file path linkage (ADR-0051 STEP 2).
+
+Wiki pages record the source file(s) they document in one of three legacy
+frontmatter forms (``source_file_path:``, ``file:``, or a ``file:<path>``
+tag), all three of which already carry the value produced by
+``wiki_coverage.list_source_files`` / ``wiki_file_doc_skeleton``: a path
+*relative to the project source root*, forward-slash separated
+(``mcp_server.shared.platform.to_posix``). This module is the single place
+that normalizes any of those raw strings into that one canonical form
+before it reaches ``wiki.page_sources.source_path`` — reusing the existing
+convention rather than inventing a new one (see
+``mcp_server/core/wiki_coverage.py::list_source_files`` and
+``mcp_server/core/wiki_drift.py::audit_wiki_drift``, both of which already
+produce/consume this exact shape).
+
+Canonical form: POSIX-separated, no leading ``./``, no leading ``/``,
+project-source-root-relative. Pure string processing — no filesystem
+access, no project-source-root resolution — hence shared/ (stdlib only).
+
+Pre-condition:  raw frontmatter values are strings (scalar) or lists of
+                strings, as parsed by ``mcp_server.core.wiki_pages.parse_page``.
+Post-condition: every path returned by ``extract_document_paths`` is
+                non-empty, forward-slash separated, and has no leading
+                ``./`` or ``/``. Duplicates are removed, order preserved.
+"""
+
+from __future__ import annotations
+
+_FILE_TAG_PREFIX = "file:"
+
+
+def normalize_source_path(raw: str) -> str | None:
+    """Canonicalize one raw path string. Returns None for blank input.
+
+    Pre-condition:  ``raw`` is a str (possibly with backslashes, a leading
+                    ``./``, or leading ``/`` — the forms this repo has
+                    actually emitted or could plausibly copy-paste).
+    Post-condition: return value is forward-slash separated with no
+                    leading ``./`` or ``/``, or None if ``raw`` was blank.
+    """
+    if not raw or not isinstance(raw, str):
+        return None
+    text = raw.strip().replace("\\", "/")
+    while text.startswith("./"):
+        text = text[2:]
+    text = text.lstrip("/")
+    return text or None
+
+
+def extract_document_paths(
+    frontmatter: dict[str, object], tags: list[str] | None = None
+) -> list[str]:
+    """Pull every documented-file path out of a page's frontmatter + tags.
+
+    Reads, in this precedence order, every legacy form this repo has
+    written (back-compat — all are read, none is preferred over the
+    others as a *source*; results are deduped, not chosen-between):
+
+      * ``documents:`` — the new field (list or scalar).
+      * ``source_file_path:`` — file-doc skeleton pages (scalar).
+      * ``file:`` — ``build_file_doc`` pages (scalar).
+      * ``file:<path>`` tags — legacy tag-encoded form.
+
+    Post-condition: returned list is deduplicated (first occurrence wins,
+                    insertion order preserved) and every entry is
+                    canonical per ``normalize_source_path``.
+    """
+    raw_values: list[str] = []
+
+    documents = frontmatter.get("documents")
+    if isinstance(documents, list):
+        raw_values.extend(str(v) for v in documents)
+    elif isinstance(documents, str) and documents:
+        raw_values.append(documents)
+
+    source_file_path = frontmatter.get("source_file_path")
+    if isinstance(source_file_path, str) and source_file_path:
+        raw_values.append(source_file_path)
+
+    file_field = frontmatter.get("file")
+    if isinstance(file_field, str) and file_field:
+        raw_values.append(file_field)
+
+    for tag in tags or []:
+        if isinstance(tag, str) and tag.startswith(_FILE_TAG_PREFIX):
+            raw_values.append(tag[len(_FILE_TAG_PREFIX) :])
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_values:
+        canonical = normalize_source_path(raw)
+        if canonical and canonical not in seen:
+            seen.add(canonical)
+            out.append(canonical)
+    return out

--- a/tests_py/core/test_wiki_drift.py
+++ b/tests_py/core/test_wiki_drift.py
@@ -174,7 +174,9 @@ Undocumented linkage.
 None cited here.
 """
         _write(str(wiki / "reference" / "cortex" / "foo.md"), body)
-        d = audit_page_drift(str(wiki), "reference/cortex/foo.md", None, max_age_days=365)
+        d = audit_page_drift(
+            str(wiki), "reference/cortex/foo.md", None, max_age_days=365
+        )
         assert d is not None
         assert REASON_MISSING_LINK in d.reasons
 
@@ -202,7 +204,9 @@ Documented linkage.
 N/A.
 """
         _write(str(wiki / "reference" / "cortex" / "foo.md"), body)
-        d = audit_page_drift(str(wiki), "reference/cortex/foo.md", None, max_age_days=365)
+        d = audit_page_drift(
+            str(wiki), "reference/cortex/foo.md", None, max_age_days=365
+        )
         if d is not None:
             assert REASON_MISSING_LINK not in d.reasons
 

--- a/tests_py/core/test_wiki_drift.py
+++ b/tests_py/core/test_wiki_drift.py
@@ -6,6 +6,7 @@ import os
 import time
 
 from mcp_server.core.wiki_drift import (
+    REASON_MISSING_LINK,
     REASON_MISSING_SOURCE,
     REASON_OFF_TEMPLATE,
     REASON_STALE,
@@ -149,6 +150,72 @@ class TestAuditPageDrift:
         # No source root → no missing-source flag. Other reasons may still fire.
         if d is not None:
             assert REASON_MISSING_SOURCE not in d.reasons
+
+    def test_reference_page_without_link_flagged_missing_link(self, tmp_path):
+        """A source-documenting page with no frontmatter documents: and
+        no groundable body citation is missing-link drift (ADR-0051
+        STEP 3 — REASON_MISSING_LINK)."""
+        wiki = tmp_path / "wiki"
+        body = """\
+---
+title: Foo
+kind: reference
+updated: 2026-01-01
+---
+
+# `mcp_server/core/foo.py`
+
+## Scope
+
+Undocumented linkage.
+
+## API
+
+None cited here.
+"""
+        _write(str(wiki / "reference" / "cortex" / "foo.md"), body)
+        d = audit_page_drift(str(wiki), "reference/cortex/foo.md", None, max_age_days=365)
+        assert d is not None
+        assert REASON_MISSING_LINK in d.reasons
+
+    def test_reference_page_with_frontmatter_documents_not_flagged(self, tmp_path):
+        """A page whose frontmatter already declares documents: is
+        linked — REASON_MISSING_LINK must not fire even without a
+        source root to verify against."""
+        wiki = tmp_path / "wiki"
+        body = """\
+---
+title: Foo
+kind: reference
+updated: 2026-01-01
+documents: mcp_server/core/foo.py
+---
+
+# `mcp_server/core/foo.py`
+
+## Scope
+
+Documented linkage.
+
+## API
+
+N/A.
+"""
+        _write(str(wiki / "reference" / "cortex" / "foo.md"), body)
+        d = audit_page_drift(str(wiki), "reference/cortex/foo.md", None, max_age_days=365)
+        if d is not None:
+            assert REASON_MISSING_LINK not in d.reasons
+
+    def test_non_reference_kind_never_flagged_missing_link(self, tmp_path):
+        """An ADR page doesn't claim to document a single source file,
+        so REASON_MISSING_LINK never applies to it."""
+        wiki = tmp_path / "wiki"
+        src = tmp_path / "src"
+        _write(str(wiki / "adr" / "p" / "0001-foo.md"), ADR_BODY_WITH_SOURCE)
+        _write(str(src / "mcp_server" / "core" / "foo.py"), "x")
+        d = audit_page_drift(str(wiki), "adr/p/0001-foo.md", str(src), max_age_days=365)
+        if d is not None:
+            assert REASON_MISSING_LINK not in d.reasons
 
 
 class TestAuditWikiDrift:

--- a/tests_py/core/test_wiki_source_backfill.py
+++ b/tests_py/core/test_wiki_source_backfill.py
@@ -43,16 +43,20 @@ class TestClaimEvidence:
 
 class TestCodebaseGrounding:
     def test_slug_reversed_and_grounded(self):
-        page = {"rel_path": "reference/cortex/mcp_server-core-foo.py.md", "domain": "cortex"}
-        result = derive_primary_source(
-            page, [], _exists_only("mcp_server/core/foo.py")
-        )
+        page = {
+            "rel_path": "reference/cortex/mcp_server-core-foo.py.md",
+            "domain": "cortex",
+        }
+        result = derive_primary_source(page, [], _exists_only("mcp_server/core/foo.py"))
         assert result == ("mcp_server/core/foo.py", SOURCE_CODEBASE_GROUNDING)
 
     def test_refuses_to_fabricate_when_guess_does_not_exist(self):
         """Anti-fabrication: a plausible-looking guess that doesn't
         resolve to a real file must never be accepted."""
-        page = {"rel_path": "reference/cortex/mcp_server-core-foo.py.md", "domain": "cortex"}
+        page = {
+            "rel_path": "reference/cortex/mcp_server-core-foo.py.md",
+            "domain": "cortex",
+        }
         result = derive_primary_source(page, [], _exists_only())
         assert result is None
 

--- a/tests_py/core/test_wiki_source_backfill.py
+++ b/tests_py/core/test_wiki_source_backfill.py
@@ -1,0 +1,124 @@
+"""Tests for core.wiki_source_backfill — primary source derivation
+(ADR-0051 STEP 3)."""
+
+from __future__ import annotations
+
+from mcp_server.core.wiki_source_backfill import (
+    SOURCE_BODY,
+    SOURCE_CLAIM_EVIDENCE,
+    SOURCE_CODEBASE_GROUNDING,
+    derive_primary_source,
+)
+
+
+def _exists_only(*paths: str):
+    allowed = set(paths)
+    return lambda p: p in allowed
+
+
+class TestClaimEvidence:
+    def test_single_claim_file_wins(self):
+        page = {"rel_path": "reference/cortex/foo.md", "domain": "cortex"}
+        result = derive_primary_source(page, ["mcp_server/core/foo.py"], _exists_only())
+        assert result == ("mcp_server/core/foo.py", SOURCE_CLAIM_EVIDENCE)
+
+    def test_multiple_distinct_claim_files_refuse_to_guess(self):
+        page = {"rel_path": "reference/cortex/foo.md", "domain": "cortex"}
+        result = derive_primary_source(
+            page,
+            ["mcp_server/core/foo.py", "mcp_server/core/bar.py"],
+            _exists_only("mcp_server/core/foo.py", "mcp_server/core/bar.py"),
+        )
+        assert result is None
+
+    def test_duplicate_claim_files_after_normalization_collapse_to_one(self):
+        page = {"rel_path": "reference/cortex/foo.md", "domain": "cortex"}
+        result = derive_primary_source(
+            page,
+            ["./mcp_server/core/foo.py", "mcp_server/core/foo.py"],
+            _exists_only(),
+        )
+        assert result == ("mcp_server/core/foo.py", SOURCE_CLAIM_EVIDENCE)
+
+
+class TestCodebaseGrounding:
+    def test_slug_reversed_and_grounded(self):
+        page = {"rel_path": "reference/cortex/mcp_server-core-foo.py.md", "domain": "cortex"}
+        result = derive_primary_source(
+            page, [], _exists_only("mcp_server/core/foo.py")
+        )
+        assert result == ("mcp_server/core/foo.py", SOURCE_CODEBASE_GROUNDING)
+
+    def test_refuses_to_fabricate_when_guess_does_not_exist(self):
+        """Anti-fabrication: a plausible-looking guess that doesn't
+        resolve to a real file must never be accepted."""
+        page = {"rel_path": "reference/cortex/mcp_server-core-foo.py.md", "domain": "cortex"}
+        result = derive_primary_source(page, [], _exists_only())
+        assert result is None
+
+
+class TestBodyCitation:
+    def test_single_groundable_citation_in_lead(self):
+        page = {
+            "rel_path": "reference/cortex/some-note.md",
+            "domain": "cortex",
+            "lead": "Implemented in `mcp_server/core/foo.py`.",
+            "sections": {},
+        }
+        result = derive_primary_source(page, [], _exists_only("mcp_server/core/foo.py"))
+        assert result == ("mcp_server/core/foo.py", SOURCE_BODY)
+
+    def test_single_groundable_citation_in_sections(self):
+        page = {
+            "rel_path": "reference/cortex/some-note.md",
+            "domain": "cortex",
+            "lead": "",
+            "sections": {"Notes": "See `mcp_server/core/foo.py` for details."},
+        }
+        result = derive_primary_source(page, [], _exists_only("mcp_server/core/foo.py"))
+        assert result == ("mcp_server/core/foo.py", SOURCE_BODY)
+
+    def test_multiple_groundable_citations_refuse_to_guess(self):
+        page = {
+            "rel_path": "reference/cortex/some-note.md",
+            "domain": "cortex",
+            "lead": "See `mcp_server/core/foo.py` and `mcp_server/core/bar.py`.",
+            "sections": {},
+        }
+        result = derive_primary_source(
+            page,
+            [],
+            _exists_only("mcp_server/core/foo.py", "mcp_server/core/bar.py"),
+        )
+        assert result is None
+
+    def test_ungroundable_citation_is_ignored(self):
+        page = {
+            "rel_path": "reference/cortex/some-note.md",
+            "domain": "cortex",
+            "lead": "See `mcp_server/core/ghost.py`.",
+            "sections": {},
+        }
+        result = derive_primary_source(page, [], _exists_only())
+        assert result is None
+
+
+class TestPriorityOrder:
+    def test_claim_evidence_wins_over_body_citation(self):
+        page = {
+            "rel_path": "reference/cortex/some-note.md",
+            "domain": "cortex",
+            "lead": "See `mcp_server/core/bar.py`.",
+            "sections": {},
+        }
+        result = derive_primary_source(
+            page,
+            ["mcp_server/core/foo.py"],
+            _exists_only("mcp_server/core/bar.py"),
+        )
+        assert result == ("mcp_server/core/foo.py", SOURCE_CLAIM_EVIDENCE)
+
+    def test_no_candidate_anywhere_returns_none(self):
+        page = {"rel_path": "reference/cortex/some-note.md", "domain": "cortex"}
+        result = derive_primary_source(page, [], _exists_only())
+        assert result is None

--- a/tests_py/core/test_wiki_staleness_typed.py
+++ b/tests_py/core/test_wiki_staleness_typed.py
@@ -1,0 +1,119 @@
+"""Tests for ADR-0051 STEP 4 typed harvest additions to core.wiki_staleness.
+
+Covers:
+  1. ``harvest_page_refs_typed`` — per-path provenance, claim wins over body.
+  2. ``harvest_page_refs`` still returns the same sorted-union list it did
+     before the typed refactor (behavior-preserving).
+  3. ``normalize_typed_refs`` — canonicalization + merge-on-collision with
+     claim_evidence winning regardless of iteration order.
+"""
+
+from __future__ import annotations
+
+from mcp_server.core.wiki_staleness import (
+    REF_SOURCE_BODY,
+    REF_SOURCE_CLAIM_EVIDENCE,
+    harvest_page_refs,
+    harvest_page_refs_typed,
+    normalize_typed_refs,
+)
+
+
+# ── harvest_page_refs_typed ──────────────────────────────────────────────
+
+
+def test_typed_harvest_tags_claim_evidence() -> None:
+    page = {"lead": "", "sections": {}}
+    typed = harvest_page_refs_typed(page, ["mcp_server/core/foo.py"])
+    assert typed == {"mcp_server/core/foo.py": REF_SOURCE_CLAIM_EVIDENCE}
+
+
+def test_typed_harvest_tags_body_refs() -> None:
+    page = {"lead": "See mcp_server/core/bar.py for details.", "sections": {}}
+    typed = harvest_page_refs_typed(page, [])
+    assert typed == {"mcp_server/core/bar.py": REF_SOURCE_BODY}
+
+
+def test_typed_harvest_claim_wins_over_body_on_same_path() -> None:
+    page = {"lead": "See mcp_server/core/baz.py.", "sections": {}}
+    typed = harvest_page_refs_typed(page, ["mcp_server/core/baz.py"])
+    assert typed == {"mcp_server/core/baz.py": REF_SOURCE_CLAIM_EVIDENCE}
+
+
+def test_typed_harvest_scans_sections_dict() -> None:
+    page = {"lead": "", "sections": {"details": "mcp_server/core/qux.py cited here"}}
+    typed = harvest_page_refs_typed(page, [])
+    assert typed == {"mcp_server/core/qux.py": REF_SOURCE_BODY}
+
+
+def test_typed_harvest_scans_sections_list() -> None:
+    page = {
+        "lead": "",
+        "sections": [{"body": "mcp_server/core/list_form.py referenced"}],
+    }
+    typed = harvest_page_refs_typed(page, [])
+    assert typed == {"mcp_server/core/list_form.py": REF_SOURCE_BODY}
+
+
+def test_typed_harvest_empty_page_no_claims_is_empty() -> None:
+    assert harvest_page_refs_typed({"lead": "", "sections": {}}, []) == {}
+
+
+# ── harvest_page_refs (behavior-preserving adapter) ──────────────────────
+
+
+def test_harvest_page_refs_returns_sorted_union() -> None:
+    page = {"lead": "mcp_server/core/a.py and mcp_server/core/c.py", "sections": {}}
+    refs = harvest_page_refs(page, ["mcp_server/core/b.py"])
+    assert refs == [
+        "mcp_server/core/a.py",
+        "mcp_server/core/b.py",
+        "mcp_server/core/c.py",
+    ]
+
+
+def test_harvest_page_refs_dedupes_claim_and_body_overlap() -> None:
+    page = {"lead": "mcp_server/core/dup.py", "sections": {}}
+    refs = harvest_page_refs(page, ["mcp_server/core/dup.py"])
+    assert refs == ["mcp_server/core/dup.py"]
+
+
+# ── normalize_typed_refs ──────────────────────────────────────────────────
+
+
+def test_normalize_typed_refs_canonicalizes_paths() -> None:
+    typed = {"./mcp_server/core/a.py": REF_SOURCE_BODY}
+    assert normalize_typed_refs(typed) == {"mcp_server/core/a.py": REF_SOURCE_BODY}
+
+
+def test_normalize_typed_refs_merges_colliding_paths_claim_wins_body_first() -> None:
+    # Iteration order: body entry inserted before the claim entry that
+    # normalizes to the same canonical path.
+    typed = {
+        "./mcp_server/core/a.py": REF_SOURCE_BODY,
+        "mcp_server/core/a.py": REF_SOURCE_CLAIM_EVIDENCE,
+    }
+    assert normalize_typed_refs(typed) == {
+        "mcp_server/core/a.py": REF_SOURCE_CLAIM_EVIDENCE
+    }
+
+
+def test_normalize_typed_refs_merges_colliding_paths_claim_wins_claim_first() -> None:
+    # Iteration order: claim entry inserted before the body entry that
+    # normalizes to the same canonical path — claim must not be demoted.
+    typed = {
+        "mcp_server/core/a.py": REF_SOURCE_CLAIM_EVIDENCE,
+        "./mcp_server/core/a.py": REF_SOURCE_BODY,
+    }
+    assert normalize_typed_refs(typed) == {
+        "mcp_server/core/a.py": REF_SOURCE_CLAIM_EVIDENCE
+    }
+
+
+def test_normalize_typed_refs_drops_blank_paths() -> None:
+    typed = {"": REF_SOURCE_BODY, "   ": REF_SOURCE_CLAIM_EVIDENCE}
+    assert normalize_typed_refs(typed) == {}
+
+
+def test_normalize_typed_refs_empty_input_is_empty() -> None:
+    assert normalize_typed_refs({}) == {}

--- a/tests_py/handlers/test_wiki_consolidate_staleness.py
+++ b/tests_py/handlers/test_wiki_consolidate_staleness.py
@@ -1,0 +1,69 @@
+"""Tests for ADR-0051 STEP 4 — wiki_consolidate Pass 2 reference-link
+persistence (mcp_server.handlers.wiki_consolidate_staleness).
+
+Covers:
+  1. dry_run guard — zero DB writes (no apply_staleness_decisions, no
+     insert_memo, no upsert_page_sources) when dry_run=True.
+  2. references_written / staleness summary shape when not dry_run.
+  3. references land normalized + with correct per-path origin end to end
+     (harvest -> normalize -> persist), via the actual upsert call args.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from mcp_server.handlers.wiki_consolidate_staleness import run_staleness_pass
+
+
+def _page(page_id: int, *, lead: str = "", is_stale: bool = False) -> dict:
+    return {"id": page_id, "lead": lead, "sections": {}, "is_stale": is_stale}
+
+
+@patch("mcp_server.handlers.wiki_consolidate_staleness.upsert_page_sources")
+@patch("mcp_server.handlers.wiki_consolidate_staleness.insert_memo")
+@patch("mcp_server.handlers.wiki_consolidate_staleness.apply_staleness_decisions")
+@patch("mcp_server.handlers.wiki_consolidate_staleness.get_claim_file_refs_for_pages")
+def test_dry_run_performs_zero_writes(
+    mock_claims, mock_apply, mock_memo, mock_upsert
+) -> None:
+    mock_claims.return_value = {1: ["mcp_server/core/a.py"]}
+    pages = [_page(1, lead="mcp_server/core/a.py cited")]
+
+    summary = run_staleness_pass(
+        conn=object(), pages=pages, repo_root=Path("/tmp/nonexistent"), dry_run=True
+    )
+
+    mock_apply.assert_not_called()
+    mock_memo.assert_not_called()
+    mock_upsert.assert_not_called()
+    assert summary["transitions_written"] == 0
+    assert summary["references_written"] == 0
+    assert summary["skipped"] is False
+
+
+@patch("mcp_server.handlers.wiki_consolidate_staleness.upsert_page_sources")
+@patch("mcp_server.handlers.wiki_consolidate_staleness.insert_memo")
+@patch("mcp_server.handlers.wiki_consolidate_staleness.apply_staleness_decisions")
+@patch("mcp_server.handlers.wiki_consolidate_staleness.get_claim_file_refs_for_pages")
+def test_not_dry_run_persists_references_per_page(
+    mock_claims, mock_apply, mock_memo, mock_upsert
+) -> None:
+    mock_claims.return_value = {1: ["mcp_server/core/a.py"]}
+    mock_apply.return_value = 0
+    mock_upsert.return_value = 1
+    pages = [_page(1, lead="mcp_server/core/a.py and mcp_server/core/b.py cited")]
+
+    summary = run_staleness_pass(
+        conn=object(), pages=pages, repo_root=Path("/tmp/nonexistent"), dry_run=False
+    )
+
+    mock_apply.assert_called_once()
+    mock_upsert.assert_called_once()
+    call_args = mock_upsert.call_args
+    assert call_args.kwargs["link_kind"] == "references"
+    entries = dict(call_args.args[2])
+    assert entries["mcp_server/core/a.py"] == "claim_evidence"
+    assert entries["mcp_server/core/b.py"] == "body"
+    assert summary["references_written"] == 1

--- a/tests_py/handlers/test_wiki_page_sources.py
+++ b/tests_py/handlers/test_wiki_page_sources.py
@@ -184,3 +184,69 @@ def test_upsert_page_sources_calling_twice_reissues_same_delete_and_insert() -> 
     )
     assert cur.execute.call_args_list[0] == expected_delete
     assert cur.execute.call_args_list[1] == expected_delete
+
+
+# ── upsert_page_sources — per-entry (path, source) tuples (ADR-0051 STEP 4) ──
+
+
+def test_upsert_page_sources_accepts_tuple_entries_with_per_entry_source() -> None:
+    conn = _mock_conn()
+    cur = conn.cursor.return_value.__enter__.return_value
+
+    result = upsert_page_sources(
+        conn,
+        page_id=7,
+        documents=[("a/b.py", "claim_evidence"), ("a/c.py", "body")],
+        link_kind="references",
+    )
+
+    assert result == 2
+    rows = cur.executemany.call_args.args[1]
+    assert (7, "a/b.py", "references", 1.0, "claim_evidence") in rows
+    assert (7, "a/c.py", "references", 1.0, "body") in rows
+
+
+def test_upsert_page_sources_tuple_entry_can_override_confidence() -> None:
+    conn = _mock_conn()
+    cur = conn.cursor.return_value.__enter__.return_value
+
+    upsert_page_sources(
+        conn, page_id=1, documents=[("a/b.py", "body", 0.5)], link_kind="references"
+    )
+
+    rows = cur.executemany.call_args.args[1]
+    assert rows == [(1, "a/b.py", "references", 0.5, "body")]
+
+
+def test_upsert_page_sources_str_entries_unaffected_by_tuple_support() -> None:
+    """The pre-existing all-``str`` documents call site keeps its exact shape."""
+    conn = _mock_conn()
+    cur = conn.cursor.return_value.__enter__.return_value
+
+    upsert_page_sources(
+        conn, page_id=1, documents=["a/b.py"], source="frontmatter", confidence=1.0
+    )
+
+    rows = cur.executemany.call_args.args[1]
+    assert rows == [(1, "a/b.py", "documents", 1.0, "frontmatter")]
+
+
+def test_upsert_page_sources_references_idempotent_double_call_same_rows() -> None:
+    """Two identical 'references' calls with mixed-origin tuples are idempotent."""
+    conn = _mock_conn()
+    cur = conn.cursor.return_value.__enter__.return_value
+    entries = [("a/b.py", "claim_evidence"), ("a/c.py", "body")]
+
+    upsert_page_sources(conn, page_id=3, documents=entries, link_kind="references")
+    first_rows = cur.executemany.call_args.args[1]
+
+    upsert_page_sources(conn, page_id=3, documents=entries, link_kind="references")
+    second_rows = cur.executemany.call_args.args[1]
+
+    assert first_rows == second_rows
+    expected_delete = call(
+        "DELETE FROM wiki.page_sources WHERE page_id = %s AND link_kind = %s",
+        (3, "references"),
+    )
+    assert cur.execute.call_args_list[0] == expected_delete
+    assert cur.execute.call_args_list[1] == expected_delete

--- a/tests_py/handlers/test_wiki_page_sources.py
+++ b/tests_py/handlers/test_wiki_page_sources.py
@@ -1,0 +1,186 @@
+"""Tests for ADR-0051 STEP 2 — the wiki page->source-file writer.
+
+Covers:
+  1. ``mcp_server.shared.wiki_source_paths.extract_document_paths`` reads
+     each legacy frontmatter form (documents:/source_file_path:/file:/
+     file:<path> tag) and canonicalizes them.
+  2. ``wiki_migrate._page_row_from_md`` wires that extraction into the
+     upsert_page payload (documents/documents_primary).
+  3. ``pg_store_wiki_sources.upsert_page_sources`` is idempotent —
+     calling it twice with the same documents yields the same rows.
+
+The DB-touching idempotency test uses a mocked cursor (no live Postgres
+required for the unit tier); the live integration proof against a real
+throwaway database is run separately and reported in the task output.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call
+
+from mcp_server.handlers.wiki_migrate import _page_row_from_md
+from mcp_server.infrastructure.pg_store_wiki_sources import upsert_page_sources
+from mcp_server.shared.wiki_source_paths import (
+    extract_document_paths,
+    normalize_source_path,
+)
+
+
+# ── normalize_source_path ───────────────────────────────────────────────
+
+
+def test_normalize_strips_leading_dot_slash() -> None:
+    assert normalize_source_path("./src/foo.py") == "src/foo.py"
+
+
+def test_normalize_converts_backslashes() -> None:
+    assert normalize_source_path("src\\foo\\bar.py") == "src/foo/bar.py"
+
+
+def test_normalize_strips_leading_slash() -> None:
+    assert normalize_source_path("/src/foo.py") == "src/foo.py"
+
+
+def test_normalize_blank_returns_none() -> None:
+    assert normalize_source_path("") is None
+    assert normalize_source_path("   ") is None
+
+
+# ── extract_document_paths — legacy forms ───────────────────────────────
+
+
+def test_extract_from_source_file_path_frontmatter() -> None:
+    fm = {"source_file_path": "mcp_server/core/foo.py"}
+    assert extract_document_paths(fm, []) == ["mcp_server/core/foo.py"]
+
+
+def test_extract_from_file_field_frontmatter() -> None:
+    fm = {"file": "mcp_server/core/bar.py"}
+    assert extract_document_paths(fm, []) == ["mcp_server/core/bar.py"]
+
+
+def test_extract_from_file_tag() -> None:
+    fm: dict[str, object] = {}
+    tags = ["reference", "file:mcp_server/core/baz.py", "lang:python"]
+    assert extract_document_paths(fm, tags) == ["mcp_server/core/baz.py"]
+
+
+def test_extract_from_documents_list() -> None:
+    fm = {"documents": ["a/b.py", "a/c.py"]}
+    assert extract_document_paths(fm, []) == ["a/b.py", "a/c.py"]
+
+
+def test_extract_from_documents_scalar() -> None:
+    fm = {"documents": "a/b.py"}
+    assert extract_document_paths(fm, []) == ["a/b.py"]
+
+
+def test_extract_dedupes_across_forms_preserving_order() -> None:
+    fm = {"source_file_path": "a/b.py", "file": "a/b.py"}
+    tags = ["file:a/b.py", "file:a/c.py"]
+    assert extract_document_paths(fm, tags) == ["a/b.py", "a/c.py"]
+
+
+def test_extract_canonicalizes_each_path() -> None:
+    fm = {"source_file_path": "./a/b.py"}
+    assert extract_document_paths(fm, []) == ["a/b.py"]
+
+
+def test_extract_no_documented_files_returns_empty() -> None:
+    assert extract_document_paths({}, ["unrelated"]) == []
+
+
+# ── _page_row_from_md wiring ─────────────────────────────────────────────
+
+
+def test_page_row_from_md_carries_documents_primary() -> None:
+    content = (
+        "---\n"
+        "title: File: mcp_server/core/foo.py\n"
+        "kind: reference\n"
+        "domain: cortex\n"
+        "source_file_path: mcp_server/core/foo.py\n"
+        "tags:\n"
+        "  - file\n"
+        "---\n\n"
+        "# foo.py\n"
+    )
+    row = _page_row_from_md("reference/cortex/1-foo-py.md", content)
+    assert row["documents"] == ["mcp_server/core/foo.py"]
+    assert row["documents_primary"] == "mcp_server/core/foo.py"
+
+
+def test_page_row_from_md_no_documents_is_none() -> None:
+    content = "---\ntitle: Some ADR\nkind: adr\ndomain: cortex\n---\n\nBody.\n"
+    row = _page_row_from_md("adr/cortex/1-some-adr.md", content)
+    assert row["documents"] == []
+    assert row["documents_primary"] is None
+
+
+def test_page_row_from_md_file_tag_form() -> None:
+    content = (
+        "---\n"
+        "title: File: mcp_server/core/bar.py\n"
+        "kind: file\n"
+        "domain: cortex\n"
+        "tags:\n"
+        "  - file:mcp_server/core/bar.py\n"
+        "---\n\n"
+        "# bar.py\n"
+    )
+    row = _page_row_from_md("reference/cortex/2-bar-py.md", content)
+    assert row["documents"] == ["mcp_server/core/bar.py"]
+    assert row["documents_primary"] == "mcp_server/core/bar.py"
+
+
+# ── upsert_page_sources idempotency (mocked cursor) ─────────────────────
+
+
+def _mock_conn() -> MagicMock:
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    return conn
+
+
+def test_upsert_page_sources_deletes_before_insert() -> None:
+    conn = _mock_conn()
+    cur = conn.cursor.return_value.__enter__.return_value
+
+    upsert_page_sources(conn, page_id=1, documents=["a/b.py", "a/c.py"])
+
+    delete_call = cur.execute.call_args_list[0]
+    assert "DELETE FROM wiki.page_sources" in delete_call.args[0]
+    assert delete_call.args[1] == (1, "documents")
+    cur.executemany.assert_called_once()
+
+
+def test_upsert_page_sources_empty_documents_only_deletes() -> None:
+    conn = _mock_conn()
+    cur = conn.cursor.return_value.__enter__.return_value
+
+    result = upsert_page_sources(conn, page_id=1, documents=[])
+
+    assert result == 0
+    cur.execute.assert_called_once()
+    cur.executemany.assert_not_called()
+
+
+def test_upsert_page_sources_calling_twice_reissues_same_delete_and_insert() -> None:
+    """Idempotency: two identical calls each delete-then-insert the same set."""
+    conn = _mock_conn()
+    cur = conn.cursor.return_value.__enter__.return_value
+
+    upsert_page_sources(conn, page_id=1, documents=["a/b.py"])
+    first_executemany_args = cur.executemany.call_args
+
+    upsert_page_sources(conn, page_id=1, documents=["a/b.py"])
+    second_executemany_args = cur.executemany.call_args
+
+    assert first_executemany_args == second_executemany_args
+    expected_delete = call(
+        "DELETE FROM wiki.page_sources WHERE page_id = %s AND link_kind = %s",
+        (1, "documents"),
+    )
+    assert cur.execute.call_args_list[0] == expected_delete
+    assert cur.execute.call_args_list[1] == expected_delete

--- a/uv.lock
+++ b/uv.lock
@@ -1234,7 +1234,7 @@ wheels = [
 
 [[package]]
 name = "hypermnesia-mcp"
-version = "4.0.0"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -1311,8 +1311,8 @@ requires-dist = [
     { name = "networkx", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "pandas", marker = "extra == 'viz-tile'", specifier = ">=2.2" },
-    { name = "pgvector", marker = "extra == 'benchmarks'", specifier = ">=0.3" },
-    { name = "pgvector", marker = "extra == 'postgresql'", specifier = ">=0.3" },
+    { name = "pgvector", marker = "extra == 'benchmarks'", specifier = ">=0.4,<0.6" },
+    { name = "pgvector", marker = "extra == 'postgresql'", specifier = ">=0.4,<0.6" },
     { name = "pillow", marker = "extra == 'viz-tile'", specifier = ">=10.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'benchmarks'", specifier = ">=3.1" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgresql'", specifier = ">=3.1" },


### PR DESCRIPTION
## Résumé

Implémente la liaison page wiki → fichier source (ADR-0051) de bout en bout, du schéma à la persistance des `references` typées, avec backfill des pages sans frontmatter.

## Commits
- `efacf2aa` feat(wiki): schema surface for page→source-file linkage (ADR-0051)
- `dfda3111` feat(wiki): writer persists page→source-file linkage (STEP 2)
- `a91150ba` refactor(wiki): split pg_store_wiki.py sous la règle des 300 lignes
- `820945ec` feat(wiki): backfill primary page→source linkage pour pages sans frontmatter (STEP 3)
- `62fd2bc1` feat(wiki): persist references link_kind for wiki page sources (STEP 4)
- `ee633115` chore(deps): sync uv.lock 4.0.0→4.1.0 + pgvector >=0.4,<0.6

## Résultat vérifié
- **546 références** écrites (395 `claim_evidence` + 151 `body`) sur 58 pages, 13 documents intacts.
- Aucun effet de bord : heat des pages ∈ [0.995, 1.000], `is_stale=0` (decay NON déclenché — peuplement isolé via `_harvest_all_pages` + `_persist_reference_links`, pas `run_staleness_pass`).
- 206 tests verts.

## Reste (itérations futures, non bloquant)
- Rendre le peuplement `wiki.page_sources` reproductible (script + note ADR au lieu du scratchpad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sqrkUai6jddPoFG4gRS3N