### PR TITLE
fix(wiki): enforce frontmatter normalization and governance contract on all write paths

### DIFF
--- a/mcp_server/core/wiki_frontmatter_validation.py
+++ b/mcp_server/core/wiki_frontmatter_validation.py
@@ -10,12 +10,18 @@ read-time parser doesn't yet know about would still land on disk
 uncorrected.
 
 This module round-trips content through ``parse_page`` + ``render_page``
-so what ``write_governed_page`` persists is ALWAYS the canonical form —
-whatever ``parse_page`` already knows how to repair is repaired before
-the first byte reaches disk, not after. The read-time tolerance stays in
-place unchanged as defense in depth (content written before this gate
-existed, or by a write path that bypasses ``write_governed_page`` — see
-that module's docstring for the audited list).
+so what reaches disk is ALWAYS the canonical form — whatever
+``parse_page`` already knows how to repair is repaired before the first
+byte is written, not after. Issue #110 moved the call site of this
+function from ``wiki_write.write_governed_page`` down to
+``infrastructure.wiki_store.write_page`` itself, so normalization covers
+every caller (governed or direct) rather than only the interactive
+``wiki_write`` tool path — see that module's docstring for the contract
+and ``tests_py/architecture/test_write_page_call_sites.py`` for the
+audited list of direct callers. The read-time tolerance
+(``wiki_pages.parse_page``'s scalar-branch repair) stays in place
+unchanged as defense in depth for content written before this gate
+existed.
 
 Deliberately does NOT duplicate ``parse_page``'s parsing state machine —
 only the one shape it cannot repair (an unclosed frontmatter fence, which

--- a/mcp_server/handlers/wiki_write.py
+++ b/mcp_server/handlers/wiki_write.py
@@ -32,7 +32,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from mcp_server.core.wiki_frontmatter_validation import normalize_frontmatter
+from mcp_server.core.wiki_frontmatter_validation import UnclosedFrontmatterError
 from mcp_server.core.wiki_layout import page_path
 from mcp_server.core.wiki_pages import (
     build_adr,
@@ -239,30 +239,27 @@ async def write_governed_page(
     tags: list[str] | None = None,
     memory_ids: list[int] | None = None,
 ) -> dict[str, Any]:
-    """The single governed wiki-write path — every wiki-tree byte goes through here.
+    """The governed wiki-write path — adds pointer-memory + citation
+    bookkeeping on top of a plain ``write_page`` call.
 
     precondition: ``root`` is a wiki root (production ``WIKI_ROOT`` or, for a
     caller operating on an alternate tree such as a test fixture, that
     tree's own root); ``rel_path`` is root-relative; ``content`` is the full
     markdown (frontmatter + body) to persist.
-    postcondition: for ``mode != "append"`` (a full page, not a fragment),
-    ``content`` is first run through ``normalize_frontmatter`` (issue #107)
-    so the bytes actually written are ALWAYS the canonical
-    ``render_page(parse_page(...))`` form — this closes the corruption
-    class PR #104/commit 53712df8 repaired reactively at read-time (a
-    duplicated ``title: title: "..."`` label, stray YAML quotes) instead of
-    persisting the two known signatures and relying on the reader to
-    tolerate them. ``append`` mode's ``content`` is a fragment appended
-    below existing content, not a full page, so it is never normalized.
-    On success, the page is written atomically (tmp+rename,
-    ``write_page``'s existing guarantee) AND a protected
-    ``write_class='mechanical'`` pointer memory is stored via ``remember``
-    (best-effort — never blocks or fails the write; mechanical is correct
-    per remember_schema.py's own vocabulary: "structural indexing — ...
-    wiki pointer sync — bypasses the gate entirely, force=true semantics";
-    this call stores a 500-char pointer, not the full authored content, so
-    the class describes the pointer-write, not who authored the page body)
-    AND ``wiki.pages``/``wiki.citations`` are synced best-effort (same
+    postcondition: write-time frontmatter normalization (issue #107) is
+    enforced by ``write_page`` itself (issue #110 — the choke point moved
+    down to ``infrastructure.wiki_store`` so it covers every caller, not
+    just this one), so this function no longer needs to (and does not)
+    call ``normalize_frontmatter`` a second time. On success, the page is
+    written atomically (tmp+rename, ``write_page``'s existing guarantee)
+    AND a protected ``write_class='mechanical'`` pointer memory is stored
+    via ``remember`` (best-effort — never blocks or fails the write;
+    mechanical is correct per remember_schema.py's own vocabulary:
+    "structural indexing — ... wiki pointer sync — bypasses the gate
+    entirely, force=true semantics"; this call stores a 500-char pointer,
+    not the full authored content, so the class describes the
+    pointer-write, not who authored the page body) AND
+    ``wiki.pages``/``wiki.citations`` are synced best-effort (same
     degrade-to-no-op discipline as ``_sync_page_and_cite``'s own contract).
     Write-time provenance grading (``INC7.5`` — ``grade_from_content``,
     triggered inside ``remember()``'s insert path) fires automatically as a
@@ -270,30 +267,42 @@ async def write_governed_page(
     Returns ``{path, mode, created, bytes_written, root, citations_written}``
     or ``{error}``.
 
-    This is deliberately the ONLY function in the codebase that may call
-    ``write_page`` — the interactive ``wiki_write`` MCP tool (``handler``,
-    below) and the headless authoring worker
-    (``consolidation/page_io.py``) both route through here so no caller can
-    write wiki-tree bytes while skipping write_class/citation/pointer-memory
-    bookkeeping (Move 1: one governed path, no shadow I/O).
+    This is the ONLY function in the codebase that may register the
+    pointer-memory + citations governance side effects — the interactive
+    ``wiki_write`` MCP tool (``handler``, below) and the headless
+    authoring worker (``consolidation/page_io.py``) both route through
+    here so no caller performing an authored, citable write skips that
+    bookkeeping. It is emphatically NOT the only caller of ``write_page``:
+    several handlers (redirect stubs, generated reference/PRD/finding
+    pages, ADRs, links) call ``write_page`` directly because pointer
+    memories and citations do not apply to their output — see
+    ``tests_py/architecture/test_write_page_call_sites.py`` for the
+    audited whitelist that guards against a new, unreviewed direct
+    caller appearing silently. Frontmatter normalization is unconditional
+    for all of them regardless (see ``write_page``'s own contract).
 
     raises: ``UnclosedFrontmatterError`` (propagated, uncaught, from
-    ``normalize_frontmatter``) when ``content`` opens a frontmatter fence
-    it never closes — the one shape that is structurally inexploitable.
-    The interactive tool call (``handler``, below, registered via
-    ``safe_handler``) turns this into a ``fastmcp.exceptions.ToolError``
-    automatically (the repo's standing idiom — see commits
-    c7dfc243/49f29e98); ``consolidation/page_io.py``'s non-tool callers
-    catch it explicitly and degrade to their existing failure contract.
+    ``write_page``'s call to ``normalize_frontmatter``) when ``content``
+    opens a frontmatter fence it never closes — the one shape that is
+    structurally inexploitable. The interactive tool call (``handler``,
+    below, registered via ``safe_handler``) turns this into a
+    ``fastmcp.exceptions.ToolError`` automatically (the repo's standing
+    idiom — see commits c7dfc243/49f29e98); ``consolidation/page_io.py``'s
+    non-tool callers catch it explicitly and degrade to their existing
+    failure contract.
     """
-    if mode != "append":
-        content = normalize_frontmatter(content)
     try:
         result = write_page(root, rel_path, content, mode=mode)
     except WikiExists:
         return {"error": f"page already exists: {rel_path}"}
     except WikiMissing:
         return {"error": f"page does not exist: {rel_path}"}
+    except UnclosedFrontmatterError:
+        # Propagate uncaught (see docstring) — narrower than the ValueError
+        # catch below, which must not swallow this one. write_page now
+        # raises it from its own normalize_frontmatter call (issue #110
+        # moved that call down from this function).
+        raise
     except (ValueError, OSError) as exc:
         return {"error": f"write failed: {exc}"}
 

--- a/mcp_server/infrastructure/wiki_store.py
+++ b/mcp_server/infrastructure/wiki_store.py
@@ -10,6 +10,24 @@ Operations:
 Never deletes pages. Never regenerates content. The only file that may
 be overwritten by regeneration is ``.generated/INDEX.md`` (owned by the
 wiki_reindex handler, not this module).
+
+Issue #110: ``write_page`` is the true choke point for every wiki-tree
+byte, not ``wiki_write.write_governed_page`` (that function's docstring
+claimed otherwise pre-fix; corrected there). At least 7 handlers plus
+this module's own ``sync_memory_strict`` call ``write_page`` directly,
+bypassing ``write_governed_page``'s governance side effects (pointer
+memory, citations) — deliberately, in most cases (e.g. redirect stubs,
+generated reference pages) where that bookkeeping does not apply. What
+those callers must NOT be able to bypass is write-time frontmatter
+normalization (issue #107/PR #109): ``write_page`` itself now runs
+``normalize_frontmatter`` on any full-page write (``create``/``replace``;
+``append``'s content is a fragment, never normalized — same exclusion
+``write_governed_page`` already documented), so no caller, present or
+future, can persist a non-canonical frontmatter shape. This module
+already imports ``core.wiki_layout``/``core.wiki_sync`` for the same
+wiki-specific pure-function reasons (an established exception to the
+general infrastructure→core dependency rule, scoped to this subsystem);
+``wiki_frontmatter_validation`` is the same kind of dependency.
 """
 
 from __future__ import annotations
@@ -17,6 +35,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from mcp_server.core.wiki_frontmatter_validation import normalize_frontmatter
 from mcp_server.core.wiki_layout import PAGE_KINDS
 from mcp_server.core.wiki_sync import build_from_memory
 from mcp_server.infrastructure.file_io import ensure_dir
@@ -131,6 +150,22 @@ def write_page(
     * ``replace`` — overwrites regardless.
     * ``append`` — appends the content to the existing file (with a
       separating blank line), raises WikiMissing if the file does not exist.
+
+    precondition: for ``create``/``replace``, ``content`` is a FULL page
+    (frontmatter + body, or plain body with no frontmatter) the caller
+    intends to persist verbatim; for ``append``, ``content`` is a
+    fragment appended below whatever is already on disk.
+    postcondition: for ``create``/``replace``, the bytes actually written
+    are always ``normalize_frontmatter(content)`` (issue #110) — this is
+    the one choke point every wiki-tree write passes through, so no
+    caller (governed via ``write_governed_page`` or direct) can persist a
+    non-canonical frontmatter shape. ``append``'s fragment is never
+    normalized (there is no frontmatter fence to canonicalize in a
+    fragment, and treating one as a full page would corrupt it — see
+    ``normalize_frontmatter``'s own precondition).
+    raises: ``UnclosedFrontmatterError`` (from ``normalize_frontmatter``,
+    propagated uncaught) for ``create``/``replace`` when ``content`` opens
+    a frontmatter fence it never closes.
     """
     import os
 
@@ -147,6 +182,9 @@ def write_page(
     # Defence-in-depth against prefix-aliasing.
     if fullpath != base_path and not fullpath[len(base_path) :].startswith(os.sep):
         raise ValueError(f"path escapes wiki root: {rel_path!r}")
+
+    if mode != "append":
+        content = normalize_frontmatter(content)
 
     # fullpath is sanitized — use it directly at every sink.
     existed = os.path.exists(fullpath)

--- a/tests_py/architecture/test_write_page_call_sites.py
+++ b/tests_py/architecture/test_write_page_call_sites.py
@@ -1,0 +1,96 @@
+"""Issue #110: guard against a new, unreviewed direct caller of
+``wiki_store.write_page`` appearing silently.
+
+Frontmatter normalization (issue #107) is now enforced unconditionally
+inside ``write_page`` itself (see that function's docstring), so a new
+direct caller can no longer persist non-canonical frontmatter — that
+corruption class is closed structurally. What this test protects
+against is different: ``write_governed_page``
+(``mcp_server/handlers/wiki_write.py``) is the ONLY place that registers
+pointer-memory + citation governance for a wiki write. Every existing
+direct ``write_page`` caller was individually audited (see the whitelist
+below and each call site's own surrounding comment/docstring) as a
+deliberate governance bypass — e.g. a redirect stub, a generated
+reference/PRD/finding page, an ADR, or a link-frontmatter rewrite, none
+of which should acquire a citable pointer memory. A new direct caller
+that appears without being added here has NOT been through that review;
+this test fails loudly so the reviewer either (a) adds it to the
+whitelist with a one-line justification, or (b) routes it through
+``write_governed_page`` instead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MCP_SERVER_ROOT = Path(__file__).resolve().parents[2] / "mcp_server"
+
+# The one module allowed to *define* write_page — excluded from the scan
+# entirely (its own `def write_page(` would otherwise match the call regex).
+_DEFINITION_MODULE = MCP_SERVER_ROOT / "infrastructure" / "wiki_store.py"
+
+# A call is `write_page(` not preceded by an identifier character (so
+# `_rewrite_page(` — a different, unrelated function — never matches).
+_CALL_RE = re.compile(r"(?<![A-Za-z0-9_])write_page\(")
+
+# Audited whitelist: relative path (from mcp_server/) -> expected number of
+# direct write_page(...) call expressions in that file. Each entry below
+# was reviewed as a deliberate governance bypass (see module docstring);
+# adding a NEW call increases the count and must update this table —
+# forcing the reviewer to consciously decide whether the new write
+# belongs here or should route through write_governed_page instead.
+_EXPECTED_CALL_COUNTS = {
+    "handlers/ingest_prd.py": 1,  # generated PRD spec page, no citations
+    "handlers/ingest_findings_writers.py": 1,  # generated finding page
+    "handlers/wiki_adr.py": 1,  # ADR creation (own pointer-memory path)
+    "handlers/wiki_rename.py": 2,  # destination copy + redirect stub
+    "handlers/ingest_codebase_pages.py": 1,  # generated process reference page
+    "handlers/wiki_link.py": 1,  # in-place frontmatter link rewrite
+    "handlers/wiki_write.py": 1,  # write_governed_page's own delegation call
+    "handlers/wiki_compile.py": 1,  # publishing an already-curated draft
+}
+
+
+def _iter_python_files():
+    for path in MCP_SERVER_ROOT.rglob("*.py"):
+        if path == _DEFINITION_MODULE:
+            continue
+        yield path
+
+
+def test_write_page_direct_callers_match_audited_whitelist() -> None:
+    observed: dict[str, int] = {}
+    for path in _iter_python_files():
+        text = path.read_text(encoding="utf-8")
+        count = len(_CALL_RE.findall(text))
+        if count:
+            rel = str(path.relative_to(MCP_SERVER_ROOT)).replace("\\", "/")
+            observed[rel] = count
+
+    unexpected_files = sorted(set(observed) - set(_EXPECTED_CALL_COUNTS))
+    missing_files = sorted(set(_EXPECTED_CALL_COUNTS) - set(observed))
+    mismatched_counts = {
+        rel: (observed[rel], _EXPECTED_CALL_COUNTS[rel])
+        for rel in set(observed) & set(_EXPECTED_CALL_COUNTS)
+        if observed[rel] != _EXPECTED_CALL_COUNTS[rel]
+    }
+
+    assert not unexpected_files, (
+        "New direct caller(s) of write_page() found, not in the audited "
+        f"whitelist: {unexpected_files}. Either add them to "
+        "_EXPECTED_CALL_COUNTS with a one-line justification (why this "
+        "write doesn't need write_governed_page's pointer-memory/citation "
+        "bookkeeping), or route the write through write_governed_page "
+        "instead."
+    )
+    assert not missing_files, (
+        f"Whitelisted file(s) no longer call write_page(): {missing_files}. "
+        "Remove the stale entry from _EXPECTED_CALL_COUNTS."
+    )
+    assert not mismatched_counts, (
+        "Call count changed for whitelisted file(s) (observed, expected): "
+        f"{mismatched_counts}. A new write_page() call was added to an "
+        "already-whitelisted file — review it the same way as a brand new "
+        "caller and update the expected count once satisfied."
+    )

--- a/tests_py/handlers/test_wiki_write_path_governance.py
+++ b/tests_py/handlers/test_wiki_write_path_governance.py
@@ -1,0 +1,130 @@
+"""Issue #110: write-time frontmatter normalization now applies to every
+``write_page`` caller, not just the governed ``wiki_write`` tool path.
+
+These tests exercise two of the direct (governance-bypassing) callers —
+``wiki_adr`` and ``wiki_link`` — end to end through their real handlers,
+proving the normalization boundary moved down to
+``infrastructure.wiki_store.write_page`` actually covers them. See
+``tests_py/architecture/test_write_page_call_sites.py`` for the audited
+whitelist of every direct caller, and
+``tests_py/handlers/test_wiki_write_frontmatter_validation.py`` for the
+equivalent coverage of the governed path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from mcp_server.handlers import wiki_adr, wiki_link
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# ── wiki_adr: a corrupted rendered ADR is persisted canonically ──────────
+
+
+def test_wiki_adr_persists_corrupted_content_canonically(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(wiki_adr, "WIKI_ROOT", str(tmp_path))
+
+    async def _noop_pointer_memory(*_a, **_kw):
+        return None
+
+    monkeypatch.setattr(wiki_adr, "_store_pointer_memory", _noop_pointer_memory)
+
+    corrupt_content = (
+        "---\n"
+        'title: title: "Some decision"\n'
+        "kind: adr\n"
+        "status: accepted\n"
+        "---\n\n# ADR-0001: Some decision\n\nBody.\n"
+    )
+    monkeypatch.setattr(wiki_adr, "build_adr", lambda **_kw: corrupt_content)
+
+    result = _run(
+        wiki_adr.handler(
+            {
+                "title": "Some decision",
+                "context": "ctx",
+                "decision": "dec",
+                "consequences": "cons",
+            }
+        )
+    )
+
+    assert "error" not in result
+    on_disk = (tmp_path / result["path"]).read_text(encoding="utf-8")
+    assert "title: title:" not in on_disk
+    assert "title: Some decision" in on_disk
+
+
+# ── wiki_link: linking a pre-existing corrupted page canonicalizes it ────
+
+
+def test_wiki_link_persists_corrupted_page_canonically(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(wiki_link, "WIKI_ROOT", str(tmp_path))
+
+    from_dir = tmp_path / "notes"
+    from_dir.mkdir(parents=True)
+    corrupt_content = (
+        '---\ntitle: title: "Corrupted source page"\nkind: note\n---\n\nBody text.\n'
+    )
+    (from_dir / "a.md").write_text(corrupt_content, encoding="utf-8")
+    (from_dir / "b.md").write_text(
+        "---\ntitle: Clean target page\nkind: note\n---\n\nOther body.\n",
+        encoding="utf-8",
+    )
+
+    result = _run(
+        wiki_link.handler(
+            {
+                "from_path": "notes/a.md",
+                "to_path": "notes/b.md",
+                "relation": "see_also",
+            }
+        )
+    )
+
+    assert "error" not in result
+    on_disk_a = (from_dir / "a.md").read_text(encoding="utf-8")
+    assert "title: title:" not in on_disk_a
+    assert "title: Corrupted source page" in on_disk_a
+    assert "## Related" in on_disk_a
+    assert "notes/b.md" in on_disk_a
+
+
+# ── append_section (a distinct write_page-adjacent function) is unaffected ─
+
+
+def test_append_section_unchanged_by_normalization(tmp_path: Path) -> None:
+    """append_section never calls write_page (it uses its own atomic-write
+    helper), so it is out of scope for issue #110's normalization gate —
+    confirm behavior is unchanged: no frontmatter round-trip, fragment
+    appended verbatim under the target heading."""
+    from mcp_server.infrastructure.wiki_store import append_section, write_page
+
+    write_page(
+        tmp_path,
+        "notes/c.md",
+        '---\ntitle: title: "Still corrupted"\nkind: note\n---\n\nBody.\n',
+        mode="create",
+    )
+    # write_page itself normalizes on the way in (issue #110) — start from
+    # the canonical form so this test isolates append_section's own
+    # behavior rather than re-testing write_page's gate.
+    before = (tmp_path / "notes/c.md").read_text(encoding="utf-8")
+    assert "title: title:" not in before
+
+    result = append_section(tmp_path, "notes/c.md", "Notes", "A new fragment.")
+
+    assert result.mode == "append-section"
+    after = (tmp_path / "notes/c.md").read_text(encoding="utf-8")
+    assert after.startswith(before.rstrip("\n"))
+    assert "## Notes" in after
+    assert "A new fragment." in after


### PR DESCRIPTION
Closes #110

(Initialement empilée sur #109 ; rebasée sur main après son merge en squash — diff net d'un seul commit.)

## Mécanisme
Analyse des 8 call sites contournants : tous écrivent des pages complètes (jamais de fragments), aucun ne doit légitimement échapper à la normalisation — mais plusieurs contournent la *gouvernance* délibérément (stubs de redirect, pages générées PRD/findings/référence, réécritures de liens). D'où la séparation :

1. **Normalisation** : déplacée inconditionnellement dans `wiki_store.write_page` (`mode != "append"`) — le point d'étranglement partagé. Ferme la classe de corruption pour tout appelant, présent et futur. Import infra→core suivant l'exception documentée préexistante du sous-système wiki (`wiki_layout`, `wiki_sync`).
2. **Gouvernance** : reste la responsabilité exclusive de `write_governed_page` ; les 8 contournements restent délibérés. Docstring mensongère (« the ONLY function that may call write_page ») corrigée.
3. **Bug réel corrigé en chemin** : `write_governed_page` avalait `UnclosedFrontmatterError` (sous-classe de `ValueError`) dans son `except (ValueError, OSError)` générique — contrat documenté cassé. Ré-levée explicite ajoutée, attrapée par le test préexistant.
4. **Garde-fou exécutable** : `tests_py/architecture/test_write_page_call_sites.py` — scan regex de `mcp_server/` diffé contre une liste blanche auditée par fichier ; prouvé qu'il échoue sur un bypass injecté artificiellement (puis retiré).

## Tests
- Corruption `title: title:` persistée canonique via 2 des 8 chemins contournants (`wiki_adr`, `wiki_link`) ; `append_section` inchangé.
- Baseline 481 → 484 passed (3 nouveaux tests), 0 régression ; re-validé post-rebase (8 tests ciblés + ruff format/check propres, 0.15.20).

## Limites connues
Garde-fou par comptage par fichier (pas par ligne) — le modèle de menace principal est un nouveau fichier contournant ; corruption des tests `wiki_adr`/`wiki_link` injectée par seed (leur génération réelle ne la produit pas) — prouve la frontière d'enforcement. Dette de taille préexistante (`wiki_write.py`/`wiki_store.py` vs guideline 300 l.) hors scope, sous le cap dur de 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)