### PR TITLE
fix(wiki): strip quoted/duplicated-label frontmatter scalar values

### DIFF
--- a/mcp_server/core/wiki_pages.py
+++ b/mcp_server/core/wiki_pages.py
@@ -58,6 +58,42 @@ def _strip_inline_list(value: str) -> list[str]:
     return [item.strip() for item in inner.split(",") if item.strip()]
 
 
+def _clean_scalar_value(key: str, raw_stripped: str) -> str:
+    """Normalize a non-list frontmatter scalar value.
+
+    precondition: ``raw_stripped`` is the whitespace-trimmed text found
+    after the FIRST ``:`` on a frontmatter line (i.e. ``line.partition(":")``
+    already removed exactly one ``<key>:`` label); ``raw_stripped`` is
+    non-empty and is not an inline ``[...]`` list (both handled by the
+    caller before this is reached).
+    postcondition: returns ``raw_stripped`` with (a) a duplicated leading
+    ``"<key>: "`` label removed, at most once, matched case-insensitively
+    against ``key`` — this repairs content where the author's own
+    frontmatter emission echoed the key a second time inside its value
+    (observed on disk: ``title: title: "Public API surface: ..."``,
+    written verbatim by an LLM-authored page routed through
+    ``write_governed_page``, which persists caller-supplied markdown
+    without re-deriving frontmatter); (b) one matching pair of surrounding
+    quote characters (``"`` or ``'``) removed, mirroring the quote-stripping
+    the block-list branch (``items.append(...strip("\"'"))``, above) and
+    ``_strip_inline_list`` already perform for list values — the scalar
+    branch previously had no equivalent, so a value legitimately quoted
+    per YAML convention because it contains a colon (e.g.
+    ``title: "Public API surface: automatised-pipeline"``) kept its
+    literal quote characters. A value that merely starts with the key
+    name as a normal word (e.g. ``title: titleist golf clubs``) is
+    unaffected — the duplicate-label check requires the exact
+    ``"<key>:"`` token, not just a shared prefix.
+    """
+    value = raw_stripped
+    dup_prefix = f"{key}:"
+    if value.lower().startswith(dup_prefix.lower()):
+        value = value[len(dup_prefix) :].strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        value = value[1:-1]
+    return value
+
+
 def parse_page(text: str) -> PageDocument:
     """Parse a page's frontmatter + body. Tolerant of missing frontmatter.
 
@@ -115,7 +151,7 @@ def parse_page(text: str) -> PageDocument:
         if raw_stripped.startswith("[") and raw_stripped.endswith("]"):
             fm[key] = _strip_inline_list(raw_stripped)
         else:
-            fm[key] = raw_stripped
+            fm[key] = _clean_scalar_value(key, raw_stripped)
         idx += 1
     body_lines = lines[body_start:]
     while body_lines and body_lines[0] == "":

--- a/scripts/backfill_wiki_titles_2026_07_14.py
+++ b/scripts/backfill_wiki_titles_2026_07_14.py
@@ -1,0 +1,151 @@
+"""One-shot migration: repair wiki.pages.title corrupted by the parse_page
+frontmatter-scalar bug fixed in mcp_server/core/wiki_pages.py (2026-07-14).
+
+Root cause: parse_page's scalar branch (1) never stripped surrounding
+quote characters from a YAML-quoted value, and (2) never stripped a
+duplicated "<key>: " label an LLM-authored page's own frontmatter echoed
+into its value (e.g. on-disk file content literally
+``title: title: "Public API surface: automatised-pipeline"``). Both
+defects are fixed and covered by tests_py/core/test_wiki_pages.py
+(test_parse_page_strips_quoted_scalar_value,
+test_parse_page_strips_duplicated_key_label).
+
+This script targets ONLY rows whose title still carries one of these two
+corruption signatures (`title LIKE 'title:%'` or `title LIKE '"%"'`) and
+re-derives the title from the CURRENT on-disk file via the same
+`page_row_from_md` the live wiki_write/wiki_migrate path uses — not a
+duplicated parser.
+
+Why not just re-run `wiki_migrate`: `upsert_page`'s UPDATE is gated on
+`body_hash <> EXCLUDED.body_hash` (pg_store_wiki_pages.py) — a body-hash
+optimization that correctly skips no-op writes for unchanged file
+content. Because the corrupted title was derived from an unchanged file
+body (only the DERIVATION changed, not the file), that gate silently
+skips exactly the rows this migration must fix. This script performs a
+direct, explicitly-scoped `UPDATE ... SET title = %s WHERE id = %s`
+for the affected id set only — it does not touch any other column and
+does not run for rows outside the corruption signature.
+
+Usage:
+    DATABASE_URL=postgresql://cdeust@localhost:5432/cortex \\
+        python3 scripts/backfill_wiki_titles_2026_07_14.py [--dry-run]
+
+Precondition: a CSV backup of (id, rel_path, title) for every affected
+row has already been taken (see the task's
+wiki-titles-backup.csv artifact) before this script is run with
+--dry-run absent.
+Postcondition: every wiki.pages row matched by the corruption signature
+at start-of-run either (a) has its title replaced by the value
+`page_row_from_md` derives from the current on-disk file, or (b) is
+reported as "source file missing" and left untouched (never guessed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mcp_server.handlers.wiki_migrate import page_row_from_md  # noqa: E402
+from mcp_server.infrastructure.config import WIKI_ROOT  # noqa: E402
+from mcp_server.infrastructure.memory_config import get_memory_settings  # noqa: E402
+from mcp_server.infrastructure.memory_store import get_shared_store  # noqa: E402
+
+_CORRUPTION_SIGNATURE_SQL = "title LIKE 'title:%' OR title LIKE '\"%%\"'"
+
+
+def find_affected_rows(conn) -> list[tuple[int, str, str]]:
+    """Return (id, rel_path, title) for every row matching the corruption
+    signature. Pure query — no writes.
+
+    The store's cursor may use a dict_row factory (confirmed: rows come
+    back as dicts, not positional tuples — see
+    wiki_migrate.py::_existing_memory_ids for the same defensive
+    pattern) so index by column name, not position.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT id, rel_path, title FROM wiki.pages WHERE {_CORRUPTION_SIGNATURE_SQL} ORDER BY id"
+        )
+        raw_rows = cur.fetchall()
+    out: list[tuple[int, str, str]] = []
+    for r in raw_rows:
+        if isinstance(r, dict):
+            out.append((r["id"], r["rel_path"], r["title"]))
+        else:
+            out.append((r[0], r[1], r[2]))
+    return out
+
+
+def repair_row(
+    conn, wiki_root: Path, row_id: int, rel_path: str, old_title: str, *, dry_run: bool
+) -> str:
+    """Re-derive and, unless dry_run, persist the corrected title for one row.
+
+    postcondition: returns one of "fixed", "source_missing", "unchanged"
+    (derived title equals the stored title — corruption signature was a
+    false positive) — never raises for a missing file, only for a real
+    DB error.
+    """
+    full = wiki_root / rel_path
+    if not full.exists():
+        return "source_missing"
+    content = full.read_text(encoding="utf-8", errors="ignore")
+    row = page_row_from_md(rel_path, content)
+    new_title = row["title"]
+    if new_title == old_title:
+        return "unchanged"
+    if not dry_run:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE wiki.pages SET title = %s, tended = NOW() WHERE id = %s",
+                (new_title, row_id),
+            )
+    return "fixed"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report only, no writes."
+    )
+    args = parser.parse_args()
+
+    settings = get_memory_settings()
+    store = get_shared_store(settings.DB_PATH, settings.EMBEDDING_DIM)
+    conn = store._conn
+
+    rows = find_affected_rows(conn)
+    print(f"Found {len(rows)} rows matching the corruption signature.")
+
+    outcomes: dict[str, int] = {"fixed": 0, "source_missing": 0, "unchanged": 0}
+    for row_id, rel_path, old_title in rows:
+        outcome = repair_row(
+            conn, Path(WIKI_ROOT), row_id, rel_path, old_title, dry_run=args.dry_run
+        )
+        outcomes[outcome] += 1
+        print(
+            f"  [{outcome}] id={row_id} rel_path={rel_path!r} old_title={old_title!r}"
+        )
+
+    if not args.dry_run:
+        conn.commit()
+
+    print(f"\nSummary: {outcomes}")
+    remaining = 0
+    if not args.dry_run:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT count(*) AS n FROM wiki.pages WHERE {_CORRUPTION_SIGNATURE_SQL}"
+            )
+            row = cur.fetchone()
+            remaining = row["n"] if isinstance(row, dict) else row[0]
+        print(f"Rows still matching corruption signature after migration: {remaining}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_py/core/test_wiki_pages.py
+++ b/tests_py/core/test_wiki_pages.py
@@ -95,5 +95,59 @@ def test_render_roundtrip() -> None:
     assert "## Decision" in re_rendered
 
 
+def test_parse_page_strips_quoted_scalar_value() -> None:
+    """Reproduction (wiki.pages.title corruption, 36 rows, 2026-07-14):
+
+    a scalar value quoted per YAML convention because it contains a
+    colon (``title: "Public API surface: automatised-pipeline"``) must
+    have its surrounding quotes stripped, matching the block-list item
+    branch (line ~103) and the inline-list branch (``_strip_inline_list``)
+    which already do this. Before the fix, the scalar branch assigned
+    ``raw_stripped`` verbatim, leaving the literal quote characters in
+    ``fm["title"]`` and, downstream, in ``wiki.pages.title``.
+    """
+    text = (
+        "---\n"
+        'title: "Public API surface: automatised-pipeline"\n'
+        "kind: reference\n"
+        "---\n\nbody\n"
+    )
+    doc = parse_page(text)
+    assert doc.frontmatter["title"] == "Public API surface: automatised-pipeline"
+
+
+def test_parse_page_strips_duplicated_key_label() -> None:
+    """Reproduction (wiki.pages.title corruption, 26 rows, 2026-07-14):
+
+    real files under ~/.claude/methodology/wiki/ (authored by an LLM
+    completion routed verbatim through write_governed_page, see
+    wiki_write.py) contain a duplicated ``title: title: "..."`` label —
+    the frontmatter's own key echoed into its own value. ``line.partition(":")``
+    only ever strips the FIRST ``title:`` label, so the second one used to
+    ride along into ``fm["title"]`` verbatim and then into
+    ``wiki.pages.title`` via ``wiki_migrate.page_row_from_md``. Confirmed
+    against the actual on-disk file (id 913,
+    ``reference/_general/4196397-title-public-api-surface-automatised-pipeline.md``).
+    """
+    text = '---\ntitle: title: "Public API surface: automatised-pipeline"\nkind: reference\n---\n\nbody\n'
+    doc = parse_page(text)
+    assert doc.frontmatter["title"] == "Public API surface: automatised-pipeline"
+
+    # Unquoted duplicated-label variant (id 2916 on disk: title: title: agentic-ai — tutorials)
+    text2 = (
+        "---\ntitle: title: agentic-ai — tutorials\nkind: explanation\n---\n\nbody\n"
+    )
+    doc2 = parse_page(text2)
+    assert doc2.frontmatter["title"] == "agentic-ai — tutorials"
+
+
+def test_parse_page_does_not_strip_legitimate_colon_value() -> None:
+    """A value that legitimately starts with the key name followed by other
+    text (not the ``key: `` duplicate-label pattern) must be preserved."""
+    text = "---\ntitle: titleist golf clubs review\n---\n\nbody\n"
+    doc = parse_page(text)
+    assert doc.frontmatter["title"] == "titleist golf clubs review"
+
+
 def test_empty_page_document() -> None:
     assert render_page(PageDocument()) == ""


### PR DESCRIPTION
## Root cause (proven on disk)

`parse_page`'s scalar branch (`mcp_server/core/wiki_pages.py:115-118`) assigned `raw_stripped` verbatim, so:

1. **36 rows**: a YAML-quoted value (`title: "Public API surface: automatised-pipeline"`) kept its literal quote characters — the list branches already stripped quotes, the scalar branch never did.
2. **26 rows**: LLM-authored pages routed verbatim through `write_governed_page` contain a duplicated label on disk (`title: title: "..."` — confirmed on ids 913 and 2916); `line.partition(":")` only strips the first `title:`, so the second rode into `wiki.pages.title`.

## Fix

New `_clean_scalar_value(key, raw_stripped)` helper: strips one duplicated `<key>:` label (exact token match, case-insensitive — `titleist ...` is untouched) then one matching pair of surrounding quotes, mirroring the existing list-branch behavior.

## Tests

3 new tests: 2 reproductions anchored to the real on-disk corruption (quoted scalar, duplicated label quoted + unquoted variants) and 1 negative (no over-stripping of a value that merely starts with the key name). `tests_py/core/test_wiki_pages.py`: 12/12 green; full suite 5102/5102 green; ruff check + format clean.

## ⚠️ DB migration ALREADY EXECUTED

`scripts/backfill_wiki_titles_2026_07_14.py` has **already been run against prod** (2026-07-14): 62 corrupted rows matched the signature (`title LIKE 'title:%'` OR `title LIKE '"%"'`), 61 repaired + 1 already fixed incidentally; post-check via psql = 0 remaining. CSV backup of (id, rel_path, title) was taken beforehand. The script is committed for provenance/reproducibility — do not re-run.

Rationale for a dedicated script: `upsert_page`'s UPDATE is gated on `body_hash <> EXCLUDED.body_hash`, which correctly skips unchanged files — but the corruption was in the *derivation*, not the file, so re-running `wiki_migrate` silently skips exactly the affected rows.

## Known follow-ups (not in this PR)

- `wiki_migrate --dry-run` actually commits its passes 1-3 despite the name (footgun, separate fix)
- `wiki_pages.py` at 452 lines exceeds the 500-target trajectory (pre-existing debt → refactorer)
- Design question: frontmatter validation at write time in `write_governed_page`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HM6rjMN4oHHmL6qPwv6ZPN