### PR TITLE
feat(config): project settings, /preflight command, catalogue, headless CI regimes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(pytest*)",
+      "Bash(ruff check*)",
+      "Bash(ruff format*)",
+      "Bash(uv *)",
+      "Bash(uv pip install*)",
+      "Bash(python -m mcp_server.doctor*)",
+      "Bash(python3 -m mcp_server.doctor*)",
+      "Bash(git status*)",
+      "Bash(git log*)"
+    ],
+    "deny": [
+      "Bash(curl *)",
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/.ssh/**)",
+      "Read(~/.ssh/**)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,11 @@ pyright-*.json
 traces/
 
 # Internal dev tooling, agent config & task notes — excluded from the public
-# submission repo (untracked via `git rm --cached`; kept locally on disk)
-.claude/
+# submission repo (untracked via `git rm --cached`; kept locally on disk).
+# Exception: .claude/settings.json is project-scope policy (#119) and must
+# be committed — its deny list is only irremovable-from-local if it ships.
+.claude/*
+!.claude/settings.json
 tasks/
 benchmarks/snapshots/
 .memsearch/

--- a/commands/preflight.md
+++ b/commands/preflight.md
@@ -1,0 +1,33 @@
+---
+name: preflight
+description: Diagnostique l'environnement Cortex et guide la réparation (DB, extensions, modèles)
+allowed-tools: Bash(python -m mcp_server.doctor*), Bash(python3 -m mcp_server.doctor*), Read
+---
+
+## Préflight Cortex $ARGUMENTS
+
+Tu diagnostiques l'installation de Cortex pour un utilisateur qui vient de
+cloner le repo ou d'installer le plugin — il n'est ni expert PostgreSQL ni
+expert Python. S'il a passé un argument ($ARGUMENTS), c'est le symptôme
+qu'il observe : commence par le relier au check concerné.
+
+Exécute `python -m mcp_server.doctor` (essaie `python3` si `python` échoue)
+et interprète la sortie :
+
+- Pour CHAQUE check en échec : cite le nom exact du check, explique en une
+  phrase ce qu'il vérifie, puis donne LA commande de réparation que le
+  doctor propose — telle quelle, prête à copier.
+- Ordonne les réparations par dépendance (Python → driver → DATABASE_URL →
+  connexion → extensions → filesystem), pas dans l'ordre d'affichage.
+- Si tous les checks passent : dis-le en une ligne et indique le premier
+  usage (`query_methodology` au prochain démarrage de session).
+
+Format de sortie :
+1. **Verdict** : PRÊT / X réparations nécessaires
+2. **Réparations dans l'ordre** (numérotées, une commande par étape)
+3. **Vérification finale** : la commande à relancer pour confirmer
+
+Ne modifie AUCUN fichier. Ne devine jamais une commande de réparation qui
+n'est pas dans la sortie du doctor : si le doctor ne propose rien, dis
+« le doctor ne propose pas de fix automatique pour ce check » et cite la
+section concernée de PRIVACY.md ou README.md.

--- a/docs/deployment-scenarios.md
+++ b/docs/deployment-scenarios.md
@@ -230,3 +230,60 @@ this section apply only to the outbound HTTPS calls
 `sentence-transformers`/`huggingface_hub`/`flashrank` make; they have no
 effect on `DATABASE_URL`'s `sslcert`/`sslkey`/`sslrootcert` parameters, and
 vice versa.
+
+---
+
+## Two headless CI regimes — pick one per job, never both
+
+Running `claude -p` (headless, no interactive session) in your own CI is a
+different decision from running Cortex's *own* test suite (`.github/workflows/ci.yml`,
+which never invokes the Claude CLI at all). This section is for teams that
+drive Claude Code itself inside a pipeline — linting with an agent, an
+authoring/review bot, a scheduled task — and need to decide whether Cortex's
+memory is available to it. The two regimes are mutually exclusive by
+construction; do not expect both properties from a single job.
+
+### Regime A — `claude -p --bare`: reproducible, no Cortex
+
+`--bare` loads no project/user settings, no hooks, and no MCP servers — it
+forces `ANTHROPIC_API_KEY` billing and starts from a blank configuration
+slate every invocation (see `mcp_server/handlers/consolidation/claude_cli.py`,
+module docstring, "Solo mode" discussion, for the verified behavior Cortex's
+own headless wiki-authoring drain relies on when contrasting `--bare` against
+`--safe-mode`). Because MCP servers never load in this mode, **Cortex is not
+present**: no `SessionStart` context injection, no `remember`/`recall`, no
+consolidation. The job's output depends only on the prompt, the pinned CLI
+version, and whatever files are in the checkout — nothing else.
+
+Use this regime when the job's correctness argument is "this must produce
+the same result on every run" — e.g. a CI check that a diff violates no
+lint rule, or a report-generation step being asserted against a golden file.
+Reproducibility is the whole point; adding Cortex's memory would make the
+job's output depend on accumulated state from prior runs, which defeats that
+argument.
+
+### Regime B — containerized, pinned versions, with memory
+
+Run the Claude CLI (pinned version) and Cortex (pinned plugin/package
+version, PostgreSQL reachable) normally inside a container — project/user
+settings, hooks, and MCP servers all load as they would locally. `SessionStart`
+injects hot/anchored memories, `remember`/`recall` work, and the autonomous
+wiki cycle can consolidate across scheduled runs. This gives the pipeline
+continuity: a nightly review-agent job can accumulate "we already flagged
+this pattern" across weeks of runs instead of starting blank every time.
+
+The trade-off is exactly the one this repo already documents for release
+benchmarks (see `CLAUDE.md`, Build & Test): a job with persistent state
+behind it is not byte-for-byte reproducible run-to-run, because the DB state
+differs. Do not use this regime to gate anything that must be a clean,
+repeatable pass/fail (that is what Regime A, or `benchmarks/reproduce.sh`'s
+isolated ephemeral container, is for) — use it for jobs whose value *is*
+the accumulated memory.
+
+### The rule
+
+One job, one regime. A job that needs both a clean reproducible verdict and
+persistent Cortex memory is asking for a contradiction — `--bare` strips the
+MCP/hooks layer that memory depends on, and enabling that layer reintroduces
+the run-to-run state dependency `--bare` exists to remove. If a pipeline
+needs both properties, split it into two jobs instead of one.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -91,8 +91,22 @@ lives in the automatised-pipeline MCP.
 
 ## Slash Commands
 
-- `/methodology` — View cognitive methodology profile
-- `/why` — Deterministic blame-path entry point: resolve the ⟦rcpt:id⟧ markers in context via the `why` tool (decision 4255039 correction 6)
+Discovered from `commands/*.md` at the repo root (not `.claude/commands/` —
+this is a plugin repo, so the plugin loader picks these up directly). Each
+command is a single Markdown file with a `name`/`description` frontmatter
+pair; `/preflight` additionally scopes `allowed-tools` to keep itself
+read-only.
+
+| Command | What it does | Roles |
+|---|---|---|
+| `/methodology` | Retrieves the cognitive methodology profile (via `query_methodology`) for the current working directory and offers `rebuild_profiles` / `list_domains` / `get_methodology_graph` follow-ups | Any user, any session — the general entry point into a domain's profile |
+| `/why` | Deterministic blame-path: resolves `⟦rcpt:id⟧` presence-in-context markers via the `why` tool, reports which memories were in context (never that they *caused* an answer — Pearl-rung-1 evidence only) | Anyone auditing why an answer looked the way it did |
+| `/preflight [symptôme]` | Runs `python -m mcp_server.doctor` (7 checks) and turns the output into a dependency-ordered, copy-paste repair plan; takes an optional symptom argument to prioritize the relevant check first. Read-only — modifies no files | New users whose install doesn't work yet; support; first-deploy DevOps (issue #119) |
+
+**Convention for adding a new command:** one new `.md` file under
+`commands/` (frontmatter: `name`, `description`, and `allowed-tools` if the
+command should run with restricted permissions) **plus** one new row in the
+table above — the catalogue and the command ship in the same commit.
 
 ## Data Flow
 


### PR DESCRIPTION
Fixes #119 (4 commits séparés).

1. `.claude/settings.json` scope Projet : $schema, allow ciblés (pytest/ruff/uv/doctor/git status-log), deny anti-exfiltration — avec le trou de gitignore chirurgical (`.claude/*` + `!.claude/settings.json`) pour ne shipper QUE ce fichier.
2. `/preflight` dans `commands/` (surface plugin, convention du repo vérifiée) — la commande validée en assessment : façade doctor, $ARGUMENTS = symptôme, allowed-tools réduit, sortie verdict/réparations/vérification.
3. Catalogue des commandes : extension de la section existante de docs/mcp-tools.md (une seule surface de catalogue — pas de doublon qui dériverait) + convention d'ajout. Vérifié contre le contenu réel de commands/ (le README citait un Skill comme commande — exclu à raison).
4. Doc des deux régimes CI headless : `--bare` (reproductible, coupe MCP+hooks donc Cortex) vs conteneur+pins (avec mémoire) — cross-référence la règle de gate bench existante au lieu de la répéter.

Follow-up honnête flaggé : la vérification picker (`/` dans une session sur le repo) exige une session interactive — étape 2 de l'artifact à faire au merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)