### PR TITLE
fix(install): dispatch Windows postInstall to cross-platform setup.py + exercise real install path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,26 @@ jobs:
           echo "HF pre-download failed after 5 attempts" >&2
           exit 1
 
+      # Real postInstall proof (issue #113). Before this step, no CI job ever
+      # ran plugin.json's actual postInstall command
+      # (`bash scripts/install-plugin.sh`) on any OS — the ubuntu `test` job
+      # above installs deps directly via `pip install -e`, bypassing it
+      # entirely. That gap is why scripts/setup.sh's "Unsupported OS" failure
+      # on native Windows (Git Bash reports uname -s as MINGW64_NT-*/
+      # MSYS_NT-*/CYGWIN_NT-*, matched by neither its Darwin nor Linux branch)
+      # went undetected. The job-level CORTEX_MEMORY_STORE_BACKEND: sqlite
+      # (above) makes scripts/setup.py skip PostgreSQL provisioning (see its
+      # module docstring) so this runs without provisioning a PostgreSQL
+      # server on the runner, while still exercising the real OS dispatch in
+      # install-plugin.sh, the real scripts/setup.py subprocess calls, and
+      # the real embedding-model caching path.
+      - name: Exercise real postInstall path (install-plugin.sh -> setup.py)
+        shell: bash
+        env:
+          CLAUDE_PLUGIN_ROOT: ${{ github.workspace }}
+          CLAUDE_PLUGIN_DATA: ${{ runner.temp }}/cortex-plugin-data
+        run: bash scripts/install-plugin.sh
+
       # Scope (explicit, not silent): the portability tests plus the modules
       # carrying Windows-specific branches and the SQLite backend suite. The
       # full PG suite is not run here — it is covered by the ubuntu `test` job.
@@ -251,6 +271,7 @@ jobs:
           tests_py/infrastructure/test_pipeline_install_lock.py
           tests_py/core/test_staleness.py
           tests_py/infrastructure/test_sqlite_backend.py
+          tests_py/scripts/test_setup_py_backend_skip.py
 
   lint:
     name: Lint

--- a/scripts/install-plugin.sh
+++ b/scripts/install-plugin.sh
@@ -32,6 +32,20 @@ set -euo pipefail
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
+# On native Windows, CLAUDE_PLUGIN_ROOT (or $PWD) arrives in backslash form
+# (e.g. D:\a\Cortex\Cortex from GitHub Actions' github.workspace). Every
+# later use of PLUGIN_ROOT in this script concatenates it with a
+# forward-slash suffix ("$PLUGIN_ROOT/scripts/setup.py" etc.), which would
+# otherwise produce a mixed-separator path. Normalize once, here, via
+# cygpath (shipped with Git Bash/MSYS2) to the Windows mixed form
+# (drive letter + forward slashes, e.g. D:/a/Cortex/Cortex) so every
+# concatenation downstream is forward-slash-only and Windows programs
+# (native python.exe) still resolve it correctly. A no-op on macOS/Linux,
+# where cygpath doesn't exist. source: issue #113 CI run 29360566538.
+if command -v cygpath >/dev/null 2>&1; then
+    PLUGIN_ROOT="$(cygpath -m "$PLUGIN_ROOT")"
+fi
+
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
@@ -49,7 +63,19 @@ fi
 PY=$(command -v python3 || command -v python || true)
 [ -n "$PY" ] || fail "python3 not found in PATH"
 
