### PR TITLE
docs(claude-md): refactor to 92 lines with @-references — measured counts, per-surface storage truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,463 +1,92 @@
-# Cortex — Methodology Agent
+# Cortex — Persistent Memory MCP Server
 
-Persistent memory and cognitive profiling MCP server for Claude Code. Python 3.10+ with FastMCP, Pydantic, and numpy.
+Persistent memory and cognitive profiling MCP server for Claude Code.
+Python 3.10+, FastMCP, Pydantic, numpy. Storage: PostgreSQL+pgvector
+(plugin/CLI mode) or SQLite (`.mcpb`/Cowork sandboxed launches) — see
+`PRIVACY.md` for the per-surface truth.
 
 ## Problem Statement
 
-Claude Code sessions generate rich behavioral data (tool usage, session duration, first messages, keyword patterns) but this data is lost between sessions. Cortex mines this history to build a cognitive profile per domain and provides a thermodynamic memory system with heat/decay, predictive coding write gates, causal graphs, and intent-aware retrieval.
+Claude Code sessions generate rich behavioral data (tool usage, session
+duration, first messages, keyword patterns) but this data is lost between
+sessions. Cortex mines this history to build a cognitive profile per domain
+and provides a thermodynamic memory system with heat/decay, predictive
+coding write gates, causal graphs, and intent-aware retrieval.
 
-## Code Quality Rules
+## Build & Test
 
