### PR TITLE
feat(wiki): validate and normalize frontmatter at write time in write_governed_page

### DIFF
--- a/mcp_server/core/wiki_frontmatter_validation.py
+++ b/mcp_server/core/wiki_frontmatter_validation.py
@@ -1,0 +1,101 @@
+"""Write-time frontmatter validation/normalization — pure, no I/O.
+
+Closes the corruption class that PR #104 (commit 53712df8) repaired
+reactively at read-time inside ``wiki_pages.parse_page`` (dup-label
+strip, quote strip). That fix made ``recall``/`wiki_read`` tolerant of
+the two corruption signatures already on disk; it did nothing to stop
+``write_governed_page`` (``mcp_server/handlers/wiki_write.py``) from
+persisting caller-supplied markdown verbatim, so any new signature the
+read-time parser doesn't yet know about would still land on disk
+uncorrected.
+
+This module round-trips content through ``parse_page`` + ``render_page``
+so what ``write_governed_page`` persists is ALWAYS the canonical form —
+whatever ``parse_page`` already knows how to repair is repaired before
+the first byte reaches disk, not after. The read-time tolerance stays in
+place unchanged as defense in depth (content written before this gate
+existed, or by a write path that bypasses ``write_governed_page`` — see
+that module's docstring for the audited list).
+
+Deliberately does NOT duplicate ``parse_page``'s parsing state machine —
+only the one shape it cannot repair (an unclosed frontmatter fence, which
+would silently fold the intended body into misparsed frontmatter keys)
+is detected and rejected here.
+"""
+
+from __future__ import annotations
+
+from mcp_server.core.wiki_pages import parse_page, render_page
+
+
+class UnclosedFrontmatterError(ValueError):
+    """Content opens a frontmatter fence (``---``) but never closes it.
+
+    This is the one frontmatter shape ``parse_page`` cannot tolerate:
+    with no closing ``---`` line, every subsequent line — including what
+    the author intended as body prose — is consumed as a frontmatter
+    key/value pair (``parse_page``'s scan loop never finds the ``break``
+    condition and keeps assigning ``fm[key] = ...`` for every remaining
+    line), silently destroying the body. Every other malformed-but-closed
+    shape (duplicated ``<key>: <key>: ...`` label, YAML-quoted scalar,
+    empty value) is repaired by ``parse_page``'s existing scalar/list
+    branches and is never rejected by this gate.
+    """
+
+
+def _opens_frontmatter_fence(content: str) -> bool:
+    """True iff ``content`` begins with a frontmatter fence line.
+
+    Mirrors ``parse_page``'s own opening check (wiki_pages.py) exactly,
+    so this gate and the parser agree on what counts as "has frontmatter".
+    """
+    return content.startswith("---\n") or content.startswith("---\r\n")
+
+
+def _has_closing_fence(content: str) -> bool:
+    """True iff some line after the opening fence is itself exactly ``---``.
+
+    precondition: ``_opens_frontmatter_fence(content)`` is already True.
+    postcondition: returns whether ``parse_page`` would find its
+    ``body_start`` inside the text (line ~117, wiki_pages.py) rather than
+    falling off the end with ``body_start`` still at its ``len(lines)``
+    initial value.
+    """
+    lines = content.splitlines()
+    return any(line.strip() == "---" for line in lines[1:])
+
+
+def normalize_frontmatter(content: str) -> str:
+    """Canonicalize a wiki page's frontmatter at write time.
+
+    precondition: ``content`` is the FULL markdown (frontmatter + body,
+    or plain body with no frontmatter) a caller intends to persist
+    verbatim to the wiki tree — never a partial fragment (the ``append``
+    write mode's content is a fragment appended below existing content,
+    not a full page, and must not be passed through this function; see
+    ``write_governed_page``'s call site).
+    postcondition: content carrying no frontmatter fence is returned
+    completely unchanged — plain markdown pages are outside this gate's
+    concern. Content that opens AND closes a fence is returned as
+    ``render_page(parse_page(content))`` — the exact canonical form every
+    ``build_*`` template (``wiki_pages.build_adr``/``build_note``/etc.)
+    already emits, so a healthy page round-trips byte-identical
+    (idempotent) and a corrupted one (duplicated label, stray quotes) is
+    repaired before the first byte reaches disk.
+    raises: ``UnclosedFrontmatterError`` when content opens a fence with
+    no closing ``---`` — the one shape that is structurally inexploitable.
+    Every other shape is normalized, never rejected.
+    """
+    if not _opens_frontmatter_fence(content):
+        return content
+    if not _has_closing_fence(content):
+        raise UnclosedFrontmatterError(
+            "frontmatter fence ('---') opened but never closed — refusing "
+            "to write: parse_page would silently consume the entire body "
+            "as malformed frontmatter keys, destroying it"
+        )
+    doc = parse_page(content)
+    return render_page(doc)
+
+
+__all__ = ["normalize_frontmatter", "UnclosedFrontmatterError"]

