### PR TITLE
docs(readme): lead tagline with computational-neuroscience differentiator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  <strong>Persistent memory for Claude Code that holds itself accountable</strong> — forgets on purpose, says "I don't know" when unsure, flags its own contradictions. Local-first, single-click MCP install.
+  <strong>Persistent memory for Claude Code built on computational neuroscience — not just retrieval.</strong> 36 cited brain mechanisms consolidate what matters, keep it current as your project evolves, and reconstruct the right context at the right time — a living memory, not a flat RAG. Says "I don't know" when unsure, flags its own contradictions. Local-first, single-click MCP install.
 </p>
 
 <p align="center">


### PR DESCRIPTION
## What

Rewrites the README hero tagline (and the matching GitHub About description, already applied) to lead with Cortex's real differentiator: it is **built on computational neuroscience**, not a flat retrieval RAG like Obsidian / mem0 / supermemory.

**Before:** _"Persistent memory for Claude Code that holds itself accountable — forgets on purpose, …"_
**After:** _"Persistent memory for Claude Code built on computational neuroscience — not just retrieval. 36 cited brain mechanisms consolidate what matters, keep it current as your project evolves, and reconstruct the right context at the right time — a living memory, not a flat RAG. …"_

## Why

- The biomimetic-memory angle is what converts visitors (≈40 stars in one month came from exactly this framing). The old About/tagline never surfaced it — the `neuroscience`, `hopfield-network`, `predictive-coding` topics were the only hint.
- Dropped the "forgets on purpose" framing from the **public** vitrine: to a newcomer who doesn't know why active forgetting is necessary, it reads as a liability and creates an immediate no-go. Active forgetting is still fully documented in the Science section — it's just not the headline.
- Every claim maps to already-shipped, cited mechanisms (Friston 2005 write gate, McClelland 1995 CLS, Nader 2000 reconsolidation, hippocampal replay).

Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)