### PR TITLE
chore(marketplace): bump zetetic-team-subagents pin to 2.29.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -71,7 +71,7 @@
         "repo": "cdeust/zetetic-team-subagents"
       },
       "description": "Zetetic agent team for Cortex — 97 genius reasoning patterns from history's greatest minds + 19 team specialists (architect, engineer, code-reviewer, refactorer, …), 63 skills, 24 commands, 18 tools, 17 hooks, under one epistemic standard none of them can bypass. Composes with Cortex memory: every agent recalls/remembers through the Cortex MCP and routes via /genius, /agent, /zetetic, /quality, /research commands.",
-      "version": "2.28.1",
+      "version": "2.29.0",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"


### PR DESCRIPTION
zetetic-team-subagents v2.29.0 is published (ACL _user scope fix #31, worktree sweep safety #33, CMA facilitators). The Cortex marketplace entry still pins 2.28.1. One-field bump; the marketplace serves from the git tree so no Cortex re-release is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxpvWMSYo2FLCw4c1xw7iJ