-- **300 lines max** per file — split into focused modules when exceeded
-- **40 lines max** per method — extract helpers for readability
-- **Clean Architecture** — inner layers never import outer layers
-- **SOLID principles** — single responsibility, dependency inversion
-- **Reverse dependency injection** — core defines interfaces, infrastructure implements
-- **Factory injection** — handlers compose core + infrastructure via factories
-- **No dead code** — remove unused functions, backward-compat shims, commented-out code
-- **No unwired code** — if it's built, it must be called somewhere
-
-See `docs/provenance/refactoring-plan.md` for the file-by-file split plan (31 files over 300 lines).
-
-## Research Methodology
-
-When implementing neuroscience-inspired mechanisms, always consult primary research papers before coding. Use [arxivisual](https://arxivisual.com) to explore and understand referenced papers visually — it provides detailed visual explanations of arxiv papers. Paper references are listed in `docs/adr/`. The implementation should follow the computational model described in the paper, not just the metaphor. Every new mechanism must cite its source paper and match the paper's equations/algorithms as closely as practical for a memory system operating at hours/days timescale (vs milliseconds in biology).
+- Install (dev): `uv pip install -e ".[dev]"` — SQLite backend: `".[dev,sqlite]"`
+- Environment preflight: `python -m mcp_server.doctor` (7 checks, fix message per check)
+- Tests: `pytest` (full suite, 3000+ tests) · `pytest tests_py/core/` (one layer) · `pytest --cov=mcp_server --cov-report=term-missing`
+- Lint BEFORE every commit: `ruff check && ruff format --check` — the CI enforces **both**; passing only `ruff check` is not enough.
+- Release gate benchmarks (isolated, ephemeral container — the only source
+  of truth for pre-tag/floor decisions): `benchmarks/reproduce.sh`. Do NOT
+  gate a release against the live production database — same-day
+  same-machine checks against it drift ±0.003 on LoCoMo MRR intra-day
+  (measured 2026-07-14, `benchmarks/results/repro/20260714-floors-rebaseline/`)
+  and nearly false-failed a floor that passes cleanly under `reproduce.sh`.
+- Iteration benchmarks: `python3 benchmarks/{longmemeval,locomo,beam}/run_benchmark.py`
+  ⚠ Consolidation is OFF by default → scores collapse to ≈0%. This is a
+  harness artifact (every candidate is prefiltered by the read-path heat
+  gate before consolidation ever advances the stage), not a bug — pass
+  `--with-consolidation` for representative numbers.
 
 ## Architecture
 
-Clean Architecture with concentric layers. Inner layers never import outer layers.
+Clean Architecture, concentric layers: `server → handlers → core ← shared`,
+`infrastructure → shared`. Handlers are the composition roots — the only
+layer allowed to import both core and infrastructure; core is pure (zero
+I/O, testable without mocks). The graph/visualization stack lives in the
+separate **cortex-viz** MCP (reads this same store read-only).
 
-```
-SERVER → HANDLERS → CORE ← SHARED
-                      ↓
-                INFRASTRUCTURE → SHARED
-```
+- @docs/adr/ — Architecture Decision Records (013 = thermodynamic memory
+  model, 014 = biological mechanisms, 012 = Python migration from Node.js)
+- @docs/module-inventory.md — per-layer module catalogue + dependency rules
+- @docs/mcp-tools.md — the 50 standalone + 3 conditionally-registered MCP
+  tools, by tier, with purpose and target latency
+- @PRIVACY.md — storage truth by launch surface (lines 26–36): SQLite is
+  the default for `.mcpb`/Cowork; PostgreSQL is used in plugin/CLI mode
 
-Handlers are the **composition roots**: they wire infrastructure (I/O) to core (logic) and are the only layer allowed to import both.
+## Code Style
 
-### Dependency Rules
+- 300 lines max per file; 40 lines max per method. Enforced by the
+  craftsmanship-checker pre-commit hook.
+- Import rule: `core/` imports only `shared/` + stdlib; `infrastructure/`
+  never imports core/handlers. Verify: `grep -rn "from mcp_server.infrastructure" mcp_server/core/`
+  should return nothing for new code — 3 pre-existing violations in
+  `wiki_axis_registry.py`, `wiki_classifier.py`, `wiki_schema_loader.py`
+  are tracked as a follow-up (found 2026-07-14 during #114), not a
+  standard to add to.
+- No invented constants: every hardcoded number carries a `# source:`
+  comment (paper, committed benchmark, or dated measurement). A number
+  without one blocks the diff in review.
 
-| Layer | May Import | Must NOT Import |
-|---|---|---|
-| **shared/** | Python stdlib only | core, infrastructure, handlers, server |
-| **core/** | shared/ only | infrastructure, handlers, server, os/pathlib |
-| **infrastructure/** | shared/, Python stdlib | core, handlers, server |
-| **validation/** | shared/, errors/ | core, infrastructure, handlers |
-| **errors/** | nothing | everything |
-| **handlers/** | core, infrastructure, shared, validation, errors | server |
-| **server/** | handlers, errors | core, infrastructure (except via handlers) |
-| **hooks/** | infrastructure, core, shared | server |
+## What NOT to do
 
-### Module Inventory
-
-**shared/** — Pure utility functions (11 modules)
-- `text.py` — Keyword extraction with stopword filtering
-- `categorizer.py` — 10-category work classification
-- `similarity.py` — Jaccard similarity coefficient
-- `hash.py` — DJB2 non-cryptographic hash
-- `project_ids.py` — Path ↔ project ID ↔ label ↔ domain ID conversion
-- `yaml_parser.py` — Lightweight YAML frontmatter parser
-- `types.py` — Pydantic models (ProfilesV2, DomainProfile, CognitiveStyle, etc.)
-- `types_profiles.py` — Profile-specific Pydantic models
-- `linear_algebra.py` — Dense vector math via numpy (dot, norm, cosine, project, clamp)
-- `sparse.py` — Sparse vector operations (dict-based, topK, conversions)
-- `memory_types.py` — Runtime validation types for the memory subsystem
-
-**core/** — Pure business logic, zero I/O (108 modules)
-
-*Cognitive Profiling:*
-- `domain_detector.py` — 3-signal weighted domain classification
-- `context_generator.py` — Human-readable profile text generation
-- `pattern_extractor.py` — Entry points, recurring patterns, tool preferences, session shape
-- `style_classifier.py` — Felder-Silverman cognitive style classification + EMA update
-- `style_classifier_ema.py` — EMA update logic for style classification
-- `bridge_finder.py` — Cross-domain connection detection (structural + analogical)
-- `blindspot_detector.py` — Category, tool, and pattern gap analysis
-- `profile_builder.py` — Profile orchestration (assembles all core modules)
-- `profile_assembler.py` — Profile assembly from extracted components
-- `blindspot_patterns.py` — Blind spot pattern definitions
-- `session_shape.py` — Session shape analysis
-- *(graph construction — `graph_builder*.py`, `graph_quality_scorer.py` — was extracted to the standalone **cortex-viz** MCP along with the HTTP/3D visualization stack)*
-
-*Behavioral Interpretability:*
-- `sparse_dictionary.py` — Behavioral feature dictionary learning (OMP sparse coding, K-SVD)
-- `sparse_dictionary_learning.py` — Dictionary learning algorithms
-- `sparse_dictionary_activation.py` — Activation computation
-- `persona_vector.py` — 12D persona vector with drift detection and context steering
-- `behavioral_crosscoder.py` — Cross-domain behavioral feature persistence detection
-- `attribution_tracer.py` — Pipeline attribution graph via perturbation-based tracing
-
-*Memory Thermodynamics:*
-- `thermodynamics.py` — Heat, surprise, importance, valence, metamemory
-- `hierarchical_predictive_coding.py` — 3-level Friston free energy gate (sensory/entity/schema) replacing flat 4-signal
-- `predictive_coding_flat.py` — Flat predictive coding fallback
-- `predictive_coding_gate.py` — Gate decision logic
-- `predictive_coding_signals.py` — Signal computation for predictive coding
-- `coupled_neuromodulation.py` — DA/NE/ACh/5-HT coupled cascade with cross-channel effects (Doya 2002, Schultz 1997)
-- `neuromodulation_channels.py` — Individual neuromodulator channel definitions
-- `emotional_tagging.py` — Amygdala-inspired priority encoding (Qasim et al. 2023) with the Hebb 1955 inverted-U arousal curve
-- `synaptic_tagging.py` — Retroactive promotion of weak memories sharing entities (Frey & Morris 1997)
-- `curation.py` — Active curation logic (merge, link, create decisions)
-- `engram.py` — Memory trace structure (Josselyn & Tonegawa 2020)
-- `decay_cycle.py` — Thermodynamic cooling with stage-dependent rates
-- `tripartite_synapse.py` — Astrocyte calcium dynamics, D-serine LTP facilitation, metabolic gating (Perea 2009)
-- `tripartite_calcium.py` — Calcium dynamics computation for tripartite synapse
-- `write_gate.py` — Write gate decision logic
-- `write_post_store.py` — Post-store processing after memory write
-- `memory_ingest.py` — Memory ingestion pipeline
-- `memory_decomposer.py` — Decompose complex memories into atomic units
-- `compression.py` — Full-text → gist → tag compression
-- `staleness.py` — File-reference staleness scoring
-- `response_budget.py` — Bounded MCP responses: total payload budget (measured 100k-char Claude Code MAX_MCP_OUTPUT_TOKENS cap × 0.75 UTF-16-divergence safety factor) + priority-weighted water-filling (budget proportional to retrieval score/heat, least relevant condensed first); truncated items keep ids for dynamic fetch-by-id
-- `gist_extraction.py` — Deterministic gist (head + signal lines + tail) for oversized auto-captures; GIST_BUDGET = measured p90 curated memory length; full raw output lives in a filesystem artifact, one Read away (no truncation)
-
-*Oscillatory & Cascade:*
-- `oscillatory_clock.py` — Theta/gamma/SWR phase gating (Hasselmo 2005, Buzsaki 2015)
-- `oscillatory_phases.py` — Phase definitions and gating logic
-- `cascade.py` — Consolidation stages: LABILE → EARLY_LTP → LATE_LTP → CONSOLIDATED (Kandel 2001)
-- `cascade_stages.py` — Stage definitions and transitions
-- `cascade_advancement.py` — Stage advancement logic
-- `pattern_separation.py` — DG orthogonalization + neurogenesis analog (Leutgeb 2007, Yassa & Stark 2011)
-- `separation_core.py` — Core orthogonalization algorithms
-- `neurogenesis.py` — Neurogenesis analog for pattern separation
-- `schema_engine.py` — Cortical knowledge structures with Piaget accommodation (Tse 2007, Gilboa & Marlatte 2017)
-- `schema_extraction.py` — Schema extraction from memories
-- `interference.py` — Proactive/retroactive interference detection + sleep orthogonalization
-- `interference_detection.py` — Interference detection algorithms
-- `homeostatic_plasticity.py` — Synaptic scaling + BCM threshold (Turrigiano 2008, Abraham & Bear 1996)
-- `homeostatic_health.py` — Homeostatic health metrics
-- `dendritic_clusters.py` — Branch-specific nonlinear integration + priming (Kastellakis 2015)
-- `dendritic_computation.py` — Branch-specific computation logic
-- `two_stage_model.py` — Hippocampal-cortical transfer protocol (McClelland 1995)
-- `two_stage_transfer.py` — Transfer protocol execution
-- `emergence_tracker.py` — System-level metrics: forgetting curve, spacing effect, schema acceleration
-- `emergence_metrics.py` — Emergence metric definitions
-- `ablation.py` — Lesion study framework (41 ablatable units spanning the 36 neuroscience-grounded mechanisms)
-- `active_forgetting.py` — Two independent dopaminergic forgetting circuits: permanent Rac1 trace erosion (chronic interference × stage vulnerability) + transient DAMB retrieval block (Davis & Zhong 2017, Sabandal et al. 2021)
-- `ablation_report.py` — Ablation report generation
-
-*Consolidation:*
-- `consolidation_engine.py` — Orchestrates decay, compression, CLS, causal discovery
-- `dual_store_cls.py` — Episodic → semantic memory consolidation (CLS)
-- `dual_store_cls_abstraction.py` — CLS abstraction extraction
-- `causal_graph.py` — PC Algorithm for causal discovery
-- `reconsolidation.py` — Memory updating on access
-- `replay.py` — Hippocampal replay for memory consolidation
-- `replay_types.py` — Replay type definitions
-- `replay_selection.py` — Replay candidate selection
-- `replay_execution.py` — Replay execution logic
-- `replay_formatting.py` — Replay result formatting
-- `sleep_compute.py` — Dream replay, cluster summarization, re-embedding, auto-narration
-- `synaptic_plasticity.py` — LTP/LTD Hebbian learning + STDP causal direction + stochastic transmission + phase-gated plasticity (Hebb 1949, BCM 1982, Bi & Poo 1998, Markram 1998)
-- `synaptic_plasticity_hebbian.py` — Hebbian learning algorithms
-- `synaptic_plasticity_stochastic.py` — Stochastic transmission
-- `microglial_pruning.py` — Complement-dependent edge elimination + orphan archival (Wang et al. 2020)
-
-*Retrieval & Navigation:*
-- `query_intent.py` — Intent classification (temporal/causal/semantic/entity/knowledge_update/multi_hop) + weight profiles
-- `query_decomposition.py` — Multi-entity query splitting + entity extraction
-- `retrieval_dispatch.py` — 3-tier dispatch (simple/mixed/deep) + WRRF weight computation
-- `retrieval_signals.py` — Retrieval signal definitions and computation
-- `query_router.py` — Query routing to appropriate retrieval tier
-- `pg_recall.py` — PostgreSQL recall orchestration
-- `reranker.py` — FlashRank ONNX cross-encoder reranking (client-side post-PG)
-- `scoring.py` — BM25, n-gram, keyword scoring (reference; PG does this server-side)
-- `temporal.py` — Date parsing, distance decay, recency boost (reference; PG does this server-side)
-- `spreading_activation.py` — Collins & Loftus 1975 semantic priming over entity graph
-- `hdc_encoder.py` — 1024D bipolar HDC (bind/bundle/permute/similarity)
-- `cognitive_map.py` — Successor Representation co-access graph + 2D projection
-- `hopfield.py` — Hopfield network for content-addressable recall
-- `fractal.py` — Hierarchical clustering (L0/L1/L2 levels)
-- `fractal_clustering.py` — Clustering algorithm implementation
-- `enrichment.py` — Doc2Query synthetic queries + concept synonym expansion
-- `concept_vocabulary.py` — Concept vocabulary for synonym expansion
-- `sensory_buffer.py` — Bounded pre-consolidation ring buffer
-- `knowledge_graph.py` — Entity and relationship extraction
-- `prospective.py` — Trigger-based proactive recall (keyword, time, file, domain)
-- `memory_rules.py` — Neuro-symbolic rules system (soft/hard filtering)
-
-*Analysis & Narrative:*
-- `narrative.py` — Story generation from memories
-- `metacognition.py` — Self-reflection on memory system performance
-- `metacognition_analysis.py` — Metacognition analysis algorithms
-- `session_critique.py` — Post-session analysis and improvement suggestions
-- `session_critique_format.py` — Session critique output formatting
-- `session_extractor.py` — Extracts memories from session transcripts
-
-**infrastructure/** — All I/O (21 modules)
-- `config.py` — Centralized path constants via pathlib
-- `file_io.py` — Generic JSON/text read/write operations
-- `profile_store.py` — profiles.json persistence
-- `session_store.py` — session-log.json persistence
-- `brain_index_store.py` — brain-index.json reader
-- `scanner.py` — Discovers memories + conversations from ~/.claude/
-- `scanner_parse.py` — JSONL conversation parsing
-- `mcp_client.py` — Async MCP client over stdio (JSON-RPC 2.0, version negotiation)
-- `mcp_client_pool.py` — Singleton connection pool (lazy connect, reuse, idle timeout)
-- `pg_store.py` — PostgreSQL + pgvector persistence (MANDATORY)
-- `pg_store_entities.py` — Entity storage and retrieval
-- `pg_store_relationships.py` — Relationship storage, co-activation strengthening
-- `pg_store_queries.py` — Query execution helpers
-- `pg_store_auxiliary.py` — Auxiliary storage operations
-- `pg_store_rules.py` — Rule storage and retrieval
-- `pg_store_stats.py` — Statistics and diagnostics queries
-- `pg_schema.py` — DDL, extensions, PL/pgSQL stored procedures, migrations
-- `memory_config.py` — Runtime configuration (DATABASE_URL, env vars with CORTEX_MEMORY_ prefix)
-- `memory_store.py` — Memory store abstraction
-- `embedding_engine.py` — Vector embeddings (384-dim, sentence-transformers)
-- `artifact_store.py` — Content-addressed raw-output artifacts (`~/.claude/methodology/artifacts/<yyyy-mm>/<sha256[:16]>.md`) backing gist+pointer memories
-- `agent_config.py` — Agent configuration and topic scoping
-
-**handlers/** — Composition roots (50 standalone tools + 3 upstream-integration tools conditionally registered = 53 total + helpers, one per tool)
-
-**validation/** — `schemas.py` — Per-tool argument validation
-
-**errors/** — `__init__.py` — MethodologyError, ValidationError, StorageError, AnalysisError, McpConnectionError
-
-**server/** — MCP tool registration + composition roots. The HTTP visualization
-stack (galaxy/trace/wiki/knowledge/board UI) was extracted to the standalone
-**cortex-viz** MCP, which reads this same PostgreSQL store read-only.
-
-**hooks/** — Session lifecycle automation
-- `session_lifecycle.py` — SessionEnd hook for automatic profile updates
-- `session_start.py` — SessionStart hook: injects anchored + hot memories + checkpoint state
-- `post_tool_capture.py` — PostToolUse auto-capture hook
-- `compaction_checkpoint.py` — Saves state before context compaction
-
-## MCP Tools
-
-### Tier 1 — Core Memory & Profiling (21 tools)
-
-| Tool | Purpose | Target Latency |
-|---|---|---|
-| `query_methodology` | Returns cognitive profile + hot memories for current domain | <50ms |
-| `detect_domain` | Lightweight domain classification | <20ms |
-| `rebuild_profiles` | Full rescan of session data | <10s |
-| `list_domains` | Overview of all domains | <10ms |
-| `record_session_end` | Incremental profile update + session critique | <200ms |
-| `explore_features` | Interpretability exploration (features, attribution, persona, crosscoder) | <100ms |
-| `remember` | Store a memory through the 4-signal predictive coding gate | <100ms |
-| `recall` | Retrieve memories via 6-signal WRRF fusion | <200ms |
-| `consolidate` | Run maintenance: decay, compression, CLS, sleep compute | <5s |
-| `checkpoint` | Save/restore working state for hippocampal replay | <100ms |
-| `narrative` | Generate project narrative from stored memories | <500ms |
-| `memory_stats` | Memory system diagnostics | <50ms |
-| `import_sessions` | Import conversation history into memory store | varies |
-| `forget` | Hard/soft delete with is_protected guard | <50ms |
-| `validate_memory` | Validate memories against filesystem state | <500ms |
-| `rate_memory` | Useful/not-useful feedback → metamemory confidence | <50ms |
-| `seed_project` | 5-stage codebase bootstrap | varies |
-| `anchor` | Mark memory as compaction-resistant (heat=1.0) | <50ms |
-| `backfill_memories` | Auto-import prior Claude Code conversations | varies |
-| `unified_search` | Unified retrieval across memories, wiki, and code graph | <200ms |
-| `get_telemetry` | Retrieval and memory-system telemetry metrics | <50ms |
-
-### Tier 2 — Navigation & Exploration (7 tools)
-
-| Tool | Purpose | Target Latency |
-|---|---|---|
-| `recall_hierarchical` | Fractal L0/L1/L2 weighted recall | <200ms |
-| `drill_down` | Navigate into fractal cluster (L2 → L1 → memories) | <100ms |
-| `navigate_memory` | Successor Representation co-access BFS traversal | <200ms |
-| `get_causal_chain` | Trace entity relationships through knowledge graph | <200ms |
-| `detect_gaps` | Identify isolated entities, sparse domains, temporal drift | <500ms |
-| `recall_skills` | Recall learned procedural skills by situation | <200ms |
-| `why` | Resolve ⟦rcpt:id⟧ injection receipts into presence-in-context evidence (blame path, decision 4255039) | <100ms |
-
-### Tier 3 — Automation & Intelligence (9 tools)
-
-| Tool | Purpose | Target Latency |
-|---|---|---|
-| `sync_instructions` | Push top memory insights into CLAUDE.md | <500ms |
-| `create_trigger` | Prospective memory triggers (keyword/time/file/domain) | <100ms |
-| `add_rule` | Add neuro-symbolic hard/soft/tag rules | <100ms |
-| `get_rules` | List active rules by scope/type | <50ms |
-| `get_project_story` | Period-based autobiographical narrative | <500ms |
-| `assess_coverage` | Knowledge coverage score (0-100) + recommendations | <500ms |
-| `codebase_analyze` | Native AST codebase analysis (tree-sitter, 7 languages) | varies |
-| `curate_wiki` | Auto-curate wiki pages from memory clusters | varies |
-| `curate_distill` | Return understanding-level distillation dossiers (error->success, co-access, entity family) for the LLM to author `lesson` memories from (M-D8) | ~200-500ms |
-
-### Tier 4 — Wiki (10 tools)
-
-| Tool | Purpose | Target Latency |
-|---|---|---|
-| `wiki_write` | Create a first-class wiki page (ADR, spec, note) | <100ms |
-| `wiki_read` | Read a wiki page | <50ms |
-| `wiki_list` | List wiki pages by scope/kind | <50ms |
-| `wiki_link` | Create a typed link between wiki pages | <50ms |
-| `wiki_adr` | Create an Architecture Decision Record | <100ms |
-| `wiki_rename` | Rename a wiki page and update backlinks | <100ms |
-| `wiki_verify` | Verify wiki page integrity and links | <100ms |
-| `wiki_reindex` | Reindex wiki pages into memory pointers | varies |
-| `wiki_purge` | Permanently delete a wiki page | <50ms |
-| `wiki_migrate` | Reconcile wiki.pages against FS (backfill + ghost purge) | varies |
-
-**Upstream-integration tools (3, conditionally registered)** — these register
-only when their upstream MCP server is configured, bringing the total to 53:
-`ingest_codebase` + `change_impact` (automatised-pipeline) and `ingest_prd`
-(prd-spec-generator). With no upstream present, exactly the **50 standalone
-tools** above register (ground truth: `tests_py/test_main.py::test_standalone_baseline_is_50_tools`
-— the 49 tools re-verified 2026-07-12 by a live DB-less `tools/list` stdio
-round-trip against `bare-container-contract` + `wiki_migrate`, commit
-4be298a3). Driving the ai-architect pipeline end-to-end (formerly
-`run_pipeline`) is **not** part of this server — it lives in the
-automatised-pipeline MCP.
-
-## Slash Commands
-
-- `/methodology` — View cognitive methodology profile
-- `/why` — Deterministic blame-path entry point: resolve the ⟦rcpt:id⟧ markers in context via the `why` tool (decision 4255039 correction 6)
-
-## Data Flow
-
-### Memory Write Path
-
-1. **Gate**: 4-signal novelty filter (embedding distance, entity overlap, temporal proximity, structural similarity)
-2. **Curate**: Active curation — merge with similar, link to related, or create new
-3. **Store**: PostgreSQL + pgvector with auto tsvector indexing → entity extraction → knowledge graph
-
-### Memory Read Path
-
-1. **Route**: Intent classification (temporal/causal/semantic/entity/knowledge_update/multi_hop)
-2. **Enrich**: Doc2Query expansion + concept synonyms
-3. **Fuse**: PL/pgSQL `recall_memories()` — WRRF fusion of vector + FTS + trigram + heat + recency (server-side)
-4. **Rerank**: FlashRank cross-encoder (client-side, top-3x candidates)
-5. **Filter**: Neuro-symbolic rules → ranked results
-
-### Cognitive Profile Pipeline
-
-1. **Scan**: Read ~/.claude/projects/ for JSONL conversations and memory .md files
-2. **Group**: Map projects to domains via project ID matching
-3. **Extract**: Per-domain pattern extraction (clustering, n-grams, tool stats, session shape)
-4. **Classify**: Felder-Silverman cognitive style from behavioral signals
-5. **Bridge**: Cross-domain connections from brain-index cross-refs and text analogies
-6. **Detect gaps**: Blind spots by comparing domain coverage against global averages
-7. **Learn features**: Sparse dictionary learning on 27D behavioral activation space
-8. **Encode**: Per-domain sparse feature activations + persona vectors
-9. **Crosscode**: Detect persistent behavioral features across domains
-10. **Store**: Persist as ~/.claude/methodology/profiles.json
-
-## Testing
-
-```bash
-pytest                                      # All tests (3000+ passing)
-pytest --cov=mcp_server --cov-report=term-missing  # With coverage
-pytest tests_py/core/                       # Core layer only
-pytest tests_py/shared/                     # Shared layer only
-pytest tests_py/handlers/                   # Handler layer only
-```
-
-**Coverage targets**: shared 95%+, core 90%+, infrastructure 85%+, handlers 85%+, validation/errors 95%+, server 80%+, hooks 90%+.
-
-## Benchmarks
-
-6 benchmarks covering long-term memory from 2024-2026:
-
-```bash
-# Tier 1 — Active (results tracked)
-python3 benchmarks/longmemeval/run_benchmark.py --variant s        # LongMemEval (ICLR 2025) — 500 Qs
-python3 benchmarks/locomo/run_benchmark.py                          # LoCoMo (ACL 2024) — 1986 Qs
-python3 benchmarks/beam/run_benchmark.py --split 100K              # BEAM (ICLR 2026) — 200 Qs
-
-# Tier 2 — Additional
-python3 benchmarks/memoryagentbench/run_benchmark.py               # MemoryAgentBench (ICLR 2026)
-python3 benchmarks/evermembench/run_benchmark.py                    # EverMemBench (2026) — 2400 Qs
-python3 benchmarks/episodic/run_benchmark.py --events 20           # Episodic Memories (ICLR 2025)
-```
-
-**Current benchmark scores (E1 v3; canonical source: the arxiv papers under `docs/arxiv-thermodynamic/` and `docs/arxiv-context-assembly/`):**
-| Benchmark | Cortex | Best in paper |
-|---|---|---|
-| LongMemEval R@10 | **98.2%** | 78.4% |
-| LongMemEval MRR | **0.915** | -- |
-| LoCoMo R@10 | **91.5%** | -- |
-| LoCoMo MRR | **0.805** | 0.794 |
-| BEAM-100K MRR (retrieval-proxy) | **0.591** | -- |
-
-Consolidation note: these retrieval scores are measured `--with-consolidation`.
-The benchmark runners default to consolidation OFF, in which mode every loaded
-memory keeps its ingest-time `heat_base_set_at`/`stage_entered_at`
-(`hours_elapsed ≈ 0`), so the consolidation stage never advances past *labile*,
-`effective_heat` stays at the labile floor (`≈1e-4`, see `pg_schema.py`
-`effective_heat` and `core/pg_recall.py`), and the read-path heat gate
-(`min_heat = 0.01`) prefilters every candidate — retrieval collapses to ≈0%.
-This is a harness artifact of the OFF default, not a property of the stored
-memories; it reproduces identically across branches. Subset reconfirmation
-(`cortex_bench`, 2026-06-30, `--with-consolidation` vs OFF): LongMemEval-s n=50
-R@10 94.0% / MRR 0.854 vs 0%; LoCoMo n=10 (1982 Qs) R@10 93.8% / MRR 0.821 vs
-9.3%.
-
-BEAM note: 0.591 is a retrieval-proxy MRR (the rank of the first gold-matching
-memory), which is **not** commensurable with BEAM's end-to-end LLM-as-judge
-metric; no head-to-head BEAM claim is made — it is used only for within-system,
-same-harness comparisons. The context-assembly architecture adds +33.4% on
-BEAM-10M with label-free temporal stage detection (+21.5% with oracle labels).
-Source of truth: `docs/arxiv-thermodynamic/main.pdf` and
-`docs/arxiv-context-assembly/main.pdf` (the CLAUDE.md numbers must match the
-papers, not the other way around).
-
-## Research-Driven Improvement Workflow
-
-When improving benchmark scores or adding capabilities:
-
-1. **Identify weakness** — Run benchmarks, find the lowest-scoring categories
-2. **Research** — Find relevant papers (neuroscience, IR, NLP) that address the specific weakness
-3. **Implement** — Translate the paper's key insight into a core module (pure logic, no I/O)
-4. **Wire** — Connect via handlers (composition roots) with ablation support
-5. **Benchmark** — Re-run affected benchmarks, compare before/after
-6. **Record** — Update CLAUDE.md scores, commit with paper reference
-
-Every mechanism should trace back to a published paper. No ad-hoc heuristics.
-
-## Key Design Decisions
-
-See `docs/adr/` for Architecture Decision Records:
-- ADR-001: Zero external dependencies (superseded by ADR-012)
-- ADR-002: Clean architecture layers
-- ADR-003: Felder-Silverman cognitive model
-- ADR-004: Jaccard over cosine similarity
-- ADR-005: Agglomerative over k-means clustering
-- ADR-006: EMA for incremental updates
-- ADR-007: Head/tail JSONL reading
-- ADR-008: Handler as composition root
-- ADR-009: node:test over Jest (superseded by ADR-012)
-- ADR-010: Sparse dictionary learning for behavioral features
-- ADR-011: 12D persona vector design
-- ADR-012: Python migration from Node.js
-- ADR-013: Thermodynamic memory model
-- ADR-014: Biological mechanisms (spreading activation, synaptic tagging, neuromodulation, LTP/LTD, STDP, emotional tagging, microglial pruning)
-
-## Technology Stack
-
-**Runtime:** Python 3.10+ with `fastmcp>=2.0.0`, `pydantic>=2.0.0`, `numpy>=1.24.0`.
-
-**Storage (MANDATORY):** PostgreSQL 15+ with pgvector and pg_trgm extensions. No SQLite. No in-memory fallbacks.
-- `psycopg[binary]>=3.1` — PostgreSQL driver
-- `pgvector>=0.3` — Vector similarity search (HNSW index)
-- `pg_trgm` — Trigram similarity for n-gram signal
-- Connection via `DATABASE_URL` env var: `postgresql://cortex:password@localhost:5432/cortex`
-
-**Retrieval engine:** PL/pgSQL stored procedures. WRRF fusion, vector search, FTS, trigram similarity, heat filtering — all server-side. Client-side: intent classification (regex), FlashRank reranking (ONNX), embedding generation (sentence-transformers).
-
-**Benchmarks run through `benchmarks/reproduce.sh`'s isolated, ephemeral pgvector container** — the single source of truth for reproducible numbers (see the script's own header). No custom retrievers: load data → call `recall_memories()` → measure, same code path as production, but against a throwaway per-run database, never the live production store. Ad-hoc same-day development checks against the production database are fine for quick sanity checks, but are NOT comparable across days (measured intra-day drift ±0.003 on LoCoMo MRR, 2026-07-14) and must never be used to gate a release: any pre-tag / floor decision goes through `reproduce.sh` on the exact release tree, not the production DB (source: `benchmarks/results/repro/20260714-floors-rebaseline/`, finding logged 2026-07-14 — a pre-tag guard run against production nearly false-failed a floor that passes cleanly in the isolated instrument).
-
-Pre-computed profiles stored at `~/.claude/methodology/profiles.json`.
+- Do NOT gate a release benchmark against the live production database —
+  use `benchmarks/reproduce.sh` (isolated container) instead; see Build & Test.
+- Do NOT add silent fallbacks or backward-compat shims — explicit
+  contracts, one-shot migrations.
+- Do NOT write model caches under `/tmp` — the FlashRank incident (silently
+  absent re-ranker, 6 benchmarks invalidated) came from exactly this.
+  `HF_HOME`/`cache_dir` must be persistent.
 
 ## Scientific Implementation Standard (Zetetic Principle)
 
-Every change to the retrieval or memory system MUST follow this protocol:
+Every change to the retrieval or memory system:
 
-1. **No implementation without a source.** Every algorithm, equation, constant, and threshold must trace to a published paper, verified benchmark data, or documented empirical result. If no source exists, say "I don't know" and stop.
+1. **No source, no implementation.** Every algorithm/constant/threshold
+   traces to a published paper, a committed benchmark, or a dated
+   measurement. No source → say "I don't know" and stop.
+2. **Verify sources, don't guess.** Read the actual paper; confirm its
+   experimental conditions match ours (small corpus, conversational
+   content, 384-dim embeddings) before reusing an equation or constant.
+3. **Benchmark before commit.** Re-run the affected benchmarks; no
+   regression accepted. Results must be reproducible on a clean DB.
+4. **Audit trail.** Every module docstring cites its paper and equations;
+   `docs/provenance/paper-implementation-audit.md` stays current.
 
-2. **Multiple sources required.** A single paper is a hypothesis, not a fact. Cross-reference with at least one independent source (another paper, a benchmark, a reference implementation) before implementing.
-
-3. **Verify sources before accepting.** Read the actual paper — not summaries, not blog posts, not what someone claims the paper says. Extract the exact equations. Check the experimental conditions match our setting (small corpus, conversational content, 384-dim embeddings).
-
-4. **No invented constants.** Every hardcoded number must come from the paper's equations, the paper's experimental results, or measured ablation data from our own benchmarks. If a value can't be justified, it doesn't go in the code.
-
-5. **Benchmark before commit.** Every change must be benchmarked on all three benchmarks (LongMemEval, LoCoMo, BEAM). No regression is accepted. Results must be reproducible — run on clean DB, single process.
-
-6. **Say "I don't know" when you don't know.** Do not fabricate solutions, invent heuristics, or approximate algorithms without explicitly stating what was changed and why. A faithful "I don't know" is worth more than a confident wrong answer.
-
-7. **Audit trail.** Every module's docstring must cite the exact paper, the exact equations implemented, and document any adaptations with justification. The audit at `docs/provenance/paper-implementation-audit.md` must stay current.
+Current scores are sourced to the papers under `docs/arxiv-thermodynamic/`
+and `docs/arxiv-context-assembly/` — the papers are the source of truth,
+CLAUDE.md numbers must match them, never the reverse (see those PDFs for
+current LongMemEval/LoCoMo/BEAM figures).

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,124 @@
+---
+description: "MCP tool catalogue (tiers, purpose, target latency) + slash commands + data flow — extracted from CLAUDE.md (issue #114)."
+---
+
+# MCP Tools
+
+50 standalone tools register unconditionally; 3 more register only when an
+upstream MCP server is configured (53 total with both present).
+
+```
+# source: tests_py/test_main.py::test_standalone_baseline_is_50_tools
+#   verified 2026-07-12 by a live DB-less `tools/list` stdio round-trip
+#   against `bare-container-contract` + `wiki_migrate`, commit 4be298a3.
+```
+
+## Tier 1 — Core Memory & Profiling (21 tools)
+
+| Tool | Purpose | Target Latency |
+|---|---|---|
+| `query_methodology` | Returns cognitive profile + hot memories for current domain | <50ms |
+| `detect_domain` | Lightweight domain classification | <20ms |
+| `rebuild_profiles` | Full rescan of session data | <10s |
+| `list_domains` | Overview of all domains | <10ms |
+| `record_session_end` | Incremental profile update + session critique | <200ms |
+| `explore_features` | Interpretability exploration (features, attribution, persona, crosscoder) | <100ms |
+| `remember` | Store a memory through the 4-signal predictive coding gate | <100ms |
+| `recall` | Retrieve memories via 6-signal WRRF fusion | <200ms |
+| `consolidate` | Run maintenance: decay, compression, CLS, sleep compute | <5s |
+| `checkpoint` | Save/restore working state for hippocampal replay | <100ms |
+| `narrative` | Generate project narrative from stored memories | <500ms |
+| `memory_stats` | Memory system diagnostics | <50ms |
+| `import_sessions` | Import conversation history into memory store | varies |
+| `forget` | Hard/soft delete with is_protected guard | <50ms |
+| `validate_memory` | Validate memories against filesystem state | <500ms |
+| `rate_memory` | Useful/not-useful feedback → metamemory confidence | <50ms |
+| `seed_project` | 5-stage codebase bootstrap | varies |
+| `anchor` | Mark memory as compaction-resistant (heat=1.0) | <50ms |
+| `backfill_memories` | Auto-import prior Claude Code conversations | varies |
+| `unified_search` | Unified retrieval across memories, wiki, and code graph | <200ms |
+| `get_telemetry` | Retrieval and memory-system telemetry metrics | <50ms |
+
+## Tier 2 — Navigation & Exploration (7 tools)
+
+| Tool | Purpose | Target Latency |
+|---|---|---|
+| `recall_hierarchical` | Fractal L0/L1/L2 weighted recall | <200ms |
+| `drill_down` | Navigate into fractal cluster (L2 → L1 → memories) | <100ms |
+| `navigate_memory` | Successor Representation co-access BFS traversal | <200ms |
+| `get_causal_chain` | Trace entity relationships through knowledge graph | <200ms |
+| `detect_gaps` | Identify isolated entities, sparse domains, temporal drift | <500ms |
+| `recall_skills` | Recall learned procedural skills by situation | <200ms |
+| `why` | Resolve ⟦rcpt:id⟧ injection receipts into presence-in-context evidence (blame path, decision 4255039) | <100ms |
+
+## Tier 3 — Automation & Intelligence (9 tools)
+
+| Tool | Purpose | Target Latency |
+|---|---|---|
+| `sync_instructions` | Push top memory insights into CLAUDE.md | <500ms |
+| `create_trigger` | Prospective memory triggers (keyword/time/file/domain) | <100ms |
+| `add_rule` | Add neuro-symbolic hard/soft/tag rules | <100ms |
+| `get_rules` | List active rules by scope/type | <50ms |
+| `get_project_story` | Period-based autobiographical narrative | <500ms |
+| `assess_coverage` | Knowledge coverage score (0-100) + recommendations | <500ms |
+| `codebase_analyze` | Native AST codebase analysis (tree-sitter, 7 languages) | varies |
+| `curate_wiki` | Auto-curate wiki pages from memory clusters | varies |
+| `curate_distill` | Return understanding-level distillation dossiers (error->success, co-access, entity family) for the LLM to author `lesson` memories from (M-D8) | ~200-500ms |
+
+## Tier 4 — Wiki (10 tools)
+
+| Tool | Purpose | Target Latency |
+|---|---|---|
+| `wiki_write` | Create a first-class wiki page (ADR, spec, note) | <100ms |
+| `wiki_read` | Read a wiki page | <50ms |
+| `wiki_list` | List wiki pages by scope/kind | <50ms |
+| `wiki_link` | Create a typed link between wiki pages | <50ms |
+| `wiki_adr` | Create an Architecture Decision Record | <100ms |
+| `wiki_rename` | Rename a wiki page and update backlinks | <100ms |
+| `wiki_verify` | Verify wiki page integrity and links | <100ms |
+| `wiki_reindex` | Reindex wiki pages into memory pointers | varies |
+| `wiki_purge` | Permanently delete a wiki page | <50ms |
+| `wiki_migrate` | Reconcile wiki.pages against FS (backfill + ghost purge) | varies |
+
+## Upstream-integration tools (3, conditionally registered)
+
+These register only when their upstream MCP server is configured, bringing
+the total to 53: `ingest_codebase` + `change_impact` (automatised-pipeline)
+and `ingest_prd` (prd-spec-generator). With no upstream present, exactly the
+**50 standalone tools** above register. Driving the ai-architect pipeline
+end-to-end (formerly `run_pipeline`) is **not** part of this server — it
+lives in the automatised-pipeline MCP.
+
+## Slash Commands
+
+- `/methodology` — View cognitive methodology profile
+- `/why` — Deterministic blame-path entry point: resolve the ⟦rcpt:id⟧ markers in context via the `why` tool (decision 4255039 correction 6)
+
+## Data Flow
+
+### Memory Write Path
+
+1. **Gate**: 4-signal novelty filter (embedding distance, entity overlap, temporal proximity, structural similarity)
+2. **Curate**: Active curation — merge with similar, link to related, or create new
+3. **Store**: PostgreSQL + pgvector with auto tsvector indexing → entity extraction → knowledge graph
+
+### Memory Read Path
+
+1. **Route**: Intent classification (temporal/causal/semantic/entity/knowledge_update/multi_hop)
+2. **Enrich**: Doc2Query expansion + concept synonyms
+3. **Fuse**: PL/pgSQL `recall_memories()` — WRRF fusion of vector + FTS + trigram + heat + recency (server-side)
+4. **Rerank**: FlashRank cross-encoder (client-side, top-3x candidates)
+5. **Filter**: Neuro-symbolic rules → ranked results
+
+### Cognitive Profile Pipeline
+
+1. **Scan**: Read ~/.claude/projects/ for JSONL conversations and memory .md files
+2. **Group**: Map projects to domains via project ID matching
+3. **Extract**: Per-domain pattern extraction (clustering, n-grams, tool stats, session shape)
+4. **Classify**: Felder-Silverman cognitive style from behavioral signals
+5. **Bridge**: Cross-domain connections from brain-index cross-refs and text analogies
+6. **Detect gaps**: Blind spots by comparing domain coverage against global averages
+7. **Learn features**: Sparse dictionary learning on 27D behavioral activation space
+8. **Encode**: Per-domain sparse feature activations + persona vectors
+9. **Crosscode**: Detect persistent behavioral features across domains
+10. **Store**: Persist as ~/.claude/methodology/profiles.json

--- a/docs/module-inventory.md
+++ b/docs/module-inventory.md
@@ -1,0 +1,241 @@
+---
+description: "Per-layer module inventory for mcp_server/ — extracted from CLAUDE.md (issue #114) so the root file stays under 200 lines."
+---
+
+# Module Inventory
+
+Layer-by-layer catalogue of `mcp_server/`. This file is the curated/documented
+subset that existed in CLAUDE.md before the #114 refactor — every module below
+was already described there; nothing has been dropped. Counts below are
+**measured**, not carried over from the prior (stale) prose, per the
+zetetic source rule:
+
+```
+# source: measured on 2026-07-14 via
+#   find mcp_server/<layer> -name "*.py" | grep -v __init__ | grep -v __pycache__ | wc -l
+shared/           25 files   (11 documented below — curated subset)
+core/            208 files   (~90 documented below — curated subset, incl. core/streaming, core/context_assembly)
+infrastructure/   77 files   (21 documented below — curated subset)
+handlers/        131 files   (53 registered tools — see docs/mcp-tools.md — + composition-root helpers)
+```
+
+The prior CLAUDE.md text asserted "108 modules" for `core/` and similar
+counts for the other layers; that was a session-authored estimate, not a
+measured one, and had drifted from the actual tree. The counts above are the
+corrected, sourced figures. The module descriptions that follow remain a
+**curated subset** (the modules judged worth a one-line description at the
+time they were documented) — not a 1:1 listing of every file in the layer.
+Treat gaps as "undocumented," not "does not exist."
+
+## Dependency Rules
+
+| Layer | May Import | Must NOT Import |
+|---|---|---|
+| **shared/** | Python stdlib only | core, infrastructure, handlers, server |
+| **core/** | shared/ only | infrastructure, handlers, server, os/pathlib |
+| **infrastructure/** | shared/, Python stdlib | core, handlers, server |
+| **validation/** | shared/, errors/ | core, infrastructure, handlers |
+| **errors/** | nothing | everything |
+| **handlers/** | core, infrastructure, shared, validation, errors | server |
+| **server/** | handlers, errors | core, infrastructure (except via handlers) |
+| **hooks/** | infrastructure, core, shared | server |
+
+## shared/ — Pure utility functions
+
+- `text.py` — Keyword extraction with stopword filtering
+- `categorizer.py` — 10-category work classification
+- `similarity.py` — Jaccard similarity coefficient
+- `hash.py` — DJB2 non-cryptographic hash
+- `project_ids.py` — Path ↔ project ID ↔ label ↔ domain ID conversion
+- `yaml_parser.py` — Lightweight YAML frontmatter parser
+- `types.py` — Pydantic models (ProfilesV2, DomainProfile, CognitiveStyle, etc.)
+- `types_profiles.py` — Profile-specific Pydantic models
+- `linear_algebra.py` — Dense vector math via numpy (dot, norm, cosine, project, clamp)
+- `sparse.py` — Sparse vector operations (dict-based, topK, conversions)
+- `memory_types.py` — Runtime validation types for the memory subsystem
+
+## core/ — Pure business logic, zero I/O
+
+*Cognitive Profiling:*
+- `domain_detector.py` — 3-signal weighted domain classification
+- `context_generator.py` — Human-readable profile text generation
+- `pattern_extractor.py` — Entry points, recurring patterns, tool preferences, session shape
+- `style_classifier.py` — Felder-Silverman cognitive style classification + EMA update
+- `style_classifier_ema.py` — EMA update logic for style classification
+- `bridge_finder.py` — Cross-domain connection detection (structural + analogical)
+- `blindspot_detector.py` — Category, tool, and pattern gap analysis
+- `profile_builder.py` — Profile orchestration (assembles all core modules)
+- `profile_assembler.py` — Profile assembly from extracted components
+- `blindspot_patterns.py` — Blind spot pattern definitions
+- `session_shape.py` — Session shape analysis
+- *(graph construction — `graph_builder*.py`, `graph_quality_scorer.py` — was extracted to the standalone **cortex-viz** MCP along with the HTTP/3D visualization stack)*
+
+*Behavioral Interpretability:*
+- `sparse_dictionary.py` — Behavioral feature dictionary learning (OMP sparse coding, K-SVD)
+- `sparse_dictionary_learning.py` — Dictionary learning algorithms
+- `sparse_dictionary_activation.py` — Activation computation
+- `persona_vector.py` — 12D persona vector with drift detection and context steering
+- `behavioral_crosscoder.py` — Cross-domain behavioral feature persistence detection
+- `attribution_tracer.py` — Pipeline attribution graph via perturbation-based tracing
+
+*Memory Thermodynamics:*
+- `thermodynamics.py` — Heat, surprise, importance, valence, metamemory
+- `hierarchical_predictive_coding.py` — 3-level Friston free energy gate (sensory/entity/schema) replacing flat 4-signal
+- `predictive_coding_flat.py` — Flat predictive coding fallback
+- `predictive_coding_gate.py` — Gate decision logic
+- `predictive_coding_signals.py` — Signal computation for predictive coding
+- `coupled_neuromodulation.py` — DA/NE/ACh/5-HT coupled cascade with cross-channel effects (Doya 2002, Schultz 1997)
+- `neuromodulation_channels.py` — Individual neuromodulator channel definitions
+- `emotional_tagging.py` — Amygdala-inspired priority encoding (Qasim et al. 2023) with the Hebb 1955 inverted-U arousal curve
+- `synaptic_tagging.py` — Retroactive promotion of weak memories sharing entities (Frey & Morris 1997)
+- `curation.py` — Active curation logic (merge, link, create decisions)
+- `engram.py` — Memory trace structure (Josselyn & Tonegawa 2020)
+- `decay_cycle.py` — Thermodynamic cooling with stage-dependent rates
+- `tripartite_synapse.py` — Astrocyte calcium dynamics, D-serine LTP facilitation, metabolic gating (Perea 2009)
+- `tripartite_calcium.py` — Calcium dynamics computation for tripartite synapse
+- `write_gate.py` — Write gate decision logic
+- `write_post_store.py` — Post-store processing after memory write
+- `memory_ingest.py` — Memory ingestion pipeline
+- `memory_decomposer.py` — Decompose complex memories into atomic units
+- `compression.py` — Full-text → gist → tag compression
+- `staleness.py` — File-reference staleness scoring
+- `response_budget.py` — Bounded MCP responses: total payload budget (measured 100k-char Claude Code MAX_MCP_OUTPUT_TOKENS cap × 0.75 UTF-16-divergence safety factor) + priority-weighted water-filling (budget proportional to retrieval score/heat, least relevant condensed first); truncated items keep ids for dynamic fetch-by-id
+- `gist_extraction.py` — Deterministic gist (head + signal lines + tail) for oversized auto-captures; GIST_BUDGET = measured p90 curated memory length; full raw output lives in a filesystem artifact, one Read away (no truncation)
+
+*Oscillatory & Cascade:*
+- `oscillatory_clock.py` — Theta/gamma/SWR phase gating (Hasselmo 2005, Buzsaki 2015)
+- `oscillatory_phases.py` — Phase definitions and gating logic
+- `cascade.py` — Consolidation stages: LABILE → EARLY_LTP → LATE_LTP → CONSOLIDATED (Kandel 2001)
+- `cascade_stages.py` — Stage definitions and transitions
+- `cascade_advancement.py` — Stage advancement logic
+- `pattern_separation.py` — DG orthogonalization + neurogenesis analog (Leutgeb 2007, Yassa & Stark 2011)
+- `separation_core.py` — Core orthogonalization algorithms
+- `neurogenesis.py` — Neurogenesis analog for pattern separation
+- `schema_engine.py` — Cortical knowledge structures with Piaget accommodation (Tse 2007, Gilboa & Marlatte 2017)
+- `schema_extraction.py` — Schema extraction from memories
+- `interference.py` — Proactive/retroactive interference detection + sleep orthogonalization
+- `interference_detection.py` — Interference detection algorithms
+- `homeostatic_plasticity.py` — Synaptic scaling + BCM threshold (Turrigiano 2008, Abraham & Bear 1996)
+- `homeostatic_health.py` — Homeostatic health metrics
+- `dendritic_clusters.py` — Branch-specific nonlinear integration + priming (Kastellakis 2015)
+- `dendritic_computation.py` — Branch-specific computation logic
+- `two_stage_model.py` — Hippocampal-cortical transfer protocol (McClelland 1995)
+- `two_stage_transfer.py` — Transfer protocol execution
+- `emergence_tracker.py` — System-level metrics: forgetting curve, spacing effect, schema acceleration
+- `emergence_metrics.py` — Emergence metric definitions
+- `ablation.py` — Lesion study framework (41 ablatable units spanning the 36 neuroscience-grounded mechanisms)
+- `active_forgetting.py` — Two independent dopaminergic forgetting circuits: permanent Rac1 trace erosion (chronic interference × stage vulnerability) + transient DAMB retrieval block (Davis & Zhong 2017, Sabandal et al. 2021)
+- `ablation_report.py` — Ablation report generation
+
+*Consolidation:*
+- `consolidation_engine.py` — Orchestrates decay, compression, CLS, causal discovery
+- `dual_store_cls.py` — Episodic → semantic memory consolidation (CLS)
+- `dual_store_cls_abstraction.py` — CLS abstraction extraction
+- `causal_graph.py` — PC Algorithm for causal discovery
+- `reconsolidation.py` — Memory updating on access
+- `replay.py` — Hippocampal replay for memory consolidation
+- `replay_types.py` — Replay type definitions
+- `replay_selection.py` — Replay candidate selection
+- `replay_execution.py` — Replay execution logic
+- `replay_formatting.py` — Replay result formatting
+- `sleep_compute.py` — Dream replay, cluster summarization, re-embedding, auto-narration
+- `synaptic_plasticity.py` — LTP/LTD Hebbian learning + STDP causal direction + stochastic transmission + phase-gated plasticity (Hebb 1949, BCM 1982, Bi & Poo 1998, Markram 1998)
+- `synaptic_plasticity_hebbian.py` — Hebbian learning algorithms
+- `synaptic_plasticity_stochastic.py` — Stochastic transmission
+- `microglial_pruning.py` — Complement-dependent edge elimination + orphan archival (Wang et al. 2020)
+
+*Retrieval & Navigation:*
+- `query_intent.py` — Intent classification (temporal/causal/semantic/entity/knowledge_update/multi_hop) + weight profiles
+- `query_decomposition.py` — Multi-entity query splitting + entity extraction
+- `retrieval_dispatch.py` — 3-tier dispatch (simple/mixed/deep) + WRRF weight computation
+- `retrieval_signals.py` — Retrieval signal definitions and computation
+- `query_router.py` — Query routing to appropriate retrieval tier
+- `pg_recall.py` — PostgreSQL recall orchestration
+- `reranker.py` — FlashRank ONNX cross-encoder reranking (client-side post-PG)
+- `scoring.py` — BM25, n-gram, keyword scoring (reference; PG does this server-side)
+- `temporal.py` — Date parsing, distance decay, recency boost (reference; PG does this server-side)
+- `spreading_activation.py` — Collins & Loftus 1975 semantic priming over entity graph
+- `hdc_encoder.py` — 1024D bipolar HDC (bind/bundle/permute/similarity)
+- `cognitive_map.py` — Successor Representation co-access graph + 2D projection
+- `hopfield.py` — Hopfield network for content-addressable recall
+- `fractal.py` — Hierarchical clustering (L0/L1/L2 levels)
+- `fractal_clustering.py` — Clustering algorithm implementation
+- `enrichment.py` — Doc2Query synthetic queries + concept synonym expansion
+- `concept_vocabulary.py` — Concept vocabulary for synonym expansion
+- `sensory_buffer.py` — Bounded pre-consolidation ring buffer
+- `knowledge_graph.py` — Entity and relationship extraction
+- `prospective.py` — Trigger-based proactive recall (keyword, time, file, domain)
+- `memory_rules.py` — Neuro-symbolic rules system (soft/hard filtering)
+
+*Analysis & Narrative:*
+- `narrative.py` — Story generation from memories
+- `metacognition.py` — Self-reflection on memory system performance
+- `metacognition_analysis.py` — Metacognition analysis algorithms
+- `session_critique.py` — Post-session analysis and improvement suggestions
+- `session_critique_format.py` — Session critique output formatting
+- `session_extractor.py` — Extracts memories from session transcripts
+
+*Undocumented (measured, not yet catalogued individually):* `core/streaming/`
+(5 files) and `core/context_assembly/` (9 files) plus ~100 additional
+top-level `core/` modules added since the last curation pass — ast
+extraction, capture normalization, redaction, abstention gating, adaptive
+control/writing, backpressure, and other mechanisms not yet described above.
+Run the measurement command in the header to get a current file listing.
+
+## infrastructure/ — All I/O
+
+- `config.py` — Centralized path constants via pathlib
+- `file_io.py` — Generic JSON/text read/write operations
+- `profile_store.py` — profiles.json persistence
+- `session_store.py` — session-log.json persistence
+- `brain_index_store.py` — brain-index.json reader
+- `scanner.py` — Discovers memories + conversations from ~/.claude/
+- `scanner_parse.py` — JSONL conversation parsing
+- `mcp_client.py` — Async MCP client over stdio (JSON-RPC 2.0, version negotiation)
+- `mcp_client_pool.py` — Singleton connection pool (lazy connect, reuse, idle timeout)
+- `pg_store.py` — PostgreSQL + pgvector persistence
+- `pg_store_entities.py` — Entity storage and retrieval
+- `pg_store_relationships.py` — Relationship storage, co-activation strengthening
+- `pg_store_queries.py` — Query execution helpers
+- `pg_store_auxiliary.py` — Auxiliary storage operations
+- `pg_store_rules.py` — Rule storage and retrieval
+- `pg_store_stats.py` — Statistics and diagnostics queries
+- `pg_schema.py` — DDL, extensions, PL/pgSQL stored procedures, migrations
+- `memory_config.py` — Runtime configuration (DATABASE_URL, env vars with CORTEX_MEMORY_ prefix)
+- `memory_store.py` — Memory store abstraction
+- `embedding_engine.py` — Vector embeddings (384-dim, sentence-transformers)
+- `artifact_store.py` — Content-addressed raw-output artifacts (`~/.claude/methodology/artifacts/<yyyy-mm>/<sha256[:16]>.md`) backing gist+pointer memories
+- `agent_config.py` — Agent configuration and topic scoping
+
+Note: `pg_store.py` persists to PostgreSQL when configured (plugin/CLI mode);
+see `PRIVACY.md` for the SQLite-default fallback used by `.mcpb`/Cowork
+launches — this file does not assert PostgreSQL is mandatory (that assertion
+was the drift #114 was filed against).
+
+## handlers/ — Composition roots
+
+50 standalone tools + 3 upstream-integration tools conditionally registered
+(53 total) + a `handlers/consolidation/` subpackage + per-tool helpers. See
+`docs/mcp-tools.md` for the full tool catalogue with purpose and target
+latency.
+
+## validation/
+
+- `schemas.py` — Per-tool argument validation
+
+## errors/
+
+- `__init__.py` — MethodologyError, ValidationError, StorageError, AnalysisError, McpConnectionError
+
+## server/
+
+MCP tool registration + composition roots. The HTTP visualization stack
+(galaxy/trace/wiki/knowledge/board UI) was extracted to the standalone
+**cortex-viz** MCP, which reads this same store read-only.
+
+## hooks/ — Session lifecycle automation
+
+- `session_lifecycle.py` — SessionEnd hook for automatic profile updates
+- `session_start.py` — SessionStart hook: injects anchored + hot memories + checkpoint state
+- `post_tool_capture.py` — PostToolUse auto-capture hook
+- `compaction_checkpoint.py` — Saves state before context compaction


### PR DESCRIPTION
Fixes #114 (périmètre étendu).

- CLAUDE.md : 463 → **92 lignes**. Extraction sans perte vers `docs/module-inventory.md` (inventaire par couche + dependency rules) et `docs/mcp-tools.md` (tiers d'outils + data flows). Sections : Build & Test (pièges ruff-double-check, consolidation-OFF), Architecture (3 phrases + @-références), Code Style (3 règles vérifiables), What NOT to do (3 prohibitions issues d'incidents datés).
- **Resync stockage** (la dérive d'origine de l'issue) : renvoi vers PRIVACY.md:26-36 — SQLite défaut .mcpb/Cowork, PostgreSQL plugin/CLI. Vérité bench PR #121 préservée verbatim.
- **Comptes de modules remesurés** : l'ancien CLAUDE.md affirmait 108 core / 21 infra / 11 shared ; le réel (find|wc -l, commande citée et datée) : 208 / 77 / 25 (+131 handlers). Les descriptions existantes sont conservées mais étiquetées « sous-ensemble curaté » au lieu d'une exhaustivité fausse.
- Supprimé uniquement ce qui vit ailleurs (vérifié par grep avant suppression) : scores bench (README + papers), liste ADR (noms de fichiers auto-descriptifs), coverage/stack (docs dédiés).

Dérives hors-scope découvertes et signalées (issues de suivi) : 3 violations de couche core→infrastructure préexistantes ; comptes périmés dans docs/architecture.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5Z1wfiBpADgENq6pB6E2i