### PR TITLE
feat(telemetry): optional OTLP exporter, OFF by default (ports-and-adapters)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -43,8 +43,10 @@ removes it. The `forget` tool deletes individual memories.
 
 Cortex itself does **not** transmit your memories, conversations, profiles, or
 any personal content to the author, to Anthropic, or to third-party analytics.
-There is no telemetry phone-home; the `get_telemetry` tool reports **local**
-performance statistics only.
+There is no telemetry phone-home **by default**; the `get_telemetry` tool
+reports **local** performance statistics only, and every recorded sample is
+appended to a local, no-egress JSONL file
+(`~/.claude/methodology/telemetry.jsonl`).
 
 The only outbound network activity is:
 
@@ -56,6 +58,13 @@ The only outbound network activity is:
 2. **Integrations you explicitly enable.** If you configure optional upstream MCP
    servers or a remote PostgreSQL database, Cortex communicates only with the
    endpoints you provided.
+3. **Optional OTLP telemetry export (opt-in, OFF by default).** If you set the
+   `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable, Cortex additionally
+   mirrors the same aggregate, content-free metrics already visible via
+   `get_telemetry` (per-tool call counts, latencies, and result counts —
+   never memory content) to the OTLP collector endpoint you configured.
+   Requires the optional `[otel]` install extra. Absent this env var, nothing
+   changes: the local JSONL sink remains the only telemetry sink.
 
 ## Data sharing
 

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -49,12 +49,22 @@ from mcp_server import (
     tool_registry_nav,
     tool_registry_wiki,
 )
+from mcp_server.core import telemetry
 from mcp_server.handlers._tool_meta import apply_param_docs
 from mcp_server.infrastructure.mcp_client_pool import close_all
+from mcp_server.infrastructure.otel_exporter import build_otel_exporter
 from mcp_server.infrastructure.upstream_availability import (
     codebase_upstream_available,
     prd_upstream_available,
 )
+
+# Optional OTLP telemetry export (issue #122) -- OFF by default. Wiring the
+# concrete exporter into the core port happens only here, in the
+# composition root; core/telemetry.py never imports infrastructure.
+# build_otel_exporter() returns None (no-op) unless the operator set
+# OTEL_EXPORTER_OTLP_ENDPOINT, so this line is a zero-behavior-change no-op
+# for every existing deployment.
+telemetry.set_exporter(build_otel_exporter())
 
 # ── Server Instance ────────────────────────────────────────────────────────
 

--- a/mcp_server/core/telemetry.py
+++ b/mcp_server/core/telemetry.py
@@ -19,6 +19,18 @@ Opt-out:
   Set ``CORTEX_TELEMETRY_DISABLED=1`` in the environment to disable both
   the in-memory counters and the JSONL append.
 
+Optional export (issue #122):
+  ``TelemetryExporter`` is a port (Protocol) that outer layers may
+  implement to mirror each recorded sample onto an external sink (e.g.
+  OTLP). Core declares the port only -- it never imports an exporter
+  implementation. The composition root (mcp_server/__main__.py) wires a
+  concrete exporter via ``set_exporter()`` at startup, OFF by default
+  (``set_exporter`` is never called unless the operator opted in via
+  env var -- see infrastructure/otel_exporter.py::build_otel_exporter).
+  Export is best-effort: any exception raised by the exporter is caught
+  here and never propagates to the caller, same guarantee as the JSONL
+  append below.
+
 Layer:
   Pure logic. No MCP, no DB, no embeddings. Filesystem write is local
   and best-effort (try/except OSError) so a full disk or permission
@@ -28,18 +40,58 @@ Contract (record):
   precondition: ``op`` is a non-empty string; ``latency_ms`` >= 0;
                 byte / count fields are non-negative ints.
   postcondition: counters[op] is updated atomically; one JSONL line is
-                appended on success or silently dropped on OSError; no
+                appended on success or silently dropped on OSError; the
+                registered exporter (if any) is invoked with the same
+                sample and any exception it raises is swallowed; no
                 exception escapes to the handler.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import os
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class TelemetryExporter(Protocol):
+    """Port for mirroring recorded samples onto an external sink.
+
+    Contract:
+      - ``export`` receives the same dict shape written to the JSONL log
+        (``ts``, ``op``, ``latency_ms``, ``bytes_in``, ``bytes_out``,
+        ``result_count``, ``ok``).
+      - ``export`` MUST NOT raise for control flow that reaches the
+        caller -- ``record()`` catches any exception defensively, but a
+        well-behaved implementation handles its own I/O errors.
+    """
+
+    def export(self, sample: dict[str, Any]) -> None:
+        """Mirror one recorded sample onto the external sink."""
+        ...
+
+
+_exporter: TelemetryExporter | None = None
+
+
+def set_exporter(exporter: TelemetryExporter | None) -> None:
+    """Register (or clear, with ``None``) the optional telemetry exporter.
+
+    precondition: none (``exporter`` may be ``None`` to disable export).
+    postcondition: subsequent ``record()`` calls invoke
+                   ``exporter.export(sample)`` best-effort; the local
+                   in-memory counters and JSONL sink are unaffected
+                   either way.
+    """
+    global _exporter
+    _exporter = exporter
+
 
 _LOG_PATH = Path.home() / ".claude" / "methodology" / "telemetry.jsonl"
 try:
@@ -114,6 +166,15 @@ def record(
             f.write(json.dumps(record_line) + "\n")
     except OSError:
         pass
+    # Optional external export (issue #122): best-effort, never breaks the
+    # caller. Reads the module-level reference once so a concurrent
+    # set_exporter(None) mid-call degrades to a no-op rather than racing.
+    exporter = _exporter
+    if exporter is not None:
+        try:
+            exporter.export(record_line)
+        except Exception:
+            logger.debug("telemetry exporter raised; sample dropped", exc_info=True)
 
 
 def snapshot() -> dict[str, dict[str, float | int]]:

--- a/mcp_server/infrastructure/otel_exporter.py
+++ b/mcp_server/infrastructure/otel_exporter.py
@@ -1,0 +1,134 @@
+"""OTLP telemetry exporter (infrastructure) -- optional, OFF by default.
+
+Implements the ``core.telemetry.TelemetryExporter`` port declared in the
+core layer. Core never imports this module; the composition root
+(mcp_server/__main__.py) imports it and wires it via
+``telemetry.set_exporter(build_otel_exporter())`` at startup.
+
+Activation:
+  Set ``OTEL_EXPORTER_OTLP_ENDPOINT`` (the standard OTel SDK env var) to
+  opt in. Absent that var, ``build_otel_exporter()`` returns ``None`` and
+  nothing is wired -- the local, no-egress
+  ``~/.claude/methodology/telemetry.jsonl`` sink (core/telemetry.py)
+  remains the sole sink, preserving the default compliance posture: zero
+  network egress unless the operator explicitly configures an endpoint.
+  ``OTEL_SERVICE_NAME`` optionally overrides the reported service name
+  (default ``cortex-mcp``).
+
+Metric naming (issue #122 comment, cdeust/Cortex):
+  Mirrors Claude Code's own ``cortex.*``-prefixed OTel convention so both
+  sources coexist in one collector without name collisions. Every metric
+  below is a direct mapping from an existing ``telemetry.record()`` field
+  -- no new counters are invented:
+    - cortex.tool.duration   (histogram, ms)     <- sample["latency_ms"]
+    - cortex.tool.calls      (counter, {tool,status}) <- one per sample
+    - cortex.recall.results  (histogram)          <- sample["result_count"]
+
+Degradation:
+  If ``opentelemetry-sdk`` (the optional ``[otel]`` extra) is not
+  installed, ``build_otel_exporter()`` logs one warning (not per call)
+  and returns ``None``. Telemetry export must never break a tool call --
+  every ``export()`` call is wrapped defensively.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_warned_once = False
+_warn_lock = threading.Lock()
+
+
+def _warn_missing_sdk_once() -> None:
+    """Log the missing-SDK degradation warning exactly once per process."""
+    global _warned_once
+    with _warn_lock:
+        if _warned_once:
+            return
+        _warned_once = True
+    logger.warning(
+        "OTEL_EXPORTER_OTLP_ENDPOINT is set but opentelemetry-sdk is not "
+        "installed. Install the optional extra to enable OTLP export: "
+        "pip install 'hypermnesia-mcp[otel]'. Local telemetry.jsonl "
+        "logging is unaffected."
+    )
+
+
+class OtelTelemetryExporter:
+    """Adapts ``telemetry.record()`` samples to OTel metric instruments.
+
+    precondition: ``meter`` is a live ``opentelemetry.metrics.Meter``.
+    postcondition: each ``export()`` call records exactly one point on
+                   each of the three cortex.* instruments below, tagged
+                   with {tool: op, status: ok|fail}; an instrument error
+                   is caught and logged at debug level, never raised.
+    """
+
+    def __init__(self, meter: Any) -> None:
+        self._duration = meter.create_histogram(
+            "cortex.tool.duration",
+            unit="ms",
+            description="Per-call latency of a Cortex MCP tool handler.",
+        )
+        self._calls = meter.create_counter(
+            "cortex.tool.calls",
+            description="Number of Cortex MCP tool handler invocations.",
+        )
+        self._results = meter.create_histogram(
+            "cortex.recall.results",
+            description="result_count reported by a Cortex MCP tool call.",
+        )
+
+    def export(self, sample: dict[str, Any]) -> None:
+        op = str(sample.get("op", "unknown"))
+        ok = bool(sample.get("ok", True))
+        attributes = {"tool": op, "status": "ok" if ok else "fail"}
+        try:
+            self._duration.record(float(sample.get("latency_ms", 0.0)), attributes)
+            self._calls.add(1, attributes)
+            result_count = sample.get("result_count", 0)
+            if result_count:
+                self._results.record(float(result_count), attributes)
+        except Exception:
+            # Telemetry export must never break the calling tool.
+            logger.debug("OTLP metric export failed", exc_info=True)
+
+
+def build_otel_exporter() -> OtelTelemetryExporter | None:
+    """Build the OTLP exporter iff ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set.
+
+    precondition: none.
+    postcondition: returns ``None`` when the env var is absent (default
+                   OFF, zero behavior change from pre-#122 Cortex) or
+                   when ``opentelemetry-sdk`` is not importable (logs one
+                   warning via ``_warn_missing_sdk_once``). Otherwise
+                   returns a live ``OtelTelemetryExporter`` backed by a
+                   periodic-exporting OTLP metric pipeline; the SDK
+                   resolves endpoint/headers/protocol from the standard
+                   ``OTEL_EXPORTER_OTLP_*`` env vars itself.
+    """
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not endpoint:
+        return None
+    try:
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+            OTLPMetricExporter,
+        )
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+    except ImportError:
+        _warn_missing_sdk_once()
+        return None
+
+    service_name = os.environ.get("OTEL_SERVICE_NAME", "cortex-mcp")
+    resource = Resource.create({"service.name": service_name})
+    reader = PeriodicExportingMetricReader(OTLPMetricExporter())
+    provider = MeterProvider(resource=resource, metric_readers=[reader])
+    meter = provider.get_meter("cortex.telemetry")
+    return OtelTelemetryExporter(meter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,16 @@ benchmarks = [
     "pgvector>=0.4,<0.6",        # vector similarity in PostgreSQL (bounds: see [postgresql])
     "pymupdf>=1.24.0",           # PDF parsing for some benchmark sources
 ]
+# Optional OTLP telemetry export (issue #122) -- OFF by default. Absent this
+# extra (and OTEL_EXPORTER_OTLP_ENDPOINT), Cortex telemetry stays local-only
+# (~/.claude/methodology/telemetry.jsonl, no network egress). Installing this
+# extra alone changes nothing either -- see
+# infrastructure/otel_exporter.py::build_otel_exporter, which additionally
+# requires the endpoint env var before wiring any exporter.
+otel = [
+    "opentelemetry-sdk>=1.24.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.24.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-cov>=5.0.0",

--- a/tests_py/core/test_telemetry_exporter_port.py
+++ b/tests_py/core/test_telemetry_exporter_port.py
@@ -1,0 +1,115 @@
+"""Tests for the optional TelemetryExporter port (issue #122).
+
+Covers:
+  - default (no exporter set): record() behaves exactly as before -- no
+    export attempted, in-memory counters + JSONL write unaffected.
+  - set_exporter(x): record() invokes x.export(sample) with the same
+    shape written to the JSONL log.
+  - a raising exporter never breaks record() (telemetry must never break
+    the calling tool).
+  - set_exporter(None) clears a previously registered exporter.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.core import telemetry
+
+
+class _RecordingExporter:
+    def __init__(self) -> None:
+        self.samples: list[dict] = []
+
+    def export(self, sample: dict) -> None:
+        self.samples.append(sample)
+
+
+class _RaisingExporter:
+    def export(self, sample: dict) -> None:
+        raise RuntimeError("boom in exporter")
+
+
+@pytest.fixture(autouse=True)
+def _clean_exporter_and_counters():
+    """Every test starts and ends with no exporter registered."""
+    telemetry.set_exporter(None)
+    telemetry.reset()
+    yield
+    telemetry.set_exporter(None)
+    telemetry.reset()
+
+
+class TestNoExporterRegistered:
+    """Default behavior (no #122 wiring) must be unchanged."""
+
+    def test_record_succeeds_with_no_exporter(self):
+        telemetry.record("recall", latency_ms=1.5, ok=True)
+        snap = telemetry.snapshot()
+        assert snap["recall"]["count"] == 1
+
+
+class TestExporterInvoked:
+    """set_exporter(x) makes record() mirror the sample to x.export()."""
+
+    def test_export_receives_matching_sample(self):
+        exporter = _RecordingExporter()
+        telemetry.set_exporter(exporter)
+
+        telemetry.record(
+            "remember", latency_ms=12.0, bytes_in=100, result_count=3, ok=True
+        )
+
+        assert len(exporter.samples) == 1
+        sample = exporter.samples[0]
+        assert sample["op"] == "remember"
+        assert sample["latency_ms"] == 12.0
+        assert sample["bytes_in"] == 100
+        assert sample["result_count"] == 3
+        assert sample["ok"] is True
+
+    def test_export_called_once_per_record_call(self):
+        exporter = _RecordingExporter()
+        telemetry.set_exporter(exporter)
+
+        telemetry.record("recall", latency_ms=1.0, ok=True)
+        telemetry.record("recall", latency_ms=2.0, ok=False)
+
+        assert len(exporter.samples) == 2
+        assert exporter.samples[0]["ok"] is True
+        assert exporter.samples[1]["ok"] is False
+
+    def test_set_exporter_none_clears_registration(self):
+        exporter = _RecordingExporter()
+        telemetry.set_exporter(exporter)
+        telemetry.record("recall", latency_ms=1.0, ok=True)
+        assert len(exporter.samples) == 1
+
+        telemetry.set_exporter(None)
+        telemetry.record("recall", latency_ms=1.0, ok=True)
+        # exporter no longer registered -- no new sample delivered to it
+        assert len(exporter.samples) == 1
+
+
+class TestExporterFailureIsolated:
+    """A raising exporter must never break the caller of record()."""
+
+    def test_raising_exporter_does_not_propagate(self):
+        telemetry.set_exporter(_RaisingExporter())
+
+        # Must not raise.
+        telemetry.record("recall", latency_ms=1.0, ok=True)
+
+        # In-memory counters were still updated -- the failure is isolated
+        # to the exporter call, which happens after the counters section.
+        snap = telemetry.snapshot()
+        assert snap["recall"]["count"] == 1
+
+    def test_disabled_telemetry_skips_exporter_too(self, monkeypatch):
+        monkeypatch.setenv("CORTEX_TELEMETRY_DISABLED", "1")
+        exporter = _RecordingExporter()
+        telemetry.set_exporter(exporter)
+
+        telemetry.record("recall", latency_ms=1.0, ok=True)
+
+        assert exporter.samples == []

--- a/tests_py/infrastructure/test_otel_exporter.py
+++ b/tests_py/infrastructure/test_otel_exporter.py
@@ -1,0 +1,194 @@
+"""Tests for mcp_server.infrastructure.otel_exporter (issue #122).
+
+Covers:
+  - OFF by default: no OTEL_EXPORTER_OTLP_ENDPOINT -> build_otel_exporter()
+    returns None, regardless of whether the SDK is installed.
+  - Graceful degradation: endpoint set but opentelemetry-sdk NOT
+    importable -> returns None, logs exactly one warning (not per call).
+  - Mapping: with the SDK mocked, OtelTelemetryExporter.export() maps a
+    telemetry.record()-shaped sample onto the three cortex.* instruments
+    with the documented attributes, and does not raise if an instrument
+    call throws.
+"""
+
+from __future__ import annotations
+
+import builtins
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_server.infrastructure import otel_exporter
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_once_flag():
+    otel_exporter._warned_once = False
+    yield
+    otel_exporter._warned_once = False
+
+
+class TestOffByDefault:
+    """No endpoint env var -> exporter is never built."""
+
+    def test_no_endpoint_returns_none(self, monkeypatch):
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        assert otel_exporter.build_otel_exporter() is None
+
+    def test_empty_endpoint_returns_none(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+        assert otel_exporter.build_otel_exporter() is None
+
+
+class TestDegradesWithoutSdk:
+    """Endpoint set but opentelemetry-sdk not importable -> None + 1 warning."""
+
+    def test_missing_sdk_returns_none_and_warns_once(self, monkeypatch, caplog):
+        monkeypatch.setenv(
+            "OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example.com"
+        )
+
+        real_import = builtins.__import__
+
+        def _blocking_import(name, *args, **kwargs):
+            if name.startswith("opentelemetry"):
+                raise ImportError(f"simulated missing SDK: {name}")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _blocking_import)
+
+        with caplog.at_level("WARNING"):
+            result = otel_exporter.build_otel_exporter()
+            assert result is None
+            result2 = otel_exporter.build_otel_exporter()
+            assert result2 is None
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert "opentelemetry-sdk" in warnings[0].message
+
+
+def _install_fake_opentelemetry_sdk(monkeypatch, meter: MagicMock) -> MagicMock:
+    """Register a minimal fake `opentelemetry.*` package tree in sys.modules."""
+    provider_cls = MagicMock(
+        return_value=MagicMock(get_meter=MagicMock(return_value=meter))
+    )
+
+    otel_pkg = ModuleType("opentelemetry")
+    sdk_pkg = ModuleType("opentelemetry.sdk")
+    sdk_metrics_pkg = ModuleType("opentelemetry.sdk.metrics")
+    sdk_metrics_pkg.MeterProvider = provider_cls
+    sdk_metrics_export_pkg = ModuleType("opentelemetry.sdk.metrics.export")
+    sdk_metrics_export_pkg.PeriodicExportingMetricReader = MagicMock()
+    sdk_resources_pkg = ModuleType("opentelemetry.sdk.resources")
+    sdk_resources_pkg.Resource = MagicMock(create=MagicMock(return_value=MagicMock()))
+
+    exporter_pkg = ModuleType("opentelemetry.exporter")
+    otlp_pkg = ModuleType("opentelemetry.exporter.otlp")
+    proto_pkg = ModuleType("opentelemetry.exporter.otlp.proto")
+    http_pkg = ModuleType("opentelemetry.exporter.otlp.proto.http")
+    metric_exporter_pkg = ModuleType(
+        "opentelemetry.exporter.otlp.proto.http.metric_exporter"
+    )
+    metric_exporter_pkg.OTLPMetricExporter = MagicMock()
+
+    modules = {
+        "opentelemetry": otel_pkg,
+        "opentelemetry.sdk": sdk_pkg,
+        "opentelemetry.sdk.metrics": sdk_metrics_pkg,
+        "opentelemetry.sdk.metrics.export": sdk_metrics_export_pkg,
+        "opentelemetry.sdk.resources": sdk_resources_pkg,
+        "opentelemetry.exporter": exporter_pkg,
+        "opentelemetry.exporter.otlp": otlp_pkg,
+        "opentelemetry.exporter.otlp.proto": proto_pkg,
+        "opentelemetry.exporter.otlp.proto.http": http_pkg,
+        "opentelemetry.exporter.otlp.proto.http.metric_exporter": metric_exporter_pkg,
+    }
+    for name, mod in modules.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+    return provider_cls
+
+
+class TestBuildsWithSdkMocked:
+    """Endpoint set + SDK importable (mocked) -> a live exporter is built."""
+
+    def test_returns_exporter_wired_to_meter(self, monkeypatch):
+        monkeypatch.setenv(
+            "OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example.com"
+        )
+        meter = MagicMock()
+        _install_fake_opentelemetry_sdk(monkeypatch, meter)
+
+        result = otel_exporter.build_otel_exporter()
+
+        assert isinstance(result, otel_exporter.OtelTelemetryExporter)
+        # Three instruments created against the fake meter, per docstring.
+        assert meter.create_histogram.call_count == 2
+        assert meter.create_counter.call_count == 1
+        created_names = [c.args[0] for c in meter.create_histogram.call_args_list]
+        assert "cortex.tool.duration" in created_names
+        assert "cortex.recall.results" in created_names
+        assert meter.create_counter.call_args.args[0] == "cortex.tool.calls"
+
+
+class TestExportMapping:
+    """OtelTelemetryExporter.export() maps sample fields to instruments."""
+
+    def _build_exporter_with_mock_instruments(self):
+        meter = MagicMock()
+        duration = MagicMock()
+        calls = MagicMock()
+        results = MagicMock()
+        meter.create_histogram.side_effect = [duration, results]
+        meter.create_counter.return_value = calls
+        exporter = otel_exporter.OtelTelemetryExporter(meter)
+        return exporter, duration, calls, results
+
+    def test_export_records_duration_and_calls(self):
+        exporter, duration, calls, results = (
+            self._build_exporter_with_mock_instruments()
+        )
+
+        exporter.export(
+            {
+                "op": "recall",
+                "latency_ms": 12.5,
+                "result_count": 4,
+                "ok": True,
+            }
+        )
+
+        duration.record.assert_called_once_with(
+            12.5, {"tool": "recall", "status": "ok"}
+        )
+        calls.add.assert_called_once_with(1, {"tool": "recall", "status": "ok"})
+        results.record.assert_called_once_with(4.0, {"tool": "recall", "status": "ok"})
+
+    def test_export_maps_failure_status(self):
+        exporter, duration, calls, results = (
+            self._build_exporter_with_mock_instruments()
+        )
+
+        exporter.export({"op": "remember", "latency_ms": 3.0, "ok": False})
+
+        calls.add.assert_called_once_with(1, {"tool": "remember", "status": "fail"})
+
+    def test_export_skips_result_histogram_when_zero(self):
+        exporter, duration, calls, results = (
+            self._build_exporter_with_mock_instruments()
+        )
+
+        exporter.export({"op": "forget", "latency_ms": 1.0, "ok": True})
+
+        results.record.assert_not_called()
+
+    def test_export_swallows_instrument_exception(self):
+        exporter, duration, calls, results = (
+            self._build_exporter_with_mock_instruments()
+        )
+        duration.record.side_effect = RuntimeError("instrument down")
+
+        # Must not raise -- telemetry must never break the calling tool.
+        exporter.export({"op": "recall", "latency_ms": 1.0, "ok": True})

--- a/uv.lock
+++ b/uv.lock
@@ -1126,6 +1126,18 @@ http = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1234,7 +1246,7 @@ wheels = [
 
 [[package]]
 name = "hypermnesia-mcp"
-version = "4.13.3"
+version = "4.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -1273,6 +1285,10 @@ dev = [
     { name = "pytest-timeout" },
     { name = "sentence-transformers" },
 ]
+otel = [
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+]
 postgresql = [
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary"] },
@@ -1310,6 +1326,8 @@ requires-dist = [
     { name = "networkx", marker = "extra == 'codebase'", specifier = ">=3.0" },
     { name = "networkx", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=1.24.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.24.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.24.0" },
     { name = "pandas", marker = "extra == 'viz-tile'", specifier = ">=2.2" },
     { name = "pgvector", marker = "extra == 'benchmarks'", specifier = ">=0.4,<0.6" },
     { name = "pgvector", marker = "extra == 'postgresql'", specifier = ">=0.4,<0.6" },
@@ -1333,7 +1351,7 @@ requires-dist = [
     { name = "tree-sitter", marker = "extra == 'codebase'", specifier = ">=0.24.0,<0.26" },
     { name = "tree-sitter-language-pack", marker = "extra == 'codebase'", specifier = ">=0.24.0,<1.7" },
 ]
-provides-extras = ["postgresql", "sqlite", "codebase", "viz-tile", "benchmarks", "dev"]
+provides-extras = ["postgresql", "sqlite", "codebase", "viz-tile", "benchmarks", "otel", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "mutmut", specifier = ">=3.6.0" }]
@@ -1377,7 +1395,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -2507,15 +2525,83 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.41.0"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #122.

- **OFF par défaut, comportement inchangé octet-pour-octet sans `OTEL_EXPORTER_OTLP_ENDPOINT`** — le défaut local-sans-egress (telemetry.jsonl) est préservé ; PRIVACY.md mis à jour en conséquence (la claim inconditionnelle devient « opt-in explicite », honnêteté de source plutôt que changement silencieux).
- Architecture : Protocol `TelemetryExporter` déclaré dans `core/telemetry.py` (zéro import infra, vérifié par grep), implémentation OTel SDK isolée dans `infrastructure/otel_exporter.py`, câblage unique dans `__main__.py` (composition root) — même précédent que `core/streaming/ports.py`.
- Métriques : exactement les 3 noms décidés dans l'issue (`cortex.tool.duration`, `cortex.tool.calls{tool,status}`, `cortex.recall.results`) — rien d'inventé au-delà.
- Robustesse : la télémétrie ne casse JAMAIS l'outil (exceptions d'export avalées, contract-testé) ; SDK absent = un seul warning par process ; extra optionnel `[otel]` dans pyproject (+ uv.lock régénéré).
- Tests : 14 nouveaux (port : défaut inchangé, invocation, exporter défaillant, CORTEX_TELEMETRY_DISABLED ; adaptateur : OFF par défaut, dégradation sans SDK, mapping des 3 instruments, skip zero-count, exception avalée) ; suite complète : 5136 passed, 0 failure.
- Limite honnête (flaggée par l'agent) : pas de run e2e contre un vrai collector/SDK installé (frontière SDK mockée) — candidat à un test d'intégration CI futur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)