### PR TITLE
feat(tools): check_setup MCP tool — preflight facade over doctor.py (50→51 tools)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ separate **cortex-viz** MCP (reads this same store read-only).
 - @docs/adr/ — Architecture Decision Records (013 = thermodynamic memory
   model, 014 = biological mechanisms, 012 = Python migration from Node.js)
 - @docs/module-inventory.md — per-layer module catalogue + dependency rules
-- @docs/mcp-tools.md — the 50 standalone + 3 conditionally-registered MCP
+- @docs/mcp-tools.md — the 51 standalone + 3 conditionally-registered MCP
   tools, by tier, with purpose and target latency
 - @PRIVACY.md — storage truth by launch surface (lines 26–36): SQLite is
   the default for `.mcpb`/Cowork; PostgreSQL is used in plugin/CLI mode

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -4,16 +4,17 @@ description: "MCP tool catalogue (tiers, purpose, target latency) + slash comman
 
 # MCP Tools
 
-50 standalone tools register unconditionally; 3 more register only when an
-upstream MCP server is configured (53 total with both present).
+51 standalone tools register unconditionally; 3 more register only when an
+upstream MCP server is configured (54 total with both present).
 
 ```
-# source: tests_py/test_main.py::test_standalone_baseline_is_50_tools
+# source: tests_py/test_main.py::test_standalone_baseline_is_51_tools
 #   verified 2026-07-12 by a live DB-less `tools/list` stdio round-trip
-#   against `bare-container-contract` + `wiki_migrate`, commit 4be298a3.
+#   against `bare-container-contract` + `wiki_migrate`, commit 4be298a3;
+#   bumped to 51 by `check_setup` (issue #115).
 ```
 
-## Tier 1 — Core Memory & Profiling (21 tools)
+## Tier 1 — Core Memory & Profiling (22 tools)
 
 | Tool | Purpose | Target Latency |
 |---|---|---|
@@ -38,6 +39,7 @@ upstream MCP server is configured (53 total with both present).
 | `backfill_memories` | Auto-import prior Claude Code conversations | varies |
 | `unified_search` | Unified retrieval across memories, wiki, and code graph | <200ms |
 | `get_telemetry` | Retrieval and memory-system telemetry metrics | <50ms |
+| `check_setup` | Verify local install (Python, PG driver, DATABASE_URL, connection, extensions, FS) — facade over `mcp_server.doctor` | <500ms |
 
 ## Tier 2 — Navigation & Exploration (7 tools)
 
@@ -83,9 +85,9 @@ upstream MCP server is configured (53 total with both present).
 ## Upstream-integration tools (3, conditionally registered)
 
 These register only when their upstream MCP server is configured, bringing
-the total to 53: `ingest_codebase` + `change_impact` (automatised-pipeline)
+the total to 54: `ingest_codebase` + `change_impact` (automatised-pipeline)
 and `ingest_prd` (prd-spec-generator). With no upstream present, exactly the
-**50 standalone tools** above register. Driving the ai-architect pipeline
+**51 standalone tools** above register. Driving the ai-architect pipeline
 end-to-end (formerly `run_pipeline`) is **not** part of this server — it
 lives in the automatised-pipeline MCP.
 

