### PR TITLE
feat(devcontainer): one-command isolated environment — models baked, versions pinned, doctor-gated

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,75 @@
+# Cortex development container — one-command environment for contributors
+# and for `claude` running inside an isolated devcontainer (issue #118).
+#
+# Reuses (does not reinvent) the production build recipe already validated
+# in ../Dockerfile's builder stage: same CPU-only torch pin rationale, same
+# `pip install .[postgresql]` base. Docker has no cross-Dockerfile stage
+# inheritance without a prebuilt image tag (`FROM <tag>` requires the tag to
+# already exist, which `docker compose build` cannot guarantee ordering for
+# across two separate Dockerfiles) — so the recipe is duplicated here, not
+# FROM-chained. Keep the two in sync; see docs/deployment-scenarios.md
+# "Dev container" for the tradeoff.
+#
+# Build:  docker compose -f .devcontainer/docker-compose.yml build
+# (normally invoked by the Dev Containers CLI / VS Code "Reopen in
+# Container", never by hand.)
+
+FROM python:3.13-slim
+
+LABEL org.opencontainers.image.source="https://github.com/cdeust/Cortex"
+LABEL org.opencontainers.image.description="Cortex development container (issue #118)"
+
+# gcc/libpq-dev: same build deps as ../Dockerfile's builder stage (psycopg
+# has no manylinux wheel for every platform this image might run on).
+# postgresql-client: scripts/setup_db.py shells out to psql/createdb/
+# pg_isready (see that file) — required for postCreateCommand to work.
+# git: contributor workflow inside the container.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc \
+        libpq-dev \
+        postgresql-client \
+        git \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 10001 cortex
+
+WORKDIR /workspace
+
+COPY pyproject.toml README.md ./
+COPY mcp_server ./mcp_server
+
+# CPU-only torch wheel: sentence-transformers pulls torch transitively as a
+# mandatory base dependency (pyproject.toml); pip's default index resolves
+# the full CUDA build (~2GB across torch/cudnn/cusparselt/cublas/etc.) even
+# though this container never uses a GPU — identical rationale to
+# ../Dockerfile:38-45 and benchmarks/reproduce.sh's own CPU-only builds.
+# Versions pinned exactly to this repo's lockfile so the devcontainer
+# never silently drifts from what CI/production actually run.
+# source: uv.lock (this repo, checked 2026-07-14) — torch==2.11.0,
+# sentence-transformers==5.4.1, flashrank==0.2.10.
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir torch==2.11.0 --index-url https://download.pytorch.org/whl/cpu && \
+    pip install --no-cache-dir ".[postgresql,codebase]" \
+        "sentence-transformers==5.4.1" \
+        "flashrank==0.2.10"
+
+# ── Model prewarming AT BUILD TIME ─────────────────────────────────────────
+# HF_HOME / XDG_CACHE_HOME point at a durable image path baked into a layer
+# — never /tmp. mcp_server/core/reranker.py's module docstring documents
+# the exact incident this avoids: FlashRank 0.2.10's own default cache_dir
+# IS /tmp, and an ephemeral-fs purge between the download and first use
+# caused a silent reranker skip in production (fix 2026-07-11). Baking both
+# caches into an image layer means the FIRST recall/remember call in a
+# freshly-opened devcontainer never pays (or risks) a cold-start network
+# fetch, and never touches /tmp.
+ENV HF_HOME=/opt/model-cache/huggingface \
+    XDG_CACHE_HOME=/opt/model-cache \
+    CORTEX_RUNTIME=cowork
+
+RUN mkdir -p /opt/model-cache && \
+    python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')" && \
+    python -c "from mcp_server.core.reranker import _ensure_reranker; assert _ensure_reranker() is not None, 'FlashRank prewarm failed at build time'" && \
+    chown -R cortex:cortex /opt/model-cache /workspace
+
+USER cortex

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "Cortex dev environment",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "shutdownAction": "stopCompose",
+  "remoteUser": "cortex",
+  "features": {
+    "ghcr.io/devcontainers/features/node:2.1.0": {
+      "version": "22"
+    },
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0.5": {}
+  },
+  "containerEnv": {
+    "DISABLE_AUTOUPDATER": "1"
+  },
+  "postCreateCommand": "python scripts/setup_db.py && python -m mcp_server.doctor",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "anthropic.claude-code"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    environment:
+      # Same "auto" backend the production image (../Dockerfile) opts into
+      # via CORTEX_RUNTIME=cowork — DATABASE_URL present here always wins,
+      # so the devcontainer talks to the `db` service, never SQLite.
+      DATABASE_URL: postgresql://cortex:cortex@db:5432/cortex
+      # scripts/setup_db.py shells out to psql/createdb/pg_isready without
+      # passing -U/-W; these PG* env vars are the standard libpq
+      # credential/connection source those binaries read implicitly.
+      # Dev-only credentials, not reachable outside the compose network.
+      PGHOST: db
+      PGPORT: "5432"
+      PGUSER: cortex
+      PGPASSWORD: cortex
+      PGDATABASE: cortex
+    depends_on:
+      db:
+        condition: service_healthy
+    # Devcontainer CLI / VS Code attach to a long-lived container; the
+    # actual entrypoint (Claude Code CLI, installed by the devcontainer
+    # feature) is launched interactively by the editor, not by compose.
+    command: sleep infinity
+
+  db:
+    # source: benchmarks/reproduce.sh:116 — the exact image Cortex's own
+    # benchmark harness already uses for its ephemeral PostgreSQL+pgvector
+    # instances (LongMemEval/LoCoMo/BEAM reproduction).
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: cortex
+      POSTGRES_PASSWORD: cortex
+      POSTGRES_DB: cortex
+    volumes:
+      - cortex-devcontainer-pgdata:/var/lib/postgresql/data
+      # Directory-to-directory bind, not a single-file mount: mounting one
+      # file directly at a path absent from the base image proved
+      # unreliable here (verified 2026-07-14 — see initdb/01-extensions.sql
+      # header for the exact failure).
+      - ./initdb:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cortex -d cortex"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  cortex-devcontainer-pgdata:

--- a/.devcontainer/initdb/01-extensions.sql
+++ b/.devcontainer/initdb/01-extensions.sql
@@ -1,0 +1,27 @@
+-- Postgres init-script for the devcontainer's `db` service. This whole
+-- directory (not this file alone) is bind-mounted at
+-- /docker-entrypoint-initdb.d — single-file bind mounts proved unreliable
+-- here: verified 2026-07-14 that mounting this file directly at
+-- /docker-entrypoint-initdb.d/init-extensions.sql (a path absent from the
+-- base pgvector/pgvector:pg16 image) made the container's runtime create
+-- a DIRECTORY at that path instead of the file, and psql failed with
+-- "could not read from input file: Is a directory". Mounting the parent
+-- directory as a directory-to-directory bind avoids that failure mode.
+--
+-- Mirrors mcp_server/infrastructure/pg_schema.py::EXTENSIONS_DDL and the
+-- identical idiom already validated in docker/entrypoint.sh's single-
+-- container runtime image (both run "CREATE EXTENSION IF NOT EXISTS
+-- vector; CREATE EXTENSION IF NOT EXISTS pg_trgm;" before Cortex's own
+-- schema DDL). Kept as a separate init script (rather than only relying on
+-- scripts/setup_db.py at postCreateCommand) so the extensions exist from
+-- the FIRST moment the `db` container reports healthy, before the `app`
+-- container has run anything.
+--
+-- Runs exactly once, at first-ever initialization of the named volume
+-- backing this service (official postgres image's
+-- /docker-entrypoint-initdb.d/ contract — scripts here do not re-run on
+-- container restart once PGDATA already exists).
+-- source: https://github.com/docker-library/docs/blob/master/postgres/README.md#initialization-scripts
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/docs/deployment-scenarios.md
+++ b/docs/deployment-scenarios.md
@@ -86,6 +86,103 @@ that contains no password field is printed unchanged.
 
 ---
 