--- a/mcp_server/handlers/consolidation/page_io.py
+++ b/mcp_server/handlers/consolidation/page_io.py
@@ -16,6 +16,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from mcp_server.core.wiki_frontmatter_validation import UnclosedFrontmatterError
 from mcp_server.handlers.wiki_write import write_governed_page
 from mcp_server.observability import silent_failure
 
@@ -208,13 +209,22 @@ async def _rewrite_page(
         return False
 
     rel_path = str(page_path.relative_to(wiki_root))
-    result = await write_governed_page(
-        wiki_root,
-        rel_path,
-        new_text,
-        mode="replace",
-        tags=[_HEADLESS_TAG],
-    )
+    try:
+        result = await write_governed_page(
+            wiki_root,
+            rel_path,
+            new_text,
+            mode="replace",
+            tags=[_HEADLESS_TAG],
+        )
+    except UnclosedFrontmatterError as exc:
+        # This worker only ever rebuilds a page via
+        # _compute_rewritten_page, which always emits a closed fence —
+        # this branch is unreachable in practice but the write-time
+        # gate (issue #107) makes the failure mode explicit rather than
+        # letting an unhandled exception crash the batch drain cycle.
+        silent_failure.note("headless_authoring.rewrite_page.frontmatter", exc)
+        return False
     if "error" in result:
         silent_failure.note(
             "headless_authoring.rewrite_page.governed_write",
@@ -458,13 +468,23 @@ async def _write_anchor_page(
         "---\n\n"
     )
     content = frontmatter + body_markdown.strip() + "\n"
-    result = await write_governed_page(
-        wiki_root,
-        suggested_path,
-        content,
-        mode="create",
-        tags=[_HEADLESS_TAG, "anchor"],
-    )
+    try:
+        result = await write_governed_page(
+            wiki_root,
+            suggested_path,
+            content,
+            mode="create",
+            tags=[_HEADLESS_TAG, "anchor"],
+        )
+    except UnclosedFrontmatterError as exc:
+        # The frontmatter block above is always closed by this function's
+        # own literal "---\n\n" — unreachable in practice, but this call
+        # runs under asyncio.gather(return_exceptions=False) (see below),
+        # so an unhandled exception here would crash sibling anchor-page
+        # writes too. Catching keeps the write-time gate (issue #107)
+        # from becoming a new way for one page to take the batch down.
+        silent_failure.note("headless_authoring.write_anchor_page.frontmatter", exc)
+        return None
     if "error" in result:
         # Covers both the mkdir/write OSError the raw path used to swallow
         # AND a create-mode race (page authored concurrently) — both are

--- a/mcp_server/handlers/wiki_write.py
+++ b/mcp_server/handlers/wiki_write.py
@@ -32,6 +32,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from mcp_server.core.wiki_frontmatter_validation import normalize_frontmatter
 from mcp_server.core.wiki_layout import page_path
 from mcp_server.core.wiki_pages import (
     build_adr,
@@ -244,7 +245,16 @@ async def write_governed_page(
     caller operating on an alternate tree such as a test fixture, that
     tree's own root); ``rel_path`` is root-relative; ``content`` is the full
     markdown (frontmatter + body) to persist.
-    postcondition: on success, the page is written atomically (tmp+rename,
+    postcondition: for ``mode != "append"`` (a full page, not a fragment),
+    ``content`` is first run through ``normalize_frontmatter`` (issue #107)
+    so the bytes actually written are ALWAYS the canonical
+    ``render_page(parse_page(...))`` form — this closes the corruption
+    class PR #104/commit 53712df8 repaired reactively at read-time (a
+    duplicated ``title: title: "..."`` label, stray YAML quotes) instead of
+    persisting the two known signatures and relying on the reader to
+    tolerate them. ``append`` mode's ``content`` is a fragment appended
+    below existing content, not a full page, so it is never normalized.
+    On success, the page is written atomically (tmp+rename,
     ``write_page``'s existing guarantee) AND a protected
     ``write_class='mechanical'`` pointer memory is stored via ``remember``
     (best-effort — never blocks or fails the write; mechanical is correct
@@ -266,7 +276,18 @@ async def write_governed_page(
     (``consolidation/page_io.py``) both route through here so no caller can
     write wiki-tree bytes while skipping write_class/citation/pointer-memory
     bookkeeping (Move 1: one governed path, no shadow I/O).
+
+    raises: ``UnclosedFrontmatterError`` (propagated, uncaught, from
+    ``normalize_frontmatter``) when ``content`` opens a frontmatter fence
+    it never closes — the one shape that is structurally inexploitable.
+    The interactive tool call (``handler``, below, registered via
+    ``safe_handler``) turns this into a ``fastmcp.exceptions.ToolError``
+    automatically (the repo's standing idiom — see commits
+    c7dfc243/49f29e98); ``consolidation/page_io.py``'s non-tool callers
+    catch it explicitly and degrade to their existing failure contract.
     """
+    if mode != "append":
+        content = normalize_frontmatter(content)
     try:
         result = write_page(root, rel_path, content, mode=mode)
     except WikiExists:

--- a/tests_py/core/test_wiki_frontmatter_validation.py
+++ b/tests_py/core/test_wiki_frontmatter_validation.py
@@ -1,0 +1,82 @@
+"""Tests for core.wiki_frontmatter_validation — issue #107.
+
+write_governed_page persisted caller-supplied markdown verbatim without
+re-deriving/validating frontmatter, which is how the `title: title: "..."`
+corruption (fixed reactively at read-time by commit 53712df8/PR #104) got
+onto disk in the first place. These tests cover the write-time gate that
+closes the corruption CLASS: normalize (round-trip through parse_page +
+render_page) for anything parse_page can repair, reject only the one
+shape it cannot (an unclosed frontmatter fence).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.core.wiki_frontmatter_validation import (
+    UnclosedFrontmatterError,
+    normalize_frontmatter,
+)
+from mcp_server.core.wiki_pages import parse_page
+
+
+def test_duplicated_key_label_is_normalized_to_canonical_form() -> None:
+    """Reproduction of the exact corruption signature from commit 53712df8:
+    an LLM-authored page's own frontmatter echoed the key into its value.
+    """
+    corrupt = (
+        "---\n"
+        'title: title: "Public API surface: automatised-pipeline"\n'
+        "kind: reference\n"
+        "---\n\nBody text.\n"
+    )
+    normalized = normalize_frontmatter(corrupt)
+
+    doc = parse_page(normalized)
+    assert doc.frontmatter["title"] == "Public API surface: automatised-pipeline"
+    assert "title: title:" not in normalized
+    # Persisted form no longer carries the raw duplicated label at all.
+    assert normalized.count("title:") == 1
+
+
+def test_healthy_page_round_trips_unchanged() -> None:
+    """Idempotence: a page already in canonical form (as any build_*
+    template already emits) must be persisted byte-identical.
+    """
+    from mcp_server.core.wiki_pages import build_note
+
+    healthy = build_note(title="A clean note", body="Nothing to fix here.")
+
+    normalized = normalize_frontmatter(healthy)
+
+    assert normalized == healthy
+
+
+def test_unclosed_frontmatter_fence_is_rejected() -> None:
+    """The one shape parse_page cannot repair: no closing '---' means every
+    remaining line -- including the intended body -- is swallowed as a
+    frontmatter key/value pair, destroying the body. Must be rejected,
+    not silently persisted.
+    """
+    unclosed = "---\ntitle: Something\nkind: note\n\nThis was meant to be the body.\n"
+
+    with pytest.raises(UnclosedFrontmatterError):
+        normalize_frontmatter(unclosed)
+
+
+def test_plain_markdown_with_no_frontmatter_is_untouched() -> None:
+    plain = "# Just a heading\n\nSome prose, no frontmatter at all.\n"
+
+    assert normalize_frontmatter(plain) == plain
+
+
+def test_quoted_scalar_value_is_normalized() -> None:
+    quoted = (
+        "---\n"
+        'title: "Public API surface: automatised-pipeline"\n'
+        "kind: reference\n"
+        "---\n\nBody.\n"
+    )
+    normalized = normalize_frontmatter(quoted)
+    doc = parse_page(normalized)
+    assert doc.frontmatter["title"] == "Public API surface: automatised-pipeline"

--- a/tests_py/handlers/test_wiki_write_frontmatter_validation.py
+++ b/tests_py/handlers/test_wiki_write_frontmatter_validation.py
@@ -1,0 +1,134 @@
+"""Issue #107: write_governed_page validates/normalizes frontmatter at
+write time instead of persisting caller-supplied markdown verbatim.
+
+Mirrors test_wiki_write_citations.py's fixture approach (fake PG
+collaborators, real tmp_path wiki root, real write_page/write_governed_page
+code path) so these assertions exercise the actual disk-write, not a mock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from mcp_server.handlers import wiki_write
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+@pytest.fixture
+def tmp_wiki(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(wiki_write, "WIKI_ROOT", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _no_pg(monkeypatch):
+    """These tests only care about the on-disk bytes; degrade the
+    best-effort PG side effects to no-ops (same contract the citations
+    test suite already relies on: page-sync/citation failure never blocks
+    the write)."""
+
+    def _boom(*a, **kw):
+        raise RuntimeError("no PG in this test")
+
+    monkeypatch.setattr(wiki_write, "get_shared_store", _boom)
+
+
+# ── (a) corrupted duplicated-label frontmatter is persisted canonically ──
+
+
+def test_duplicated_label_frontmatter_persisted_canonically(tmp_wiki) -> None:
+    corrupt_content = (
+        "---\n"
+        'title: title: "Public API surface: automatised-pipeline"\n'
+        "kind: reference\n"
+        "---\n\nBody text.\n"
+    )
+
+    result = _run(
+        wiki_write.handler({"path": "reference/a.md", "content": corrupt_content})
+    )
+
+    assert "error" not in result
+    on_disk = (tmp_wiki / "reference/a.md").read_text(encoding="utf-8")
+    assert "title: title:" not in on_disk
+    assert "title: Public API surface: automatised-pipeline" in on_disk
+
+
+# ── (b) a healthy page round-trips byte-identical (idempotence) ──────────
+
+
+def test_healthy_page_persisted_unchanged(tmp_wiki) -> None:
+    from mcp_server.core.wiki_pages import build_note
+
+    healthy_content = build_note(title="Clean note", body="Nothing to repair.")
+
+    result = _run(
+        wiki_write.handler({"path": "notes/clean.md", "content": healthy_content})
+    )
+
+    assert "error" not in result
+    on_disk = (tmp_wiki / "notes/clean.md").read_text(encoding="utf-8")
+    assert on_disk == healthy_content
+
+
+# ── (c) structurally inexploitable frontmatter is rejected with ToolError ─
+
+
+def test_unclosed_frontmatter_fence_raises_tool_error(tmp_wiki) -> None:
+    """Calling wiki_write.handler directly raises the plain
+    UnclosedFrontmatterError (a ValueError) — the handler itself never
+    imports fastmcp. The ToolError conversion is the repo's standing
+    safe_handler idiom (commits c7dfc243/49f29e98): any exception a
+    handler raises becomes a ToolError at the tool-registration boundary,
+    verified here the same way test_remember.py pins the dict contract.
+    """
+    from mcp_server.core.wiki_frontmatter_validation import UnclosedFrontmatterError
+    from mcp_server.tool_error_handler import safe_handler
+
+    unclosed_content = (
+        "---\ntitle: Something\nkind: note\n\nThis was meant to be the body.\n"
+    )
+
+    with pytest.raises(UnclosedFrontmatterError):
+        _run(
+            wiki_write.handler({"path": "notes/broken.md", "content": unclosed_content})
+        )
+    assert not (tmp_wiki / "notes/broken.md").exists()
+
+    with pytest.raises(ToolError):
+        _run(
+            safe_handler(
+                wiki_write.handler,
+                {"path": "notes/broken2.md", "content": unclosed_content},
+                tool_name="wiki_write",
+            )
+        )
+    assert not (tmp_wiki / "notes/broken2.md").exists()
+
+
+# ── append mode is a fragment, not a full page — never normalized ────────
+
+
+def test_append_mode_content_is_never_frontmatter_normalized(tmp_wiki) -> None:
+    _run(wiki_write.handler({"path": "notes/x.md", "content": "# X\n\nInitial.\n"}))
+
+    result = _run(
+        wiki_write.handler(
+            {
+                "path": "notes/x.md",
+                "content": "---\nnot: closed",
+                "mode": "append",
+            }
+        )
+    )
+
+    assert "error" not in result
+    on_disk = (tmp_wiki / "notes/x.md").read_text(encoding="utf-8")
+    assert "---\nnot: closed" in on_disk


### PR DESCRIPTION
Closes #107

## Design decision
Write-time normalization (option retenue dans l'issue) : chaque écriture full-page passant par `write_governed_page` est round-trippée via `parse_page`/`render_page`, donc les octets persistés sont toujours la forme canonique. Cela ferme la classe entière de corruption (dont `title: title: "..."`, 62 lignes réparées par la migration du 2026-07-14) au lieu des seules signatures connues. La tolérance read-time du fix #104 reste en défense en profondeur.

## Implementation
- Nouveau module core pur `mcp_server/core/wiki_frontmatter_validation.py` (`normalize_frontmatter`) — importe uniquement `wiki_pages`, aucun I/O. `wiki_pages.py` non touché (refactor #106 en cours à part).
- `write_governed_page` (`mcp_server/handlers/wiki_write.py`) normalise tout write `mode != "append"` ; seul un fence de frontmatter jamais fermé (structurellement inexploitable) est rejeté via `UnclosedFrontmatterError` → `ToolError` par `safe_handler`.
- `mcp_server/handlers/consolidation/page_io.py` : gestion d'exception aux call-sites existants.

## Tests
- 5 tests core : normalisation dup-label, idempotence page saine, rejet fence non fermé, passthrough markdown pur, normalisation scalaires quotés.
- 4 tests handler : persistance canonique d'une page corrompue, byte-identique pour page saine, rejet direct + via `safe_handler`, mode `append` jamais normalisé.
- 27 tests ciblés verts ; suite wiki 475 tests, 0 régression ; ruff format + check propres.

## Hors scope (signalé, à traiter séparément)
8 chemins d'écriture appellent `wiki_store.write_page` directement en contournant `write_governed_page` (ingest_prd, ingest_findings_writers, wiki_rename, ingest_codebase_pages, wiki_adr, wiki_link, wiki_compile, append_section), contredisant la docstring « the ONLY function that may call write_page ». Follow-up recommandé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)