### PR TITLE
fix(write-gate): make decision/error/success bypass cues language-aware

### DIFF
--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -42,6 +42,15 @@ flowchart TD
 
 The gate uses `CORTEX_MEMORY_SURPRISAL_THRESHOLD` (default 0.3) as the minimum combined novelty score. `force=True` bypasses the gate entirely.
 
+### Write Gate Bypass
+
+Decision and error content is never rejected by novelty gating (`bypass_decision` / `bypass_error` in `write_gate.determine_bypass`). Detection is language-aware (`core/content_cues.py`, issue #158), in two layers:
+
+1. **Structural markers** (any language): runtime-emitted error shapes — Python traceback headers and frame lines, JVM/Node stack frames, CamelCase exception class names (`ValueError`, `NullPointerException`), POSIX signal names (`SIGSEGV`, …). These are matched case-sensitively; casing is the signal.
+2. **Multilingual keyword sets** for: English, Spanish, Portuguese, Russian, Japanese (the four non-English languages Stack Overflow runs dedicated sites for), German and French (remaining top W3Techs web content languages), and Romanian (issue #158 repro language). The same coverage applies to the success cue that feeds neuromodulation salience.
+
+For any language not listed, structural error markers still work, and the universal fallbacks always work: `force=true`, or an `important` / `critical` tag. Both bypass the gate and are excluded from the per-domain calibration EMA, so they never skew the threshold.
+
 ## Memory Read Path (`recall`)
 
 The read path uses intent-aware routing and multi-signal fusion.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -114,7 +114,7 @@ table above — the catalogue and the command ship in the same commit.
 
 ### Memory Write Path
 
-1. **Gate**: 4-signal novelty filter (embedding distance, entity overlap, temporal proximity, structural similarity)
+1. **Gate**: 4-signal novelty filter (embedding distance, entity overlap, temporal proximity, structural similarity). Decision/error content bypasses the gate — detection is language-aware (see `docs/data-flow.md` § Write Gate Bypass); `force=true` or an `important`/`critical` tag always bypasses, in any language
 2. **Curate**: Active curation — merge with similar, link to related, or create new
 3. **Store**: PostgreSQL + pgvector with auto tsvector indexing → entity extraction → knowledge graph
 

--- a/docs/module-inventory.md
+++ b/docs/module-inventory.md
@@ -80,6 +80,7 @@ Treat gaps as "undocumented," not "does not exist."
 
 *Memory Thermodynamics:*
 - `thermodynamics.py` — Heat, surprise, importance, valence, metamemory
+- `content_cues.py` — Language-aware decision/error/success cue detection for write-gate bypass (structural runtime markers + multilingual keyword sets, issue #158)
 - `hierarchical_predictive_coding.py` — 3-level Friston free energy gate (sensory/entity/schema) replacing flat 4-signal
 - `predictive_coding_flat.py` — Flat predictive coding fallback
 - `predictive_coding_gate.py` — Gate decision logic

--- a/mcp_server/core/content_cues.py
+++ b/mcp_server/core/content_cues.py
@@ -1,0 +1,262 @@
+"""Language-aware decision / error / success cue detection (issue #158).
+
+Pure business logic — no I/O. Single purpose: decide whether memory
+content carries a decision, error, or success cue so the write gate can
+honor ``bypass_decision`` / ``bypass_error`` and the neuromodulation
+success signal regardless of the language the note is written in.
+
+Detection order and rationale
+-----------------------------
+1. **Structural markers** (error detector only, checked first): runtime
+   artifacts — traceback headers, stack-trace frames, CamelCase
+   exception class names, POSIX signal names — are emitted by
+   interpreters and runtimes in fixed ASCII form regardless of the
+   author's natural language. They are matched case-SENSITIVELY because
+   the casing is the signal (``ValueError`` vs. prose "value error").
+2. **Multilingual keyword sets**: per-language regex fragments, one
+   entry per language, each with a provenance comment listing the
+   surface forms it covers. English entries are byte-for-byte the
+   pre-#158 patterns, so English behavior is a strict superset of the
+   old behavior (no English regressions).
+
+Language selection (each language must trace to a source):
+  - en — original behavior (``_DECISION_KW`` / ``_ERROR_KW`` /
+    ``_SUCCESS_KW`` before this module existed).
+  - es, pt, ru, ja — the four languages Stack Overflow runs dedicated
+    non-English sites for (es/pt/ru/ja.stackoverflow.com), the best
+    available demand signal for non-English developer populations.
+    source: https://en.wikipedia.org/wiki/Stack_Overflow ("available in
+    English, Spanish, Russian, Portuguese, and Japanese").
+  - de, fr — remaining top web content languages after the above.
+    source: https://w3techs.com/technologies/overview/content_language
+    (W3Techs, Usage statistics of content languages for websites).
+  - ro — the reporting user's repro language in issue #158.
+
+Precision/recall trade-off (deliberate, recall-biased): a false
+positive here costs one extra stored memory that ``try_curation``
+merges/links afterwards (see ``write_gate.determine_bypass`` docstring);
+a false negative silently drops a decision/error note as a "duplicate"
+(the issue #158 failure). Stems therefore use ``\\w*`` suffixes to cover
+inflection, and rare cross-language collisions (noted inline) are
+accepted. The ``important``/``critical`` tag and ``force=True`` remain
+the universal, language-independent fallback.
+
+For languages not listed, keyword detection does not fire; structural
+error markers still work, and the tag/force fallback always works.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ── Structural error markers (language-agnostic, case-sensitive) ──────────
+# Runtime-emitted shapes; the author's natural language never changes them.
+_STRUCTURAL_ERROR_PATTERNS: tuple[str, ...] = (
+    # CPython traceback header — fixed string emitted by the interpreter.
+    # source: https://docs.python.org/3/library/traceback.html
+    r"Traceback \(most recent call last\)",
+    # CPython traceback frame line: File "app.py", line 3
+    # source: https://docs.python.org/3/library/traceback.html
+    r"File \"[^\"]+\", line \d+",
+    # JVM / Node stack frame: "at pkg.Cls.m(File.java:42)" /
+    # "at fn (/app/x.js:10:5)".
+    # sources: java.lang.Throwable#printStackTrace javadoc;
+    # https://v8.dev/docs/stack-trace-api
+    r"\bat [^\s(]+ ?\([^()]*:\d+(?::\d+)?\)",
+    # CamelCase exception class identifiers (ValueError,
+    # NullPointerException) as printed by runtimes.
+    # sources: PEP 8 (exception names use the suffix "Error");
+    # Java tutorial/JLS convention (suffix "Exception")
+    r"\b[A-Z][A-Za-z0-9]*(?:Error|Exception)\b",
+    # POSIX signal names printed by shells/runtimes on abnormal exit.
+    # source: POSIX.1-2017 <signal.h>
+    r"\bSIG(?:SEGV|ABRT|BUS|FPE|ILL|KILL|TERM)\b",
+)
+
+# ── Decision cues ──────────────────────────────────────────────────────────
+# "made a choice": decide / choose / switch / migrate / select / opt.
+_DECISION_PATTERNS: dict[str, str] = {
+    # en: verbatim pre-#158 _DECISION_KW (thermodynamics.py) — regression anchor
+    "en": r"\b(?:decided|chose|switched|migrated|selected|picked|opted)\b",
+    # es: decidí/decidimos/decidido, decisión, elegí/elegimos/elegido,
+    #     eligió, escogimos/escogido, optamos/opté/optó/optado,
+    #     seleccionó/seleccionado, cambiamos/cambié/cambió (switched)
+    "es": (
+        r"\bdecid\w*|\bdecisi[oó]n\w*|\beleg[ií]\w*|\beligi\w*|\bescog\w*"
+        r"|\bopt(?:amos|é|ó|ado|aron)\b|\bseleccion\w*"
+        r"|\bcambi(?:amos|é|ó)\b"
+    ),
+    # pt: decidimos/decidiu/decidido, decisão/decisões, escolhemos/escolhido/
+    #     escolha, optamos/optou/optado, selecionou/selecionado,
+    #     migramos/migrou/migrado, mudamos (switched)
+    "pt": (
+        r"\bdecid\w*|\bdecis[aã]o\b|\bdecis[oõ]es\b|\bescolh\w*"
+        r"|\bopt(?:amos|ou|ado|aram)\b|\bselecion\w*"
+        r"|\bmigr(?:amos|ou|ado|aram)\b|\bmudamos\b"
+    ),
+    # fr: décidé/décidons (accented or not), décision, choisi/choisie/
+    #     choisissons, opté, sélectionné, migré/migration, basculé (switched)
+    "fr": (
+        r"\bd[ée]cid\w*|\bd[ée]cisi\w*|\bchoisi\w*|\bopt[ée]\b"
+        r"|\bs[ée]lectionn\w*|\bmigr[ée]\w*|\bbascul[ée]\w*"
+    ),
+    # de: entschied/entschieden, Entscheidung, gewählt, ausgewählt,
+    #     entschlossen, migriert, gewechselt/umgestiegen (switched)
+    "de": (
+        r"\bentschied\w*|\bentscheidung\w*|\bgew[äa]hlt\b|\bausgew[äa]hlt\b"
+        r"|\bentschlossen\b|\bmigriert\w*|\bgewechselt\b|\bumgestiegen\b"
+    ),
+    # ru: решил/решили/решено/решение, выбрал/выбрали/выбрано, выбор,
+    #     перешёл/перешли (switched to), мигрировали
+    "ru": (
+        r"\bреши\w*|\bрешен\w*|\bрешён\w*|\bвыбр\w*|\bвыбор\w*"
+        r"|\bпереш[её]л\w*|\bперешли\b|\bмигрир\w*"
+    ),
+    # ja: 決定 (decision), 決め(た/ました) (decided), 選択 (selection),
+    #     選ん/選び (chose), 採用 (adopted), 移行 (migrated). No \b — CJK
+    #     text has no word boundaries; substring match is the correct form.
+    "ja": r"決定|決め|選択|選ん|選び|採用|移行",
+    # ro: (am) decis, decidem, decizie/decizia, (am) ales, alegem,
+    #     aleasă, optat, optăm, migrat. Issue #158 repro language.
+    #     Collision note: \bales\b also matches the English plural "ales"
+    #     (beers) — accepted, see recall-bias rationale in module docstring.
+    "ro": (
+        r"\bdecis\w*|\bdecid\w*|\bdecizi\w*|\bales\b|\baleas[aă]\b"
+        r"|\baleg\w*|\boptat\b|\bopt[aă]m\b|\bmigrat\w*"
+    ),
+}
+
+# ── Error cues ─────────────────────────────────────────────────────────────
+_ERROR_PATTERNS: dict[str, str] = {
+    # en: verbatim pre-#158 _ERROR_KW (thermodynamics.py) — regression anchor
+    "en": (
+        r"\b(?:error|exception|traceback|failed|failure|bug|crash|broken|"
+        r"timeout|denied|rejected|deprecated)\b"
+    ),
+    # es: excepción, falla/fallo/falló/fallado/fallando/fallaron/fallamos,
+    #     roto/rota (broken), rechazado, caída (crash/outage).
+    #     "error" is identical in Spanish — already covered by en.
+    #     Collision note: \brota\b also matches BrE "rota" (schedule) —
+    #     accepted (recall bias).
+    "es": (
+        r"\bexcepci[oó]n\w*|\bfall(?:[aoó]|ad[oa]s?|ando|aron|amos)\b"
+        r"|\brot[oa]s?\b|\brechazad\w*|\bca[ií]da\b"
+    ),
+    # pt: erro(s), exceção/exceções, falha/falhou/falhado, quebrado (broken),
+    #     rejeitado, travou (froze/crashed)
+    "pt": (
+        r"\berros?\b|\bexce[çc][aã]o\w*|\bexce[çc][oõ]es\b|\bfalh\w*"
+        r"|\bquebrad\w*|\brejeitad\w*|\btravou\b"
+    ),
+    # fr: erreur(s), échec(s), échoué/échouons (accented or not),
+    #     rejeté, cassé/cassée(s) (broken), expiré (timed out).
+    #     "exception" is identical in French — already covered by en.
+    "fr": (
+        r"\berreurs?\b|\b[ée]checs?\b|\b[ée]chou\w*|\brejet[ée]\w*"
+        r"|\bcass[ée]e?s?\b|\bexpir[ée]\w*"
+    ),
+    # de: Fehler(-meldung), fehlgeschlagen/Fehlschlag, Ausnahme,
+    #     Absturz/abgestürzt, kaputt, abgelehnt, defekt
+    "de": (
+        r"\bfehler\w*|\bfehlgeschlagen\b|\bfehlschlag\w*|\bausnahme\w*"
+        r"|\babsturz\w*|\babgest[üu]rzt\b|\bkaputt\b|\babgelehnt\b|\bdefekt\w*"
+    ),
+    # ru: ошибка/ошибки/ошибок/ошибся, исключение, сбой/сбоя/сбои,
+    #     не удалось (failed to), упал/упало (crashed), сломался (broke),
+    #     отклонен/отклонён, таймаут/тайм-аут
+    "ru": (
+        r"\bошиб\w*|\bисключени\w*|\bсбо[йяие]\w*|\bне удалось\b"
+        r"|\bупал[оаи]?\b|\bслома\w*|\bотклонен\w*|\bотклонён\w*"
+        r"|\bтайм-?аут\w*"
+    ),
+    # ja: エラー (error), 例外 (exception), 失敗 (failure), バグ (bug),
+    #     クラッシュ (crash), タイムアウト (timeout), 拒否 (denied/rejected),
+    #     壊れ (broken), 不具合 (defect/glitch)
+    "ja": r"エラー|例外|失敗|バグ|クラッシュ|タイムアウト|拒否|壊れ|不具合",
+    # ro: eroare/erori, excepție/excepția, eșuat/eșec (accented or not),
+    #     defect, stricat (broken), respins (rejected), căzut (crashed/down)
+    "ro": (
+        r"\beroare\b|\berori\w*|\bexcep[țt]i\w*|\be[șs]uat\w*|\be[șs]ec\w*"
+        r"|\bdefect\w*|\bstricat\w*|\brespins\w*|\bc[ăa]zut\w*"
+    ),
+}
+
+# ── Success cues ───────────────────────────────────────────────────────────
+_SUCCESS_PATTERNS: dict[str, str] = {
+    # en: verbatim pre-#158 _SUCCESS_KW (write_gate.py) — regression anchor
+    "en": r"\b(?:fixed|resolved|succeeded|passed|completed|done)\b",
+    # es: arreglado/arreglamos/arreglé, resuelto/resolvimos, éxito/exitoso,
+    #     completado, corregido/corregimos, funcionó, aprobado (passed),
+    #     terminado
+    "es": (
+        r"\barregl\w*|\bresuelt\w*|\bresolvi\w*|\b[ée]xito\w*|\bexitos\w*"
+        r"|\bcompletad\w*|\bcorregid\w*|\bcorregimos\b|\bfuncion[oó]\b"
+        r"|\baprobad\w*|\bterminad\w*"
+    ),
+    # pt: consertado, corrigido, resolvido/resolvemos, sucesso(s),
+    #     concluído, aprovado (passed), funcionou
+    "pt": (
+        r"\bconsertad\w*|\bcorrigid\w*|\bresolvid\w*|\bresolvemos\b"
+        r"|\bsucessos?\b|\bconclu[ií]d\w*|\baprovad\w*|\bfuncionou\b"
+    ),
+    # fr: corrigé, résolu, réussi, terminé, achevé, réparé
+    #     (all with or without accents)
+    "fr": (
+        r"\bcorrig[ée]\w*|\br[ée]solu\w*|\br[ée]ussi\w*|\btermin[ée]\w*"
+        r"|\bachev[ée]\w*|\br[ée]par[ée]\w*"
+    ),
+    # de: behoben, gelöst, erfolgreich, abgeschlossen, repariert,
+    #     bestanden (passed), funktioniert
+    "de": (
+        r"\bbehoben\b|\bgel[öo]st\b|\berfolgreich\w*|\babgeschlossen\b"
+        r"|\brepariert\w*|\bbestanden\b|\bfunktioniert\w*"
+    ),
+    # ru: исправил/исправлено/исправили, решено/решен (also "decided" —
+    #     решить means both decide and solve; the overlap is inherent to the
+    #     language and both cues bypass anyway), успешно/успех, завершено,
+    #     починил, заработало (works now), готово (done)
+    "ru": (
+        r"\bисправ\w*|\bрешен\w*|\bрешён\w*|\bуспешн\w*|\bуспех\w*"
+        r"|\bзаверш\w*|\bпочин\w*|\bзаработал\w*|\bготово\b"
+    ),
+    # ja: 修正 (fix), 解決 (resolved), 成功 (success), 完了 (completed),
+    #     直した/直しました (fixed)
+    "ja": r"修正|解決|成功|完了|直した|直しました",
+    # ro: reparat, rezolvat/rezolvăm, reușit (accented or not), succes,
+    #     finalizat, corectat, funcționează (it works)
+    "ro": (
+        r"\breparat\w*|\brezolvat\w*|\brezolv[aă]m\b|\breu[șs]it\w*"
+        r"|\bsucces\w*|\bfinalizat\w*|\bcorectat\w*"
+        r"|\bfunc[țt]ioneaz[ăa]\b"
+    ),
+}
+
+
+def _compile_keyword_union(patterns: dict[str, str]) -> re.Pattern[str]:
+    """Union of the per-language fragments, case-insensitive.
+
+    IGNORECASE folds Latin and Cyrillic; it is a no-op for CJK.
+    """
+    return re.compile("|".join(patterns.values()), re.IGNORECASE)
+
+
+_DECISION_RE = _compile_keyword_union(_DECISION_PATTERNS)
+_ERROR_RE = _compile_keyword_union(_ERROR_PATTERNS)
+_SUCCESS_RE = _compile_keyword_union(_SUCCESS_PATTERNS)
+# Case-sensitive on purpose — casing is the structural signal (see docstring).
+_STRUCTURAL_ERROR_RE = re.compile("|".join(_STRUCTURAL_ERROR_PATTERNS))
+
+
+def is_decision_cue(content: str) -> bool:
+    """True when content carries a decision cue in any covered language."""
+    return bool(_DECISION_RE.search(content))
+
+
+def is_error_cue(content: str) -> bool:
+    """True on structural error markers (any language) or error keywords."""
+    return bool(_STRUCTURAL_ERROR_RE.search(content) or _ERROR_RE.search(content))
+
+
+def is_success_cue(content: str) -> bool:
+    """True when content carries a success cue in any covered language."""
+    return bool(_SUCCESS_RE.search(content))

--- a/mcp_server/core/thermodynamics.py
+++ b/mcp_server/core/thermodynamics.py
@@ -38,6 +38,7 @@ import re
 from collections import Counter
 from datetime import datetime, timezone
 
+from mcp_server.core import content_cues
 from mcp_server.shared.vader import vader_compound
 
 # Dose-response sweep override for the Python-side hourly decay factor
@@ -116,18 +117,6 @@ _STIGMA_WORDS = frozenset(
 _CODE_BLOCK_RE = re.compile(r"```|`[^`]+`")
 _FILE_PATH_RE = re.compile(r"(?:\.{0,2}/)?(?:[\w@.-]+/)+[\w@.-]+\.\w+")
 _WORD_RE = re.compile(r"[a-z]+(?:'[a-z]+)?", re.IGNORECASE)
-
-# ── Keyword patterns for backward-compatible helper functions ─────────────
-
-_ERROR_KW = re.compile(
-    r"\b(error|exception|traceback|failed|failure|bug|crash|broken|timeout|"
-    r"denied|rejected|deprecated)\b",
-    re.IGNORECASE,
-)
-_DECISION_KW = re.compile(
-    r"\b(decided|chose|switched|migrated|selected|picked|opted)\b",
-    re.IGNORECASE,
-)
 
 
 def compute_surprise(content: str, existing_similarities: list[float]) -> float:
@@ -345,10 +334,19 @@ def compute_metamemory_confidence(access_count: int, useful_count: int) -> float
 
 
 def is_error_content(content: str) -> bool:
-    """Check if content contains error/exception keywords."""
-    return bool(_ERROR_KW.search(content))
+    """Check if content carries an error cue (issue #158: language-aware).
+
+    Delegates to ``content_cues.is_error_cue`` — structural runtime markers
+    (tracebacks, stack frames, exception class names, POSIX signals) plus
+    multilingual error keywords. See ``content_cues`` for language coverage.
+    """
+    return content_cues.is_error_cue(content)
 
 
 def is_decision_content(content: str) -> bool:
-    """Check if content contains decision keywords."""
-    return bool(_DECISION_KW.search(content))
+    """Check if content carries a decision cue (issue #158: language-aware).
+
+    Delegates to ``content_cues.is_decision_cue`` — multilingual decision
+    keywords. See ``content_cues`` for language coverage.
+    """
+    return content_cues.is_decision_cue(content)

--- a/mcp_server/core/write_gate.py
+++ b/mcp_server/core/write_gate.py
@@ -5,12 +5,12 @@ Pure business logic for the memory write path. No I/O.
 
 from __future__ import annotations
 
-import re
 from datetime import datetime, timezone
 from typing import Any
 
 from mcp_server.core import coupled_neuromodulation as coupled_nm
 from mcp_server.core import (
+    content_cues,
     goal_maintenance,
     habituation,
     knowledge_graph,
@@ -42,10 +42,6 @@ from mcp_server.core.separation_core import (
     orthogonalize_embedding,
 )
 from mcp_server.observability import silent_failure
-
-_SUCCESS_KW = re.compile(
-    r"\b(fixed|resolved|succeeded|passed|completed|done)\b", re.IGNORECASE
-)
 
 
 def compute_embedding_novelty(
@@ -224,7 +220,9 @@ def apply_neuromodulation(
     """Apply coupled neuromodulation. Returns (heat, importance, composite)."""
     try:
         is_err = thermodynamics.is_error_content(content)
-        is_succ = bool(_SUCCESS_KW.search(content))
+        # Language-aware success cue (issue #158) — same coverage rules as
+        # the decision/error detectors; see content_cues module docstring.
+        is_succ = content_cues.is_success_cue(content)
         novel_ent = len([n for n in new_entity_names if n not in known_entity_names])
         signals = coupled_nm.OperationSignals(
             error_encountered=is_err,

--- a/tests_py/core/test_content_cues.py
+++ b/tests_py/core/test_content_cues.py
@@ -1,0 +1,196 @@
+"""Unit tests for mcp_server.core.content_cues — language-aware cue detection.
+
+Issue #158: the write-gate bypass heuristics (decision/error/success) were
+English-only regexes, so non-English decision/error notes never earned
+``bypass_decision``/``bypass_error`` and were rejected by novelty gating.
+
+Covers, per detector:
+  - the exact Romanian repro string from issue #158
+  - at least 3 further non-English languages
+  - the pre-#158 English keyword behavior (regression anchor)
+  - negatives in English and a covered non-English language
+  - the structural error-marker path with NO keyword match in any language
+    (traceback header, stack frames, exception class names, POSIX signals)
+
+Pure logic, no I/O, no DB.
+"""
+
+from __future__ import annotations
+
+from mcp_server.core.content_cues import (
+    is_decision_cue,
+    is_error_cue,
+    is_success_cue,
+)
+
+
+class TestDecisionCue:
+    def test_issue_158_english_repro(self):
+        assert is_decision_cue("DECISION: we decided to choose option A")
+
+    def test_issue_158_romanian_repro(self):
+        # Exact repro string from issue #158 — was False before the fix.
+        assert is_decision_cue("Am decis sa alegem optiunea A")
+
+    def test_spanish(self):
+        assert is_decision_cue("Decidimos usar PostgreSQL en lugar de MySQL")
+        assert is_decision_cue("Elegimos la opción B")
+
+    def test_portuguese(self):
+        assert is_decision_cue("Decidimos migrar para PostgreSQL")
+        assert is_decision_cue("Escolhemos a segunda abordagem")
+
+    def test_french(self):
+        assert is_decision_cue("Nous avons choisi PostgreSQL")
+        assert is_decision_cue("Décision : basculé vers PostgreSQL")
+
+    def test_german(self):
+        assert is_decision_cue("Wir haben uns entschieden, PostgreSQL zu verwenden")
+        assert is_decision_cue("Wir sind auf PostgreSQL umgestiegen")
+
+    def test_russian(self):
+        assert is_decision_cue("Мы решили использовать PostgreSQL")
+        assert is_decision_cue("Выбрали второй вариант")
+
+    def test_japanese(self):
+        assert is_decision_cue("PostgreSQLを採用することに決定した")
+        assert is_decision_cue("オプションBを選んだ")
+
+    def test_english_regressions_pre_158_keywords(self):
+        # Byte-for-byte the pre-#158 _DECISION_KW words must still match.
+        for kw in (
+            "decided",
+            "chose",
+            "switched",
+            "migrated",
+            "selected",
+            "picked",
+            "opted",
+        ):
+            assert is_decision_cue(f"We {kw} something"), kw
+
+    def test_negative_english(self):
+        assert not is_decision_cue("The weather is nice")
+        assert not is_decision_cue("Updated the README with installation instructions")
+
+    def test_negative_romanian(self):
+        assert not is_decision_cue("Vremea este frumoasa azi")
+
+
+class TestErrorCue:
+    def test_romanian(self):
+        assert is_error_cue("A aparut o eroare la compilare")
+        assert is_error_cue("Testul a esuat din nou")
+
+    def test_spanish(self):
+        assert is_error_cue("Falló la conexión a la base de datos")
+        assert is_error_cue("Fallo la conexion")  # unaccented typing
+
+    def test_german(self):
+        assert is_error_cue("Der Build ist fehlgeschlagen")
+        assert is_error_cue("Die Anwendung ist abgestürzt")
+
+    def test_russian(self):
+        assert is_error_cue("Произошла ошибка при сборке")
+        assert is_error_cue("Не удалось подключиться к базе")
+
+    def test_japanese(self):
+        assert is_error_cue("ビルドが失敗しました")
+        assert is_error_cue("タイムアウトが発生")
+
+    def test_french(self):
+        assert is_error_cue("Le déploiement a échoué")
+
+    def test_portuguese(self):
+        assert is_error_cue("O teste falhou de novo")
+
+    def test_english_regressions_pre_158_keywords(self):
+        # Byte-for-byte the pre-#158 _ERROR_KW words must still match.
+        for kw in (
+            "error",
+            "exception",
+            "traceback",
+            "failed",
+            "failure",
+            "bug",
+            "crash",
+            "broken",
+            "timeout",
+            "denied",
+            "rejected",
+            "deprecated",
+        ):
+            assert is_error_cue(f"Saw a {kw} today"), kw
+
+    def test_negative_english(self):
+        assert not is_error_cue("Everything is fine")
+        assert not is_error_cue("Normal memory")
+
+    def test_negative_romanian(self):
+        assert not is_error_cue("Totul merge bine")
+
+
+class TestErrorCueStructuralMarkers:
+    """Structural runtime markers fire with NO keyword match in any covered
+    language — the surrounding prose below is Finnish/Romanian/German, none
+    of whose words appear in any keyword set."""
+
+    def test_python_traceback_header(self):
+        assert is_error_cue("Traceback (most recent call last):")
+
+    def test_python_frame_line(self):
+        assert is_error_cue('File "app.py", line 3, in <module>')
+
+    def test_jvm_stack_frame_in_uncovered_language(self):
+        # Finnish prose (uncovered language) + JVM frame.
+        assert is_error_cue("Sovellus kaatui: at com.acme.Main.run(Main.java:42)")
+
+    def test_node_stack_frame(self):
+        assert is_error_cue("at processTicks (/app/index.js:10:5)")
+
+    def test_camelcase_exception_class(self):
+        assert is_error_cue("Sovellus lopetti: NullPointerException nähtiin")
+        assert is_error_cue("ValueError: invalid literal for int()")
+
+    def test_posix_signal_name(self):
+        assert is_error_cue("Prozess beendet: SIGSEGV")
+
+    def test_structural_markers_are_case_sensitive(self):
+        # Lowercase "sigsegv" is prose, not a runtime-printed signal name.
+        # (No keyword set contains it either.)
+        assert not is_error_cue("wrote about sigsegv handling someday")
+
+
+class TestSuccessCue:
+    def test_romanian(self):
+        assert is_success_cue("Am rezolvat problema de memorie")
+
+    def test_spanish(self):
+        assert is_success_cue("Arreglamos el problema de memoria")
+        assert is_success_cue("Los tests aprobados")
+
+    def test_russian(self):
+        assert is_success_cue("Исправлено, тесты проходят")
+
+    def test_japanese(self):
+        assert is_success_cue("バグを修正しました")
+
+    def test_french(self):
+        assert is_success_cue("Problème résolu")
+
+    def test_german(self):
+        assert is_success_cue("Der Fehler wurde behoben")
+
+    def test_portuguese(self):
+        assert is_success_cue("Problema resolvido")
+
+    def test_english_regressions_pre_158_keywords(self):
+        # Byte-for-byte the pre-#158 _SUCCESS_KW words must still match.
+        for kw in ("fixed", "resolved", "succeeded", "passed", "completed", "done"):
+            assert is_success_cue(f"Task {kw} today"), kw
+
+    def test_negative_english(self):
+        assert not is_success_cue("Investigating the memory layout")
+
+    def test_negative_romanian(self):
+        assert not is_success_cue("Investigam structura memoriei")

--- a/tests_py/core/test_thermodynamics.py
+++ b/tests_py/core/test_thermodynamics.py
@@ -216,3 +216,11 @@ class TestContentDetectors:
 
     def test_non_decision_content(self):
         assert not is_decision_content("The weather is nice")
+
+    def test_non_english_content_detected(self):
+        # Issue #158: detectors are language-aware (see core/content_cues).
+        assert is_decision_content("Am decis sa alegem optiunea A")  # repro
+        assert is_error_content("Der Build ist fehlgeschlagen")
+
+    def test_structural_error_marker_detected(self):
+        assert is_error_content("Traceback (most recent call last):")

--- a/tests_py/core/test_write_gate.py
+++ b/tests_py/core/test_write_gate.py
@@ -99,6 +99,31 @@ class TestDetermineBypass:
         assert bypassed is True
         assert reason == "bypass_decision"
 
+    def test_non_english_decision_bypasses(self):
+        # Issue #158 exact repro: Romanian decision was rejected as duplicate.
+        bypassed, reason = wg.determine_bypass(
+            force=False, content="Am decis sa alegem optiunea A", tags=[]
+        )
+        assert bypassed is True
+        assert reason == "bypass_decision"
+
+    def test_non_english_error_bypasses(self):
+        bypassed, reason = wg.determine_bypass(
+            force=False, content="Произошла ошибка при сборке", tags=[]
+        )
+        assert bypassed is True
+        assert reason == "bypass_error"
+
+    def test_structural_stack_trace_bypasses_without_keywords(self):
+        # No keyword in any covered language — structural marker only.
+        bypassed, reason = wg.determine_bypass(
+            force=False,
+            content="Sovellus kaatui: at com.acme.Main.run(Main.java:42)",
+            tags=[],
+        )
+        assert bypassed is True
+        assert reason == "bypass_error"
+
     def test_important_tag_bypasses(self):
         bypassed, reason = wg.determine_bypass(
             force=False, content="Routine progress update", tags=["important"]
@@ -590,6 +615,15 @@ class TestApplyNeuromodulation:
 
     def test_success_keyword_does_not_raise(self):
         heat, importance, composite = self._call(content="Fixed the bug successfully.")
+        assert composite is not None
+        assert 0.0 <= heat <= 1.0
+
+    def test_non_english_success_keyword_detected(self):
+        # Issue #158: the success cue feeding error_resolved is
+        # language-aware; Romanian "rezolvat" must count as success.
+        heat, importance, composite = self._call(
+            content="Am rezolvat problema de memorie."
+        )
         assert composite is not None
         assert 0.0 <= heat <= 1.0
 


### PR DESCRIPTION
Fixes #158.

The bypass detectors in `determine_bypass` and the neuromodulation success cue treated "decision/error cue" as "English keyword", so detection now lives in a new `core/content_cues.py` module (stdlib-only, pure logic).

- **Structural runtime markers first, language-agnostic**: CPython traceback header + `File "...", line N` frames, JVM/Node stack frames, CamelCase `*Error`/`*Exception` class names, POSIX signal names — these fire in any prose language because runtimes emit them in fixed ASCII form. Each pattern cited to its spec (CPython docs, Throwable javadoc, V8 stack-trace API, PEP 8/Java naming, POSIX.1-2017).
- **Multilingual keyword sets** with per-language provenance: en (pre-#158 patterns preserved verbatim as regression anchors) + es/pt/ru/ja (the four non-English languages Stack Overflow runs dedicated sites for — the best available developer-demand signal) + de/fr (top W3Techs web-content languages) + ro (the reporter's repro language). Stems use `\w*` suffixes for inflection; the two known cross-language collisions are documented inline.
- **Deliberately recall-biased**: a false bypass costs one extra memory that `try_curation` merges afterwards; a false negative silently drops a decision — exactly the reported failure.
- The issue's repro now passes: `is_decision_content("Am decis sa alegem optiunea A")` → True, `determine_bypass` → `(True, "bypass_decision")`. Structural-only case with zero keywords in any language also bypasses (Finnish prose + Java frame).
- `force=true` / `important`/`critical` tags remain the universal fallback and stay excluded from the calibration EMA (`remember_helpers.py` untouched — no new bypass reasons). `docs/data-flow.md` documents the exact coverage.

## Test plan
- [x] `tests_py/core`: 2785 passed, 9 skipped (41 new detector tests + 4 integration)
- [x] Targeted handler suites (write_class, remember, novelty, gate wiring): 55 passed
- [x] `ruff check` + `ruff format --check` clean; 36-case multilingual smoke matrix: 0 failures
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)