### PR TITLE
docs(deployment): corporate proxy / custom CA for model downloads

### DIFF
--- a/docs/deployment-scenarios.md
+++ b/docs/deployment-scenarios.md
@@ -1,8 +1,8 @@
 # Cortex — Deployment Scenarios
 
-Two scenarios that have caused friction for Discord users: running under WSL
-and connecting with TLS client-certificate authentication instead of a
-password.
+Scenarios that have caused friction for Discord users: running under WSL,
+connecting with TLS client-certificate authentication instead of a password,
+and downloading model weights behind a corporate proxy / inspection CA.
 
 ---
 
@@ -108,3 +108,125 @@ python3 -m mcp_server.doctor
 
 The `DATABASE_URL` check and the `PG connection` check both probe the host
 from your DSN.
+
+---
+
+## Corporate proxy / custom CA (model downloads)
+
+Cortex downloads two model artifacts on first use, both from Hugging Face:
+
+- **sentence-transformers embedding model** (`all-MiniLM-L6-v2`, ~100MB),
+  fetched via `huggingface_hub`/`requests` inside
+  `mcp_server/infrastructure/embedding_engine.py` (`_ensure_model`), and
+  pre-cached once by `scripts/setup.py` (`cache_embedding_model`, step 5).
+- **FlashRank cross-encoder reranker** (`ms-marco-MiniLM-L-12-v2`, ~34MB
+  ONNX), fetched by the `flashrank` library itself from
+  `https://huggingface.co/prithivida/flashrank/resolve/main/{model}.zip`
+  (`mcp_server/core/reranker.py`, module docstring; verified by reading the
+  installed `flashrank==0.2.10` package, not assumed).
+
+Neither of these paths has Cortex-specific proxy/CA handling — there is none
+to add. Both `sentence-transformers`/`huggingface_hub` and `flashrank` use
+Python's `requests` under the hood, which honors the standard environment
+variables natively. `scripts/setup.py` passes the pre-caching step through
+`subprocess.run(..., env={**os.environ, ...})` (see `cache_embedding_model`),
+so anything exported in your shell before running the installer reaches the
+download.
+
+### Proxy variables (read by `requests`/`urllib3`, and by `huggingface_hub`)
+
+```bash
+export HTTPS_PROXY="http://proxy.corp.example.com:8080"
+export HTTP_PROXY="http://proxy.corp.example.com:8080"
+export NO_PROXY="localhost,127.0.0.1,.corp.example.com"
+```
+
+These are read once per process at first HTTP(S) request. Set them before
+running `scripts/setup.py`, and before starting Claude Code / the Cortex MCP
+server if the reranker or embedding model has not been cached yet.
+
+### The central trap: which CA variable Python actually reads
+
+If your proxy terminates TLS and re-signs traffic with a corporate root CA
+(common with inspection proxies), **the variable that matters for Cortex's
+downloads is a Python/`requests` variable, not a Node one**:
+
+| Variable | Honored by | Relevant to Cortex? |
+|---|---|---|
+| `REQUESTS_CA_BUNDLE` | Python `requests` (and therefore `huggingface_hub`, `sentence-transformers`, `flashrank`) | **Yes — this is the one to set.** |
+| `SSL_CERT_FILE` | Python's `ssl` module directly (used by libraries that bypass `requests`) | Yes, as a second/fallback path — set alongside `REQUESTS_CA_BUNDLE` for defense in depth. |
+| `NODE_EXTRA_CA_CERTS` | Node.js's TLS stack | **No.** This only affects Claude Code's own Node process (npm registry TLS, Claude Code's network calls). It has zero effect on Cortex's Python model downloads. Setting only this variable and expecting model downloads to trust the corporate CA is the classic mistake this section exists to head off. |
+
+```bash
+export REQUESTS_CA_BUNDLE=/etc/ssl/certs/corp-ca-bundle.crt
+export SSL_CERT_FILE=/etc/ssl/certs/corp-ca-bundle.crt
+```
+
+If you already set `NODE_EXTRA_CA_CERTS` for Claude Code itself, keep it —
+it is still required for Claude Code's own TLS — but it is a separate,
+additional variable, not a substitute for `REQUESTS_CA_BUNDLE`/`SSL_CERT_FILE`.
+
+### Cache location: never let it land in `/tmp`
+
+Cortex has already been bitten by exactly this failure mode once, in the
+reranker: FlashRank 0.2.10's own default `cache_dir` is `/tmp`
+(`flashrank/Config.py`, `default_cache_dir = "/tmp"`). macOS periodically
+purges `/tmp`, which silently disabled reranking for the remainder of a
+process's life and went unnoticed through 6 benchmark runs (fixed in
+`bb1c581f`, "fix(reranker): durable cache_dir + non-silent failure + bench
+fail-fast", 2026-07-11). The fix was to pass an **explicit, durable**
+`cache_dir` — `reranker_cache_dir()` in `mcp_server/core/reranker.py`,
+which resolves to `~/.cache/flashrank` and honors `$XDG_CACHE_HOME` via
+`mcp_server.shared.platform.cache_dir()` — instead of relying on the
+library default.
+
+The sentence-transformers embedding model does **not** have this same
+Cortex-side override: `embedding_engine.py` calls `SentenceTransformer(...)`
+without a `cache_folder` argument, so it defers entirely to
+`huggingface_hub`'s own cache resolution — `$HF_HOME` if set, else the
+library default `~/.cache/huggingface`. That default is durable (not
+`/tmp`) on every platform `huggingface_hub` supports, so there is no
+equivalent bug here today, but the lesson still applies operationally: if
+you redirect the cache, redirect it somewhere persistent.
+
+```bash
+# Optional: put both model caches under one durable, shared location
+export HF_HOME=/opt/cortex-cache/huggingface
+export XDG_CACHE_HOME=/opt/cortex-cache        # FlashRank reads this via
+                                                 # mcp_server.shared.platform.cache_dir()
+```
+
+Do **not** point either variable at `/tmp` or any other path a cleanup job,
+container restart, or OS policy can purge — you will reproduce the exact
+silent-failure pattern from the FlashRank incident, except for the
+embedding model instead of the reranker.
+
+### Air-gapped / no outbound internet
+
+If the deployment environment has no route to `huggingface.co` at all (a
+stricter case than a proxy — no egress permitted, even through a proxy),
+neither `HTTPS_PROXY` nor the CA variables above help; the download itself
+must not happen at runtime. Two options:
+
+1. **Pre-warm the cache at build time.** Run the same pre-caching step
+   `scripts/setup.py` performs (`cache_embedding_model`) and the
+   FlashRank `Ranker(...)` construction inside your container/VM image
+   build, while the build host still has network access, then ship the
+   resulting `$HF_HOME` and `$XDG_CACHE_HOME/flashrank` directories baked
+   into the image. This is the approach tracked for the official devcontainer
+   in [#118](https://github.com/cdeust/Cortex/issues/118).
+2. **Mirror Hugging Face internally.** Point `HF_HOME`'s resolution at an
+   internal Hugging Face Hub mirror (or a static file mirror serving the
+   same paths) reachable from the air-gapped network, and set
+   `HF_ENDPOINT` to that mirror's base URL — this is a `huggingface_hub`
+   convention, not a Cortex-specific mechanism; Cortex's downloads are
+   ordinary `huggingface_hub`/`flashrank` HTTP calls and inherit whatever
+   endpoint those libraries are configured to use.
+
+See also the TLS client-certificate section above for a related but
+distinct concern — that section covers CA/cert configuration for Cortex's
+own PostgreSQL connection, not model downloads. The proxy/CA variables in
+this section apply only to the outbound HTTPS calls
+`sentence-transformers`/`huggingface_hub`/`flashrank` make; they have no
+effect on `DATABASE_URL`'s `sslcert`/`sslkey`/`sslrootcert` parameters, and
+vice versa.


### PR DESCRIPTION
Fixes #116. Section « Corporate proxy / custom CA (model downloads) » ajoutée à docs/deployment-scenarios.md (~125 lignes), après la section Remote PostgreSQL.

Cœur : la table de distinction REQUESTS_CA_BUNDLE / SSL_CERT_FILE (Python — honorées par huggingface_hub/sentence-transformers/flashrank) vs NODE_EXTRA_CA_CERTS (Node/Claude Code uniquement — l'erreur classique), + HF_HOME/cache persistant, + option air-gapped (préchauffage au build, renvoi #118).

Chaque affirmation vérifiée contre le code réel (embedding_engine.py:213-259, reranker.py cache_dir + commit bb1c581f, setup.py:272-296 propagation d'env au subprocess) — la doc décrit le comportement effectif, pas le supposé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)