### PR TITLE
feat(install): SQLite-first plugin install — full hook experience, zero system PostgreSQL

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -20,9 +20,9 @@
   "userConfig": {
     "database_url": {
       "type": "string",
-      "title": "Cortex database URL",
-      "description": "PostgreSQL connection string (postgresql://[user[:pass]@]host[:port]/dbname). Leave as the default for a local install; set this to point Cortex at a remote or credentialed database. Your value persists across plugin updates.",
-      "default": "postgresql://127.0.0.1:5432/cortex"
+      "title": "Cortex database URL (optional — PostgreSQL only)",
+      "description": "Leave empty for the default zero-config SQLite store (~/.claude/methodology/memory.db). To use PostgreSQL instead, set a connection string (postgresql://[user[:pass]@]host[:port]/dbname) — a non-empty value here always wins over the SQLite default and is never silently downgraded. Your value persists across plugin updates.",
+      "default": ""
     }
   },
   "mcpServers": {
@@ -41,7 +41,7 @@
   },
   "postInstall": {
     "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/install-plugin.sh",
-    "message": "Installing Cortex (PostgreSQL + pgvector + Python deps + embedding model) and removing any stale older Cortex installs..."
+    "message": "Installing Cortex (Python deps + zero-config SQLite memory; existing PostgreSQL installs are detected and kept). Upgrade anytime: bash <plugin>/scripts/install-plugin.sh --postgres"
   },
   "hooks": {
     "SessionStart": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,11 +245,14 @@ jobs:
       # on native Windows (Git Bash reports uname -s as MINGW64_NT-*/
       # MSYS_NT-*/CYGWIN_NT-*, matched by neither its Darwin nor Linux branch)
       # went undetected. The job-level CORTEX_MEMORY_STORE_BACKEND: sqlite
-      # (above) makes scripts/setup.py skip PostgreSQL provisioning (see its
-      # module docstring) so this runs without provisioning a PostgreSQL
-      # server on the runner, while still exercising the real OS dispatch in
-      # install-plugin.sh, the real scripts/setup.py subprocess calls, and
-      # the real embedding-model caching path.
+      # (above) makes install-plugin.sh/scripts/setup.py take the SQLite
+      # path — now the plugin's production DEFAULT, not a CI-only mode —
+      # so this runs without provisioning a PostgreSQL server on the
+      # runner, while still exercising the real backend selection +
+      # marker write in install-plugin.sh and the real scripts/setup.py
+      # subprocess calls. The embedding model is deliberately NOT cached
+      # by this path anymore (lazy first-use download); the HF
+      # pre-download step above provides the model for the test steps.
       - name: Exercise real postInstall path (install-plugin.sh -> setup.py)
         shell: bash
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,12 @@
 # Cortex — Persistent Memory MCP Server
 
 Persistent memory and cognitive profiling MCP server for Claude Code.
-Python 3.10+, FastMCP, Pydantic, numpy. Storage: PostgreSQL+pgvector
-(plugin/CLI mode) or SQLite (`.mcpb`/Cowork sandboxed launches) — see
-`PRIVACY.md` for the per-surface truth.
+Python 3.10+, FastMCP, Pydantic, numpy. Storage: SQLite by default
+(plugin installs, `.mcpb`/Cowork sandboxed launches) or
+PostgreSQL+pgvector as the opt-in upgrade (`install-plugin.sh
+--postgres`, CLI/dev mode, team databases) — see `PRIVACY.md` for the
+per-surface truth and `mcp_server/infrastructure/backend_marker.py`
+for how the plugin persists the choice.
 
 ## Problem Statement
 
@@ -16,7 +19,7 @@ coding write gates, causal graphs, and intent-aware retrieval.
 ## Build & Test
 
 - Install (dev): `uv pip install -e ".[dev]"` — SQLite backend: `".[dev,sqlite]"`
-- Environment preflight: `python -m mcp_server.doctor` (7 checks, fix message per check)
+- Environment preflight: `python -m mcp_server.doctor` (backend-aware check list, fix message per check)
 - Tests: `pytest` (full suite, 3000+ tests) · `pytest tests_py/core/` (one layer) · `pytest --cov=mcp_server --cov-report=term-missing`
 - Lint BEFORE every commit: `ruff check && ruff format --check` — the CI enforces **both**; passing only `ruff check` is not enough.
 - Release gate benchmarks (isolated, ephemeral container — the only source
@@ -44,8 +47,10 @@ separate **cortex-viz** MCP (reads this same store read-only).
 - @docs/module-inventory.md — per-layer module catalogue + dependency rules
 - @docs/mcp-tools.md — the 51 standalone + 3 conditionally-registered MCP
   tools, by tier, with purpose and target latency
-- @PRIVACY.md — storage truth by launch surface (lines 26–36): SQLite is
-  the default for `.mcpb`/Cowork; PostgreSQL is used in plugin/CLI mode
+- @PRIVACY.md — storage truth by launch surface (lines 26–38): SQLite is
+  the default for plugin installs and `.mcpb`/Cowork; PostgreSQL is the
+  opt-in upgrade (`install-plugin.sh --postgres` / configured
+  `DATABASE_URL`)
 
 ## Code Style
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -23,18 +23,19 @@ like any other memory (locally) — avoid doing so.
 
 ## Where your data is stored
 
-- **SQLite (default — Claude Desktop `.mcpb` connector, Claude Cowork, and
-  other sandboxed launches):** all memories, entities, the knowledge graph, and
-  profiles are stored in a single local database file at
-  `~/.claude/methodology/memory.db`. If a configured PostgreSQL instance is
-  unreachable, Cortex falls back to this SQLite store with an explicit warning
-  in the logs. Nothing is uploaded.
-- **PostgreSQL + pgvector (Claude Code plugin / CLI mode, large stores, shared
-  team databases):** your data is stored in **your own** database, configured
-  via the `DATABASE_URL` environment variable (default
-  `postgresql://127.0.0.1:5432/cortex`); the plugin's setup script installs
-  PostgreSQL locally on your machine. Cortex never provisions or connects to
-  any database you did not configure.
+- **SQLite (default — Claude Code plugin installs, Claude Desktop `.mcpb`
+  connector, Claude Cowork, and other sandboxed launches):** all memories,
+  entities, the knowledge graph, and profiles are stored in a single local
+  database file at `~/.claude/methodology/memory.db`. If a configured
+  PostgreSQL instance is unreachable, Cortex falls back to this SQLite store
+  with an explicit warning in the logs. Nothing is uploaded.
+- **PostgreSQL + pgvector (opt-in — `install-plugin.sh --postgres`, large
+  stores, shared team databases):** your data is stored in **your own**
+  database, configured via the `DATABASE_URL` environment variable (default
+  `postgresql://127.0.0.1:5432/cortex`); the opt-in setup script installs
+  PostgreSQL locally on your machine, and an existing PostgreSQL install is
+  detected and kept across plugin updates. Cortex never provisions or
+  connects to any database you did not configure.
 
 You own this data. Deleting the database file (or the relevant rows) permanently
 removes it. The `forget` tool deletes individual memories.

--- a/README.md
+++ b/README.md
@@ -55,21 +55,31 @@ It runs immediately on the built-in **SQLite backend**: zero configuration, no d
 
 Want PostgreSQL + pgvector instead (for very large stores or a shared team database)? It's a single configuration field — see [Configuration](#configuration) below. SQLite is the default; PostgreSQL is opt-in.
 
-<details>
-<summary><strong>More options</strong> (Claude Code plugin, Clone, Docker)</summary>
-
 **Claude Code plugin (marketplace):**
 ```bash
 claude plugin marketplace add cdeust/Cortex
 claude plugin install cortex
 ```
-The plugin path also registers the lifecycle hooks (session-start context injection, compaction checkpointing, the autonomous wiki cycle) and the `/cortex-setup-project` command. If you point the plugin at PostgreSQL, run `/cortex-setup-project` once — it handles pgvector installation, database creation, the embedding-model download, profile building, codebase seeding, and hook registration.
+That is the whole install — zero configuration, no PostgreSQL, no system packages. The postInstall provisions Python dependencies and selects the local **SQLite** store (`~/.claude/methodology/memory.db`); the store schema auto-creates on first use. The embedding model is *not* downloaded at install time — it fetches lazily on first use (~100 MB, one-time; see [PRIVACY.md](PRIVACY.md)) and runs fully offline afterwards. The plugin path registers all lifecycle hooks (session-start context injection, per-prompt auto-recall, auto-capture, compaction checkpointing, the autonomous wiki cycle) and the `/cortex-setup-project` command.
 
-If you configured the **PostgreSQL** backend, verify the connection:
+An **existing PostgreSQL install is never downgraded**: the installer detects a configured `DATABASE_URL`, a prior PostgreSQL backend marker, or a reachable local `cortex` database and keeps using it across plugin updates.
+
+**Upgrading the plugin to PostgreSQL (optional):**
+```bash
+bash <plugin-dir>/scripts/install-plugin.sh --postgres   # <plugin-dir> = the installed plugin root
+```
+In one line: PostgreSQL adds connection-pooled concurrency (two `psycopg_pool` latency classes), server-side PL/pgSQL WRRF fusion, and pgvector HNSW ANN indexing — worth it for very large stores or a shared team database (see [Under the Hood](#under-the-hood)); the memory tools and retrieval contract are identical on both backends. After upgrading, run `/cortex-setup-project` once — it handles pgvector setup, database creation, the embedding-model pre-cache, profile building, codebase seeding, and hook registration.
+
+**What SQLite mode does *not* do (honest disclosure):** the WRRF fusion runs in-process instead of server-side, without HNSW ANN indexing (fine at personal-store scale, slower at very large scale); and three PostgreSQL-only hook enrichments degrade to silent no-ops — cross-agent team-decision injection (`agent_briefing`, plus the banner's Team Decisions section), file-based preemptive context (`preemptive_context`), and pipeline symbol heat-bumps (`pipeline_impact_bump`). Session-start banners, auto-recall injection, auto-capture, checkpoints, and all 50 memory tools work on both backends.
+
+Verify any install:
 ```bash
 python3 -m mcp_server.doctor
 ```
-Seven checks in two seconds: Python, the PG driver, `DATABASE_URL`, connection, extensions, a writable methodology dir, and the pool-capacity invariant. Exit 0 means the PostgreSQL path is ready. (On the default SQLite backend the PostgreSQL checks report "not set" and can be ignored — SQLite needs no doctor.)
+The check list is backend-aware: on SQLite it verifies Python, the store opens, a writable methodology dir, and the pool-capacity invariant; on PostgreSQL it additionally checks the PG driver, `DATABASE_URL`, connection, and extensions. Exit 0 means ready.
+
+<details>
+<summary><strong>More options</strong> (Clone, Docker, PyPI)</summary>
 
 **Clone + setup script:**
 ```bash

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -39,7 +39,7 @@ upstream MCP server is configured (54 total with both present).
 | `backfill_memories` | Auto-import prior Claude Code conversations | varies |
 | `unified_search` | Unified retrieval across memories, wiki, and code graph | <200ms |
 | `get_telemetry` | Retrieval and memory-system telemetry metrics | <50ms |
-| `check_setup` | Verify local install (Python, PG driver, DATABASE_URL, connection, extensions, FS) — facade over `mcp_server.doctor` | <500ms |
+| `check_setup` | Verify local install, backend-aware (SQLite: store open + FS; PostgreSQL: PG driver, DATABASE_URL, connection, extensions, FS) — facade over `mcp_server.doctor` | <500ms |
 
 ## Tier 2 — Navigation & Exploration (7 tools)
 
@@ -103,7 +103,7 @@ read-only.
 |---|---|---|
 | `/methodology` | Retrieves the cognitive methodology profile (via `query_methodology`) for the current working directory and offers `rebuild_profiles` / `list_domains` / `get_methodology_graph` follow-ups | Any user, any session — the general entry point into a domain's profile |
 | `/why` | Deterministic blame-path: resolves `⟦rcpt:id⟧` presence-in-context markers via the `why` tool, reports which memories were in context (never that they *caused* an answer — Pearl-rung-1 evidence only) | Anyone auditing why an answer looked the way it did |
-| `/preflight [symptôme]` | Runs `python -m mcp_server.doctor` (7 checks) and turns the output into a dependency-ordered, copy-paste repair plan; takes an optional symptom argument to prioritize the relevant check first. Read-only — modifies no files | New users whose install doesn't work yet; support; first-deploy DevOps (issue #119) |
+| `/preflight [symptôme]` | Runs `python -m mcp_server.doctor` (backend-aware check list) and turns the output into a dependency-ordered, copy-paste repair plan; takes an optional symptom argument to prioritize the relevant check first. Read-only — modifies no files | New users whose install doesn't work yet; support; first-deploy DevOps (issue #119) |
 
 **Convention for adding a new command:** one new `.md` file under
 `commands/` (frontmatter: `name`, `description`, and `allowed-tools` if the

--- a/docs/module-inventory.md
+++ b/docs/module-inventory.md
@@ -202,14 +202,16 @@ Run the measurement command in the header to get a current file listing.
 - `pg_store_stats.py` — Statistics and diagnostics queries
 - `pg_schema.py` — DDL, extensions, PL/pgSQL stored procedures, migrations
 - `memory_config.py` — Runtime configuration (DATABASE_URL, env vars with CORTEX_MEMORY_ prefix)
+- `backend_marker.py` — Persisted plugin backend selection: reads `~/.claude/methodology/backend.json` (written by `scripts/install-plugin.sh`) and resolves it into `CORTEX_MEMORY_STORE_BACKEND` for the launcher, hooks, and doctor
 - `memory_store.py` — Memory store abstraction
 - `embedding_engine.py` — Vector embeddings (384-dim, sentence-transformers)
 - `artifact_store.py` — Content-addressed raw-output artifacts (`~/.claude/methodology/artifacts/<yyyy-mm>/<sha256[:16]>.md`) backing gist+pointer memories
 - `agent_config.py` — Agent configuration and topic scoping
 - `wiki_schema_reader.py` — Filesystem adapter for `core/wiki_schema_loader.py`'s data model/parsers; walks `wiki/_kinds|_rules|_views|_triggers/` and builds a `WikiRegistry` (issue #126 port-and-adapter split)
 
-Note: `pg_store.py` persists to PostgreSQL when configured (plugin/CLI mode);
-see `PRIVACY.md` for the SQLite-default fallback used by `.mcpb`/Cowork
+Note: `pg_store.py` persists to PostgreSQL when configured (the
+`install-plugin.sh --postgres` opt-in or an explicit `DATABASE_URL`);
+see `PRIVACY.md` for the SQLite default used by plugin installs and `.mcpb`/Cowork
 launches — this file does not assert PostgreSQL is mandatory (that assertion
 was the drift #114 was filed against).
 

--- a/mcp_server/doctor.py
+++ b/mcp_server/doctor.py
@@ -1,12 +1,24 @@
 """`cortex doctor` — diagnostic CLI for plugin-marketplace users.
 
 Helps users verify Cortex has everything it needs before first
-interactive session. Checks:
+interactive session. The check list is backend-aware
+(``active_checks()``): on the zero-config SQLite default the PostgreSQL
+driver/connection/extension checks are replaced by a SQLite store-open
+check, so a healthy SQLite install reports green instead of four false
+failures.
+
+PostgreSQL backend checks:
   * Python version >= 3.10
   * psycopg + pgvector Python packages import
   * DATABASE_URL reachable, PG >= 15
   * pgvector + pg_trgm extensions installed
   * memories table exists (schema auto-init ran)
+  * cache dir ~/.claude/methodology is writable
+  * POOL_INTERACTIVE_MAX matches I10 invariant
+
+SQLite backend checks:
+  * Python version >= 3.10
+  * SQLite store opens and its schema initializes
   * cache dir ~/.claude/methodology is writable
   * POOL_INTERACTIVE_MAX matches I10 invariant
 
@@ -262,6 +274,35 @@ def _i10_config() -> Check:
         return Check("I10 pool capacity", False, f"{type(exc).__name__}: {exc}", "")
 
 
+def _sqlite_store() -> Check:
+    """SQLite backend: the store opens and its schema initializes.
+
+    One check replaces the four PG checks (driver, URL, connection,
+    extensions): SqliteMemoryStore's constructor runs the DDL +
+    migrations, so a successful open proves the whole storage path.
+    """
+    try:
+        from mcp_server.infrastructure.memory_config import get_memory_settings
+        from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
+
+        path = get_memory_settings().SQLITE_FALLBACK_PATH
+        store = SqliteMemoryStore(db_path=path)
+        try:
+            total = int(store.count_memories().get("total") or 0)
+        finally:
+            store.close()
+        return Check("SQLite store", True, f"{path} ({total} memories)")
+    except Exception as exc:
+        return Check(
+            "SQLite store",
+            False,
+            f"{type(exc).__name__}: {exc}",
+            "Check that ~/.claude/methodology is writable and memory.db is "
+            "not corrupt (back it up, then delete it to let the schema "
+            "re-initialize).",
+        )
+
+
 CHECKS: list[Callable[[], Check]] = [
     _python_version,
     _pg_driver,
@@ -272,6 +313,34 @@ CHECKS: list[Callable[[], Check]] = [
     _i10_config,
     _codebase_pipeline,  # optional — doesn't fail doctor
 ]
+
+SQLITE_CHECKS: list[Callable[[], Check]] = [
+    _python_version,
+    _sqlite_store,
+    _methodology_dir,
+    _i10_config,
+    _codebase_pipeline,  # optional — doesn't fail doctor
+]
+
+
+def active_checks() -> list[Callable[[], Check]]:
+    """Backend-appropriate check list (single point of truth).
+
+    Resolves the backend exactly like the launcher/hooks do
+    (env var, then the installer's backend marker — see
+    ``infrastructure.backend_marker.effective_backend``), so doctor
+    diagnoses the same store the server would actually open. Any
+    resolution failure falls back to the PostgreSQL list — the
+    stricter, historical behaviour.
+    """
+    try:
+        from mcp_server.infrastructure.backend_marker import effective_backend
+
+        if effective_backend(os.environ) == "sqlite":
+            return SQLITE_CHECKS
+    except Exception:
+        pass
+    return CHECKS
 
 
 def run() -> int:
@@ -298,7 +367,7 @@ def run() -> int:
 
 def _run_full_check() -> int:
     """Full setup verification (legacy `cortex-doctor` behaviour)."""
-    checks = [c() for c in CHECKS]
+    checks = [c() for c in active_checks()]
     width = max(len(c.name) for c in checks) + 2
 
     print("Cortex doctor — setup verification")

--- a/mcp_server/handlers/check_setup.py
+++ b/mcp_server/handlers/check_setup.py
@@ -7,20 +7,22 @@ instead of console text, mirroring the `check_vision_setup` /
 plugins: call once before first interactive session to confirm the
 environment before install day.
 
-No check logic is duplicated here — every entry in `doctor.CHECKS` is
-imported and invoked as-is, in doctor's own dependency order (Python
-version -> PG driver -> DATABASE_URL -> live PG connection -> pgvector
-/pg_trgm extensions -> ~/.claude/methodology writability -> I10 pool
-config -> optional automatised-pipeline probe). A failure early in the
-list explains later ones (e.g. no DATABASE_URL implies no PG
-connection), so callers should fix in list order.
+No check logic is duplicated here — every entry in doctor's
+backend-aware `active_checks()` list is imported and invoked as-is, in
+doctor's own dependency order (PostgreSQL backend: Python version -> PG
+driver -> DATABASE_URL -> live PG connection -> pgvector/pg_trgm
+extensions -> ~/.claude/methodology writability -> I10 pool config ->
+optional automatised-pipeline probe; SQLite backend: Python version ->
+SQLite store open -> writability -> I10 -> pipeline probe). A failure
+early in the list explains later ones (e.g. no DATABASE_URL implies no
+PG connection), so callers should fix in list order.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from mcp_server.doctor import CHECKS, Check
+from mcp_server.doctor import Check, active_checks
 from mcp_server.handlers._tool_meta import READ_ONLY_EXTERNAL
 
 # ── Schema ────────────────────────────────────────────────────────────────
@@ -31,11 +33,14 @@ schema = {
     "description": (
         "Verify the local Cortex installation before first interactive "
         "use. Runs the identical check functions as `python -m "
-        "mcp_server.doctor` (no duplicated logic): Python >= 3.10, "
+        "mcp_server.doctor` (no duplicated logic), backend-aware. "
+        "PostgreSQL backend: Python >= 3.10, "
         "psycopg/psycopg_pool/pgvector driver imports, DATABASE_URL set, "
         "live PostgreSQL connection, pgvector + pg_trgm extensions, "
         "~/.claude/methodology writability, I10 pool-capacity invariant, "
         "and an optional automatised-pipeline codebase-tool probe. "
+        "SQLite backend (zero-config default): the PG checks are replaced "
+        "by a single SQLite store-open check. "
         "Checks run in doctor's own dependency order, so an early "
         "failure (e.g. missing DATABASE_URL) explains later ones (e.g. "
         "no PG connection) -- fix in list order. Call this once before "
@@ -58,16 +63,17 @@ schema = {
 
 def _run_checks() -> list[Check]:
     """precondition: none.
-    postcondition: returns one Check per `doctor.CHECKS` entry, in
-    doctor's own order -- this function performs no reordering or
-    filtering; it only invokes doctor's callables and collects results.
+    postcondition: returns one Check per `doctor.active_checks()` entry
+    (backend-aware list), in doctor's own order -- this function performs
+    no reordering or filtering; it only invokes doctor's callables and
+    collects results.
     """
-    return [check_fn() for check_fn in CHECKS]
+    return [check_fn() for check_fn in active_checks()]
 
 
 async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
     """precondition: none -- takes no arguments.
-    postcondition: `checks` has exactly `len(CHECKS)` entries in
+    postcondition: `checks` has exactly `len(active_checks())` entries in
     doctor's dependency order; `ready` is True iff no non-optional
     check failed; `fixes_needed` counts failing non-optional checks
     only (an optional-check failure, e.g. the codebase-pipeline probe,

--- a/mcp_server/hooks/auto_recall.py
+++ b/mcp_server/hooks/auto_recall.py
@@ -25,7 +25,9 @@ Source backing:
 
 Strategy:
   1. Receive user message text from stdin JSON
-  2. Run fast PG query: FTS match + heat filter (no embedding load)
+  2. Run a fast FTS query — PG plainto_tsquery, or SQLite FTS5 through
+     the store abstraction on the zero-config backend — plus heat filter
+     (no embedding load either way)
   3. If relevant memories found, format as compact context block
   4. Exit 0 → stdout injected into Claude's context
   5. If nothing found, exit 1 → no injection, no noise
@@ -33,7 +35,7 @@ Strategy:
 Performance constraints:
   - Must complete within 3s (hook timeout)
   - No embedding model load (takes 5-8s)
-  - FTS-only query on PG (plainto_tsquery, sub-100ms)
+  - FTS-only query (PG plainto_tsquery / SQLite FTS5, sub-100ms)
   - Max 3 memories injected (keep context compact)
   - Skip very short queries (<10 chars) to avoid noise
 
@@ -70,6 +72,7 @@ from typing import Any
 
 from mcp_server.handlers.injection_receipts import (
     emit_hook_receipt,
+    emit_injection_receipt,
     receipt_marker,
     session_id_from_transcript,
 )
@@ -200,6 +203,111 @@ def _recall_memories(conn, query: str) -> list[dict]:
     return results[:_MAX_MEMORIES]
 
 
+# ── SQLite backend path (zero-config plugin default) ─────────────────────
+
+
+def _backend_is_sqlite() -> bool:
+    """True when the resolved store backend is the SQLite store."""
+    try:
+        from mcp_server.infrastructure.backend_marker import effective_backend
+
+        return effective_backend(os.environ) == "sqlite"
+    except Exception:
+        return False
+
+
+def _fts_query_from_prompt(query: str) -> str:
+    """Build a defensive FTS5 OR-query from the prompt's content words.
+
+    PG's ``plainto_tsquery`` strips stopwords and stems before matching;
+    SQLite FTS5's default unicode61 tokenizer does neither, so MATCHing
+    the raw prompt ANDs every token ("why is the deploy script...") and
+    almost never hits. Mirror the stopword strip with the shared
+    ``STOPWORDS`` list, then OR the remaining terms: FTS5 has no
+    stemming, so exact-token AND would drop the whole injection on one
+    morphological miss ("scripts" vs "script"); bm25 rank still sorts
+    multi-term matches first. Each term is double-quoted (FTS5 string
+    syntax) so user text can never inject FTS5 operators. Term count is
+    bounded upstream by the existing ``query[:200]`` cap — no new
+    constant introduced.
+    """
+    from mcp_server.shared.text import STOPWORDS
+
+    # \W+ split mirrors shared.text._SPLIT_RE (kept private there).
+    terms = [
+        w for w in re.split(r"\W+", query.lower()) if len(w) >= 2 and w not in STOPWORDS
+    ]
+    return " OR ".join(f'"{t}"' for t in terms)
+
+
+def _recall_memories_sqlite(store, query: str) -> list[dict]:
+    """FTS-based recall through the SQLite store — no embedding load.
+
+    Mirror of the PG ``_recall_memories`` contract: FTS prefilter +
+    heat floor, protected-first ordering, benchmark rows excluded.
+    ``search_fts`` already restricts to supersession chain heads and
+    non-stale rows (current_memories join) and returns [] on any FTS5
+    error.
+    """
+    fts_query = _fts_query_from_prompt(query[:200])
+    if not fts_query:
+        return []
+    results = []
+    for memory_id, _score in store.search_fts(fts_query, limit=_MAX_MEMORIES + 2):
+        m = store.get_memory(memory_id)
+        if not m or m.get("is_benchmark"):
+            continue
+        heat = float(m.get("heat") or 0.0)
+        if heat < _MIN_HEAT:
+            continue
+        results.append(
+            {
+                "id": memory_id,
+                "content": m.get("content", ""),
+                "heat": heat,
+                "domain": m.get("domain", "") or "",
+                "agent": m.get("agent_context", "") or "",
+                "protected": bool(m.get("is_protected")),
+            }
+        )
+    # Protected (decision) memories first; stable sort keeps FTS rank
+    # order within each group — same ordering contract as the PG query.
+    results.sort(key=lambda m: not m["protected"])
+    return results[:_MAX_MEMORIES]
+
+
+def _process_event_sqlite(event: dict[str, Any], query: str) -> None:
+    """Inject relevant memories from the SQLite store; exit 0 always."""
+    try:
+        from mcp_server.infrastructure.memory_store import get_shared_store
+
+        store = get_shared_store()
+        memories = _recall_memories_sqlite(store, query)
+    except Exception as exc:
+        _log(f"sqlite recall failed (non-fatal): {exc}")
+        sys.exit(0)
+
+    injection, included = _format_injection(memories)
+    if not injection:
+        sys.exit(0)
+
+    receipt_id = emit_injection_receipt(
+        store,
+        [{"memory_id": m["id"]} for m in included],
+        channel="auto_recall",
+        session_id=session_id_from_transcript(event.get("transcript_path")),
+    )
+    if receipt_id is not None:
+        first, _, rest = injection.partition("\n")
+        injection = f"{first} {receipt_marker(receipt_id)}"
+        if rest:
+            injection += "\n" + rest
+
+    print(injection)
+    _log(f"injected {len(included)} memories (sqlite) for query: {query[:50]}...")
+    sys.exit(0)
+
+
 def _format_injection(memories: list[dict]) -> tuple[str, list[dict]]:
     """Format memories as a compact context block for injection.
 
@@ -272,6 +380,12 @@ def process_event(event: dict[str, Any]) -> None:
 
     if _should_skip(query):
         sys.exit(0)
+
+    # SQLite backend (zero-config plugin default): recall through the
+    # store abstraction — no psycopg connection to attempt.
+    if _backend_is_sqlite():
+        _process_event_sqlite(event, query)
+        return
 
     conn = _connect()
     if conn is None:

--- a/mcp_server/hooks/session_start.py
+++ b/mcp_server/hooks/session_start.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 from mcp_server.handlers.injection_receipts import (
     emit_hook_receipt,
+    emit_injection_receipt,
     receipt_marker,
     session_id_from_transcript,
 )
@@ -381,6 +382,33 @@ def _fetch_grooming_staleness(conn) -> list[str]:
         return []
 
 
+def _parse_json_list(val) -> list:
+    """Tolerant list coercion for checkpoint columns (JSON text or list)."""
+    if not val:
+        return []
+    if isinstance(val, list):
+        return val
+    try:
+        return json.loads(val) or []
+    except Exception:
+        return [val] if isinstance(val, str) and val.strip() else []
+
+
+def _checkpoint_from_row(row: dict | None) -> dict | None:
+    """Map a checkpoint row (PG dict_row or SQLite normalized row) to the
+    banner's checkpoint shape. Shared by both backend paths."""
+    if not row:
+        return None
+    return {
+        "current_task": row.get("current_task", ""),
+        "next_steps": _parse_json_list(row.get("next_steps")),
+        "open_questions": _parse_json_list(row.get("open_questions")),
+        "active_errors": _parse_json_list(row.get("active_errors")),
+        "key_decisions": _parse_json_list(row.get("key_decisions")),
+        "directory": row.get("directory_context", ""),
+    }
+
+
 def _fetch_checkpoint(conn) -> dict | None:
     """Fetch the latest active checkpoint."""
     try:
@@ -393,27 +421,7 @@ def _fetch_checkpoint(conn) -> dict | None:
     except Exception:
         return None
 
-    if not row:
-        return None
-
-    def _parse_json_list(val) -> list:
-        if not val:
-            return []
-        if isinstance(val, list):
-            return val
-        try:
-            return json.loads(val) or []
-        except Exception:
-            return [val] if isinstance(val, str) and val.strip() else []
-
-    return {
-        "current_task": row.get("current_task", ""),
-        "next_steps": _parse_json_list(row.get("next_steps")),
-        "open_questions": _parse_json_list(row.get("open_questions")),
-        "active_errors": _parse_json_list(row.get("active_errors")),
-        "key_decisions": _parse_json_list(row.get("key_decisions")),
-        "directory": row.get("directory_context", ""),
-    }
+    return _checkpoint_from_row(row)
 
 
 def _count_memories(conn) -> int:
@@ -990,6 +998,123 @@ def _refresh_session_registry(event: dict) -> None:
         _log(f"session registry refresh skipped (non-fatal): {exc}")
 
 
+# ── SQLite backend path (zero-config plugin default) ─────────────────────
+#
+# The plugin's default install provisions no PostgreSQL server; the
+# launcher resolves CORTEX_MEMORY_STORE_BACKEND=sqlite from the install
+# marker (mcp_server/infrastructure/backend_marker.py). This path builds
+# the same banner (checkpoint + anchors + hot memories + injection
+# receipt) through the store abstraction instead of raw psycopg SQL.
+# PG-only banner extras — team decisions, pending wiki curation,
+# grooming staleness — are skipped here; README "Install" discloses the
+# difference.
+
+# Tier-1 noise excluded from the banner on both backends.
+# contract: zetetic-team-subagents memory/contract.md §8b
+_SQLITE_NOISE_TAGS = frozenset({"auto-captured", "memory-replica"})
+
+
+def _backend_is_sqlite() -> bool:
+    """True when the resolved store backend is the SQLite store."""
+    try:
+        from mcp_server.infrastructure.backend_marker import effective_backend
+
+        return effective_backend(os.environ) == "sqlite"
+    except Exception:
+        return False
+
+
+def _partition_banner_rows(rows: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Split hot rows into (anchors, hot) with the PG path's exclusions.
+
+    Mirrors _fetch_anchors/_fetch_hot_memories: tier-1 noise tags are
+    dropped, protected ``_anchor``-tagged rows become anchors, the rest
+    are hot-pool entries. Supersession exclusion already happened
+    upstream (``get_hot_memories(heads_only=True)`` routes through the
+    ``current_memories`` view).
+    """
+    anchors: list[dict] = []
+    hot: list[dict] = []
+    for r in rows:
+        tags = [t for t in (r.get("tags") or []) if isinstance(t, str)]
+        if _SQLITE_NOISE_TAGS & set(tags):
+            continue
+        entry = {
+            "id": r["id"],
+            "content": r.get("content", ""),
+            "domain": r.get("domain", "") or "",
+            "heat": float(r.get("heat") or 0.0),
+            "is_global": bool(r.get("is_global", False)),
+        }
+        is_anchor = bool(r.get("is_protected")) and any(
+            t == "_anchor" or t.startswith("_anchor:") for t in tags
+        )
+        (anchors if is_anchor else hot).append(entry)
+    return anchors[:_ANCHOR_LIMIT], hot[:_HOT_LIMIT]
+
+
+def _sqlite_banner_rows(store) -> tuple[list[dict], list[dict], dict | None]:
+    """Fetch (anchors, hot, checkpoint) from the SQLite store, tolerantly."""
+    try:
+        rows = store.get_hot_memories(
+            min_heat=_MIN_HEAT, limit=_HOT_LIMIT + _ANCHOR_LIMIT, heads_only=True
+        )
+    except Exception as exc:
+        _log(f"SQLite hot-memory fetch failed (non-fatal): {exc}")
+        rows = []
+    anchors, hot = _partition_banner_rows(rows)
+    try:
+        checkpoint = _checkpoint_from_row(store.get_active_checkpoint())
+    except Exception:
+        checkpoint = None
+    return anchors, hot, checkpoint
+
+
+def _sqlite_context(event: dict) -> None:
+    """Build and print the SessionStart banner on the SQLite backend."""
+    try:
+        from mcp_server.infrastructure.memory_store import get_shared_store
+
+        store = get_shared_store()
+        total = int(store.count_memories().get("total") or 0)
+    except Exception as exc:
+        _log(f"SQLite store unavailable (non-fatal): {exc}")
+        return
+
+    if total == 0:
+        session_files = _count_session_files()
+        _log(f"Empty SQLite store, {session_files} session files found")
+        msg = _build_cold_start_message(
+            {"status": "ready", "memories": 0, "session_files": session_files}
+        )
+        if msg:
+            print(msg)
+        return
+
+    anchors, hot, checkpoint = _sqlite_banner_rows(store)
+    receipt_id = None
+    payload = [{"memory_id": m["id"]} for m in (*anchors, *hot)]
+    if payload:
+        receipt_id = emit_injection_receipt(
+            store,
+            payload,
+            channel="session_start",
+            session_id=session_id_from_transcript(event.get("transcript_path")),
+        )
+
+    context = _build_context(anchors, hot, checkpoint, receipt_id=receipt_id)
+    if context:
+        print(context)
+        _log(
+            f"Injected {len(anchors)} anchors + {len(hot)} hot memories "
+            f"(total: {total}, backend: sqlite)"
+        )
+    else:
+        _log("No memories above threshold (backend: sqlite)")
+
+    _print_external_sources()
+
+
 def main() -> None:
     """Entry point — print context block to stdout."""
 
@@ -1017,6 +1142,12 @@ def main() -> None:
     # (default 6h). The user never invokes consolidate manually — every
     # session opens against a freshly-consolidated store.
     _maybe_background_consolidate()
+
+    # SQLite backend (zero-config plugin default): banner via the store
+    # abstraction — no psycopg connection to attempt.
+    if _backend_is_sqlite():
+        _sqlite_context(event)
+        return
 
     # Try connecting to PostgreSQL directly first
     conn = _connect_pg()

--- a/mcp_server/infrastructure/backend_marker.py
+++ b/mcp_server/infrastructure/backend_marker.py
@@ -1,0 +1,150 @@
+"""Persisted storage-backend selection for the Claude Code plugin path.
+
+The plugin installer (``scripts/install-plugin.sh``) records the backend
+it provisioned in a small JSON marker::
+
+    ~/.claude/methodology/backend.json
+    {"backend": "sqlite"}        # zero-config default install
+    {"backend": "postgresql"}    # --postgres opt-in, or a protected
+                                 # pre-existing PostgreSQL install
+
+At launch, ``scripts/launcher.py`` — the single entry point for the MCP
+server and every hook — calls :func:`apply_backend_resolution` to
+translate that persisted choice into the ``CORTEX_MEMORY_STORE_BACKEND``
+environment variable that ``memory_store._construct_store`` already
+understands. The engine's backend-selection contract is unchanged; this
+module only decides which env var to hand it.
+
+Precedence (first match wins). An operator's explicit configuration is
+never overridden, so an existing PostgreSQL install can never be
+silently downgraded to SQLite by a plugin update:
+
+1. ``CORTEX_MEMORY_STORE_BACKEND`` already set  -> untouched
+2. ``CORTEX_BACKEND`` = postgres|postgresql|sqlite -> mapped to (1)
+3. ``DATABASE_URL`` / ``CORTEX_MEMORY_DATABASE_URL`` non-empty ->
+   untouched (operator configured PostgreSQL; the engine's strict
+   no-silent-fallback path in memory_store applies)
+4. marker file backend -> applied
+5. nothing -> untouched (engine default: ``auto``)
+
+The marker stores the backend NAME only — never a connection URL — so
+no credentials are ever written to disk by this path; the PostgreSQL
+URL keeps coming from ``DATABASE_URL`` / plugin user config /
+``memory_config.MemorySettings.DATABASE_URL`` exactly as before.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Mapping, MutableMapping
+
+from mcp_server.infrastructure.config import METHODOLOGY_DIR
+
+logger = logging.getLogger(__name__)
+
+BACKEND_MARKER_PATH = METHODOLOGY_DIR / "backend.json"
+
+# The two backends the installer can persist — mirrors the explicit
+# (non-"auto") values of MemorySettings.STORE_BACKEND.
+VALID_BACKENDS = frozenset({"sqlite", "postgresql"})
+
+# CORTEX_BACKEND accepts the colloquial "postgres" too; the engine env
+# var only understands "postgresql".
+_BACKEND_ALIASES = {
+    "sqlite": "sqlite",
+    "postgres": "postgresql",
+    "postgresql": "postgresql",
+}
+
+
+def read_backend_marker(path: Path | None = None) -> dict | None:
+    """Read the installer's backend marker; ``None`` when absent/invalid.
+
+    Pre:  ``path`` is a marker location or ``None`` (default location).
+    Post: returns the parsed dict only when it carries a valid
+          ``backend`` value; any I/O or parse failure degrades to
+          ``None`` (the engine's ``auto`` default) with a log line —
+          a corrupt marker must never block server/hook startup.
+    """
+    marker_path = path or BACKEND_MARKER_PATH
+    try:
+        data = json.loads(marker_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.warning("unreadable backend marker %s: %s", marker_path, exc)
+        return None
+    if not isinstance(data, dict) or data.get("backend") not in VALID_BACKENDS:
+        logger.warning("invalid backend marker %s: %r", marker_path, data)
+        return None
+    return data
+
+
+def resolve_backend_env(
+    environ: Mapping[str, str], marker: dict | None
+) -> dict[str, str]:
+    """Pure resolution: env additions implementing the module precedence.
+
+    Pre:  ``environ`` is a string mapping; ``marker`` is a validated
+          marker dict (see :func:`read_backend_marker`) or ``None``.
+    Post: returns either ``{}`` (explicit operator configuration wins,
+          or nothing to apply) or
+          ``{"CORTEX_MEMORY_STORE_BACKEND": <backend>}``. Never mutates
+          ``environ``.
+    """
+    if environ.get("CORTEX_MEMORY_STORE_BACKEND", "").strip():
+        return {}
+    requested = _BACKEND_ALIASES.get(environ.get("CORTEX_BACKEND", "").strip().lower())
+    if requested:
+        return {"CORTEX_MEMORY_STORE_BACKEND": requested}
+    if environ.get("DATABASE_URL", "").strip():
+        return {}
+    if environ.get("CORTEX_MEMORY_DATABASE_URL", "").strip():
+        return {}
+    if marker is not None:
+        return {"CORTEX_MEMORY_STORE_BACKEND": marker["backend"]}
+    return {}
+
+
+def apply_backend_resolution(
+    environ: MutableMapping[str, str], marker_path: Path | None = None
+) -> dict[str, str]:
+    """Apply the resolved backend to ``environ`` in place.
+
+    Also normalizes a *blank* ``DATABASE_URL`` to absent first: the
+    plugin manifest interpolates ``${user_config.database_url}`` whose
+    default is now empty, and an empty string must mean "not
+    configured" everywhere downstream (psycopg would otherwise read
+    libpq defaults from a blank DSN, and
+    ``memory_store._database_url_is_explicit`` tests key presence).
+
+    Pre:  ``environ`` is mutable (normally ``os.environ``).
+    Post: returns the additions applied (possibly ``{}``).
+    """
+    url = environ.get("DATABASE_URL")
+    if url is not None and not url.strip():
+        del environ["DATABASE_URL"]
+    additions = resolve_backend_env(environ, read_backend_marker(marker_path))
+    environ.update(additions)
+    return additions
+
+
+def effective_backend(
+    environ: Mapping[str, str], marker_path: Path | None = None
+) -> str:
+    """The backend the precedence chain selects, without mutating env.
+
+    Post: ``"sqlite"`` / ``"postgresql"`` when the chain resolves one;
+          ``""`` when nothing is configured (engine default ``auto``
+          applies) or when the operator configured a database URL
+          (case 3 — the engine, not this module, owns that path).
+    """
+    explicit = environ.get("CORTEX_MEMORY_STORE_BACKEND", "").strip().lower()
+    if explicit in VALID_BACKENDS:
+        return explicit
+    if explicit:  # "auto" or anything else the engine will interpret
+        return ""
+    additions = resolve_backend_env(environ, read_backend_marker(marker_path))
+    return additions.get("CORTEX_MEMORY_STORE_BACKEND", "")

--- a/mcp_server/infrastructure/embedding_engine.py
+++ b/mcp_server/infrastructure/embedding_engine.py
@@ -288,11 +288,18 @@ class EmbeddingEngine:
                 )
             except _cache_miss:
                 # Model not in local cache (at all, or not at the pinned
-                # revision) — download it once.
+                # revision) — download it once. First use on the
+                # zero-config install path lands here by design: the
+                # plugin postInstall deliberately skips the eager
+                # pre-cache (scripts/setup.py SQLite mode). Size figure
+                # per PRIVACY.md "one-time model download" / the
+                # pre-cache step it replaces (scripts/setup.sh step 5).
                 logger.info(
-                    "Downloading embedding model: %s (revision=%s)",
+                    "Downloading embedding model %s (revision=%s) — "
+                    "~100 MB, one-time; cached under %s, then runs fully offline",
                     self._model_name,
                     self._revision or "refs/main",
+                    cache_folder or "$HF_HOME",
                 )
                 self._model = SentenceTransformer(
                     self._model_name,

--- a/scripts/install-plugin.sh
+++ b/scripts/install-plugin.sh
@@ -3,10 +3,23 @@ set -euo pipefail
 
 # Cortex plugin postInstall driver.
 #
+# Usage: install-plugin.sh [--postgres]
+#        CORTEX_BACKEND=postgres install-plugin.sh   (equivalent)
+#
 # Two responsibilities:
-#   1. Install Cortex — dispatches by OS to scripts/setup.sh (macOS/Linux:
-#      PostgreSQL + pgvector, Python deps, DB schema, embedding model) or
-#      scripts/setup.py (Windows via Git Bash: same steps, cross-platform).
+#   1. Install Cortex. Default backend is SQLite — zero-config: Python
+#      deps only, no PostgreSQL/pgvector system install, no eager
+#      embedding-model download (the model fetches lazily on first use).
+#      Runs scripts/setup.py in SQLite mode on every OS and persists the
+#      choice to ~/.claude/methodology/backend.json (read at launch by
+#      scripts/launcher.py -> mcp_server/infrastructure/backend_marker.py).
+#      PostgreSQL is an explicit opt-in (--postgres / CORTEX_BACKEND) —
+#      it dispatches by OS to scripts/setup.sh (macOS/Linux: PostgreSQL +
+#      pgvector + schema + model pre-cache) or scripts/setup.py (Windows
+#      via Git Bash). An EXISTING PostgreSQL install is auto-detected
+#      (env URL, prior marker, or a reachable local cortex database) and
+#      kept — an upgrade never silently downgrades a Postgres install
+#      to SQLite.
 #   2. Remove stale OTHER versions of Cortex installed elsewhere on the
 #      machine, so the freshly-installed plugin is the single source of
 #      truth.
@@ -79,30 +92,121 @@ print(json.load(open(os.environ['CORTEX_PLUGIN_JSON_PATH']))['version'])
 
 say "Installing Cortex v${CURRENT_VERSION}"
 
-# ── Phase 1: install (delegates to setup.sh or setup.py by OS) ─────────
+# ── Phase 0: backend selection ──────────────────────────────────────────
 #
-# This is the single, most-upstream OS-dispatch point for the install
-# path — do not duplicate this branch in setup.sh or plugin.json.
-# manifest.json declares win32 as a compatible platform, but
-# scripts/setup.sh only knows how to provision PostgreSQL via brew/apt
-# (macOS/Linux) and previously failed with a bare "Unsupported OS" on
-# every other uname -s, including the MINGW64_NT-*/MSYS_NT-*/CYGWIN_NT-*
-# values Git Bash reports on native Windows (fixes #113). Git Bash is the
-# shell postInstall actually runs under on Windows (plugin.json invokes
-# `bash ...`), so on those uname patterns we delegate to the already
-# cross-platform scripts/setup.py instead of scripts/setup.sh.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        say "Detected Windows ($(uname -s)) — delegating to cross-platform scripts/setup.py"
-        "$PY" "$PLUGIN_ROOT/scripts/setup.py" || fail "scripts/setup.py failed. PostgreSQL must be installed and running first (https://www.postgresql.org/download/windows/, then also install pgvector: https://github.com/pgvector/pgvector#windows). Once that is done, re-run manually: \"$PY\" \"$PLUGIN_ROOT/scripts/setup.py\""
-        ;;
-    Darwin|Linux)
-        bash "$PLUGIN_ROOT/scripts/setup.sh"
-        ;;
-    *)
-        fail "Unsupported OS: $(uname -s). Cortex supports macOS, Linux, and Windows (via Git Bash). To retry manually once you've confirmed your shell environment, run: \"$PY\" \"$PLUGIN_ROOT/scripts/setup.py\" (cross-platform) — see also https://github.com/cdeust/Cortex#readme"
-        ;;
+# Default: sqlite (zero-config). PostgreSQL only when explicitly
+# requested (--postgres flag, CORTEX_BACKEND, CORTEX_MEMORY_STORE_BACKEND)
+# or when an existing PostgreSQL install is detected — never downgrade.
+
+MARKER_PATH="${HOME}/.claude/methodology/backend.json"
+
+# Explicit request beats detection: a user who asks for a backend gets it.
+REQUESTED=""
+for arg in "$@"; do
+    case "$arg" in
+        --postgres) REQUESTED="postgresql" ;;
+        *) fail "Unknown argument: $arg (usage: install-plugin.sh [--postgres])" ;;
+    esac
+done
+case "${CORTEX_BACKEND:-}" in
+    postgres|postgresql) REQUESTED="postgresql" ;;
+    sqlite)              REQUESTED="${REQUESTED:-sqlite}" ;;
 esac
+# CI/testing contract from issue #113: CORTEX_MEMORY_STORE_BACKEND=sqlite
+# forces the SQLite path (scripts/setup.py honors the same variable).
+if [ "${CORTEX_MEMORY_STORE_BACKEND:-}" = "sqlite" ] && [ -z "$REQUESTED" ]; then
+    REQUESTED="sqlite"
+fi
+
+# detect_existing_postgres — protect a working PostgreSQL install.
+# Returns 0 (and says why) when any of these hold:
+#   a) an operator-configured URL is present in the environment
+#   b) a prior install persisted backend=postgresql in the marker
+#   c) a local PostgreSQL answers on 127.0.0.1:5432 AND already has a
+#      cortex database (i.e. a previous full install provisioned it)
+detect_existing_postgres() {
+    if [ -n "${DATABASE_URL:-}" ] || [ -n "${CORTEX_MEMORY_DATABASE_URL:-}" ]; then
+        say "Existing PostgreSQL config detected (DATABASE_URL/CORTEX_MEMORY_DATABASE_URL set)"
+        return 0
+    fi
+    if [ -f "$MARKER_PATH" ] && grep -q '"backend"[[:space:]]*:[[:space:]]*"postgresql"' "$MARKER_PATH" 2>/dev/null; then
+        say "Existing PostgreSQL install detected (marker: $MARKER_PATH)"
+        return 0
+    fi
+    # 127.0.0.1:5432 mirrors memory_config.MemorySettings.DATABASE_URL,
+    # the default every previous plugin install provisioned against.
+    if command -v psql >/dev/null 2>&1 \
+        && psql -h 127.0.0.1 -p 5432 -d cortex -tAc "SELECT 1" >/dev/null 2>&1; then
+        say "Existing local cortex database detected (127.0.0.1:5432)"
+        return 0
+    fi
+    return 1
+}
+
+if [ -n "$REQUESTED" ]; then
+    BACKEND="$REQUESTED"
+elif detect_existing_postgres; then
+    BACKEND="postgresql"
+else
+    BACKEND="sqlite"
+fi
+say "Backend: $BACKEND"
+
+# ── Phase 1: install ────────────────────────────────────────────────────
+#
+# SQLite (default): scripts/setup.py in SQLite mode on every OS —
+# Python deps + verification only; no PostgreSQL, no pgvector, no eager
+# embedding-model download (lazy on first use; see
+# mcp_server/infrastructure/embedding_engine.py).
+#
+# PostgreSQL (opt-in / protected existing install): the single,
+# most-upstream OS-dispatch point for that path — do not duplicate this
+# branch in setup.sh or plugin.json. manifest.json declares win32 as a
+# compatible platform, but scripts/setup.sh only knows how to provision
+# PostgreSQL via brew/apt (macOS/Linux) and previously failed with a
+# bare "Unsupported OS" on every other uname -s, including the
+# MINGW64_NT-*/MSYS_NT-*/CYGWIN_NT-* values Git Bash reports on native
+# Windows (fixes #113). Git Bash is the shell postInstall actually runs
+# under on Windows (plugin.json invokes `bash ...`), so on those uname
+# patterns we delegate to the already cross-platform scripts/setup.py
+# instead of scripts/setup.sh.
+if [ "$BACKEND" = "sqlite" ]; then
+    CORTEX_MEMORY_STORE_BACKEND=sqlite "$PY" "$PLUGIN_ROOT/scripts/setup.py" \
+        || fail "scripts/setup.py failed. Re-run manually: CORTEX_MEMORY_STORE_BACKEND=sqlite \"$PY\" \"$PLUGIN_ROOT/scripts/setup.py\""
+else
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*)
+            say "Detected Windows ($(uname -s)) — delegating to cross-platform scripts/setup.py"
+            "$PY" "$PLUGIN_ROOT/scripts/setup.py" || fail "scripts/setup.py failed. PostgreSQL must be installed and running first (https://www.postgresql.org/download/windows/, then also install pgvector: https://github.com/pgvector/pgvector#windows). Once that is done, re-run manually: \"$PY\" \"$PLUGIN_ROOT/scripts/setup.py\""
+            ;;
+        Darwin|Linux)
+            bash "$PLUGIN_ROOT/scripts/setup.sh"
+            ;;
+        *)
+            fail "Unsupported OS: $(uname -s). Cortex supports macOS, Linux, and Windows (via Git Bash). To retry manually once you've confirmed your shell environment, run: \"$PY\" \"$PLUGIN_ROOT/scripts/setup.py\" (cross-platform) — see also https://github.com/cdeust/Cortex#readme"
+            ;;
+    esac
+fi
+
+# Persist the provisioned backend for scripts/launcher.py (marker is the
+# backend NAME only — never a URL, so no credentials touch disk here).
+# The path is computed with Path.home() INSIDE python, not interpolated
+# from $HOME: on Windows Git Bash $HOME is a POSIX-style path (/c/Users/x)
+# that native python.exe would misresolve, while Path.home() matches
+# exactly how backend_marker.py resolves the marker at read time.
+MARKER_WRITTEN=$(CORTEX_BACKEND_MARKER_VALUE="$BACKEND" \
+CORTEX_BACKEND_MARKER_VERSION="$CURRENT_VERSION" "$PY" -c "
+import json, os, pathlib
+path = pathlib.Path.home() / '.claude' / 'methodology' / 'backend.json'
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps({
+    'backend': os.environ['CORTEX_BACKEND_MARKER_VALUE'],
+    'written_by': 'install-plugin.sh',
+    'plugin_version': os.environ['CORTEX_BACKEND_MARKER_VERSION'],
+}, indent=2) + '\n', encoding='utf-8')
+print(path)
+") || warn "could not persist backend marker (launcher falls back to auto)"
+[ -n "$MARKER_WRITTEN" ] && say "Backend persisted: $BACKEND -> $MARKER_WRITTEN"
 
 # ── Phase 2: prune stale OTHER versions ────────────────────────────────
 
