### PR TITLE
fix(release): align manifest.json and package.json versions to 4.14.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,8 +14,8 @@
       "python": ">=3.10"
     }
   },
-  "description": "Persistent memory and cognitive profiling for Claude — remembers across sessions automatically. Scientific retrieval backed by 72 published references.",
-  "display_name": "Cortex — Persistent Memory",
+  "description": "Persistent memory and cognitive profiling for Claude \u2014 remembers across sessions automatically. Scientific retrieval backed by 72 published references.",
+  "display_name": "Cortex \u2014 Persistent Memory",
   "documentation": "https://github.com/cdeust/Cortex#readme",
   "homepage": "https://github.com/cdeust/Cortex",
   "icon": "icon.png",
@@ -35,7 +35,7 @@
     "agents"
   ],
   "license": "MIT",
-  "long_description": "Cortex gives Claude a durable, scientifically-grounded memory. It stores decisions, lessons, and context across sessions and retrieves them with a hybrid WRRF fusion (vector + full-text + trigram + heat + recency) reranked by a cross-encoder. Its 23 neuroscience-grounded mechanisms are drawn from a 72-reference bibliography (spreading activation, synaptic tagging, neuromodulation, LTP/LTD, predictive-coding write gates). This connector exposes 49 memory tools standalone (52 with upstream integrations available) and runs fully local with zero external services using the built-in SQLite backend; advanced users can point it at PostgreSQL + pgvector. For the automatic session-lifecycle memory (injection at session start, auto-capture, compaction checkpointing), install the companion Claude Code plugin — its hooks drive that automation, which the MCP bundle format does not carry.",
+  "long_description": "Cortex gives Claude a durable, scientifically-grounded memory. It stores decisions, lessons, and context across sessions and retrieves them with a hybrid WRRF fusion (vector + full-text + trigram + heat + recency) reranked by a cross-encoder. Its 23 neuroscience-grounded mechanisms are drawn from a 72-reference bibliography (spreading activation, synaptic tagging, neuromodulation, LTP/LTD, predictive-coding write gates). This connector exposes 49 memory tools standalone (52 with upstream integrations available) and runs fully local with zero external services using the built-in SQLite backend; advanced users can point it at PostgreSQL + pgvector. For the automatic session-lifecycle memory (injection at session start, auto-capture, compaction checkpointing), install the companion Claude Code plugin \u2014 its hooks drive that automation, which the MCP bundle format does not carry.",
   "manifest_version": "0.4",
   "name": "hypermnesia-mcp",
   "privacy_policies": [
@@ -83,5 +83,5 @@
       "type": "string"
     }
   },
-  "version": "4.13.2"
+  "version": "4.14.3"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypermnesia-mcp",
-  "version": "3.24.0",
+  "version": "4.14.3",
   "description": "Persistent memory and cognitive profiling for Claude Code",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cowork surfaced a stale-looking version, which prompted a sweep of every version field on main. plugin.json / marketplace.json / pyproject.toml were already consistent at 4.14.3; two stragglers were not:

- `manifest.json` (the .mcpb bundle manifest) said **4.13.2** — the next Desktop/Cowork bundle build would ship mislabeled
- `package.json` said **3.24.0**

Both now read 4.14.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)