### PR TITLE
refactor(core): eliminate 3 core→infrastructure layer violations via ports-and-adapters

### DIFF
--- a/docs/module-inventory.md
+++ b/docs/module-inventory.md
@@ -206,6 +206,7 @@ Run the measurement command in the header to get a current file listing.
 - `embedding_engine.py` — Vector embeddings (384-dim, sentence-transformers)
 - `artifact_store.py` — Content-addressed raw-output artifacts (`~/.claude/methodology/artifacts/<yyyy-mm>/<sha256[:16]>.md`) backing gist+pointer memories
 - `agent_config.py` — Agent configuration and topic scoping
+- `wiki_schema_reader.py` — Filesystem adapter for `core/wiki_schema_loader.py`'s data model/parsers; walks `wiki/_kinds|_rules|_views|_triggers/` and builds a `WikiRegistry` (issue #126 port-and-adapter split)
 
 Note: `pg_store.py` persists to PostgreSQL when configured (plugin/CLI mode);
 see `PRIVACY.md` for the SQLite-default fallback used by `.mcpb`/Cowork

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -50,13 +50,27 @@ from mcp_server import (
     tool_registry_wiki,
 )
 from mcp_server.core import telemetry
+from mcp_server.core.wiki_axis_registry import configure_default_wiki_root
+from mcp_server.core.wiki_classifier import configure_user_rules_provider
 from mcp_server.handlers._tool_meta import apply_param_docs
+from mcp_server.infrastructure.config import WIKI_ROOT
 from mcp_server.infrastructure.mcp_client_pool import close_all
 from mcp_server.infrastructure.otel_exporter import build_otel_exporter
 from mcp_server.infrastructure.upstream_availability import (
     codebase_upstream_available,
     prd_upstream_available,
 )
+from mcp_server.infrastructure.wiki_schema_reader import load_registry
+
+# ── Reverse-DI wiring (issue #126) ──────────────────────────────────────────
+#
+# core/wiki_axis_registry.py and core/wiki_classifier.py declare what they
+# need (a wiki-root provider / a user-rules provider) rather than importing
+# infrastructure directly. This is the one place — the composition root —
+# that supplies the real, infrastructure-backed values.
+
+configure_default_wiki_root(lambda: WIKI_ROOT)
+configure_user_rules_provider(lambda: load_registry(WIKI_ROOT).rules)
 
 # Optional OTLP telemetry export (issue #122) -- OFF by default. Wiring the
 # concrete exporter into the core port happens only here, in the

--- a/mcp_server/core/wiki_axis_registry.py
+++ b/mcp_server/core/wiki_axis_registry.py
@@ -37,6 +37,12 @@ Schema file format::
 Unknown values fail validation; the error message proposes the closest
 match via ``difflib.get_close_matches`` (user direction 2026-05-12:
 "reject + suggest").
+
+Size-limit note (coding-standards.md §4, High-stakes per engineer.md Move 7):
+this file is well over the 500-line hard limit, pre-existing before issue #126
+(687 lines before, 705 after adding the reverse-DI wiki-root-provider port
+below). Tracked for a dedicated split — see issue #134 — rather than folded
+silently into #126's layer-violation scope.
 """
 
 from __future__ import annotations
@@ -45,7 +51,7 @@ import difflib
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Final, Iterable
+from typing import Callable, Final, Iterable
 
 # ── Axis names ──────────────────────────────────────────────────────────
 
@@ -661,9 +667,28 @@ def match_axis(
 
 
 # ── Lazy singleton — cached for in-process classifier calls ─────────────
-
+#
+# Reverse DI (issue #126): core declares the *shape* of what it needs (a
+# zero-arg callable returning the default wiki root) rather than importing
+# ``infrastructure.config.WIKI_ROOT`` directly. The composition root
+# (``mcp_server/__main__.py``) calls ``configure_default_wiki_root`` once
+# at process boot with the real path; tests inject a fixture path the same
+# way. No provider configured → ``get_registry()`` yields the seed-only
+# defaults (still correct, just without user ``_schema/`` overrides).
 
 _REGISTRY_CACHE: AxisRegistry | None = None
+_WIKI_ROOT_PROVIDER: Callable[[], Path | str | None] | None = None
+
+
+def configure_default_wiki_root(provider: Callable[[], Path | str | None]) -> None:
+    """Composition-root injection point: register how to obtain the
+    default wiki root used by the lazy ``get_registry()`` singleton.
+
+    Call once at MCP server boot. Core never imports
+    ``infrastructure.config`` directly — see issue #126.
+    """
+    global _WIKI_ROOT_PROVIDER
+    _WIKI_ROOT_PROVIDER = provider
 
 
 def get_registry() -> AxisRegistry:
@@ -675,9 +700,8 @@ def get_registry() -> AxisRegistry:
     """
     global _REGISTRY_CACHE
     if _REGISTRY_CACHE is None:
-        from mcp_server.infrastructure.config import WIKI_ROOT
-
-        _REGISTRY_CACHE = load_axis_registry(WIKI_ROOT)
+        wiki_root = _WIKI_ROOT_PROVIDER() if _WIKI_ROOT_PROVIDER is not None else None
+        _REGISTRY_CACHE = load_axis_registry(wiki_root)
     return _REGISTRY_CACHE
 
 

--- a/mcp_server/core/wiki_classifier.py
+++ b/mcp_server/core/wiki_classifier.py
@@ -12,11 +12,18 @@ either author):
   4. CONVENTION: establishes a rule or standard
   5. SPEC: describes a feature or system design
   6. NOTE: catch-all for meaningful content
+
+Size-limit note (coding-standards.md §4, High-stakes per engineer.md Move 7):
+this file is well over the 500-line hard limit, pre-existing before issue #126
+(901 lines before, 916 after adding the reverse-DI rules-provider port below).
+Tracked for a dedicated split — see issue #134 — rather than folded silently
+into #126's layer-violation scope.
 """
 
 from __future__ import annotations
 
 import re
+from typing import Callable
 
 # ── Rejection patterns ────────────────────────────────────────────────
 
@@ -443,8 +450,26 @@ _POSITIVE_SCORE_THRESHOLD = 4
 # on demand. Cached in-process; refresh by calling reset_user_rules().
 # When no rules are loaded (or the wiki isn't initialised), falls back
 # to the hardcoded defaults below.
+#
+# Reverse DI (issue #126): loading these rules requires reading files
+# under the wiki root — that is I/O, and core must not call the
+# infrastructure-backed loader (``infrastructure.wiki_schema_reader.
+# load_registry``) directly. The composition root
+# (``mcp_server/__main__.py``) supplies a zero-arg provider via
+# ``configure_user_rules_provider`` once at boot; no provider configured
+# falls back to the hardcoded defaults below, same as a load failure.
 
 _USER_RULES_CACHE = None  # None = not loaded; [] = loaded but empty
+_USER_RULES_PROVIDER: Callable[[], list] | None = None
+
+
+def configure_user_rules_provider(provider: Callable[[], list]) -> None:
+    """Composition-root injection point: register how to obtain the
+    user-editable classifier rules (``wiki/_rules/*.md``, parsed into
+    ``ClassifierRule`` objects). Call once at MCP server boot.
+    """
+    global _USER_RULES_PROVIDER
+    _USER_RULES_PROVIDER = provider
 
 
 def _load_user_rules():
@@ -453,13 +478,9 @@ def _load_user_rules():
     if _USER_RULES_CACHE is not None:
         return _USER_RULES_CACHE
     try:
-        from pathlib import Path
-
-        from mcp_server.core.wiki_schema_loader import load_registry
-        from mcp_server.infrastructure.config import WIKI_ROOT
-
-        registry = load_registry(Path(WIKI_ROOT))
-        _USER_RULES_CACHE = list(registry.rules)
+        _USER_RULES_CACHE = (
+            list(_USER_RULES_PROVIDER()) if _USER_RULES_PROVIDER is not None else []
+        )
     except Exception:
         _USER_RULES_CACHE = []
     return _USER_RULES_CACHE

--- a/mcp_server/core/wiki_schema_loader.py
+++ b/mcp_server/core/wiki_schema_loader.py
@@ -1,4 +1,4 @@
-"""Self-hosting wiki schema loader (Phase 1.3 of redesign).
+"""Self-hosting wiki schema — data model + pure parsers (Phase 1.3 of redesign).
 
 The wiki describes its own schema. Kinds, classifier rules, views, and
 triggers all live as markdown pages under reserved folders:
@@ -8,13 +8,17 @@ triggers all live as markdown pages under reserved folders:
     wiki/_views/    — saved queries (fenced ``cortex-query`` blocks)
     wiki/_triggers/ — trigger declarations
 
-This module is the READER — parses these files at MCP boot and returns
-typed in-memory registries. Behaviour wires in Phase 2 / 5; for now the
-loader is called once and its output is consumed by the gradually-migrating
-classifier / synthesiser.
+This module declares the typed registries and the pure ``str -> dataclass``
+parsers for each file shape. It performs zero I/O — every parser here takes
+already-read file content as a plain string.
 
-Pure core logic — reads via infrastructure/wiki_store.read_page, never
-writes. Never raises; missing folders produce empty registries.
+Port-and-adapter split (issue #126): the previous single-file version of
+this module also walked the filesystem (via ``infrastructure.wiki_store``)
+to actually build a registry from a wiki root. That I/O orchestration now
+lives in ``mcp_server.infrastructure.wiki_schema_reader.load_registry`` —
+the adapter that reads files on disk and calls the parsers declared here.
+Composition roots (handlers, ``mcp_server/__main__.py``) import
+``load_registry`` from that infrastructure module, not from here.
 """
 
 from __future__ import annotations
@@ -24,7 +28,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from mcp_server.core.wiki_pages import parse_page
-from mcp_server.infrastructure.wiki_store import list_pages, read_page
 
 
 # ── Registry dataclasses ──────────────────────────────────────────────
@@ -105,7 +108,7 @@ class WikiRegistry:
 # ── Parsers ───────────────────────────────────────────────────────────
 
 
-def _parse_kind(rel_path: str, content: str) -> KindDefinition | None:
+def parse_kind(rel_path: str, content: str) -> KindDefinition | None:
     doc = parse_page(content)
     fm = doc.frontmatter or {}
     name = fm.get("name") or Path(rel_path).stem
@@ -125,7 +128,7 @@ def _parse_kind(rel_path: str, content: str) -> KindDefinition | None:
 _TABLE_ROW_RE = re.compile(r"^\|(.+)\|$", re.MULTILINE)
 
 
-def _parse_rules_table(body: str) -> list[ClassifierRule]:
+def parse_rules_table(body: str) -> list[ClassifierRule]:
     """Extract rules from a markdown table.
 
     Expected columns (case-insensitive, order-flexible):
@@ -166,7 +169,7 @@ def _parse_rules_table(body: str) -> list[ClassifierRule]:
 _QUERY_BLOCK_RE = re.compile(r"```cortex-query\n(.*?)\n```", re.DOTALL)
 
 
-def _parse_view(rel_path: str, content: str) -> ViewDefinition | None:
+def parse_view(rel_path: str, content: str) -> ViewDefinition | None:
     doc = parse_page(content)
     fm = doc.frontmatter or {}
     m = _QUERY_BLOCK_RE.search(doc.body or "")
@@ -180,7 +183,7 @@ def _parse_view(rel_path: str, content: str) -> ViewDefinition | None:
     )
 
 
-def _parse_trigger(rel_path: str, content: str) -> TriggerDefinition | None:
+def parse_trigger(rel_path: str, content: str) -> TriggerDefinition | None:
     doc = parse_page(content)
     fm = doc.frontmatter or {}
     event = fm.get("event")
@@ -194,87 +197,7 @@ def _parse_trigger(rel_path: str, content: str) -> TriggerDefinition | None:
     )
 
 
-# ── Loader entry point ───────────────────────────────────────────────
-
-
-def _load_folder(root: Path, folder: str, parser) -> dict:  # type: ignore[type-arg]
-    """Read every .md under ``root/<folder>`` and apply parser.
-
-    Returns dict keyed by parser output's ``name`` (or rel_path for views).
-    """
-    results: dict = {}
-    full = root / folder
-    if not full.exists():
-        return results
-    try:
-        paths = list_pages(root, kind=None)
-    except Exception:
-        return results
-    for rel in paths:
-        # list_pages walks all PAGE_KINDS; filter to our reserved folder
-        if not rel.startswith(folder + "/") and not rel.startswith(folder):
-            continue
-        content = read_page(root, rel)
-        if content is None:
-            continue
-        try:
-            parsed = parser(rel, content)
-        except Exception:
-            continue
-        if parsed is None:
-            continue
-        key = getattr(parsed, "name", None) or rel
-        results[key] = parsed
-    return results
-
-
-def _load_folder_direct(root: Path, folder: str, parser):
-    """Alternative loader that globs directly — used for reserved folders
-    like ``_kinds``, ``_rules`` which are not in PAGE_KINDS.
-    """
-    results: dict = {}
-    full = root / folder
-    if not full.exists():
-        return results
-    for p in sorted(full.rglob("*.md")):
-        rel = str(p.relative_to(root)).replace("\\", "/")
-        try:
-            content = p.read_text(encoding="utf-8")
-        except Exception:
-            continue
-        try:
-            parsed = parser(rel, content)
-        except Exception:
-            continue
-        if parsed is None:
-            continue
-        key = getattr(parsed, "name", None) or rel
-        results[key] = parsed
-    return results
-
-
-def load_registry(wiki_root: Path | str) -> WikiRegistry:
-    """Read the self-hosting schema files and return the registry.
-
-    Safe to call at MCP boot, after wiki_migrate, or on-demand. Missing
-    folders yield empty sub-registries — no raises.
-    """
-    root = Path(wiki_root)
-    kinds = _load_folder_direct(root, "_kinds", _parse_kind)
-
-    # Rules live as a single markdown table per file; parse each and
-    # concatenate preserving file order.
-    rules: list[ClassifierRule] = []
-    rules_dir = root / "_rules"
-    if rules_dir.exists():
-        for p in sorted(rules_dir.rglob("*.md")):
-            try:
-                content = p.read_text(encoding="utf-8")
-                body = parse_page(content).body or ""
-                rules.extend(_parse_rules_table(body))
-            except Exception:
-                continue
-
-    views = _load_folder_direct(root, "_views", _parse_view)
-    triggers = _load_folder_direct(root, "_triggers", _parse_trigger)
-    return WikiRegistry(kinds=kinds, rules=rules, views=views, triggers=triggers)
+# The filesystem walk that builds a ``WikiRegistry`` from a wiki root is
+# I/O and lives in ``mcp_server.infrastructure.wiki_schema_reader.load_registry``
+# (issue #126) — it imports the dataclasses and parsers above and drives
+# them from files read via ``Path`` / ``infrastructure.wiki_store``.

--- a/mcp_server/handlers/wiki_curate.py
+++ b/mcp_server/handlers/wiki_curate.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from mcp_server.core.draft_curator import evaluate_draft
-from mcp_server.core.wiki_schema_loader import load_registry
+from mcp_server.infrastructure.wiki_schema_reader import load_registry
 from mcp_server.infrastructure.config import WIKI_ROOT
 from mcp_server.infrastructure.memory_config import get_memory_settings
 from mcp_server.infrastructure.memory_store import MemoryStore, get_shared_store

--- a/mcp_server/handlers/wiki_refine.py
+++ b/mcp_server/handlers/wiki_refine.py
@@ -30,7 +30,7 @@ import hashlib
 from pathlib import Path
 from typing import Any
 
-from mcp_server.core.wiki_schema_loader import load_registry
+from mcp_server.infrastructure.wiki_schema_reader import load_registry
 from mcp_server.infrastructure.config import WIKI_ROOT
 from mcp_server.infrastructure.memory_config import get_memory_settings
 from mcp_server.infrastructure.memory_store import MemoryStore, get_shared_store

--- a/mcp_server/handlers/wiki_synthesize.py
+++ b/mcp_server/handlers/wiki_synthesize.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any
 
 from mcp_server.core.draft_synthesizer import synthesize_draft
-from mcp_server.core.wiki_schema_loader import load_registry
+from mcp_server.infrastructure.wiki_schema_reader import load_registry
 from mcp_server.infrastructure.config import WIKI_ROOT
 from mcp_server.infrastructure.memory_config import get_memory_settings
 from mcp_server.infrastructure.memory_store import MemoryStore, get_shared_store

--- a/mcp_server/handlers/wiki_view.py
+++ b/mcp_server/handlers/wiki_view.py
@@ -10,8 +10,8 @@ Modes:
   inline (testing): wiki_view({"query": "table: pages\nlimit: 5"})
   list views:       wiki_view({"list": true})
 
-Composition root only — wiki_schema_loader supplies the views dict;
-wiki_view_executor compiles; pg_store executes.
+Composition root only — infrastructure.wiki_schema_reader supplies the
+views dict; wiki_view_executor compiles; pg_store executes.
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ from typing import Any
 # // PG-only dependencies in composition-root handlers (see memory_store.py
 # // which also defers `import psycopg` to _try_pg_verbose).
 
-from mcp_server.core.wiki_schema_loader import load_registry
+from mcp_server.infrastructure.wiki_schema_reader import load_registry
 from mcp_server.core.wiki_view_executor import compile_view
 from mcp_server.infrastructure.config import WIKI_ROOT
 from mcp_server.infrastructure.memory_config import get_memory_settings

--- a/mcp_server/infrastructure/wiki_schema_reader.py
+++ b/mcp_server/infrastructure/wiki_schema_reader.py
@@ -1,0 +1,88 @@
+"""Self-hosting wiki schema reader — I/O half of the schema loader.
+
+Port-and-adapter split (issue #126): ``mcp_server.core.wiki_schema_loader``
+declares the pure data model (``KindDefinition``, ``ClassifierRule``,
+``ViewDefinition``, ``TriggerDefinition``, ``WikiRegistry``) and the pure
+string-to-dataclass parsers. This module is the adapter — it walks the
+wiki root on disk (``Path.rglob`` + ``read_text``) and feeds file content
+through those core parsers to build a ``WikiRegistry``.
+
+Composition roots (``mcp_server/__main__.py``, and the wiki_curate /
+wiki_synthesize / wiki_refine / wiki_view handlers) call ``load_registry``
+directly with an explicit ``wiki_root`` — this module performs real I/O
+and must never be imported from ``core/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mcp_server.core.wiki_pages import parse_page
+from mcp_server.core.wiki_schema_loader import (
+    ClassifierRule,
+    WikiRegistry,
+    parse_kind,
+    parse_rules_table,
+    parse_trigger,
+    parse_view,
+)
+
+
+def _load_folder_direct(root: Path, folder: str, parser):
+    """Glob every ``.md`` under ``root/<folder>`` and apply ``parser``.
+
+    Used for reserved folders (``_kinds``, ``_rules``, ``_views``,
+    ``_triggers``) that are not part of ``PAGE_KINDS``, so they are walked
+    directly via ``rglob`` rather than through ``wiki_store.list_pages``.
+    Never raises; a folder that doesn't exist yields an empty dict, and a
+    file that fails to parse is skipped.
+    """
+    results: dict = {}
+    full = root / folder
+    if not full.exists():
+        return results
+    for p in sorted(full.rglob("*.md")):
+        rel = str(p.relative_to(root)).replace("\\", "/")
+        try:
+            content = p.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        try:
+            parsed = parser(rel, content)
+        except Exception:
+            continue
+        if parsed is None:
+            continue
+        key = getattr(parsed, "name", None) or rel
+        results[key] = parsed
+    return results
+
+
+def load_registry(wiki_root: Path | str) -> WikiRegistry:
+    """Read the self-hosting schema files and return the registry.
+
+    Safe to call at MCP boot, after wiki_migrate, or on-demand. Missing
+    folders yield empty sub-registries — no raises.
+    """
+    root = Path(wiki_root)
+    kinds = _load_folder_direct(root, "_kinds", parse_kind)
+
+    # Rules live as a single markdown table per file; parse each and
+    # concatenate preserving file order.
+    rules: list[ClassifierRule] = []
+    rules_dir = root / "_rules"
+    if rules_dir.exists():
+        for p in sorted(rules_dir.rglob("*.md")):
+            try:
+                content = p.read_text(encoding="utf-8")
+                body = parse_page(content).body or ""
+                rules.extend(parse_rules_table(body))
+            except Exception:
+                continue
+
+    views = _load_folder_direct(root, "_views", parse_view)
+    triggers = _load_folder_direct(root, "_triggers", parse_trigger)
+    return WikiRegistry(kinds=kinds, rules=rules, views=views, triggers=triggers)
+
+
+__all__ = ["load_registry"]

--- a/tests_py/core/test_wiki_axis_registry.py
+++ b/tests_py/core/test_wiki_axis_registry.py
@@ -222,9 +222,13 @@ def test_reset_registry_picks_up_new_user_file(tmp_path: Path, monkeypatch) -> N
     schema_dir = tmp_path / "_schema" / "audiences"
     schema_dir.mkdir(parents=True)
 
-    # Point WIKI_ROOT at our tmp wiki so the default get_registry picks
-    # up the user file.
-    monkeypatch.setattr("mcp_server.infrastructure.config.WIKI_ROOT", str(tmp_path))
+    # Point the injected wiki-root provider at our tmp wiki (issue #126:
+    # core no longer imports infrastructure.config directly) so the
+    # default get_registry() picks up the user file.
+    monkeypatch.setattr(
+        "mcp_server.core.wiki_axis_registry._WIKI_ROOT_PROVIDER",
+        lambda: str(tmp_path),
+    )
     reset_registry()
 
     from mcp_server.core.wiki_axis_registry import get_registry

--- a/tests_py/core/test_wiki_classifier.py
+++ b/tests_py/core/test_wiki_classifier.py
@@ -2,7 +2,41 @@
 
 from __future__ import annotations
 
+import mcp_server.core.wiki_classifier as wiki_classifier
 from mcp_server.core.wiki_classifier import classify_memory, derive_title
+
+
+# ── Reverse-DI port (issue #126) ───────────────────────────────────────
+
+
+def test_user_rules_provider_defaults_to_empty(monkeypatch) -> None:
+    """No provider configured → hardcoded defaults apply (empty rule list),
+    never an import of infrastructure from core."""
+    monkeypatch.setattr(wiki_classifier, "_USER_RULES_PROVIDER", None)
+    monkeypatch.setattr(wiki_classifier, "_USER_RULES_CACHE", None)
+    assert wiki_classifier._load_user_rules() == []
+
+
+def test_user_rules_provider_is_used_when_configured(monkeypatch) -> None:
+    """The composition root injects a provider; ``_load_user_rules`` calls
+    it exactly once, then caches the result.
+
+    Uses ``monkeypatch.setattr`` (not the public ``configure_user_rules_
+    provider``) so teardown restores the pre-test provider automatically —
+    calling the public setter directly would leak ``fake_provider`` into
+    every test that runs afterward in this module.
+    """
+    monkeypatch.setattr(wiki_classifier, "_USER_RULES_CACHE", None)
+    calls = {"n": 0}
+
+    def fake_provider():
+        calls["n"] += 1
+        return ["fake-rule"]
+
+    monkeypatch.setattr(wiki_classifier, "_USER_RULES_PROVIDER", fake_provider)
+    assert wiki_classifier._load_user_rules() == ["fake-rule"]
+    assert wiki_classifier._load_user_rules() == ["fake-rule"]
+    assert calls["n"] == 1  # cached after first load
 
 
 # ── Audit-tag gate ────────────────────────────────────────────────────

--- a/tests_py/infrastructure/test_wiki_schema_reader.py
+++ b/tests_py/infrastructure/test_wiki_schema_reader.py
@@ -1,0 +1,61 @@
+"""Tests for the infrastructure-side wiki schema reader (issue #126 split).
+
+``mcp_server.core.wiki_schema_loader`` declares the pure data model and
+parsers; ``mcp_server.infrastructure.wiki_schema_reader`` is the I/O
+adapter that walks a wiki root on disk and builds a ``WikiRegistry`` from
+it. These tests exercise the adapter end-to-end against a temp directory,
+verifying it produces the same shape the pre-split single-file module did.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mcp_server.infrastructure.wiki_schema_reader import load_registry
+
+
+def test_load_registry_on_missing_wiki_root_returns_empty(tmp_path: Path) -> None:
+    registry = load_registry(tmp_path / "does-not-exist")
+    assert registry.kinds == {}
+    assert registry.rules == []
+    assert registry.views == {}
+    assert registry.triggers == {}
+
+
+def test_load_registry_parses_kind_definition(tmp_path: Path) -> None:
+    kinds_dir = tmp_path / "_kinds"
+    kinds_dir.mkdir(parents=True)
+    (kinds_dir / "adr.md").write_text(
+        "---\nname: adr\ndisplay_name: ADR\ndir_name: adr\n"
+        "required_sections:\n  - Decision\n  - Consequences\n---\n"
+    )
+    registry = load_registry(tmp_path)
+    assert "adr" in registry.kinds
+    assert registry.kinds["adr"].display_name == "ADR"
+    assert registry.kinds["adr"].required_sections == ["Decision", "Consequences"]
+
+
+def test_load_registry_parses_rules_table(tmp_path: Path) -> None:
+    rules_dir = tmp_path / "_rules"
+    rules_dir.mkdir(parents=True)
+    (rules_dir / "default.md").write_text(
+        "---\nname: default\n---\n\n"
+        "| pattern | kind | target | weight | note |\n"
+        "|---|---|---|---|---|\n"
+        "| decision: | prefix | adr | 1.0 | |\n"
+    )
+    registry = load_registry(tmp_path)
+    assert len(registry.rules) == 1
+    assert registry.rules[0].target_kind == "adr"
+
+
+def test_load_registry_parses_view_definition(tmp_path: Path) -> None:
+    views_dir = tmp_path / "_views"
+    views_dir.mkdir(parents=True)
+    (views_dir / "open-questions.md").write_text(
+        "---\nname: open-questions\n---\n\n"
+        "```cortex-query\ntable: pages\nlimit: 5\n```\n"
+    )
+    registry = load_registry(tmp_path)
+    assert "open-questions" in registry.views
+    assert "limit: 5" in registry.views["open-questions"].query


### PR DESCRIPTION
Fixes #126.

Les 3 modules core/ important infrastructure/ corrigés à la racine (ports-and-adapters, pas de déplacement cosmétique) :
- **wiki_axis_registry** : port reverse-DI extrait (`configure_default_wiki_root(provider)`) — le seul point impur était un singleton important WIKI_ROOT ; câblé une fois dans __main__.py.
- **wiki_classifier** : idem (`configure_user_rules_provider(provider)`).
- **wiki_schema_loader** : vrai split port-and-adapter — les dataclasses/parsers PURS restent en core (importés par 3 autres modules core — un déménagement aurait créé 3 NOUVELLES violations), l'I/O (walk disque) déménage en `infrastructure/wiki_schema_reader.py`. Dead code `_load_folder()` supprimé au passage.

**Critère de fermeture prouvé** : `grep -rn "from mcp_server.infrastructure" mcp_server/core/` → vide (était 3 lignes). Suite complète : 5137/5137 verte. ruff clean.

Signalé (hors périmètre, tracés) : issue #134 pour les 2 fichiers >500 lignes préexistants (wiki_classifier 916, wiki_axis_registry 705) ; et une dérive doc de docs/module-inventory.md (la table dit infra↛core alors que infra→core est le pattern établi et permis par §2.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)