@@ -186,4 +290,9 @@ else
     say "Pruned $PRUNED stale Cortex install(s)."
 fi
 
-say "Cortex v${CURRENT_VERSION} ready. Restart Claude Code to activate."
+if [ "$BACKEND" = "sqlite" ]; then
+    say "Cortex v${CURRENT_VERSION} ready (SQLite, zero-config). Restart Claude Code to activate."
+    say "Optional PostgreSQL upgrade: bash \"$PLUGIN_ROOT/scripts/install-plugin.sh\" --postgres"
+else
+    say "Cortex v${CURRENT_VERSION} ready (PostgreSQL). Restart Claude Code to activate."
+fi

--- a/scripts/launcher.py
+++ b/scripts/launcher.py
@@ -122,8 +122,30 @@ def main() -> None:
         if p not in sys.path:
             sys.path.insert(0, p)
 
-    # Set DATABASE_URL default if not set
-    if "DATABASE_URL" not in os.environ:
+    # Persisted-backend resolution: translate the installer's
+    # ~/.claude/methodology/backend.json marker (SQLite zero-config
+    # default vs --postgres opt-in) into CORTEX_MEMORY_STORE_BACKEND.
+    # backend_marker is stdlib-only (json/pathlib), so this import is
+    # safe before ensure_deps has run. Best-effort: a broken marker or
+    # import must never block a hook or the server from starting — the
+    # engine's "auto" default then applies, exactly as before the
+    # marker existed.
+    try:
+        from mcp_server.infrastructure.backend_marker import (
+            apply_backend_resolution,
+        )
+
+        apply_backend_resolution(os.environ)
+    except Exception as exc:  # noqa: BLE001 — launch must survive any marker failure
+        print(f"[cortex-launcher] backend resolution skipped: {exc}", file=sys.stderr)
+
+    # Set DATABASE_URL default if not set — PostgreSQL paths only. On
+    # the SQLite backend the URL is unused, and injecting a PG default
+    # would make every hook attempt (and log) a doomed PG connection.
+    if (
+        "DATABASE_URL" not in os.environ
+        and os.environ.get("CORTEX_MEMORY_STORE_BACKEND", "") != "sqlite"
+    ):
         os.environ["DATABASE_URL"] = "postgresql://localhost:5432/cortex"
 
     # Install deps. The base-deps check is a stamp-gated no-op once a

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,30 +1,32 @@
 #!/usr/bin/env python3
 """Cortex — Cross-platform setup script.
 
-Works on Windows, macOS, and Linux. Installs Python dependencies,
-sets up the database schema, and pre-caches the embedding model.
-
-PostgreSQL must be installed separately on Windows:
-  https://www.postgresql.org/download/windows/
-  Also install pgvector: https://github.com/pgvector/pgvector#windows
+Works on Windows, macOS, and Linux. Installs Python dependencies and,
+per backend, sets up the database schema and pre-caches the embedding
+model.
 
 Usage:
-    python3 scripts/setup.py
+    python3 scripts/setup.py                                # PostgreSQL path
+    CORTEX_MEMORY_STORE_BACKEND=sqlite python3 scripts/setup.py   # SQLite path
 
-CI/testing mode:
-    Set CORTEX_MEMORY_STORE_BACKEND=sqlite to skip the PostgreSQL
-    provisioning/verification steps entirely. This exists so CI can
-    exercise the real cross-platform install path (OS dispatch, Python
-    dependency install, embedding model caching) on a runner with no
-    PostgreSQL server, without needing to provision one (source: issue
-    #113 — the Windows postInstall path had zero CI coverage before this
-    flag existed, which is how the "Unsupported OS" regression on native
-    Windows shipped undetected).
+SQLite mode (the Claude Code plugin's zero-config DEFAULT since the
+sqlite-first install change; scripts/install-plugin.sh invokes this
+script with CORTEX_MEMORY_STORE_BACKEND=sqlite on every OS):
+    Skips PostgreSQL provisioning, schema setup, and the eager
+    embedding-model pre-cache entirely. The store schema auto-creates on
+    first open (SqliteMemoryStore._init_schema) and the embedding model
+    downloads lazily on first encode (~100 MB, one-time — source:
+    embedding_engine._ensure_model; size figure per PRIVACY.md /
+    scripts/setup.sh step 5). Result: Python deps + verification only.
+    This same flag is what gives the Windows postInstall path CI
+    coverage on a runner with no PostgreSQL server (source: issue #113).
 
-    This is a testing convenience only: it does NOT represent a supported
-    zero-PostgreSQL install for the Claude Code plugin channel. The
-    zero-setup SQLite-by-default experience is the separate manifest.json
-    / `uv run` MCP-bundle channel, which never goes through this script.
+PostgreSQL mode (default when the flag is unset — the --postgres opt-in
+path of scripts/install-plugin.sh on Windows, and the manual
+cross-platform path):
+    PostgreSQL must already be installed and running:
+      https://www.postgresql.org/download/windows/
+      Also install pgvector: https://github.com/pgvector/pgvector#windows
 """
 
 from __future__ import annotations