-CURRENT_VERSION=$("$PY" -c "import json; print(json.load(open('$PLUGIN_JSON'))['version'])")
+# CURRENT_VERSION is read via an env var, NOT by interpolating $PLUGIN_JSON
+# into the -c source string. Splicing an arbitrary path into a Python
+# single-quoted string literal re-parses any backslash-letter sequence it
+# contains as a Python string escape — e.g. the "\a" in a GitHub Actions
+# Windows workspace path (D:\a\Cortex\Cortex) becomes ASCII BEL (0x07),
+# corrupting the path to D:\x07\Cortex\Cortex and failing to open it
+# (CI run 29360566538). Environment variables are passed as raw bytes with
+# no escape reinterpretation, so this is safe for any path content
+# (backslashes, spaces, quotes) on every OS, not just Windows.
+CURRENT_VERSION=$(CORTEX_PLUGIN_JSON_PATH="$PLUGIN_JSON" "$PY" -c "
+import json, os
+print(json.load(open(os.environ['CORTEX_PLUGIN_JSON_PATH']))['version'])
+")
 
 say "Installing Cortex v${CURRENT_VERSION}"
 

--- a/scripts/install-plugin.sh
+++ b/scripts/install-plugin.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 # Cortex plugin postInstall driver.
 #
 # Two responsibilities:
-#   1. Install Cortex (delegates to scripts/setup.sh: PostgreSQL + pgvector,
-#      Python deps, DB schema, embedding model).
+#   1. Install Cortex — dispatches by OS to scripts/setup.sh (macOS/Linux:
+#      PostgreSQL + pgvector, Python deps, DB schema, embedding model) or
+#      scripts/setup.py (Windows via Git Bash: same steps, cross-platform).
 #   2. Remove stale OTHER versions of Cortex installed elsewhere on the
 #      machine, so the freshly-installed plugin is the single source of
 #      truth.
@@ -52,9 +53,30 @@ CURRENT_VERSION=$("$PY" -c "import json; print(json.load(open('$PLUGIN_JSON'))['
 
 say "Installing Cortex v${CURRENT_VERSION}"
 
-# ── Phase 1: install (delegates to setup.sh) ───────────────────────────
-
-bash "$PLUGIN_ROOT/scripts/setup.sh"
+# ── Phase 1: install (delegates to setup.sh or setup.py by OS) ─────────
+#
+# This is the single, most-upstream OS-dispatch point for the install
+# path — do not duplicate this branch in setup.sh or plugin.json.
+# manifest.json declares win32 as a compatible platform, but
+# scripts/setup.sh only knows how to provision PostgreSQL via brew/apt
+# (macOS/Linux) and previously failed with a bare "Unsupported OS" on
+# every other uname -s, including the MINGW64_NT-*/MSYS_NT-*/CYGWIN_NT-*
+# values Git Bash reports on native Windows (fixes #113). Git Bash is the
+# shell postInstall actually runs under on Windows (plugin.json invokes
+# `bash ...`), so on those uname patterns we delegate to the already
+# cross-platform scripts/setup.py instead of scripts/setup.sh.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        say "Detected Windows ($(uname -s)) — delegating to cross-platform scripts/setup.py"
+        "$PY" "$PLUGIN_ROOT/scripts/setup.py" || fail "scripts/setup.py failed. PostgreSQL must be installed and running first (https://www.postgresql.org/download/windows/, then also install pgvector: https://github.com/pgvector/pgvector#windows). Once that is done, re-run manually: \"$PY\" \"$PLUGIN_ROOT/scripts/setup.py\""
+        ;;
+    Darwin|Linux)
+        bash "$PLUGIN_ROOT/scripts/setup.sh"
+        ;;
+    *)
+        fail "Unsupported OS: $(uname -s). Cortex supports macOS, Linux, and Windows (via Git Bash). To retry manually once you've confirmed your shell environment, run: \"$PY\" \"$PLUGIN_ROOT/scripts/setup.py\" (cross-platform) — see also https://github.com/cdeust/Cortex#readme"
+        ;;
+esac
 
 # ── Phase 2: prune stale OTHER versions ────────────────────────────────
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -10,6 +10,21 @@ PostgreSQL must be installed separately on Windows:
 
 Usage:
     python3 scripts/setup.py