--- a/mcp_server/handlers/check_setup.py
+++ b/mcp_server/handlers/check_setup.py
@@ -1,0 +1,101 @@
+"""Handler: check_setup — MCP facade over mcp_server.doctor's checks.
+
+Runs the exact same check functions as `python -m mcp_server.doctor`
+(the plugin-marketplace CLI) and returns them as structured MCP data
+instead of console text, mirroring the `check_vision_setup` /
+`check_voice_setup` pattern from the cortex-vision / cortex-voice
+plugins: call once before first interactive session to confirm the
+environment before install day.
+
+No check logic is duplicated here — every entry in `doctor.CHECKS` is
+imported and invoked as-is, in doctor's own dependency order (Python
+version -> PG driver -> DATABASE_URL -> live PG connection -> pgvector
+/pg_trgm extensions -> ~/.claude/methodology writability -> I10 pool
+config -> optional automatised-pipeline probe). A failure early in the
+list explains later ones (e.g. no DATABASE_URL implies no PG
+connection), so callers should fix in list order.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_server.doctor import CHECKS, Check
+from mcp_server.handlers._tool_meta import READ_ONLY_EXTERNAL
+
+# ── Schema ────────────────────────────────────────────────────────────────
+
+schema = {
+    "title": "Check setup",
+    "annotations": READ_ONLY_EXTERNAL,
+    "description": (
+        "Verify the local Cortex installation before first interactive "
+        "use. Runs the identical check functions as `python -m "
+        "mcp_server.doctor` (no duplicated logic): Python >= 3.10, "
+        "psycopg/psycopg_pool/pgvector driver imports, DATABASE_URL set, "
+        "live PostgreSQL connection, pgvector + pg_trgm extensions, "
+        "~/.claude/methodology writability, I10 pool-capacity invariant, "
+        "and an optional automatised-pipeline codebase-tool probe. "
+        "Checks run in doctor's own dependency order, so an early "
+        "failure (e.g. missing DATABASE_URL) explains later ones (e.g. "
+        "no PG connection) -- fix in list order. Call this once before "
+        "first session, or whenever diagnosing a setup problem. "
+        "Read-only but reaches outside the DB (env vars, filesystem, a "
+        "live connection attempt). Takes no arguments. Returns "
+        "{ready, summary, fixes_needed, checks: [{name, ok, optional, "
+        "detail, fix_command}]}. `ready` is true iff every non-optional "
+        "check passed; the codebase-pipeline probe is optional and "
+        "never blocks readiness."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "required": [],
+        "properties": {},
+        "additionalProperties": False,
+    },
+}
+
+
+def _run_checks() -> list[Check]:
+    """precondition: none.
+    postcondition: returns one Check per `doctor.CHECKS` entry, in
+    doctor's own order -- this function performs no reordering or
+    filtering; it only invokes doctor's callables and collects results.
+    """
+    return [check_fn() for check_fn in CHECKS]
+
+
+async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
+    """precondition: none -- takes no arguments.
+    postcondition: `checks` has exactly `len(CHECKS)` entries in
+    doctor's dependency order; `ready` is True iff no non-optional
+    check failed; `fixes_needed` counts failing non-optional checks
+    only (an optional-check failure, e.g. the codebase-pipeline probe,
+    is a warning and never blocks readiness -- mirrors doctor's own
+    exit-code semantics in `_run_full_check`).
+    """
+    checks = _run_checks()
+    required_fails = [c for c in checks if not c.ok and not c.optional]
+    ready = not required_fails
+
+    summary = (
+        "ready"
+        if ready
+        else f"{len(required_fails)} fix{'es' if len(required_fails) != 1 else ''} needed"
+    )
+
+    return {
+        "ready": ready,
+        "summary": summary,
+        "fixes_needed": len(required_fails),
+        "checks": [
+            {
+                "name": c.name,
+                "ok": c.ok,
+                "optional": c.optional,
+                "detail": c.detail,
+                "fix_command": c.fix,
+            }
+            for c in checks
+        ],
+    }

--- a/mcp_server/tool_registry_manage.py
+++ b/mcp_server/tool_registry_manage.py
@@ -1,6 +1,7 @@
-"""Tool registration: Tier 1 memory management tools (6 tools).
+"""Tool registration: Tier 1 memory management tools (8 tools).
 
-Registers forget, validate, rate, seed, anchor, and backfill tools.
+Registers forget, validate, rate, seed, anchor, backfill, codebase
+analyze, and check_setup tools.
 """
 
 from __future__ import annotations
@@ -10,6 +11,7 @@ from fastmcp import FastMCP
 from mcp_server.handlers import (
     anchor,
     backfill_memories,
+    check_setup,
     codebase_analyze,
     forget,
     rate_memory,
@@ -25,6 +27,7 @@ from mcp_server.handlers._tool_meta import tool_kwargs
 SCHEMAS: dict[str, dict] = {
     "anchor": anchor.schema,
     "backfill_memories": backfill_memories.schema,
+    "check_setup": check_setup.schema,
     "codebase_analyze": codebase_analyze.schema,
     "forget": forget.schema,
     "rate_memory": rate_memory.schema,
@@ -42,6 +45,7 @@ def register(mcp: FastMCP) -> None:
     _register_anchor(mcp)
     _register_backfill_memories(mcp)
     _register_codebase_analyze(mcp)
+    _register_check_setup(mcp)
 
 
 def _register_forget(mcp: FastMCP) -> None:
@@ -211,4 +215,18 @@ def _register_codebase_analyze(mcp: FastMCP) -> None:
                 "domain": domain or "",
             },
             tool_name="codebase_analyze",
+        )
+
+
+def _register_check_setup(mcp: FastMCP) -> None:
+    @mcp.tool(
+        name="check_setup",
+        **tool_kwargs(check_setup.schema),
+    )
+    async def tool_check_setup() -> dict:
+        """Verify the local install: Python, PG driver, DB, extensions, FS."""
+        return await safe_handler(
+            check_setup.handler,
+            {},
+            tool_name="check_setup",
         )

