### PR TITLE
fix(launcher-deps): defer dist-info prune until whole tmp_dir commits (issue #149)

### DIFF
--- a/scripts/launcher_deps_install.py
+++ b/scripts/launcher_deps_install.py
@@ -29,6 +29,27 @@ if _SCRIPTS_DIR not in sys.path:
 import launcher_deps_fs as _fs  # noqa: E402
 
 
+def _remove_path(path: str, *, best_effort: bool = False) -> None:
+    """Remove a file or directory at ``path``, whichever it is.
+
+    Precondition: ``path`` exists. Postcondition: ``path`` no longer
+    exists (or, with ``best_effort=True``, removal was attempted and any
+    ``OSError`` was swallowed — used for cleanup that must never mask
+    the caller's own in-flight exception).
+    """
+    if best_effort:
+        if os.path.isdir(path):
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            with contextlib.suppress(OSError):
+                os.remove(path)
+        return
+    if os.path.isdir(path):
+        shutil.rmtree(path, ignore_errors=True)
+    else:
+        os.remove(path)
+
+
 def commit_entry(tmp_dir: str, deps_dir: str, entry: str) -> str | None:
     """Move one top-level ``tmp_dir`` entry into ``deps_dir``.
 
@@ -52,10 +73,8 @@ def commit_entry(tmp_dir: str, deps_dir: str, entry: str) -> str | None:
     backup = f"{dest}.bak-{os.getpid()}"
     had_dest = os.path.exists(dest)
     if had_dest:
-        if os.path.isdir(backup):
-            shutil.rmtree(backup, ignore_errors=True)
-        elif os.path.exists(backup):
-            os.remove(backup)
+        if os.path.exists(backup):
+            _remove_path(backup, best_effort=True)
         os.replace(dest, backup)
     try:
         os.replace(src, dest)
@@ -64,19 +83,67 @@ def commit_entry(tmp_dir: str, deps_dir: str, entry: str) -> str | None:
             # Restore the pre-call state; leave `backup` for the caller's
             # rollback bookkeeping (removed once restore is confirmed).
             if os.path.exists(dest):
-                if os.path.isdir(dest):
-                    shutil.rmtree(dest, ignore_errors=True)
-                else:
-                    os.remove(dest)
+                _remove_path(dest, best_effort=True)
             os.replace(backup, dest)
         raise
     if had_dest:
-        if os.path.isdir(backup):
-            shutil.rmtree(backup, ignore_errors=True)
-        else:
-            with contextlib.suppress(OSError):
-                os.remove(backup)
+        _remove_path(backup, best_effort=True)
     return None
+
+
+def _entry_already_satisfied(
+    entry: str, tmp_versions: dict[str, str], dest_versions: dict[str, str]
+) -> bool:
+    """Idempotence guard (issue #97 suggestion 1): true iff ``dest``
+    already has the exact version ``tmp_dir`` resolved for ``entry`` --
+    protects a locked, already-correct transitive dep (e.g. numpy under
+    a running MCP server) from ever entering the rmtree/replace path."""
+    key = _fs.entry_dist_key(entry)
+    tmp_v = tmp_versions.get(key)
+    return tmp_v is not None and dest_versions.get(key) == tmp_v
+
+
+def _commit_resolved_entries(tmp_dir: str, deps_dir: str) -> tuple[bool, str | None]:
+    """Commit every top-level ``tmp_dir`` entry into ``deps_dir``.
+
+    Precondition: ``tmp_dir`` holds a completed, successful pip
+    ``--target`` install. Postcondition: ``(True, None)`` iff every
+    entry committed (or was already satisfied) and every stale
+    ``*.dist-info`` sibling has been pruned; ``(False, failed_entry)`` on
+    the first commit failure, with NO dist-info pruned and ``deps_dir``
+    restored for every entry processed so far.
+
+    Issue #149: ``os.listdir`` order is unspecified by the stdlib and
+    differs by OS/filesystem; a single distribution spans two entries
+    here (its ``.dist-info`` and its package directory), and the batch
+    is only atomic at the whole-``tmp_dir`` level (stops at the first
+    failure). Pruning the OLD dist-info per-entry, immediately after ITS
+    OWN commit, let an ordering where the dist-info committed before the
+    package directory delete the still-valid old metadata and then hit
+    the package-directory failure/rollback -- so the prune below now
+    waits for the whole batch to confirm success.
+    """
+    tmp_versions = _fs.dist_info_versions(tmp_dir)
+    dest_versions = _fs.dist_info_versions(deps_dir)
+    committed_dist_infos: list[str] = []
+    for entry in os.listdir(tmp_dir):
+        if _entry_already_satisfied(entry, tmp_versions, dest_versions):
+            continue
+        try:
+            commit_entry(tmp_dir, deps_dir, entry)
+        except OSError as exc:
+            print(
+                f"[cortex-launcher] commit failed for {entry}: {exc}. "
+                f"Rolled back; retry preserved at {tmp_dir}.",
+                file=sys.stderr,
+            )
+            return False, entry
+        if entry.endswith(".dist-info"):
+            committed_dist_infos.append(entry)
+    # Residue 2: only reached once the WHOLE tmp_dir has committed.
+    for entry in committed_dist_infos:
+        _fs.prune_superseded_dist_info(deps_dir, entry)
+    return True, None
 
 
 def pip_install(
@@ -112,6 +179,15 @@ def pip_install(
     the base pins as constraints on the ML install forces pip to solve
     within them, so a shared transitive agrees with the base pin instead
     of "whatever pip's resolver happens to pick this time."
+
+    # source: rules/coding-standards.md §4.2, §10 — this function is
+    # ~100 lines, over the 50-line / Medium-stakes-flexed 60-line budget.
+    # Pre-existing (137 lines before issue #149's fix; the fix already
+    # extracted the commit loop into `_commit_resolved_entries` and cut
+    # this by ~30 lines). The remainder is the PEP-668-retry + pip
+    # subprocess-invocation concern, unrelated to #149's bug and out of
+    # this change's blast radius; further splitting it is deferred to a
+    # dedicated structural pass rather than risked inside a flake fix.
     """
     tmp_dir = f"{deps_dir}.tmp-{os.getpid()}"
     clean_env = dict(os.environ)
@@ -178,35 +254,7 @@ def pip_install(
         shutil.rmtree(tmp_dir, ignore_errors=True)
         return False
 
-    tmp_versions = _fs.dist_info_versions(tmp_dir)
-    dest_versions = _fs.dist_info_versions(deps_dir)
-    ok = True
-    failed_entry: str | None = None
-    for entry in os.listdir(tmp_dir):
-        key = _fs.entry_dist_key(entry)
-        tmp_v = tmp_versions.get(key)
-        # Idempotence guard: dest already has this exact version — never
-        # touch it. This is what protects a locked, already-correct
-        # transitive dep (numpy under a running MCP server) from ever
-        # entering the rmtree/replace path.
-        if tmp_v is not None and dest_versions.get(key) == tmp_v:
-            continue
-        try:
-            commit_entry(tmp_dir, deps_dir, entry)
-        except OSError as exc:
-            failed_entry = entry
-            ok = False
-            print(
-                f"[cortex-launcher] commit failed for {entry}: {exc}. "
-                f"Rolled back; retry preserved at {tmp_dir}.",
-                file=sys.stderr,
-            )
-            break
-        else:
-            # Residue 2: only reached on a SUCCESSFUL commit — a
-            # cross-version bump just replaced dest's dist-info, so any
-            # older sibling for the same distribution is now stale.
-            _fs.prune_superseded_dist_info(deps_dir, entry)
+    ok, failed_entry = _commit_resolved_entries(tmp_dir, deps_dir)
     if ok:
         shutil.rmtree(tmp_dir, ignore_errors=True)
     else:

--- a/tests_py/scripts/test_launcher_deps.py
+++ b/tests_py/scripts/test_launcher_deps.py
@@ -215,6 +215,79 @@ def test_pip_install_rollback_on_mid_commit_failure(deps_mod, tmp_path, monkeypa
     assert (captured_tmp_dir["path"] / "numpy" / "__init__.py").exists()
 
 
+def test_pip_install_rollback_preserves_dist_info_regardless_of_commit_order(
+    deps_mod, tmp_path, monkeypatch
+):
+    """Issue #149 regression: ``os.listdir`` order is unspecified by the
+    stdlib and was observed to differ across CI's Python 3.10 runners,
+    making ``test_pip_install_rollback_on_mid_commit_failure`` flaky.
+    Root cause: the OLD ``numpy-2.2.6.dist-info`` was pruned as soon as
+    the NEW ``numpy-2.4.4.dist-info`` entry committed, before the
+    package-directory entry's commit failed and rolled back -- when
+    ``os.listdir`` happened to yield the dist-info entry first, the
+    prune ran and destroyed the still-valid old metadata ahead of the
+    overall failure. This test forces that exact ordering deterministically
+    (independent of host filesystem enumeration order) so the race can
+    never silently reappear."""
+    deps_dir = tmp_path / "deps"
+    deps_dir.mkdir()
+    _make_pkg_dir(deps_dir, "numpy", marker="ORIGINAL")
+    _make_dist_info(deps_dir, "numpy", "2.2.6")
+
+    captured_tmp_dir = {}
+
+    def fake_run(cmd, **kwargs):
+        tmp_dir = Path(cmd[cmd.index("--target") + 1])
+        captured_tmp_dir["path"] = tmp_dir
+        _make_pkg_dir(tmp_dir, "numpy", marker="FRESH")
+        _make_dist_info(tmp_dir, "numpy", "2.4.4")
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Result()
+
+    monkeypatch.setattr(deps_mod._install.subprocess, "run", fake_run)
+
+    real_replace = os.replace
+
+    def flaky_replace(src, dst):
+        if str(src).endswith(os.path.join("numpy")) and ".tmp-" in str(src):
+            raise PermissionError(
+                "[WinError 5] Access is denied (simulated locked .pyd)"
+            )
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(deps_mod._install.os, "replace", flaky_replace)
+
+    real_listdir = os.listdir
+
+    def forced_listdir(path):
+        # Force the dist-info entry to be enumerated BEFORE the package
+        # directory entry, for tmp_dir only -- the ordering the flake
+        # needed to trigger.
+        names = real_listdir(path)
+        if captured_tmp_dir.get("path") is not None and str(path) == str(
+            captured_tmp_dir["path"]
+        ):
+            return sorted(names, key=lambda n: (not n.endswith(".dist-info"), n))
+        return names
+
+    monkeypatch.setattr(deps_mod._install.os, "listdir", forced_listdir)
+
+    ok = deps_mod._pip_install(str(deps_dir), ["numpy==2.4.4"])
+
+    assert ok is False
+    assert "ORIGINAL" in (deps_dir / "numpy" / "__init__.py").read_text(
+        encoding="utf-8"
+    )
+    # The invariant issue #149 broke: the old dist-info must survive an
+    # overall-failed commit even when its OWN entry committed first.
+    assert (deps_dir / "numpy-2.2.6.dist-info").is_dir()
+
+
 def test_pip_install_no_backup_leaked_on_success(deps_mod, tmp_path, monkeypatch):
     """A successful commit leaves no ``*.bak-<pid>`` residue behind."""
     deps_dir = tmp_path / "deps"


### PR DESCRIPTION
## Summary

Fixes the Python-3.10-only flake in `test_pip_install_rollback_on_mid_commit_failure` (#149).

**Mechanism (confirmed by deterministic forced-ordering reproducer, not just reruns):**
`pip_install`'s per-entry commit loop in `scripts/launcher_deps_install.py` called
`_fs.prune_superseded_dist_info(deps_dir, entry)` immediately after EACH individual
entry committed, inside the loop. `os.listdir()` order is unspecified by the Python
stdlib and differs by OS/filesystem/container image (this explains "py3.10-only in
CI, always green in 3.11-3.13" — the runners differ in directory-enumeration order,
not in pip/importlib behavior). When the `*.dist-info` entry happened to be
enumerated before the package-directory entry, the prune step permanently deleted
the OLD (still-valid) dist-info right after the new one committed — then the
package-directory entry's own commit failed (simulated locked `.pyd` on Windows;
the mid-commit-failure scenario the test exercises) and rolled back to the
ORIGINAL package files, leaving `deps_dir` in a genuinely inconsistent state:
package files reverted to the old version, but the old version's metadata gone.
This was a real defect in the rollback logic, not a test artifact — it just needed
the right `os.listdir` ordering to surface, which is why it was flaky rather than
always-failing.

**Fix:** collect committed `*.dist-info` entry names during the loop; only run the
destructive prune once the *whole* `tmp_dir` has committed successfully. The one
irreversible step now waits for confirmation of overall success regardless of
`os.listdir` enumeration order — closing the race by construction, not by luck of
ordering.

**Also:** split `pip_install`'s commit loop into `_commit_resolved_entries` +
`_entry_already_satisfied` (this is the exact concern that carried the bug), and
extracted `_remove_path` to fix two pre-existing `NESTING_TOO_DEEP` violations in
`commit_entry` that the pre-commit craftsmanship hook flagged once this file was
touched. `pip_install` itself remains over the 50-line function budget
(pre-existing debt, mostly PEP-668-retry + subprocess-invocation logic unrelated
to #149) — documented as an out-of-scope §10 rationale rather than expanded into
this fix's blast radius.

## Verification

- Deterministic forced-`os.listdir`-order reproducer: fails against pre-fix code,
  passes post-fix.
- New permanent regression test
  `test_pip_install_rollback_preserves_dist_info_regardless_of_commit_order`
  monkeypatches `os.listdir` to force the dangerous ordering — confirmed it FAILS
  against the pre-fix code (mutant-kill) and passes post-fix.
- 60x loop of both the original flaky test and the new regression test under
  Python 3.10.18 (provisioned locally via `uv venv --python 3.10`, since this
  machine doesn't have 3.10 on `PATH` by default): **0/120 failures**.
- Full `tests_py/scripts/test_launcher_deps.py`: 32/32 green under 3.10.
- Full suite (`uv run pytest`, Python 3.13.7, this repo's normal env): **5179
  passed**, 2 pre-existing failures in `tests_py/hooks/test_hook_receipts.py`
  (unrelated — reproduced in isolation, independent of this change; not touched
  by this diff).
- `ruff check` + `ruff format --check`: clean.

Fixes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)