### PR TITLE
docs(architecture): replace stale module counts with single-source pointers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,11 +17,11 @@ graph TD
     E[errors/] -.->|types| H
     E -.->|types| SV
 
-    C -.-|40 modules · pure logic, zero I/O| C
-    I -.-|11 modules · SQLite, embeddings, filesystem| I
-    S -.-|10 modules · utilities, Pydantic types| S
-    H -.-|34 handlers · composition roots| H
-    HK -.-|4 hooks · lifecycle automation| HK
+    C -.-|pure logic, zero I/O| C
+    I -.-|SQLite, embeddings, filesystem| I
+    S -.-|utilities, Pydantic types| S
+    H -.-|composition roots| H
+    HK -.-|lifecycle automation| HK
 
     style C fill:#22c55e,color:#000
     style I fill:#06b6d4,color:#000
@@ -35,6 +35,10 @@ graph TD
 ```
 
 Handlers sit at the center as **composition roots**: they wire infrastructure (I/O) to core (logic) and are the only layer allowed to import both.
+
+Per-layer module counts drift too fast for a diagram to carry as a hard-coded
+label (see #114, #127) — **docs/module-inventory.md is the single source**
+for current file counts per layer.
 
 ## Dependency Rules
 
@@ -179,7 +183,9 @@ Handlers sit at the center as **composition roots**: they wire infrastructure (I
 |---|---|
 | `__init__.py` | MethodologyError, ValidationError, StorageError, AnalysisError, McpConnectionError |
 
-### `handlers/` — Tool composition roots (34 handlers)
+### `handlers/` — Tool composition roots
+
+*(file/tool counts: see docs/module-inventory.md — single source, per #127)*
 
 #### Cognitive Profiling
 
@@ -260,7 +266,7 @@ Handlers sit at the center as **composition roots**: they wire infrastructure (I
 
 | Module | Purpose |
 |---|---|
-| `__main__.py` | `python -m mcp_server` — FastMCP bootstrap, registers all 34 tools |
+| `__main__.py` | `python -m mcp_server` — FastMCP bootstrap, registers all standalone tools (see docs/mcp-tools.md for the exact, test-verified count) |
 
 ## Testing Strategy
 

--- a/docs/program/gitnexus-competitive-analysis.md
+++ b/docs/program/gitnexus-competitive-analysis.md
@@ -55,7 +55,7 @@ are the consensus.
 | Embeddings | sentence-transformers 384-dim + FlashRank ONNX cross-encoder rerank | TF-IDF only (per search/mod.rs) |
 | Search | PL/pgSQL WRRF over vector + FTS + trigram + heat + recency, client-side rerank | Tantivy BM25 + TF-IDF + RRF |
 | Clustering | Per-domain cognitive profile + cross-domain bridges | Louvain + Traag C2 repair (Blondel 2008, Traag 2019 — cited) |
-| Scale | 108 core modules, 47 MCP tools, 2500+ tests | 12 046 LOC, 23 MCP tools, 220 tests |
+| Scale | see docs/module-inventory.md for module counts (single source, per #127) · 47 MCP tools · 2500+ tests | 12 046 LOC, 23 MCP tools, 220 tests |
 | Scientific grounding | Every mechanism cites papers: cascade (Kandel 2001), homeostatic (Turrigiano 2008), neuromodulation (Doya 2002), synaptic tagging (Frey & Morris 1997), microglial pruning (Wang 2020), predictive coding (Friston 2010), … | Every stage cites papers: Louvain (Blondel 2008), Traag (2019), RRF K=60 (Cormack et al 2009), Tarjan SCC, tree-sitter … |
 | Benchmarks | **LongMemEval R@10 97.8%** (paper SOTA 78.4%); **LoCoMo 92.6%**; **BEAM 0.543** (paper SOTA 0.329) — all on clean DB, reproducible | 220 unit tests; no external benchmark yet |
 | Unique features | persistent cross-session memory, thermodynamic decay, cascade consolidation, neuromodulation, synaptic tagging, cognitive profile per domain, predictive-coding write gate, hippocampal replay | PRD validator (symbol hallucination check), security gates (auth-critical/unsafe/public API), Tarjan-SCC semantic diff, 5-layer resolver with LSP, macro expansion, stdlib indexing |


### PR DESCRIPTION
Fixes #127. Les comptes de modules en dur (40/11/10/34/4 — jamais remesurés, même origine que la dérive CLAUDE.md corrigée par #125) remplacés par des renvois vers docs/module-inventory.md et docs/mcp-tools.md — une seule source, mesurée et datée. Même traitement pour la même dérive trouvée dans docs/program/gitnexus-competitive-analysis.md (« 108 core modules »). Laissés intacts, justifié : les comptes historiques des ADR (décisions datées) et les énumérations locales auto-suffisantes. Grep de contrôle final : vide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)