+## Dev container (VS Code / Claude Code — issue #118)
+
+One command, no local Python/Postgres/model setup: open the repo in a
+container that already has Claude Code, PostgreSQL+pgvector, and Cortex's
+embedding/reranker models ready to go.
+
+```
+Open in VS Code → "Dev Containers: Reopen in Container"
+# or, headless:
+devcontainer up --workspace-folder .
+```
+
+### What's included
+
+- **`.devcontainer/devcontainer.json`** — pins the
+  `ghcr.io/anthropics/devcontainer-features/claude-code` feature and the
+  `ghcr.io/devcontainers/features/node` feature (Node 22), sets
+  `DISABLE_AUTOUPDATER=1`, and runs
+  `python scripts/setup_db.py && python -m mcp_server.doctor` as
+  `postCreateCommand` — the container is not considered ready until `doctor`
+  exits 0.
+- **`.devcontainer/docker-compose.yml`** — two services:
+  - `app`: builds `.devcontainer/Dockerfile`, mounts the repo at
+    `/workspace`, talks to `db` via `DATABASE_URL`.
+  - `db`: `pgvector/pgvector:pg16` — the *same image*
+    `benchmarks/reproduce.sh` already uses for its own ephemeral
+    PostgreSQL instances — with `vector`/`pg_trgm` created by
+    `.devcontainer/initdb/01-extensions.sql` at first boot (the same DDL as
+    `mcp_server/infrastructure/pg_schema.py::EXTENSIONS_DDL` and
+    `docker/entrypoint.sh`'s single-container runtime image).
+- **`.devcontainer/Dockerfile`** — reuses the production build recipe from
+  `../Dockerfile`'s builder stage (CPU-only torch wheel, `pip install
+  .[postgresql]`), adds the `codebase` extra, and **prewarms the embedding
+  model (`all-MiniLM-L6-v2`) and the FlashRank cross-encoder reranker at
+  build time**, cached under `HF_HOME=/opt/model-cache/huggingface` /
+  `XDG_CACHE_HOME=/opt/model-cache` — a durable image path, never `/tmp`
+  (see `mcp_server/core/reranker.py`'s module docstring for the exact
+  2026-07-11 incident this avoids: FlashRank's own default cache directory
+  IS `/tmp`, and losing that cache mid-process causes recall to silently
+  fall back to first-stage-only scores with no error logged).
+
+### Version pinning
+
+Every dependency this container introduces is pinned to a value verified
+against this repo's own lockfile or the upstream registry, not guessed:
+
+- `torch==2.11.0`, `sentence-transformers==5.4.1`, `flashrank==0.2.10` —
+  `# source: uv.lock` (this repo).
+- `ghcr.io/anthropics/devcontainer-features/claude-code:1.0.5` — the
+  feature's own manifest at this tag reports `"options": {}` (verified
+  2026-07-14 against `ghcr.io/v2/anthropics/devcontainer-features/
+  claude-code/manifests/1.0.5`): **the feature exposes no version knob for
+  the CLI it installs.** Its `install.sh` runs an unpinned
+  `npm install -g @anthropic-ai/claude-code` regardless of which feature
+  tag you pin — so pinning `:1.0.5` fixes the *install script* (and thus
+  guards against a future script-level regression), but **not** which
+  `@anthropic-ai/claude-code` release ends up in the image. This is the
+  same install-script-vs-package-release gap referenced by this issue.
+  There is currently no upstream mechanism to pin the CLI release itself
+  through this feature; rebuild the container to pick up a newer CLI, and
+  re-run `postCreateCommand` (`mcp_server.doctor` does not check the CLI
+  version) to confirm the rest of the stack is still healthy.
+- `ghcr.io/devcontainers/features/node:2.1.0` with `version: "22"` — pinned
+  explicitly rather than accepting the `claude-code` feature's best-effort
+  Node 18.x auto-install fallback (`install.sh`, only triggers when no
+  Node is already present).
+
+### Validation
+
+`postCreateCommand` runs `python scripts/setup_db.py` (idempotent —
+creates the database/extensions/schema if absent, no-ops otherwise; the
+same script the plugin's SessionStart hook already uses) followed by
+`python -m mcp_server.doctor`, which must exit 0: Python version, PG
+driver import, `DATABASE_URL` reachability, `pgvector`/`pg_trgm`
+extensions, schema presence, and the `POOL_INTERACTIVE_MAX` invariant.
+
+Verified locally (2026-07-14, `docker compose up -d` from a checkout under
+`$HOME`, both services healthy): `\dx` inside `db` lists `vector 0.8.4` and
+`pg_trgm 1.6`; `python scripts/setup_db.py` returns
+`{"status": "ready", ...}`; `python -m mcp_server.doctor` exits 0 with
+every required check green (the only warning is the optional
+codebase-pipeline capability, expected without the separate Rust
+component). The FlashRank ONNX model's on-disk `mtime` inside the running
+container matches the image's build time, not the container's start
+time — confirming the model was baked into the image layer and not
+downloaded at first use. **Caveat specific to this verification, not to
+the devcontainer itself:** the *first* attempt, from a checkout under
+`/tmp`, hit a Docker Desktop bind-mount quirk on this machine (a
+single-file mount at a path absent from the base image materialized as an
+empty directory instead of the file — `.devcontainer/initdb/` mounts a
+*directory* for exactly this reason, see that directory's file header).
+Re-running the identical compose file from a `$HOME`-rooted checkout
+worked without any file changes, isolating the quirk to `/tmp` bind
+mounts in this environment, not to the compose/Dockerfile content.
+
+---
+
 ## Remote PostgreSQL
 
 Any host reachable from the machine running Cortex works in `DATABASE_URL`.


### PR DESCRIPTION
Fixes #118.

- `.devcontainer/` : feature claude-code **1.0.5 pinnée** + Node 22 pinné, `DISABLE_AUTOUPDATER=1`, compose app+db (`pgvector/pgvector:pg16` — la même image que reproduce.sh), extensions par initdb/ (même DDL que pg_schema.py), **modèles embedding+FlashRank préchauffés AU BUILD** sous /opt/model-cache (jamais /tmp — classe d'incident FlashRank), `postCreateCommand` = setup_db + `python -m mcp_server.doctor` en gate exit-0.
- Doc : section « Dev container » dans docs/deployment-scenarios.md (le foyer unique des nuances d'environnement), incluant deux vérités utiles : la preuve extraite de ghcr.io que le tag de feature n'épingle PAS le CLI (npm -g non pinné → DISABLE_AUTOUPDATER nécessaire), et le quirk Docker Desktop des bind mounts sous /tmp (répertoires silencieusement vides — d'où le pattern initdb/ en répertoire).
- **Testé end-to-end** : build OK (modèles baked, confirmés par mtime), compose config valide, `up -d` les deux services healthy, setup_db → ready, doctor → exit 0 toutes checks vertes.

Couvre P1 (préflight au build), P3 (one-command), isolation container (seule couche confinant MCP+hooks) — réfs #113 #115 #116, META #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)