--- a/tests_py/handlers/test_check_setup.py
+++ b/tests_py/handlers/test_check_setup.py
@@ -1,0 +1,145 @@
+"""Tests for mcp_server.handlers.check_setup — MCP facade over doctor.py.
+
+Contract under test (from check_setup.py docstrings and schema):
+  POST-1: `checks` has exactly len(CHECKS) entries, in CHECKS' own order
+          (no reordering/filtering — mirrors doctor's dependency order:
+          Python -> driver -> DATABASE_URL -> connection -> extensions -> FS).
+  POST-2: `ready` is True iff no non-optional check failed.
+  POST-3: `fixes_needed` counts failing non-optional checks only; an
+          optional-check failure (e.g. codebase-pipeline probe) never
+          blocks readiness or is counted.
+  POST-4: no check logic is duplicated — the handler calls the exact
+          `Check` callables from `mcp_server.doctor.CHECKS`.
+  POST-5: schema takes no arguments (composition-root/facade, not a
+          re-implementation).
+"""
+
+import asyncio
+
+from mcp_server.doctor import Check
+from mcp_server.handlers.check_setup import handler, schema
+
+
+def _fake_check(name: str, ok: bool, optional: bool = False, fix: str = "") -> Check:
+    return Check(name, ok, detail=f"{name} detail", fix=fix, optional=optional)
+
+
+class TestCheckSetupHandlerAllGreen:
+    """DB up, everything green — POST-2, POST-3."""
+
+    def test_ready_true_when_all_pass(self, monkeypatch):
+        checks = [
+            lambda: _fake_check("Python >= 3.10", True),
+            lambda: _fake_check("PG Python drivers", True),
+            lambda: _fake_check("DATABASE_URL", True),
+            lambda: _fake_check("PG connection", True),
+            lambda: _fake_check("pgvector + pg_trgm extensions", True),
+            lambda: _fake_check("~/.claude/methodology writable", True),
+        ]
+        monkeypatch.setattr("mcp_server.handlers.check_setup.CHECKS", checks)
+
+        result = asyncio.run(handler())
+
+        assert result["ready"] is True
+        assert result["summary"] == "ready"
+        assert result["fixes_needed"] == 0
+        assert len(result["checks"]) == len(checks)
+        assert all(c["ok"] for c in result["checks"])
+
+
+class TestCheckSetupHandlerDbDown:
+    """DB down — a required check fails partway through the dependency
+    chain (mirrors: DATABASE_URL set but PG connection refused)."""
+
+    def test_ready_false_and_fixes_needed_counts_required_only(self, monkeypatch):
+        checks = [
+            lambda: _fake_check("Python >= 3.10", True),
+            lambda: _fake_check("PG Python drivers", True),
+            lambda: _fake_check("DATABASE_URL", True),
+            lambda: _fake_check(
+                "PG connection",
+                False,
+                fix="Start PostgreSQL and createdb: `brew services start "
+                "postgresql@17 && createdb cortex`",
+            ),
+            lambda: _fake_check("pgvector + pg_trgm extensions", False),
+            lambda: _fake_check("~/.claude/methodology writable", True),
+            # Optional probe also fails but must not count toward fixes_needed.
+            lambda: _fake_check("codebase-pipeline (optional)", False, optional=True),
+        ]
+        monkeypatch.setattr("mcp_server.handlers.check_setup.CHECKS", checks)
+
+        result = asyncio.run(handler())
+
+        assert result["ready"] is False
+        assert result["fixes_needed"] == 2  # PG connection + extensions, not optional
+        assert result["summary"] == "2 fixes needed"
+
+    def test_optional_only_failure_still_ready(self, monkeypatch):
+        checks = [
+            lambda: _fake_check("Python >= 3.10", True),
+            lambda: _fake_check("codebase-pipeline (optional)", False, optional=True),
+        ]
+        monkeypatch.setattr("mcp_server.handlers.check_setup.CHECKS", checks)
+
+        result = asyncio.run(handler())
+
+        assert result["ready"] is True
+        assert result["fixes_needed"] == 0
+        assert result["summary"] == "ready"
+
+    def test_single_fix_singular_wording(self, monkeypatch):
+        checks = [
+            lambda: _fake_check("DATABASE_URL", False, fix="export DATABASE_URL=..."),
+        ]
+        monkeypatch.setattr("mcp_server.handlers.check_setup.CHECKS", checks)
+
+        result = asyncio.run(handler())
+
+        assert result["fixes_needed"] == 1
+        assert result["summary"] == "1 fix needed"
+
+
+class TestCheckSetupHandlerOrder:
+    """POST-1: dependency order is preserved exactly, not re-sorted."""
+
+    def test_order_matches_checks_list(self, monkeypatch):
+        names = ["Zebra check", "Alpha check", "Middle check"]
+        checks = [lambda n=n: _fake_check(n, True) for n in names]
+        monkeypatch.setattr("mcp_server.handlers.check_setup.CHECKS", checks)
+
+        result = asyncio.run(handler())
+
+        assert [c["name"] for c in result["checks"]] == names
+
+
+class TestCheckSetupHandlerNoDuplication:
+    """POST-4: real doctor.CHECKS (unmocked) drives the handler — no
+    reimplemented check logic, exercises the real Python-version check."""
+
+    def test_uses_real_doctor_checks_python_version_passes(self):
+        result = asyncio.run(handler())
+        py_check = next(c for c in result["checks"] if c["name"] == "Python >= 3.10")
+        assert py_check["ok"] is True
+
+    def test_check_shape(self):
+        result = asyncio.run(handler())
+        for c in result["checks"]:
+            assert set(c.keys()) == {"name", "ok", "optional", "detail", "fix_command"}
+            assert isinstance(c["ok"], bool)
+            assert isinstance(c["optional"], bool)
+
+
+class TestCheckSetupSchema:
+    """POST-5: facade takes no arguments; schema artifact well-formed."""
+
+    def test_schema_exists(self):
+        assert "description" in schema
+        assert "inputSchema" in schema
+
+    def test_schema_takes_no_arguments(self):
+        assert schema["inputSchema"]["properties"] == {}
+        assert schema["inputSchema"]["required"] == []
+
+    def test_schema_additional_properties_false(self):
+        assert schema["inputSchema"]["additionalProperties"] is False