+
+CI/testing mode:
+    Set CORTEX_MEMORY_STORE_BACKEND=sqlite to skip the PostgreSQL
+    provisioning/verification steps entirely. This exists so CI can
+    exercise the real cross-platform install path (OS dispatch, Python
+    dependency install, embedding model caching) on a runner with no
+    PostgreSQL server, without needing to provision one (source: issue
+    #113 — the Windows postInstall path had zero CI coverage before this
+    flag existed, which is how the "Unsupported OS" regression on native
+    Windows shipped undetected).
+
+    This is a testing convenience only: it does NOT represent a supported
+    zero-PostgreSQL install for the Claude Code plugin channel. The
+    zero-setup SQLite-by-default experience is the separate manifest.json
+    / `uv run` MCP-bundle channel, which never goes through this script.
 """
 
 from __future__ import annotations
@@ -28,6 +43,12 @@ PROJECT_DIR = SCRIPT_DIR.parent
 PLUGIN_DATA = os.environ.get("CLAUDE_PLUGIN_DATA", str(PROJECT_DIR))
 DEPS_DIR = os.path.join(PLUGIN_DATA, "deps")
 DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://localhost:5432/cortex")
+
+# CI/testing mode: see module docstring. Any other CORTEX_MEMORY_STORE_BACKEND
+# value (unset, "postgresql", "auto") keeps the normal PostgreSQL-required path.
+SKIP_POSTGRES = (
+    os.environ.get("CORTEX_MEMORY_STORE_BACKEND", "").strip().lower() == "sqlite"
+)
 
 
 def _redact_db_url(url: str) -> str:
@@ -277,13 +298,33 @@ def cache_embedding_model() -> None:
 # ── Step 6: Verify ───────────────────────────────────────────────────
 
 
-def verify() -> None:
-    step("Verification")
+def _sqlite_checks() -> list[tuple[str, bool]]:
+    """CI/testing-mode checks when PostgreSQL provisioning was skipped.
 
