### PR TITLE
fix(wiki): make wiki_migrate --dry-run transactionally neutral

### DIFF
--- a/mcp_server/handlers/wiki_migrate.py
+++ b/mcp_server/handlers/wiki_migrate.py
@@ -411,7 +411,18 @@ def migrate_wiki(wiki_root: Path | str, conn, *, dry_run: bool = True) -> dict:
     # this run's view of the filesystem, not a stale one.
     purge_summary = purge_ghost_pages(conn, rel_paths, dry_run=dry_run)
 
-    conn.commit()
+    # dry_run must be transactionally neutral end-to-end: passes 1-3
+    # (upsert_page, delete_links_from/upsert_link, resolve_unresolved_links)
+    # write through the same `conn` as pass 4 and have no dry_run gate of
+    # their own — only pass 4 checks dry_run internally (see
+    # purge_ghost_pages). Committing unconditionally here previously made
+    # `--dry-run` persist passes 1-3 despite the name (issue #105). Roll
+    # back everything this call wrote when dry_run is requested; commit
+    # only on a real (dry_run=False) run.
+    if dry_run:
+        conn.rollback()
+    else:
+        conn.commit()
 
     errors = errors1 + errors2
     return {

--- a/tests_py/handlers/test_wiki_migrate.py
+++ b/tests_py/handlers/test_wiki_migrate.py
@@ -373,3 +373,41 @@ def test_migrate_wiki_dry_run_default_leaves_ghost_in_place(
     assert summary["purge"]["purged"] == []
     # Ghost row is still present — dry_run never deletes.
     assert "notes/deleted-page.md" in fake_store.rows
+
+
+# ── issue #105 — dry_run must be transactionally neutral end-to-end ────
+#
+# Regression: `migrate_wiki` used to call `conn.commit()` unconditionally
+# after all four passes, so passes 1-3 (upsert_page, delete_links_from /
+# upsert_link, resolve_unresolved_links) were persisted even when
+# dry_run=True — only pass 4 (purge_ghost_pages) had its own dry_run gate.
+# `--dry-run` must never leave a durable write behind on ANY pass.
+
+
+def test_migrate_wiki_dry_run_rolls_back_never_commits(tmp_path, fake_store) -> None:
+    """dry_run=True must roll back the connection, never commit it.
+
+    This is the mechanism-level proof: on the code prior to the fix,
+    `conn.commit()` was called unconditionally (this assertion fails
+    against that code — `commit.assert_not_called()` raises). After the
+    fix, dry_run rolls back so passes 1-3's writes are discarded along
+    with pass 4's.
+    """
+    _write_page(tmp_path, "notes/alive-page.md", "Alive Page")
+    conn = MagicMock()
+
+    migrate_wiki(tmp_path, conn=conn, dry_run=True)
+
+    conn.rollback.assert_called_once()
+    conn.commit.assert_not_called()
+
+
+def test_migrate_wiki_real_run_commits_never_rolls_back(tmp_path, fake_store) -> None:
+    """dry_run=False must commit — the mirror-image proof to the above."""
+    _write_page(tmp_path, "notes/alive-page.md", "Alive Page")
+    conn = MagicMock()
+
+    migrate_wiki(tmp_path, conn=conn, dry_run=False)
+
+    conn.commit.assert_called_once()
+    conn.rollback.assert_not_called()


### PR DESCRIPTION
Closes #105

## Root cause
`migrate_wiki()` (`mcp_server/handlers/wiki_migrate.py`) called `conn.commit()` unconditionally after all four passes. Only pass 4 (`purge_ghost_pages`) checked `dry_run` internally; passes 1–3 (`_upsert_all_pages`, `_upsert_all_links`, `resolve_unresolved_links`) wrote through the shared connection and the final commit persisted their writes regardless of the caller's intent. Verified this was the single point deciding transactional behavior (no commit/rollback in `pg_store_wiki*.py`).

## Fix
The commit/rollback decision is now dry_run-gated: `dry_run=True` → `conn.rollback()`, `dry_run=False` → `conn.commit()`. One central branch makes the entire 4-pass run transactionally neutral under dry-run — a mechanism fix, not per-call-site patches.

## Invariant
Exactly one of commit/rollback is called per invocation, never both, never neither.

## Tests
- `test_migrate_wiki_dry_run_rolls_back_never_commits` — fails against pre-fix code (rollback called 0 times), passes with the fix.
- `test_migrate_wiki_real_run_commits_never_rolls_back` — mirror postcondition.
- Full wiki subset 474/474 green, wiki_migrate subset 52/52 green.

## Known limits
Unit-tier proof via MagicMock call-count assertions, consistent with the file's existing test tier; no live-Postgres end-to-end rollback proof (standard DB-API behavior). Flag for future direct callers: if `migrate_wiki` were ever handed a connection inside an outer transaction, the rollback would discard that pending work — not reachable via the MCP handler today (`get_shared_store` fresh per invocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)