@@ -44,7 +46,7 @@ PLUGIN_DATA = os.environ.get("CLAUDE_PLUGIN_DATA", str(PROJECT_DIR))
 DEPS_DIR = os.path.join(PLUGIN_DATA, "deps")
 DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://localhost:5432/cortex")
 
-# CI/testing mode: see module docstring. Any other CORTEX_MEMORY_STORE_BACKEND
+# SQLite mode: see module docstring. Any other CORTEX_MEMORY_STORE_BACKEND
 # value (unset, "postgresql", "auto") keeps the normal PostgreSQL-required path.
 SKIP_POSTGRES = (
     os.environ.get("CORTEX_MEMORY_STORE_BACKEND", "").strip().lower() == "sqlite"
@@ -299,12 +301,13 @@ def cache_embedding_model() -> None:
 
 
 def _sqlite_checks() -> list[tuple[str, bool]]:
-    """CI/testing-mode checks when PostgreSQL provisioning was skipped.
+    """SQLite-mode checks when PostgreSQL provisioning was skipped.
 
     Pre:  SKIP_POSTGRES is True.
     Post: returns one (name, passed) pair confirming the sqlite3 stdlib
-          module — the only storage dependency this mode exercises — is
-          importable.
+          module — the only storage dependency this mode needs at
+          install time (the store schema auto-creates on first open) —
+          is importable.
     """
     try:
         import sqlite3  # noqa: F401
@@ -384,7 +387,7 @@ def verify() -> None:
 
     sys.path.insert(0, DEPS_DIR)
 
-    # CI/testing mode (see module docstring): no PostgreSQL server is
+    # SQLite mode (see module docstring): no PostgreSQL server is
     # provisioned, so skip the PG-specific checks rather than reporting a
     # false failure for a step that was intentionally not run.
     checks = _sqlite_checks() if SKIP_POSTGRES else _postgres_checks()
@@ -412,18 +415,25 @@ def main() -> None:
 
     check_python()
     if SKIP_POSTGRES:
-        warn(
-            "CORTEX_MEMORY_STORE_BACKEND=sqlite — skipping PostgreSQL "
-            "provisioning and schema steps (CI/testing mode; see module "
-            "docstring). Production installs via the Claude Code plugin "
-            "still require PostgreSQL + pgvector."
+        ok(
+            "SQLite backend (zero-config default) — no PostgreSQL install, "
+            "no schema step (auto-creates on first use). Upgrade anytime: "
+            "bash scripts/install-plugin.sh --postgres"
         )
     else:
         check_postgresql()
     install_deps()
-    if not SKIP_POSTGRES:
+    if SKIP_POSTGRES:
+        # Lazy model policy for the zero-config path: the embedding model
+        # downloads on first encode (embedding_engine._ensure_model), not
+        # at install time — this keeps postInstall inside its time budget.
+        print(
+            "Embedding model: downloads on first use "
+            "(~100 MB, one-time — see PRIVACY.md), then runs fully offline."
+        )
+    else:
         setup_database()
-    cache_embedding_model()
+        cache_embedding_model()
     verify()
 
     print(f"\n{GREEN}Cortex setup complete!{NC}")
@@ -435,7 +445,10 @@ def main() -> None:
     print("  2. Start a conversation — Cortex works automatically")
     print("  3. Use /cortex-recall to search memories")
     print()
-    print(f"Database: {_redact_db_url(DATABASE_URL)}")
+    if SKIP_POSTGRES:
+        print("Database: SQLite — ~/.claude/methodology/memory.db")
+    else:
+        print(f"Database: {_redact_db_url(DATABASE_URL)}")
     print(f"Deps:     {DEPS_DIR}")
 
 

--- a/skills/cortex-setup-project/SKILL.md
+++ b/skills/cortex-setup-project/SKILL.md
@@ -9,13 +9,11 @@ Execute all four phases sequentially without asking the user any questions. If a
 
 ## Phase 1: Infrastructure Verification
 
-1. Run `pg_isready` via bash to check if PostgreSQL is running.
-2. Call `cortex:memory_stats({})` to verify database connectivity.
-3. If **either** check fails:
-   - Run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh"` automatically. Do not ask for permission.
-   - After setup.sh completes, call `cortex:memory_stats({})` again to verify.
+1. Call `cortex:memory_stats({})` to verify store connectivity. If it succeeds, the store is healthy — this covers **both** backends (the zero-config SQLite default needs no PostgreSQL, so do NOT run `pg_isready` or any PostgreSQL setup when this passes). Proceed to Phase 2.
+2. Only if `memory_stats` fails: call `cortex:check_setup({})` (backend-aware diagnostics) to identify the failure.
+   - SQLite backend reported: fix per the check output (usually `~/.claude/methodology` permissions or a corrupt `memory.db`); do NOT install PostgreSQL.
+   - PostgreSQL backend reported: run `pg_isready` via bash, then `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh"` automatically. Do not ask for permission. After setup.sh completes, call `cortex:memory_stats({})` again to verify.
    - If it still fails, report the error output and **stop**. Do not continue to later phases.
-4. If both checks pass, proceed to Phase 2.
 
 ## Phase 2: Build Methodology Profiles
 

--- a/tests_py/handlers/test_check_setup.py
+++ b/tests_py/handlers/test_check_setup.py
@@ -1,7 +1,8 @@
 """Tests for mcp_server.handlers.check_setup — MCP facade over doctor.py.
 
 Contract under test (from check_setup.py docstrings and schema):
-  POST-1: `checks` has exactly len(CHECKS) entries, in CHECKS' own order
+  POST-1: `checks` has exactly len(active_checks()) entries, in that
+          list's own order
           (no reordering/filtering — mirrors doctor's dependency order:
           Python -> driver -> DATABASE_URL -> connection -> extensions -> FS).
   POST-2: `ready` is True iff no non-optional check failed.
@@ -9,7 +10,8 @@ Contract under test (from check_setup.py docstrings and schema):
           optional-check failure (e.g. codebase-pipeline probe) never
           blocks readiness or is counted.
   POST-4: no check logic is duplicated — the handler calls the exact
-          `Check` callables from `mcp_server.doctor.CHECKS`.
+          `Check` callables from `mcp_server.doctor.active_checks()`
+          (the backend-aware list).
   POST-5: schema takes no arguments (composition-root/facade, not a
           re-implementation).
 """
@@ -36,7 +38,9 @@ class TestCheckSetupHandlerAllGreen:
             lambda: _fake_check("pgvector + pg_trgm extensions", True),
             lambda: _fake_check("~/.claude/methodology writable", True),
         ]
-        monkeypatch.setattr("mcp_server.handlers.check_setup.CHECKS", checks)
+        monkeypatch.setattr(
+            "mcp_server.handlers.check_setup.active_checks", lambda: checks
+        )
 
         result = asyncio.run(handler())
 
@@ -67,7 +71,9 @@ class TestCheckSetupHandlerDbDown:
             # Optional probe also fails but must not count toward fixes_needed.
             lambda: _fake_check("codebase-pipeline (optional)", False, optional=True),
         ]
-        monkeypatch.setattr("mcp_server.handlers.check_setup.CHECKS", checks)
+        monkeypatch.setattr(
+            "mcp_server.handlers.check_setup.active_checks", lambda: checks
+        )
 
         result = asyncio.run(handler())
 
@@ -80,7 +86,9 @@ class TestCheckSetupHandlerDbDown:
             lambda: _fake_check("Python >= 3.10", True),
             lambda: _fake_check("codebase-pipeline (optional)", False, optional=True),
         ]
-        monkeypatch.setattr("mcp_server.handlers.check_setup.CHECKS", checks)
+        monkeypatch.setattr(
+            "mcp_server.handlers.check_setup.active_checks", lambda: checks
+        )
 
         result = asyncio.run(handler())
 
@@ -92,7 +100,9 @@ class TestCheckSetupHandlerDbDown:
         checks = [
             lambda: _fake_check("DATABASE_URL", False, fix="export DATABASE_URL=..."),
         ]
-        monkeypatch.setattr("mcp_server.handlers.check_setup.CHECKS", checks)
+        monkeypatch.setattr(
+            "mcp_server.handlers.check_setup.active_checks", lambda: checks
+        )
 
         result = asyncio.run(handler())
 
@@ -106,7 +116,9 @@ class TestCheckSetupHandlerOrder:
     def test_order_matches_checks_list(self, monkeypatch):
         names = ["Zebra check", "Alpha check", "Middle check"]
         checks = [lambda n=n: _fake_check(n, True) for n in names]
-        monkeypatch.setattr("mcp_server.handlers.check_setup.CHECKS", checks)
+        monkeypatch.setattr(
+            "mcp_server.handlers.check_setup.active_checks", lambda: checks
+        )
 
         result = asyncio.run(handler())
 
@@ -114,7 +126,7 @@ class TestCheckSetupHandlerOrder:
 
 
 class TestCheckSetupHandlerNoDuplication:
-    """POST-4: real doctor.CHECKS (unmocked) drives the handler — no
+    """POST-4: real doctor.active_checks() (unmocked) drives the handler — no
     reimplemented check logic, exercises the real Python-version check."""
 
     def test_uses_real_doctor_checks_python_version_passes(self):

--- a/tests_py/hooks/test_sqlite_hook_paths.py
+++ b/tests_py/hooks/test_sqlite_hook_paths.py
@@ -1,0 +1,197 @@
+"""Tests for the hooks' SQLite backend paths (sqlite-first install).
+
+The plugin's zero-config default provisions no PostgreSQL server, so the
+two context-injecting hooks that previously spoke raw psycopg SQL —
+session_start (banner) and auto_recall (per-prompt injection) — gained a
+store-abstraction path activated when the resolved backend is sqlite
+(mcp_server/infrastructure/backend_marker.effective_backend). These
+tests exercise that path against a real SqliteMemoryStore in tmp_path —
+no PostgreSQL, no network, no embedding model.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.hooks import auto_recall, session_start
+from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = SqliteMemoryStore(db_path=str(tmp_path / "memory.db"))
+    yield s
+    s.close()
+
+
+# ── backend gate ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("module", [session_start, auto_recall])
+def test_backend_gate_follows_env(module, monkeypatch):
+    monkeypatch.setenv("CORTEX_MEMORY_STORE_BACKEND", "sqlite")
+    assert module._backend_is_sqlite() is True
+    monkeypatch.setenv("CORTEX_MEMORY_STORE_BACKEND", "postgresql")
+    assert module._backend_is_sqlite() is False
+
+
+# ── session_start: banner partition ──────────────────────────────────────
+
+
+class TestPartitionBannerRows:
+    def test_noise_tags_excluded(self):
+        rows = [
+            {"id": 1, "content": "tool noise", "tags": ["auto-captured"], "heat": 0.9},
+            {"id": 2, "content": "replica", "tags": ["memory-replica"], "heat": 0.9},
+            {"id": 3, "content": "real", "tags": [], "heat": 0.8},
+        ]
+        anchors, hot = session_start._partition_banner_rows(rows)
+        assert anchors == []
+        assert [m["id"] for m in hot] == [3]
+
+    def test_protected_anchor_tag_becomes_anchor(self):
+        rows = [
+            {
+                "id": 1,
+                "content": "anchored decision",
+                "tags": ["_anchor"],
+                "is_protected": True,
+                "heat": 1.0,
+            },
+            {
+                "id": 2,
+                "content": "protected but not anchored",
+                "tags": ["decision"],
+                "is_protected": True,
+                "heat": 0.9,
+            },
+            {
+                "id": 3,
+                "content": "scoped anchor",
+                "tags": ["_anchor:project"],
+                "is_protected": True,
+                "heat": 1.0,
+            },
+        ]
+        anchors, hot = session_start._partition_banner_rows(rows)
+        assert [m["id"] for m in anchors] == [1, 3]
+        assert [m["id"] for m in hot] == [2]
+
+    def test_limits_applied(self):
+        rows = [
+            {"id": i, "content": f"m{i}", "tags": [], "heat": 0.9}
+            for i in range(session_start._HOT_LIMIT + 10)
+        ]
+        _, hot = session_start._partition_banner_rows(rows)
+        assert len(hot) == session_start._HOT_LIMIT
+
+
+# ── session_start: full banner over a seeded store ───────────────────────
+
+
+def test_sqlite_context_prints_banner_and_receipt(store, tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("CORTEX_MEMORY_STORE_BACKEND", "sqlite")
+    store.insert_memory(
+        {
+            "content": "sqlite-first install decision",
+            "heat": 1.0,
+            "is_protected": True,
+            "tags": ["_anchor"],
+        }
+    )
+    store.insert_memory({"content": "hot working memory", "heat": 0.9})
+    monkeypatch.setattr(
+        "mcp_server.infrastructure.memory_store.get_shared_store", lambda: store
+    )
+    monkeypatch.setattr(session_start, "_print_external_sources", lambda: None)
+
+    session_start._sqlite_context({"transcript_path": "/tmp/session-abc.jsonl"})
+
+    out = capsys.readouterr().out
+    assert "Cortex Memory Context" in out
+    assert "sqlite-first install decision" in out
+    assert "hot working memory" in out
+    assert "⟦rcpt:" in out  # injection receipt marker stamped in header
+    # The receipt row itself is resolvable (blame path parity).
+    rows = store.fetch_injection_receipts([1])
+    assert rows and rows[0]["channel"] == "session_start"
+
+
+def test_sqlite_context_empty_store_prints_cold_start(store, monkeypatch, capsys):
+    monkeypatch.setenv("CORTEX_MEMORY_STORE_BACKEND", "sqlite")
+    monkeypatch.setattr(
+        "mcp_server.infrastructure.memory_store.get_shared_store", lambda: store
+    )
+    monkeypatch.setattr(session_start, "_count_session_files", lambda: 0)
+
+    session_start._sqlite_context({})
+
+    out = capsys.readouterr().out
+    # Cold-start message, and NEVER the PostgreSQL install instructions.
+    assert "brew install postgresql" not in out
+    assert "PostgreSQL" not in out
+
+
+# ── auto_recall: FTS recall over a seeded store ──────────────────────────
+
+
+class TestRecallMemoriesSqlite:
+    def test_fts_match_with_heat_floor(self, store):
+        store.insert_memory(
+            {"content": "the resolver fix used topological sort", "heat": 0.8}
+        )
+        store.insert_memory({"content": "cold resolver note", "heat": 0.01})
+        store.insert_memory({"content": "unrelated grocery list", "heat": 0.9})
+
+        results = auto_recall._recall_memories_sqlite(store, "resolver fix")
+
+        contents = [m["content"] for m in results]
+        assert any("topological sort" in c for c in contents)
+        assert all("grocery" not in c for c in contents)
+        assert all(m["heat"] >= auto_recall._MIN_HEAT for m in results)
+
+    def test_protected_first_and_benchmarks_excluded(self, store):
+        store.insert_memory(
+            {"content": "resolver benchmark row", "heat": 0.9, "is_benchmark": True}
+        )
+        store.insert_memory({"content": "resolver ordinary note", "heat": 0.9})
+        store.insert_memory(
+            {
+                "content": "resolver protected decision",
+                "heat": 0.5,
+                "is_protected": True,
+            }
+        )
+
+        results = auto_recall._recall_memories_sqlite(store, "resolver")
+
+        assert results, "expected FTS hits"
+        assert results[0]["protected"] is True
+        assert all("benchmark row" not in m["content"] for m in results)
+
+    def test_hostile_fts_input_degrades_to_empty(self, store):
+        store.insert_memory({"content": "resolver note", "heat": 0.9})
+        # FTS5 syntax characters must not raise (search_fts catches them).
+        assert auto_recall._recall_memories_sqlite(store, 'a AND (b OR "') == []
+
+
+def test_process_event_sqlite_injects_and_exits_zero(store, monkeypatch, capsys):
+    monkeypatch.setenv("CORTEX_MEMORY_STORE_BACKEND", "sqlite")
+    store.insert_memory(
+        {"content": "the deploy script is resumable by design", "heat": 0.9}
+    )
+    monkeypatch.setattr(
+        "mcp_server.infrastructure.memory_store.get_shared_store", lambda: store
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        auto_recall._process_event_sqlite(
+            {"transcript_path": "/tmp/session-xyz.jsonl"},
+            "why is the deploy script resumable",
+        )
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "Cortex context:" in out
+    assert "resumable" in out
+    assert "⟦rcpt:" in out

--- a/tests_py/infrastructure/test_backend_marker.py
+++ b/tests_py/infrastructure/test_backend_marker.py
@@ -1,0 +1,165 @@
+"""Tests for infrastructure/backend_marker.py — persisted backend selection.
+
+Source: the sqlite-first install change. The plugin installer
+(scripts/install-plugin.sh) persists the provisioned backend to
+~/.claude/methodology/backend.json; scripts/launcher.py resolves it into
+CORTEX_MEMORY_STORE_BACKEND at launch. The precedence contract under
+test is the module docstring's five cases — in particular case 3, the
+"never silently downgrade an existing PostgreSQL install" invariant.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mcp_server.infrastructure.backend_marker import (
+    apply_backend_resolution,
+    effective_backend,
+    read_backend_marker,
+    resolve_backend_env,
+)
+
+
+def _marker(tmp_path: Path, payload) -> Path:
+    path = tmp_path / "backend.json"
+    path.write_text(
+        payload if isinstance(payload, str) else json.dumps(payload),
+        encoding="utf-8",
+    )
+    return path
+
+
+# ── read_backend_marker ─────────────────────────────────────────────────
+
+
+class TestReadBackendMarker:
+    def test_missing_file_returns_none(self, tmp_path):
+        assert read_backend_marker(tmp_path / "absent.json") is None
+
+    def test_invalid_json_returns_none(self, tmp_path):
+        assert read_backend_marker(_marker(tmp_path, "{not json")) is None
+
+    def test_non_dict_returns_none(self, tmp_path):
+        assert read_backend_marker(_marker(tmp_path, ["sqlite"])) is None
+
+    def test_unknown_backend_returns_none(self, tmp_path):
+        assert read_backend_marker(_marker(tmp_path, {"backend": "mongodb"})) is None
+
+    @pytest.mark.parametrize("backend", ["sqlite", "postgresql"])
+    def test_valid_marker_returned(self, tmp_path, backend):
+        marker = read_backend_marker(_marker(tmp_path, {"backend": backend}))
+        assert marker is not None
+        assert marker["backend"] == backend
+
+
+# ── resolve_backend_env — precedence chain ──────────────────────────────
+
+
+class TestResolveBackendEnv:
+    def test_explicit_store_backend_wins_over_marker(self):
+        env = {"CORTEX_MEMORY_STORE_BACKEND": "postgresql"}
+        assert resolve_backend_env(env, {"backend": "sqlite"}) == {}
+
+    @pytest.mark.parametrize(
+        "requested,expected",
+        [
+            ("postgres", "postgresql"),
+            ("postgresql", "postgresql"),
+            ("POSTGRES", "postgresql"),  # case-insensitive
+            ("sqlite", "sqlite"),
+        ],
+    )
+    def test_cortex_backend_alias_mapping(self, requested, expected):
+        env = {"CORTEX_BACKEND": requested}
+        assert resolve_backend_env(env, None) == {
+            "CORTEX_MEMORY_STORE_BACKEND": expected
+        }
+
+    def test_cortex_backend_beats_marker(self):
+        env = {"CORTEX_BACKEND": "postgres"}
+        assert resolve_backend_env(env, {"backend": "sqlite"}) == {
+            "CORTEX_MEMORY_STORE_BACKEND": "postgresql"
+        }
+
+    def test_database_url_protects_existing_postgres(self):
+        """Case 3: an operator URL means the marker must NOT downgrade."""
+        env = {"DATABASE_URL": "postgresql://db.example:5432/cortex"}
+        assert resolve_backend_env(env, {"backend": "sqlite"}) == {}
+
+    def test_prefixed_database_url_also_protects(self):
+        env = {"CORTEX_MEMORY_DATABASE_URL": "postgresql://db.example:5432/cortex"}
+        assert resolve_backend_env(env, {"backend": "sqlite"}) == {}
+
+    def test_blank_database_url_means_not_configured(self):
+        """plugin.json interpolates an empty user_config default."""
+        env = {"DATABASE_URL": "   "}
+        assert resolve_backend_env(env, {"backend": "sqlite"}) == {
+            "CORTEX_MEMORY_STORE_BACKEND": "sqlite"
+        }
+
+    @pytest.mark.parametrize("backend", ["sqlite", "postgresql"])
+    def test_marker_applies_when_nothing_configured(self, backend):
+        assert resolve_backend_env({}, {"backend": backend}) == {
+            "CORTEX_MEMORY_STORE_BACKEND": backend
+        }
+
+    def test_no_marker_no_config_is_noop(self):
+        assert resolve_backend_env({}, None) == {}
+
+    def test_never_mutates_input(self):
+        env = {"CORTEX_BACKEND": "sqlite"}
+        resolve_backend_env(env, None)
+        assert env == {"CORTEX_BACKEND": "sqlite"}
+
+
+# ── apply_backend_resolution ────────────────────────────────────────────
+
+
+class TestApplyBackendResolution:
+    def test_applies_marker_to_environ(self, tmp_path):
+        path = _marker(tmp_path, {"backend": "sqlite"})
+        env: dict[str, str] = {}
+        additions = apply_backend_resolution(env, marker_path=path)
+        assert additions == {"CORTEX_MEMORY_STORE_BACKEND": "sqlite"}
+        assert env["CORTEX_MEMORY_STORE_BACKEND"] == "sqlite"
+
+    def test_strips_blank_database_url(self, tmp_path):
+        path = _marker(tmp_path, {"backend": "sqlite"})
+        env = {"DATABASE_URL": ""}
+        apply_backend_resolution(env, marker_path=path)
+        assert "DATABASE_URL" not in env
+        assert env["CORTEX_MEMORY_STORE_BACKEND"] == "sqlite"
+
+    def test_keeps_real_database_url_and_backend_untouched(self, tmp_path):
+        path = _marker(tmp_path, {"backend": "sqlite"})
+        env = {"DATABASE_URL": "postgresql://db.example:5432/cortex"}
+        additions = apply_backend_resolution(env, marker_path=path)
+        assert additions == {}
+        assert env == {"DATABASE_URL": "postgresql://db.example:5432/cortex"}
+
+
+# ── effective_backend ───────────────────────────────────────────────────
+
+
+class TestEffectiveBackend:
+    def test_env_var_short_circuits(self, tmp_path):
+        path = _marker(tmp_path, {"backend": "postgresql"})
+        env = {"CORTEX_MEMORY_STORE_BACKEND": "sqlite"}
+        assert effective_backend(env, marker_path=path) == "sqlite"
+
+    def test_auto_env_var_resolves_to_engine_default(self, tmp_path):
+        path = _marker(tmp_path, {"backend": "sqlite"})
+        env = {"CORTEX_MEMORY_STORE_BACKEND": "auto"}
+        assert effective_backend(env, marker_path=path) == ""
+
+    def test_marker_resolves_without_mutation(self, tmp_path):
+        path = _marker(tmp_path, {"backend": "sqlite"})
+        env: dict[str, str] = {}
+        assert effective_backend(env, marker_path=path) == "sqlite"
+        assert env == {}
+
+    def test_unconfigured_is_empty(self, tmp_path):
+        assert effective_backend({}, marker_path=tmp_path / "absent.json") == ""

--- a/tests_py/scripts/test_setup_py_backend_skip.py
+++ b/tests_py/scripts/test_setup_py_backend_skip.py
@@ -116,6 +116,37 @@ def test_verify_selects_postgres_checks_when_not_skip_postgres(monkeypatch):
 
 
 @pytest.mark.parametrize("skip_postgres", [True, False])
+def test_main_model_download_is_lazy_in_sqlite_mode(monkeypatch, skip_postgres):
+    """SQLite mode (the plugin's zero-config default) must NOT pre-cache
+    the embedding model at install time — it downloads lazily on first
+    encode (embedding_engine._ensure_model). The PostgreSQL opt-in path
+    keeps the eager pre-cache. Source: sqlite-first install change."""
+    mod = _load_setup_module(monkeypatch, "sqlite" if skip_postgres else None)
+
+    for name in (
+        "check_python",
+        "check_postgresql",
+        "install_deps",
+        "setup_database",
+        "verify",
+    ):
+        monkeypatch.setattr(mod, name, mock.Mock())
+    cache_model = mock.Mock()
+    monkeypatch.setattr(mod, "cache_embedding_model", cache_model)
+
+    mod.main()
+
+    if skip_postgres:
+        cache_model.assert_not_called()
+        mod.setup_database.assert_not_called()
+        mod.check_postgresql.assert_not_called()
+    else:
+        cache_model.assert_called_once()
+        mod.setup_database.assert_called_once()
+        mod.check_postgresql.assert_called_once()
+
+
+@pytest.mark.parametrize("skip_postgres", [True, False])
 def test_verify_exits_when_any_mocked_check_fails(monkeypatch, skip_postgres):
     mod = _load_setup_module(monkeypatch, "sqlite" if skip_postgres else None)
 

--- a/tests_py/test_doctor.py
+++ b/tests_py/test_doctor.py
@@ -13,10 +13,13 @@ from __future__ import annotations
 
 from mcp_server.doctor import (
     CHECKS,
+    SQLITE_CHECKS,
     _i10_config,
     _methodology_dir,
     _pg_driver,
     _python_version,
+    _sqlite_store,
+    active_checks,
     run,
 )
 
@@ -57,3 +60,34 @@ class TestRunReportFormat:
         assert len(CHECKS) >= 5
         for c in CHECKS:
             assert callable(c)
+
+
+class TestBackendAwareChecks:
+    """active_checks() mirrors the launcher/hook backend resolution
+    (sqlite-first install): SQLite installs must not fail four PG checks."""
+
+    def test_sqlite_backend_selects_sqlite_list(self, monkeypatch):
+        monkeypatch.setenv("CORTEX_MEMORY_STORE_BACKEND", "sqlite")
+        assert active_checks() is SQLITE_CHECKS
+
+    def test_postgresql_backend_selects_pg_list(self, monkeypatch):
+        monkeypatch.setenv("CORTEX_MEMORY_STORE_BACKEND", "postgresql")
+        assert active_checks() is CHECKS
+
+    def test_sqlite_list_has_no_pg_checks(self):
+        assert _pg_driver not in SQLITE_CHECKS
+        assert _sqlite_store in SQLITE_CHECKS
+
+    def test_sqlite_store_check_passes_on_fresh_store(self, tmp_path, monkeypatch):
+        from mcp_server.infrastructure import memory_config
+
+        monkeypatch.setenv(
+            "CORTEX_MEMORY_SQLITE_FALLBACK_PATH", str(tmp_path / "memory.db")
+        )
+        memory_config.get_memory_settings.cache_clear()
+        try:
+            check = _sqlite_store()
+        finally:
+            memory_config.get_memory_settings.cache_clear()
+        assert check.ok is True
+        assert "memories" in check.detail


### PR DESCRIPTION
## Summary
The plugin install now delivers the complete experience (all 9 hooks + memory) with **no system-level PostgreSQL**: default backend is SQLite, provisioned by `setup.py` with pip deps only — no brew/apt, no pgvector, no eager model download. Postgres becomes the documented opt-in upgrade (`install-plugin.sh --postgres`).

- **Never downgrades an existing install**: three detectors (env `DATABASE_URL`, prior backend marker, reachable local `cortex` DB at 127.0.0.1:5432) force the full PostgreSQL path — verified live against a real local Postgres.
- Backend choice persists to `~/.claude/methodology/backend.json` (name only, never a URL) and resolves at runtime via new `mcp_server/infrastructure/backend_marker.py`; any operator env var beats the marker.
- **Model download was already lazy in the engine** — the install-time pre-cache is now skipped on the default path; first `encode()` prints size + cache dir + "then runs fully offline".
- **Found and fixed a real gap**: 5 of 9 hooks spoke raw psycopg despite the "SQLite fallback" claim. The two user-visible ones are ported to the store abstraction: `session_start` (full banner incl. receipts; previously printed brew-install instructions on SQLite) and `auto_recall` (FTS5 recall with stopword-stripped OR terms). `doctor`/`check_setup`/`/preflight` are backend-aware.
- README discloses honestly what SQLite mode lacks (in-process fusion instead of PL/pgSQL + HNSW; three PG-only hook enrichments degrade to no-ops).

## Test plan
- [x] 744 passed (scripts/infrastructure/architecture/invariants/doctor) + 108 (hooks incl. live PG e2e) + 10 (check_setup); new: 26 backend-marker + 11 sqlite-hook-path tests
- [x] `ruff check` + `ruff format --check` clean
- [x] Install script exercised across 8 sandbox scenarios (fresh sqlite, marker re-run, --postgres, env-URL, CORTEX_BACKEND, marker protection, bad arg, live local-PG detection)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)