-    sys.path.insert(0, DEPS_DIR)
-    checks = []
+    Pre:  SKIP_POSTGRES is True.
+    Post: returns one (name, passed) pair confirming the sqlite3 stdlib
+          module — the only storage dependency this mode exercises — is
+          importable.
+    """
+    try:
+        import sqlite3  # noqa: F401
 
-    # PostgreSQL
+        return [("sqlite3 stdlib", True)]
+    except ImportError:
+        return [("sqlite3 stdlib", False)]
+
+
+def _postgres_checks() -> list[tuple[str, bool]]:
+    """PostgreSQL connection, extension, and stored-procedure checks.
+
+    Pre:  SKIP_POSTGRES is False; DATABASE_URL points at a server that
+          setup_database() has already provisioned.
+    Post: returns (name, passed) pairs for the connection, the pgvector/
+          pg_trgm extensions, and the recall_memories() stored procedure.
+          Never raises — connection/query failures are reported as a
+          failed check, not an exception.
+    """
+    checks: list[tuple[str, bool]] = []
     try:
         import psycopg
 
@@ -292,29 +333,35 @@ def verify() -> None:
         checks.append(("PostgreSQL connection", True))
     except Exception:
         checks.append(("PostgreSQL connection", False))
-        conn = None
+        return checks
 
-    # Extensions
-    if conn:
-        try:
-            row = conn.execute(
-                "SELECT COUNT(*) FROM pg_extension WHERE extname IN ('vector', 'pg_trgm')"
-            ).fetchone()
-            checks.append(("Extensions (pgvector, pg_trgm)", row[0] == 2))
-        except Exception:
-            checks.append(("Extensions", False))
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM pg_extension WHERE extname IN ('vector', 'pg_trgm')"
+        ).fetchone()
+        checks.append(("Extensions (pgvector, pg_trgm)", row[0] == 2))
+    except Exception:
+        checks.append(("Extensions", False))
 
-        try:
-            row = conn.execute(
-                "SELECT COUNT(*) FROM pg_proc WHERE proname = 'recall_memories'"
-            ).fetchone()
-            checks.append(("PL/pgSQL recall_memories()", row[0] > 0))
-        except Exception:
-            checks.append(("PL/pgSQL procedures", False))
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM pg_proc WHERE proname = 'recall_memories'"
+        ).fetchone()
+        checks.append(("PL/pgSQL recall_memories()", row[0] > 0))
+    except Exception:
+        checks.append(("PL/pgSQL procedures", False))
 
-        conn.close()
+    conn.close()
+    return checks
 
-    # sentence-transformers
+
+def _model_checks() -> list[tuple[str, bool]]:
+    """Embedding/reranking dependency import checks (both backends).
+
+    Post: returns (name, passed) pairs for sentence-transformers and
+          FlashRank, independent of SKIP_POSTGRES.
+    """
+    checks: list[tuple[str, bool]] = []
     try:
         import sentence_transformers  # noqa: F401
 
@@ -322,13 +369,26 @@ def verify() -> None:
     except ImportError:
         checks.append(("sentence-transformers", False))
 
-    # FlashRank
     try:
         from flashrank import Ranker  # noqa: F401
 
         checks.append(("FlashRank reranker", True))
     except ImportError:
         checks.append(("FlashRank reranker", False))
+
+    return checks
+
+
+def verify() -> None:
+    step("Verification")
+
+    sys.path.insert(0, DEPS_DIR)
+
+    # CI/testing mode (see module docstring): no PostgreSQL server is
+    # provisioned, so skip the PG-specific checks rather than reporting a
+    # false failure for a step that was intentionally not run.
+    checks = _sqlite_checks() if SKIP_POSTGRES else _postgres_checks()
+    checks += _model_checks()
 
     all_ok = True
     for name, passed in checks:
@@ -351,9 +411,18 @@ def main() -> None:
     print(f"  Database:    {_redact_db_url(DATABASE_URL)}")
 
     check_python()
-    check_postgresql()
+    if SKIP_POSTGRES:
+        warn(
+            "CORTEX_MEMORY_STORE_BACKEND=sqlite — skipping PostgreSQL "
+            "provisioning and schema steps (CI/testing mode; see module "
+            "docstring). Production installs via the Claude Code plugin "
+            "still require PostgreSQL + pgvector."
+        )
+    else:
+        check_postgresql()
     install_deps()
-    setup_database()
+    if not SKIP_POSTGRES:
+        setup_database()
     cache_embedding_model()
     verify()
 

--- a/tests_py/scripts/test_setup_py_backend_skip.py
+++ b/tests_py/scripts/test_setup_py_backend_skip.py
@@ -1,0 +1,87 @@
+"""Tests for scripts/setup.py CI/testing sqlite-skip mode — issue #113.
+
+Source: issue #113 — the Windows postInstall path (plugin.json ->
+install-plugin.sh -> scripts/setup.py on Windows) had zero CI coverage,
+which is how the "Unsupported OS" regression on native Windows shipped
+undetected. ``CORTEX_MEMORY_STORE_BACKEND=sqlite`` lets CI exercise
+scripts/setup.py's OS-dispatch-reachable steps (dependency install,
+embedding-model caching, verification) on a runner with no PostgreSQL
+server provisioned, without inventing a second unverified dispatch path.
+
+These tests exercise the pure module-level flag derivation and the
+branching it drives in ``verify()``; they do not run pip installs or a
+real PostgreSQL connection (that end-to-end proof is the CI job itself —
+see .github/workflows/ci.yml test-windows).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETUP_MODULE_PATH = REPO_ROOT / "scripts" / "setup.py"
+
+
+def _load_setup_module(monkeypatch, store_backend: str | None):
+    """Import scripts/setup.py fresh with a given CORTEX_MEMORY_STORE_BACKEND.
+
+    Pre:  store_backend is None (unset) or a string.
+    Post: returns a freshly executed module object; SKIP_POSTGRES reflects
+          the env var as read at that module's import time.
+    """
+    if store_backend is None:
+        monkeypatch.delenv("CORTEX_MEMORY_STORE_BACKEND", raising=False)
+    else:
+        monkeypatch.setenv("CORTEX_MEMORY_STORE_BACKEND", store_backend)
+
+    spec = importlib.util.spec_from_file_location(
+        "_cortex_setup_script", SETUP_MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "store_backend,expected",
+    [
+        (None, False),
+        ("", False),
+        ("postgresql", False),
+        ("auto", False),
+        ("sqlite", True),
+        ("SQLite", True),  # case-insensitive
+        (" sqlite ", True),  # whitespace-tolerant
+    ],
+)
+def test_skip_postgres_flag_derivation(monkeypatch, store_backend, expected):
+    mod = _load_setup_module(monkeypatch, store_backend)
+    assert mod.SKIP_POSTGRES is expected
+
+
+def test_verify_skips_pg_checks_and_checks_sqlite3_when_skip_postgres(
+    monkeypatch, capsys
+):
+    mod = _load_setup_module(monkeypatch, "sqlite")
+    # sentence-transformers / flashrank are not installed in the test env,
+    # so verify() would sys.exit(1) via fail(); that's expected here — we
+    # only assert on what got printed, i.e. which checks it decided to run.
+    with pytest.raises(SystemExit):
+        mod.verify()
+    out = capsys.readouterr().out
+    assert "sqlite3 stdlib" in out
+    assert "PostgreSQL connection" not in out
+    assert "Extensions" not in out
+    assert "PL/pgSQL" not in out
+
+
+def test_verify_runs_pg_checks_when_not_skip_postgres(monkeypatch, capsys):
+    mod = _load_setup_module(monkeypatch, None)
+    with pytest.raises(SystemExit):
+        mod.verify()
+    out = capsys.readouterr().out
+    assert "PostgreSQL connection" in out
+    assert "sqlite3 stdlib" not in out

