### PR TITLE
fix(remember): honor write_class=deliberate gate contract; grading never blocks write

### DIFF
--- a/mcp_server/core/write_gate.py
+++ b/mcp_server/core/write_gate.py
@@ -116,8 +116,33 @@ def determine_bypass(
     force: bool,
     content: str,
     tags: list[str],
+    write_class: str = "",
 ) -> tuple[bool, str | None]:
-    """Determine if write gate should be bypassed and why."""
+    """Determine if write gate should be bypassed and why.
+
+    ``write_class`` (M-D2, issue #147): a resolved ``deliberate`` write is
+    NEVER rejected by the novelty gate — this is the tool's documented
+    contract (near-duplicates are still merged/linked/superseded by
+    ``try_curation`` afterward; bypassing the gate here only skips the
+    REJECT verdict, it does not skip curation, which reads ``force``
+    independently). ``write_class`` defaults to ``""`` (no bypass) so the
+    unit tests exercising the content/tag/force bypass paths in isolation
+    are unaffected; the real call site (``remember_helpers._compute_gate_decision``)
+    always passes the already-resolved class (never ``""`` — see
+    ``core/write_class.classify_write_class``'s postcondition: the return
+    value is always one of ``ALL_WRITE_CLASSES``).
+
+    Checked LAST (after the more specific content/tag bypasses): most
+    ``remember`` calls resolve to ``deliberate`` by default (any source not
+    in the auto/derived/mechanical sets — see ``write_class`` module
+    docstring), so checking it first would mask every content-based
+    ``bypass_error``/``bypass_decision``/``bypass_important_tag`` reason
+    behind the generic ``bypass_write_class_deliberate`` one. Ordering it
+    last preserves the more informative diagnostic reason where one
+    applies, while still guaranteeing every deliberate write bypasses
+    (falling through to the deliberate check when none of the more
+    specific conditions matched).
+    """
     is_error = thermodynamics.is_error_content(content)
     is_decision = thermodynamics.is_decision_content(content)
     has_important = bool({"important", "critical"} & {t.lower() for t in tags})