--- a/tests_py/test_main.py
+++ b/tests_py/test_main.py
@@ -46,14 +46,15 @@ class TestMain:
             # Should call mcp.run with stdio transport
             mock_run.assert_called_once_with(transport="stdio")
 
-    def test_standalone_baseline_is_50_tools(self):
-        """With no upstream available, exactly the 50 standalone tools register.
+    def test_standalone_baseline_is_51_tools(self):
+        """With no upstream available, exactly the 51 standalone tools register.
 
-        50 = the 49 tools re-derived 2026-07-12 (fix/bare-container-contract,
+        51 = the 49 tools re-derived 2026-07-12 (fix/bare-container-contract,
         live DB-less `tools/list` round-trip) + `wiki_migrate` (FS→PG wiki
-        parity, commit 4be298a3). The 3 upstream-integration tools
-        (ingest_codebase, change_impact, ingest_prd) MUST NOT be
-        advertised — every advertised tool then works out of the box.
+        parity, commit 4be298a3) + `check_setup` (doctor.py facade, issue
+        #115). The 3 upstream-integration tools (ingest_codebase,
+        change_impact, ingest_prd) MUST NOT be advertised — every advertised
+        tool then works out of the box.
         source: MCP Directory submission decision 2026-06-19.
         """
         names = _tool_names(codebase=False, prd=False)
@@ -93,22 +94,24 @@ class TestMain:
         # INC G-4: grooming backlog + staleness telemetry, PG-only, no
         # upstream needed.
         assert "get_grooming_health" in names
+        # Issue #115: doctor.py facade, no upstream needed.
+        assert "check_setup" in names
         # The upstream-integration tools are gated OFF.
         assert names.isdisjoint(_UPSTREAM_TOOLS)
-        assert len(names) == 50
+        assert len(names) == 51
 
-    def test_with_upstreams_registers_53_tools(self):
+    def test_with_upstreams_registers_54_tools(self):
         """When both upstreams are available, the 3 integration tools register."""
         names = _tool_names(codebase=True, prd=True)
         assert _UPSTREAM_TOOLS <= names
-        assert len(names) == 53
+        assert len(names) == 54
 
     def test_codebase_only_adds_two_tools(self):
         """codebase upstream gates ingest_codebase + change_impact together."""
         names = _tool_names(codebase=True, prd=False)
         assert {"ingest_codebase", "change_impact"} <= names
         assert "ingest_prd" not in names
-        assert len(names) == 52
+        assert len(names) == 53
 
     def test_mcp_server_name_and_version(self):
         assert mcp.name == "methodology-agent"


### PR DESCRIPTION
Fixes #115. Nouvel outil MCP `check_setup` — façade fine (composition root) sur les checks de `doctor.py`, sur le modèle de check_vision_setup/check_voice_setup. Expose le préflight P1 (que l'audit avait trouvé invisible) depuis la session Claude elle-même.

- Aucune logique dupliquée : importe `doctor.CHECKS` et les invoque tels quels (Liskov — mêmes objets Check que le CLI). doctor.py inchangé.
- Sortie structurée : {ready, fixes_needed (non-optionnels seulement), checks[{name, ok, fix}]} en ordre de dépendance (Python→driver→DATABASE_URL→connexion→extensions→FS).
- Compte d'outils : baseline 50→51 **vérifié par test** (`_tool_names` sur une FastMCP fraîche), test_main.py + docs/mcp-tools.md + CLAUDE.md mis à jour.
- 11 tests (all-green, DB-down mix required/optional, exclusion des optionnels du compte fixes, ordre préservé, smoke sur les vrais CHECKS, schema no-args).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5Z1wfiBpADgENq6pB6E2i