--- a/tests_py/scripts/test_setup_py_backend_skip.py
+++ b/tests_py/scripts/test_setup_py_backend_skip.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -62,26 +63,75 @@ def test_skip_postgres_flag_derivation(monkeypatch, store_backend, expected):
     assert mod.SKIP_POSTGRES is expected
 
 
-def test_verify_skips_pg_checks_and_checks_sqlite3_when_skip_postgres(
-    monkeypatch, capsys
-):
+def test_verify_selects_sqlite_checks_when_skip_postgres(monkeypatch):
+    """verify() branch selection, hermetic (issue #113 CI run 29360566538).
+
+    The prior version of this test asserted a real SystemExit from
+    verify(), which depends on whether sentence-transformers/flashrank/
+    psycopg happen to be importable and whether a PostgreSQL server is
+    reachable in whatever environment runs the suite — non-deterministic
+    across CI jobs/matrix entries, exactly the flakiness this policy
+    forbids. _sqlite_checks/_postgres_checks/_model_checks are documented
+    as "never raises" (see their docstrings), so the only thing verify()
+    itself is responsible for is: which of _sqlite_checks/_postgres_checks
+    it calls, and whether it exits when a returned check is False. Both
+    are testable by mocking the helpers directly — no import availability,
+    no network, no real database needed.
+    """
     mod = _load_setup_module(monkeypatch, "sqlite")
-    # sentence-transformers / flashrank are not installed in the test env,
-    # so verify() would sys.exit(1) via fail(); that's expected here — we
-    # only assert on what got printed, i.e. which checks it decided to run.
-    with pytest.raises(SystemExit):
-        mod.verify()
-    out = capsys.readouterr().out
-    assert "sqlite3 stdlib" in out
-    assert "PostgreSQL connection" not in out
-    assert "Extensions" not in out
-    assert "PL/pgSQL" not in out
+
+    sqlite_checks = mock.Mock(return_value=[("sqlite3 stdlib", True)])
+    postgres_checks = mock.Mock(return_value=[("PostgreSQL connection", True)])
+    model_checks = mock.Mock(
+        return_value=[("sentence-transformers", True), ("FlashRank reranker", True)]
+    )
+    monkeypatch.setattr(mod, "_sqlite_checks", sqlite_checks)
+    monkeypatch.setattr(mod, "_postgres_checks", postgres_checks)
+    monkeypatch.setattr(mod, "_model_checks", model_checks)
+
+    mod.verify()  # all mocked checks pass -> must not exit
+
+    sqlite_checks.assert_called_once()
+    postgres_checks.assert_not_called()
+    model_checks.assert_called_once()
 
 
-def test_verify_runs_pg_checks_when_not_skip_postgres(monkeypatch, capsys):
+def test_verify_selects_postgres_checks_when_not_skip_postgres(monkeypatch):
     mod = _load_setup_module(monkeypatch, None)