@@ -130,6 +155,8 @@ def determine_bypass(
         return True, "bypass_decision"
     if has_important:
         return True, "bypass_important_tag"
+    if write_class == "deliberate":
+        return True, "bypass_write_class_deliberate"
     return False, None
 
 

--- a/mcp_server/handlers/remember.py
+++ b/mcp_server/handlers/remember.py
@@ -191,7 +191,14 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
     valence = thermodynamics.compute_valence(content)
 
     gate = evaluate_gate(
-        content, tags, embedding, force, store, emb_engine, domain=domain
+        content,
+        tags,
+        embedding,
+        force,
+        store,
+        emb_engine,
+        domain=domain,
+        write_class=resolved_write_class,
     )
     if not gate["should_store"]:
         return write_gate.build_rejection_response(

--- a/mcp_server/handlers/remember_helpers.py
+++ b/mcp_server/handlers/remember_helpers.py
@@ -175,6 +175,7 @@ def _compute_gate_decision(
     content: str,
     tags: list[str],
     domain: str = "",
+    write_class: str = "",
 ) -> tuple[bool, str, float]:
     """Determine whether to store based on novelty score and bypass rules.
 
@@ -183,8 +184,14 @@ def _compute_gate_decision(
     loop); callers that observe the decision should feed it back via
     ``write_gate_calibration.record`` so the EMA converges to the target
     acceptance rate.
+
+    ``write_class`` (issue #147 fix): threaded into ``determine_bypass`` so
+    a resolved ``deliberate`` write is never rejected for low novelty, per
+    the tool's documented contract.
     """
-    bypass, bypass_reason = write_gate.determine_bypass(force, content, tags)
+    bypass, bypass_reason = write_gate.determine_bypass(
+        force, content, tags, write_class=write_class
+    )
     settings = get_memory_settings()
     base_threshold = settings.WRITE_GATE_THRESHOLD
     # Calibrated threshold overrides the static setting once the per-domain
@@ -206,18 +213,27 @@ def evaluate_gate(
     store: MemoryStore,
     emb_engine: EmbeddingEngine,
     domain: str = "",
+    write_class: str = "",
 ) -> dict[str, Any]:
     """Compute all novelty signals and gate decision.
 
     Contract:
       pre:  content is a non-empty string; embedding is either None or a
             valid vector; ``domain`` is the resolved (normalised) domain
-            for this write path.
+            for this write path; ``write_class`` is the ALREADY-RESOLVED
+            class from ``core.write_class.classify_write_class`` (issue
+            #147) — ``""`` only for callers/tests that don't care about
+            the write-class contract; production callers always pass the
+            resolved value (never ``""``).
       post: the returned dict contains ``should_store``, the observed
             ``gate_reason``, and the ``gate_threshold`` actually used for
             the decision. Side effect: the per-domain calibration EMA is
             updated via ``write_gate_calibration.record`` when the decision
             was NOT a bypass (bypasses are not informative for calibration).
+            A resolved ``write_class == "deliberate"`` NEVER yields
+            ``should_store is False`` (contract: deliberate writes are
+            never novelty-rejected; near-duplicates are still merged/
+            linked/superseded by ``try_curation`` afterward).
     """
     importance = thermodynamics.compute_importance(content, tags)
     sims, vec_hits = compute_similarities(embedding, store, emb_engine)
@@ -264,11 +280,12 @@ def evaluate_gate(
         score, content, ent_names, store
     )
     should_store, gate_reason, threshold = _compute_gate_decision(
-        score, force, content, tags, domain=domain
+        score, force, content, tags, domain=domain, write_class=write_class
     )
     # AF-5 feedback: record non-bypass decisions to drive the EMA. Bypasses
-    # (force, error, decision, important_tag) carry no calibration signal
-    # because the gate didn't actually decide on novelty.
+    # (force, error, decision, important_tag, deliberate write_class) carry
+    # no calibration signal because the gate didn't actually decide on
+    # novelty.
     settings = get_memory_settings()
     is_bypass = gate_reason in {
         "bypass",
@@ -276,6 +293,7 @@ def evaluate_gate(
         "bypass_error",
         "bypass_decision",
         "bypass_important_tag",
+        "bypass_write_class_deliberate",
     }
     if not is_bypass:
         write_gate_calibration.record(
@@ -656,6 +674,54 @@ def _run_post_store(
     return tids, tagged, slot
 
 
+def _grade_content_best_effort(
+    content: str, *, directory: str
+) -> tuple[provenance.ProvenanceReport, str | None]:
+    """Best-effort wrapper around ``validate_memory.grade_from_content``.
+
+    Root cause (issue #147): ``grade_from_content``'s ``base_dir`` fallback
+    calls ``os.getcwd()``, which raises ``FileNotFoundError`` when the
+    process's current working directory no longer exists (e.g. a worktree
+    the session was running in got cleaned up). Every OTHER enrichment step
+    in this insert path (``source_attribution`` classification, the
+    habituation signature) is already wrapped defensively; this call was
+    the sole exception -- an unguarded I/O-adjacent call inside what the
+    surrounding function's own contract calls a best-effort pass. Fixed at
+    the source by matching the established local pattern instead of
+    special-casing ``os.getcwd()``.
+
+    Postcondition: NEVER raises. On success returns
+    ``(grade_report, None)``. On any failure returns a fallback
+    ``ProvenanceReport`` graded ``UNVERIFIABLE`` (the same "we don't know"
+    default ``grade_provenance`` uses for zero extractable references) plus
+    the failing exception's type name, so the caller can surface it as an
+    observable tag instead of a silently absorbed enrichment.
+    """
+    try:
+        base_dir = directory or os.getcwd()
+    except OSError as exc:
+        return (
+            provenance.ProvenanceReport(
+                memory_id=0, grade=provenance.UNVERIFIABLE, ref_counts={}
+            ),
+            type(exc).__name__,
+        )
+    try:
+        return (
+            validate_memory.grade_from_content(
+                content, directory_context=directory, base_dir=base_dir
+            ),
+            None,
+        )
+    except Exception as exc:  # noqa: BLE001 — grading must never block a write
+        return (
+            provenance.ProvenanceReport(
+                memory_id=0, grade=provenance.UNVERIFIABLE, ref_counts={}
+            ),
+            type(exc).__name__,
+        )
+
+
 def insert_and_post_process(
     content: str,
     embedding: Any,
@@ -714,10 +780,20 @@ def insert_and_post_process(
     # evaluate_gate() (called by remember.py before this function), so the
     # tag can never influence the novelty/gate decision -- bench-neutral by
     # construction, no G-bench required for this increment.
-    grade_report = validate_memory.grade_from_content(
-        content, directory_context=directory, base_dir=directory or os.getcwd()
+    grade_report, grading_error = _grade_content_best_effort(
+        content, directory=directory
     )
     tags = [*tags, f"prov:{grade_report.grade}"]
+    if grading_error is not None:
+        # issue #147: grade_from_content's os.getcwd() fallback can raise
+        # FileNotFoundError when the process cwd has been removed mid-session
+        # (e.g. a worktree cleanup) -- unrelated to the DB and unrelated to
+        # write_class. This step is documented as best-effort (like every
+        # other enrichment in this function -- source_attribution above,
+        # habituation signature below); it must never block the insert.
+        # Surfaced as an observable tag rather than silently absorbed
+        # (coding-standards.md: no silent fallbacks).
+        tags = [*tags, f"prov-grading-failed:{grading_error}"]
     record = _build_insert_record(
         content,
         embedding,

--- a/mcp_server/tool_error_handler.py
+++ b/mcp_server/tool_error_handler.py
@@ -238,16 +238,13 @@ async def safe_handler(
                 )
             except Exception:
                 pass
-        hint = (
-            "If this persists, check that PostgreSQL is running "
-            "and DATABASE_URL is set correctly."
-            if error_type
-            not in (
-                "missing_extension",
-                "database_not_connected",
-                "explicit_database_url_unreachable",
-            )
-            else None
-        )
-        full_message = f"{error_type}: {message}" + (f"\n\n{hint}" if hint else "")
+        # issue #147: this used to append the DATABASE_URL hint to EVERY
+        # unclassified exception type (FileNotFoundError, ValueError, ...),
+        # not just DB-related ones -- misleading a user chasing a genuine
+        # filesystem/logic bug into "checking PostgreSQL" when it was
+        # demonstrably healthy. The two DB-specific categories already
+        # carry their own actionable guide as `message` itself
+        # (`_EXTENSION_GUIDE` / `_DB_SETUP_GUIDE`); a generic, unclassified
+        # exception gets no DB hint at all.
+        full_message = f"{error_type}: {message}"
         raise ToolError(full_message) from exc

--- a/tests_py/handlers/test_issue_147_write_class_and_grading.py
+++ b/tests_py/handlers/test_issue_147_write_class_and_grading.py
@@ -1,0 +1,272 @@
+"""Regression tests for issue #147.
+
+Two independent write-path defects observed in one MCP session, initially
+suspected to share a root cause but resolved to two distinct ones (Move 4,
+engineer.md — "classify the cause"):
+
+1. ``write_class="deliberate"`` (or omitted, source-fallback to deliberate)
+   was rejected by the novelty gate — violating the tool's documented
+   contract ("deliberate — NEVER rejected by the gate for low novelty").
+   Root cause: ``handlers/remember.py`` computed ``resolved_write_class``
+   but never threaded it into ``evaluate_gate`` -> ``determine_bypass``,
+   which had zero knowledge of write_class. Fixed by threading
+   ``write_class`` through ``evaluate_gate`` / ``_compute_gate_decision``
+   / ``core.write_gate.determine_bypass``.
+
+2. ``force=True`` (and plain, non-forced writes) intermittently raised a
+   bare ``FileNotFoundError`` with a misleading "check DATABASE_URL" hint,
+   even with a healthy PG connection. Root cause: the write-time provenance
+   grading step (``handlers/remember_helpers.py::insert_and_post_process``
+   calling ``validate_memory.grade_from_content(..., base_dir=directory or
+   os.getcwd())``) was the ONE unguarded I/O-adjacent call in a function
+   whose every other enrichment step (source_attribution, habituation
+   signature) is already wrapped defensively. ``os.getcwd()`` raises
+   ``FileNotFoundError`` when the process cwd has been removed (e.g. a
+   worktree cleanup mid-session) — unrelated to the DB. Fixed by wrapping
+   the grading call in ``_grade_content_best_effort`` (never raises;
+   returns a diagnostic UNVERIFIABLE report + an observable
+   ``prov-grading-failed:<ExceptionType>`` tag on failure) and by removing
+   the misleading DATABASE_URL hint for exception types
+   ``tool_error_handler._classify_error`` did not recognize as DB-related.
+
+The third symptom in the issue (``reason: "bypass_error"`` on a
+SUCCESSFUL store) was investigated and found to be BY DESIGN, not a bug:
+``bypass_error`` is the ``gate_reason`` for content that matches the
+error/exception-keyword regex (``core.thermodynamics.is_error_content``)
+— see ``TestBypassErrorIsNotAnInternalFailure`` below.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from mcp_server.core import write_gate
+from mcp_server.handlers.remember import handler
+from mcp_server.handlers.remember_helpers import (
+    _grade_content_best_effort,
+    _compute_gate_decision,
+)
+
+
+class TestDeliberateNeverNoveltyRejected:
+    """Regression (1): a resolved ``deliberate`` write must never be
+    rejected by the novelty gate, per the tool's documented contract."""
+
+    def test_determine_bypass_bypasses_plain_deliberate_content(self):
+        bypassed, reason = write_gate.determine_bypass(
+            force=False,
+            content="A routine, low-signal note with nothing special in it.",
+            tags=[],
+            write_class="deliberate",
+        )
+        assert bypassed is True
+        assert reason == "bypass_write_class_deliberate"
+
+    def test_determine_bypass_still_prefers_specific_content_reason(self):
+        """Deliberate is checked LAST — a more specific content-based
+        bypass reason (error/decision/tag) still wins when it applies, so
+        existing diagnostics are not masked by the generic deliberate
+        reason."""
+        bypassed, reason = write_gate.determine_bypass(
+            force=False,
+            content="An exception occurred during startup",
+            tags=[],
+            write_class="deliberate",
+        )
+        assert bypassed is True
+        assert reason == "bypass_error"
+
+    def test_non_deliberate_write_class_unaffected(self):
+        """auto/derived/mechanical classes still go through normal novelty
+        gating — only ``deliberate`` gets the blanket bypass."""
+        bypassed, reason = write_gate.determine_bypass(
+            force=False,
+            content="Plain content, no special keywords.",
+            tags=[],
+            write_class="auto",
+        )
+        assert bypassed is False
+        assert reason is None
+
+    def test_low_novelty_score_still_stores_for_deliberate(self):
+        """End-to-end through _compute_gate_decision: a novelty score well
+        below threshold must not produce a reject verdict when write_class
+        resolves to deliberate."""
+        should_store, gate_reason, _threshold = _compute_gate_decision(
+            score=0.01,  # far below the default 0.4 threshold
+            force=False,
+            content="Low novelty deliberate content with nothing distinctive.",
+            tags=[],
+            domain="",
+            write_class="deliberate",
+        )
+        assert should_store is True
+        assert gate_reason == "bypass_write_class_deliberate"
+
+    def test_handler_stores_low_novelty_deliberate_write_without_force(self):
+        """Full handler round-trip (issue repro): a plain, non-forced
+        write_class='deliberate' call must be stored, never
+        below_threshold-rejected."""
+        result = asyncio.run(
+            handler(
+                {
+                    "content": (
+                        "issue-147 regression: a low-novelty deliberate "
+                        "write must still be stored, never gate-rejected."
+                    ),
+                    "write_class": "deliberate",
+                }
+            )
+        )
+        assert result["stored"] is True
+        assert result["reason"] != "below_threshold"
+
+    def test_handler_stores_low_novelty_write_with_omitted_write_class(self):
+        """Omitting write_class falls back to deliberate (source-based
+        inference, core.write_class.classify_write_class) and must get the
+        same never-rejected treatment."""
+        result = asyncio.run(
+            handler(
+                {
+                    "content": (
+                        "issue-147 regression: omitted write_class also "
+                        "resolves to deliberate and must never be "
+                        "below_threshold-rejected."
+                    ),
+                }
+            )
+        )
+        assert result["stored"] is True
+        assert result["reason"] != "below_threshold"
+
+
+class TestGradingNeverBlocksTheWrite:
+    """Regression (2): a missing/removed process cwd must never surface as
+    a bare FileNotFoundError that blocks the write."""
+
+    def test_grade_content_best_effort_survives_missing_cwd(self):
+        """Direct unit test of the wrapper: os.getcwd() raising
+        FileNotFoundError (as it does when the process cwd has been
+        removed) must degrade to an UNVERIFIABLE report, never raise."""
+        with patch(
+            "os.getcwd", side_effect=FileNotFoundError(2, "No such file or directory")
+        ):
+            report, error = _grade_content_best_effort("plain content", directory="")
+        assert report.grade == "unverifiable"
+        assert error == "FileNotFoundError"
+
+    def test_grade_content_best_effort_passes_through_on_success(self, tmp_path):
+        report, error = _grade_content_best_effort(
+            "plain content with no refs", directory=str(tmp_path)
+        )
+        assert error is None
+        assert report.grade == "unverifiable"
+
+    def test_force_write_survives_missing_cwd(self):
+        """End-to-end (issue repro): a force=True write must still insert
+        even when the process cwd has been removed mid-session."""
+        with patch(
+            "os.getcwd", side_effect=FileNotFoundError(2, "No such file or directory")
+        ):
+            result = asyncio.run(
+                handler(
+                    {
+                        "content": (
+                            "issue-147 regression: force write must survive "
+                            "a missing process cwd."
+                        ),
+                        "force": True,
+                        # directory omitted so grade_from_content's
+                        # base_dir=directory or os.getcwd() fallback fires.
+                    }
+                )
+            )
+        assert result["stored"] is True
+        assert result["reason"] == "forced"
+        assert result["provenance"]["grade"] == "unverifiable"
+
+    def test_force_write_tags_grading_failure_observably(self):
+        """The grading failure must be surfaced as a tag on the row, not
+        silently absorbed (coding-standards.md: no silent fallbacks)."""
+        from mcp_server.infrastructure.memory_config import get_memory_settings
+        from mcp_server.infrastructure.memory_store import get_shared_store
+
+        with patch(
+            "os.getcwd", side_effect=FileNotFoundError(2, "No such file or directory")
+        ):
+            result = asyncio.run(
+                handler(
+                    {
+                        "content": (
+                            "issue-147 regression: grading failure must be "
+                            "tagged on the stored row."
+                        ),
+                        "force": True,
+                    }
+                )
+            )
+        assert result["stored"] is True
+        settings = get_memory_settings()
+        store = get_shared_store(settings.DB_PATH, settings.EMBEDDING_DIM)
+        row = store.get_memory(result["memory_id"])
+        tags = row.get("tags") or []
+        if isinstance(tags, str):
+            import json as _json
+
+            tags = _json.loads(tags)
+        assert any(t.startswith("prov-grading-failed:") for t in tags)
+
+
+class TestBypassErrorIsNotAnInternalFailure:
+    """Regression (3, non-bug confirmation): ``reason: "bypass_error"`` on
+    a SUCCESSFUL store is a legitimate, by-design content-based bypass
+    (error/exception-shaped content), not evidence of an internal
+    exception. Pinned here so a future "fix" doesn't rename/remove it."""
+
+    def test_error_shaped_content_bypasses_with_reason_bypass_error(self):
+        result = asyncio.run(
+            handler(
+                {
+                    "content": (
+                        "Fixed the connection exception that crashed the "
+                        "worker at startup."
+                    ),
+                }
+            )
+        )
+        assert result["stored"] is True
+        assert result["reason"] == "bypass_error"
+
+
+class TestNoMisleadingDatabaseUrlHintOnNonDbErrors:
+    """The tool_error_handler DATABASE_URL hint must not be appended to
+    unclassified, non-DB exception types (issue #147 point (d))."""
+
+    def test_filenotfound_gets_no_database_hint(self):
+        from mcp_server.tool_error_handler import _classify_error
+
+        exc = FileNotFoundError(2, "No such file or directory")
+        error_type, message = _classify_error(exc)
+        assert error_type == "FileNotFoundError"
+        # _classify_error itself never appends the hint — that happens in
+        # safe_handler's except block, which now unconditionally omits it
+        # for unclassified error types. Assert the classification is the
+        # raw, un-hinted exception type/message.
+        assert "DATABASE_URL" not in message
+
+    @pytest.mark.asyncio
+    async def test_safe_handler_omits_hint_for_filenotfounderror(self):
+        from fastmcp.exceptions import ToolError
+        from mcp_server.tool_error_handler import safe_handler
+
+        async def failing_handler(_args):
+            raise FileNotFoundError(2, "No such file or directory")
+
+        with pytest.raises(ToolError) as exc_info:
+            await safe_handler(failing_handler, {})
+
+        assert "DATABASE_URL" not in str(exc_info.value)
+        assert "FileNotFoundError" in str(exc_info.value)


### PR DESCRIPTION
## Root cause (two independent defects, not one)

### 1. `write_class="deliberate"` novelty-rejected — contract violation

`handlers/remember.py:167-169` computes `resolved_write_class` but never
threads it into `evaluate_gate` (`handlers/remember.py:193-194` pre-fix) ->
`_compute_gate_decision` -> `core/write_gate.py::determine_bypass`
(`write_gate.py:115-133` pre-fix), which had zero knowledge of write_class
— it only bypasses on `force` / error-keyword content / decision-keyword
content / `important`/`critical` tags. A plain, low-novelty `deliberate`
write (or one that omits `write_class`, which source-falls-back to
`deliberate` per `core/write_class.py`) fell straight through to the
ordinary novelty threshold and got `below_threshold`-rejected, contradicting
the tool's own documented contract ("deliberate — NEVER rejected by the
gate for low novelty; near-duplicates are still merged/linked/superseded by
curation").

**Fix:** thread the already-resolved `write_class` through `evaluate_gate` /
`_compute_gate_decision` / `determine_bypass`. `determine_bypass` now
bypasses on `write_class == "deliberate"`, checked **last** (after
force/error/decision/tag) so a more specific, more informative bypass
reason still wins when it applies — a deliberate write with error-shaped
content still reports `bypass_error`, not the generic
`bypass_write_class_deliberate`.

### 2. `force=True` intermittent `FileNotFoundError` + misleading DATABASE_URL hint

`handlers/remember_helpers.py::insert_and_post_process` (line 717-719
pre-fix) calls:

```python
grade_report = validate_memory.grade_from_content(
    content, directory_context=directory, base_dir=directory or os.getcwd()
)
```

unconditionally, for **every** successful insert (create/supersede), as
part of the M-D5 write-time provenance-grading step. This was the *one*
enrichment call in that function not wrapped in the same defensive
try/except pattern already used for its siblings (`source_attribution`
classification a few lines below, the habituation signature a few lines
after that). `os.getcwd()` raises `FileNotFoundError: [Errno 2] No such
file or directory` when the process's current working directory has been
removed — e.g. a worktree cleaned up mid-session — which is exactly the
observed intermittence (a call at ~12:30 succeeded because the cwd still
existed; two calls at ~14:00 failed because it had since been removed).
This is unrelated to the DB and unrelated to `write_class`; it happens
*before* the row is ever inserted, so the write is lost entirely.

The escaped exception then hit `tool_error_handler.py::safe_handler`'s
generic branch, which appended `"If this persists, check that PostgreSQL
is running and DATABASE_URL is set correctly."` to **any** unclassified
exception type — including `FileNotFoundError` — misleading a user chasing
a genuine filesystem issue into checking a database that was healthy the
entire time.

**Fix:**
- `_grade_content_best_effort` wraps the `os.getcwd()` + `grade_from_content`
  call; it never raises. On failure it returns a fallback `UNVERIFIABLE`
  `ProvenanceReport` and the caller appends an observable
  `prov-grading-failed:<ExceptionType>` tag to the row (never silently
  absorbed — matches the repo's anti-silent-fallback standard).
- `tool_error_handler.py::safe_handler` no longer appends the DATABASE_URL
  hint for exception types `_classify_error` didn't recognize as DB-related
  — the two genuinely DB-related categories already carry their own
  actionable guide text as the message body.

### Symptom 3 — `reason: "bypass_error"` on a successful store: not a bug

The issue speculated this was evidence of an internal exception in the
bypass machinery. Investigated and confirmed **by design**:
`bypass_error` is the `gate_reason` `determine_bypass` returns whenever
content matches `core/thermodynamics.py::is_error_content`'s
error/exception-keyword regex — a legitimate, existing, tested bypass path
(`tests_py/core/test_write_gate.py::TestDetermineBypass::test_error_content_bypasses`).
Two unrelated symptoms shared this label by pure name collision with the
observer's hypothesis, not by a shared code path. Pinned with
`TestBypassErrorIsNotAnInternalFailure` so it isn't "re-fixed" later.

## Files changed
- `mcp_server/core/write_gate.py` — `determine_bypass` gains a
  `write_class` parameter, checked last.
- `mcp_server/handlers/remember.py` — threads `resolved_write_class` into
  `evaluate_gate`.
- `mcp_server/handlers/remember_helpers.py` — `evaluate_gate` /
  `_compute_gate_decision` accept and forward `write_class`; new
  `_grade_content_best_effort` wraps the provenance-grading call.
- `mcp_server/tool_error_handler.py` — removes the misleading DATABASE_URL
  hint for unclassified, non-DB exception types.
- `tests_py/handlers/test_issue_147_write_class_and_grading.py` — 13 new
  regression tests.

## Test plan
- [x] `pytest tests_py/handlers/test_issue_147_write_class_and_grading.py` — 13/13 pass
- [x] `pytest tests_py/core/test_write_gate.py tests_py/handlers/test_remember.py tests_py/handlers/test_remember_provenance_at_write.py tests_py/handlers/test_remember_helpers_novelty_normalize.py tests_py/handlers/test_remember_helpers_silent_failures.py tests_py/server/test_tool_error_handler_classification.py` — 128/128 pass
- [x] Full suite: `pytest -q` — 5178 passed, 2 pre-existing failures
  (`tests_py/hooks/test_hook_receipts.py::test_agent_briefing_emits_receipt_with_marker`,
  `::test_agent_briefing_skips_superseded_prior_work`) confirmed failing
  identically on unmodified `main` (unrelated to this change — verified via
  `git stash` + targeted re-run before restoring the diff).
- [x] `ruff check .` — clean
- [x] `ruff format --check` on all touched files — clean

## Out of scope / self-flagged
- `mcp_server/handlers/remember_helpers.py` (935 lines) and
  `mcp_server/core/write_gate.py` (450 lines) already exceed the 300-line
  file cap on `main`, pre-dating this change. Not touched beyond the
  minimal diff required for this fix — a full split is a separate,
  much larger refactor out of this PR's blast radius.
- The recall/scoring path was not touched by this fix.

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)