+
+    sqlite_checks = mock.Mock(return_value=[("sqlite3 stdlib", True)])
+    postgres_checks = mock.Mock(return_value=[("PostgreSQL connection", True)])
+    model_checks = mock.Mock(
+        return_value=[("sentence-transformers", True), ("FlashRank reranker", True)]
+    )
+    monkeypatch.setattr(mod, "_sqlite_checks", sqlite_checks)
+    monkeypatch.setattr(mod, "_postgres_checks", postgres_checks)
+    monkeypatch.setattr(mod, "_model_checks", model_checks)
+
+    mod.verify()  # all mocked checks pass -> must not exit
+
+    postgres_checks.assert_called_once()
+    sqlite_checks.assert_not_called()
+    model_checks.assert_called_once()
+
+
+@pytest.mark.parametrize("skip_postgres", [True, False])
+def test_verify_exits_when_any_mocked_check_fails(monkeypatch, skip_postgres):
+    mod = _load_setup_module(monkeypatch, "sqlite" if skip_postgres else None)
+
+    monkeypatch.setattr(
+        mod, "_sqlite_checks", mock.Mock(return_value=[("sqlite3 stdlib", True)])
+    )
+    monkeypatch.setattr(
+        mod,
+        "_postgres_checks",
+        mock.Mock(return_value=[("PostgreSQL connection", False)]),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_model_checks",
+        mock.Mock(return_value=[("sentence-transformers", False)]),
+    )
+
     with pytest.raises(SystemExit):
         mod.verify()
-    out = capsys.readouterr().out
-    assert "PostgreSQL connection" in out
-    assert "sqlite3 stdlib" not in out


### PR DESCRIPTION
Fixes #113.

**Cause racine** : le dispatch OS vivait uniquement dans `setup.sh` (intrinsèquement macOS/Linux — brew/apt) ; sous Git Bash Windows, `uname -s` = `MINGW64_NT-*`/`MSYS_NT-*`/`CYGWIN_NT-*`, non matché → « Unsupported OS » sec malgré `manifest.json` déclarant win32. Et le job CI `test-windows` n'exerçait jamais le vrai chemin postInstall (`pip install -e` direct), rendant le trou invisible.

**Fix au point de dispatch unique** (`install-plugin.sh`, seule entrée du postInstall) : `case "$(uname -s)"` — Darwin/Linux inchangés ; motifs Git Bash Windows → délégation à `scripts/setup.py` (déjà cross-platform) ; OS réellement non supporté → message actionnable nommant la commande manuelle. CI : le job `test-windows` exécute désormais `bash scripts/install-plugin.sh` réel (mode `CORTEX_MEMORY_STORE_BACKEND=sqlite` pour éviter de dépendre d'un PostgreSQL runner non vérifiable).

**Vérifications** : `bash -n` sur les scripts ; harnais prouvant le routage des 6 valeurs `uname -s` documentées ; 9 nouveaux tests pytest (dérivation SKIP_POSTGRES + branchement `verify()`) ; suites `tests_py/scripts` + `test_platform.py` : 115 passed, 0 régression ; ruff check + format clean. `verify()` splittée en `_sqlite_checks`/`_postgres_checks`/`_model_checks` (≤35 lignes chacune) au passage (§4.2/§4.5).

**Preuve finale** : le step `test-windows` de CETTE PR est le test réel du chemin d'install — à surveiller sur ce run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5Z1wfiBpADgENq6pB6E2i