### PR TITLE
fix: three setup-run bugs — degenerate causal edges, SQLite grooming surface, legacy memory import

### DIFF
--- a/mcp_server/core/causal_graph.py
+++ b/mcp_server/core/causal_graph.py
@@ -155,6 +155,18 @@ def discover_causal_edges(
     if not entity_names or not presence:
         return []
 
+    # entities.name carries no UNIQUE constraint (pg_schema.py /
+    # sqlite_schema.py — the same name may legitimately recur across
+    # type/domain rows), so callers flattening store rows to names can
+    # pass duplicates. PC treats every list element as a distinct
+    # variable: a duplicated name turns the complete-graph
+    # initialisation's frozenset((a, a)) into a degenerate 1-element
+    # edge that crashes the 2-tuple unpack below, and hands
+    # orient_v_structures fake unshielded triples (X, X, Z). Establish
+    # the distinct-variables precondition once, at this boundary,
+    # order-preservingly (observed on a 23k-entity store, 2026-07-22).
+    entity_names = list(dict.fromkeys(entity_names))
+
     counts, pairs = _entity_and_pair_counts(presence, entity_names)
     total = len(presence)
     skeleton, sepsets = pc_skeleton(entity_names, presence, alpha, max_cond_size)

--- a/mcp_server/core/causal_pc.py
+++ b/mcp_server/core/causal_pc.py
@@ -140,6 +140,11 @@ def pc_skeleton(
 ) -> tuple[set[frozenset[str]], dict[frozenset[str], frozenset[str]]]:
     """Phase 1 of PC: learn the undirected skeleton.
 
+    Precondition: ``variables`` are pairwise distinct — a duplicated
+    variable yields a degenerate 1-element ``frozenset`` edge in the
+    complete-graph initialisation. ``discover_causal_edges``
+    (causal_graph.py) enforces this at the pipeline boundary.
+
     Starts from the complete graph and removes edge X–Y whenever some subset
     S of X's (or Y's) current neighbours renders them conditionally
     independent, recording S as the separating set. Conditioning-set size

--- a/mcp_server/handlers/get_grooming_health.py
+++ b/mcp_server/handlers/get_grooming_health.py
@@ -38,6 +38,10 @@ from mcp_server.infrastructure.memory_store import get_shared_store
 from mcp_server.infrastructure.pg_store_lesson_promotion import (
     count_lesson_promotion_candidates,
 )
+from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
+from mcp_server.infrastructure.sqlite_store_lesson_promotion import (
+    count_lesson_promotion_candidates as count_promotion_candidates_sqlite,
+)
 
 schema = {
     "title": "Grooming health (backlog + staleness)",
@@ -88,6 +92,21 @@ schema = {
 }
 
 
+def _count_promotion_candidates(store: Any) -> int:
+    """Backend dispatch for the promotion backlog count.
+
+    Composition-root concern: the eligibility query exists in two SQL
+    dialects (pg_store_lesson_promotion / sqlite_store_lesson_promotion,
+    same WHERE semantics) because jsonb operators have no SQLite
+    translation. The PG count previously ran unconditionally and raised
+    on the SQLite backend (the plugin default) — this handler was one of
+    the setup-run failures observed 2026-07-22.
+    """
+    if isinstance(store, SqliteMemoryStore):
+        return count_promotion_candidates_sqlite(store._conn)
+    return count_lesson_promotion_candidates(store._conn)
+
+
 async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
     """Aggregate backlog counts + staleness ages for the three grooming kinds.
 
@@ -106,7 +125,7 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
     wiki_result = await curate_wiki.handler(
         {"limit": 1, "coverage_jobs_max": 0, "reauthor_jobs_max": 0}
     )
-    promotion_count = count_lesson_promotion_candidates(store._conn)
+    promotion_count = _count_promotion_candidates(store)
 
     kinds: dict[str, Any] = {}
     for kind, backlog_count, last_run_at in (

--- a/mcp_server/infrastructure/scanner.py
+++ b/mcp_server/infrastructure/scanner.py
@@ -134,8 +134,11 @@ def _parse_memory_file(
         return None
 
     st = stat_file(file_path)
+    # FrontmatterResult is a NamedTuple: attribute access, never string
+    # indexing — parsed["meta"] (Node.js-port drift) raised "tuple indices
+    # must be integers" on every memory .md file, swallowed by the caller.
     parsed = parse_yaml_frontmatter(content)
-    meta = parsed["meta"]
+    meta = parsed.meta
 
     return {
         "file": file_name,
@@ -144,7 +147,7 @@ def _parse_memory_file(
         "name": meta.get("name") or file_name.replace(".md", ""),
         "description": meta.get("description") or "",
         "type": meta.get("type") or "unknown",
-        "body": parsed["body"],
+        "body": parsed.body,
         "modifiedAt": _format_timestamp(st, "st_mtime"),
         "createdAt": _format_timestamp(st, "st_ctime"),
     }

--- a/mcp_server/infrastructure/sqlite_store.py
+++ b/mcp_server/infrastructure/sqlite_store.py
@@ -1,7 +1,11 @@
 """SQLite + FTS5 + sqlite-vec fallback memory store.
 
 Drop-in replacement for PgMemoryStore when PostgreSQL is unavailable.
-Uses the same public API — all 89 methods with identical signatures.
+Mirrors the PG public API for every method the handlers/hooks call on
+the shared store (117 shared methods; 18 PG-only remain — pool
+acquisition, ingest progress, decay iteration, procedural skills,
+tag-vector search — measured 2026-07-22 via an inspect.getmembers diff
+of the two classes; the prior "all 89 methods" claim here was stale).
 
 WRRF fusion and spread activation are computed client-side
 (vs server-side PL/pgSQL in the PG backend).
@@ -30,6 +34,7 @@ from mcp_server.infrastructure.sqlite_store_entities import SqliteEntityMixin
 from mcp_server.infrastructure.sqlite_store_entity_merge import (
     SqliteEntityMergeMixin,
 )
+from mcp_server.infrastructure.sqlite_store_grooming import SqliteGroomingMixin
 from mcp_server.infrastructure.sqlite_store_mood import SqliteMoodMixin
 from mcp_server.infrastructure.sqlite_store_queries import SqliteQueryMixin
 from mcp_server.infrastructure.sqlite_store_receipts import SqliteReceiptsMixin
@@ -62,6 +67,7 @@ class SqliteMemoryStore(
     SqliteReceiptsMixin,
     SqliteRuleMixin,
     SqliteStatsMixin,
+    SqliteGroomingMixin,
     SqliteAuxiliaryMixin,
     SqliteMoodMixin,
     SqliteSearchMixin,

--- a/mcp_server/infrastructure/sqlite_store_grooming.py
+++ b/mcp_server/infrastructure/sqlite_store_grooming.py
@@ -1,0 +1,68 @@
+"""Grooming staleness reads for SqliteMemoryStore (judgment-level
+curation, not the mechanical consolidate pass -- see the
+core.grooming_health module docstring).
+
+Mirror of ``PgStatsMixin.get_grooming_ages`` (pg_store_stats.py). The
+jsonb tag queries translate to SQLite's ``json_each`` table-valued
+function; the wiki age is an honest degradation documented on the
+method. Missing entirely pre-fix: on the SQLite backend (the plugin
+default) every ``store.get_grooming_ages()`` call site raised
+``AttributeError`` -- observed on a real 30k-memory setup run,
+2026-07-22.
+"""
+
+from __future__ import annotations
+
+from mcp_server.infrastructure.sqlite_compat import PsycopgCompatConnection
+
+
+class SqliteGroomingMixin:
+    """Read-only grooming-age queries on SQLite."""
+
+    _conn: PsycopgCompatConnection
+
+    def get_grooming_ages(self) -> dict[str, str | None]:
+        """Last-executed timestamp for each judgment-level grooming kind.
+
+        Precondition: none.
+        Postcondition: returns {"wiki", "distillation", "promotion"} ->
+        timestamp string (ISO-8601, parseable by
+        ``datetime.fromisoformat``) of the most recent judgment-level
+        action of that kind recorded in this store, or None if none is
+        recorded. Read-only. Same contract as
+        ``PgStatsMixin.get_grooming_ages``, with one honest degradation:
+
+        - wiki: always None. The ``tended`` timestamp lives only in the
+          PG ``wiki.pages`` index (pg_store_wiki_pages.py); the SQLite
+          schema has no wiki table, and wiki markdown on the filesystem
+          carries no tend record this store can read. None already means
+          "never recorded" to every consumer (core.grooming_health
+          treats it as always-stale; ``legs_due`` additionally requires
+          a non-zero backlog before nudging).
+        - distillation / promotion: the SQLite translation of the PG
+          jsonb queries -- 'lesson'-tagged memories carrying a
+          'distill-of:'/'promoted:' tag prefix, matched via json_each.
+        """
+        return {
+            "wiki": None,
+            "distillation": self._last_lesson_tag_prefix("distill-of:"),
+            "promotion": self._last_lesson_tag_prefix("promoted:"),
+        }
+
+    def _last_lesson_tag_prefix(self, prefix: str) -> str | None:
+        """MAX(created_at) over 'lesson'-tagged memories with a ``prefix`` tag.
+
+        The 'lesson' prefilter is semantically required, not an
+        optimisation shortcut: curate_distill.py and lesson_promotion.py
+        both only ever tag their output 'lesson', so it cannot exclude a
+        true positive (same argument as the PG twin's docstring).
+        """
+        row = self._conn.execute(
+            "SELECT MAX(m.created_at) AS last_ts FROM memories m "
+            "WHERE EXISTS (SELECT 1 FROM json_each(m.tags) "
+            "              WHERE value = 'lesson') "
+            "AND EXISTS (SELECT 1 FROM json_each(m.tags) "
+            "            WHERE value LIKE ? || '%')",
+            (prefix,),
+        ).fetchone()
+        return row["last_ts"] if row and row["last_ts"] else None

--- a/mcp_server/infrastructure/sqlite_store_lesson_promotion.py
+++ b/mcp_server/infrastructure/sqlite_store_lesson_promotion.py
@@ -1,0 +1,49 @@
+"""Read-only SQLite query for lesson-promotion candidates.
+
+SQLite twin of ``pg_store_lesson_promotion.count_lesson_promotion_
+candidates`` -- same ``current_memories`` view, same eligibility
+semantics, same read-only contract. A separate module (not a branch in
+the PG one) because the PG SQL is untranslatable mechanically: ``@>``
+and ``jsonb_array_elements_text`` have no SQLite equivalent, and the
+psycopg-compat wrapper deliberately translates only lexical conventions
+(sqlite_compat.py's translation table), never jsonb operators. The
+composition root (handlers/get_grooming_health.py) dispatches on the
+store type.
+"""
+
+from __future__ import annotations
+
+from mcp_server.infrastructure.sqlite_compat import PsycopgCompatConnection
+
+# Same eligibility definition as pg_store_lesson_promotion._ELIGIBLE_WHERE,
+# expressed with json_each: not stale, tagged 'lesson' or
+# 'lesson-candidate', at least one recall/rating event, and no
+# 'promoted:*' tag yet. Kept as one shared constant for the same
+# anti-drift reason as the PG twin.
+_ELIGIBLE_WHERE = """
+    NOT m.is_stale
+      AND (
+        EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value = 'lesson')
+        OR EXISTS (SELECT 1 FROM json_each(m.tags)
+                   WHERE value = 'lesson-candidate')
+      )
+      AND (m.access_count > 0 OR m.useful_count > 0)
+      AND NOT EXISTS (
+        SELECT 1 FROM json_each(m.tags) WHERE value LIKE 'promoted:%'
+      )
+"""
+
+
+def count_lesson_promotion_candidates(conn: PsycopgCompatConnection) -> int:
+    """Total count of lesson-promotion candidates on the SQLite backend.
+
+    Precondition: ``conn`` is a schema-provisioned SQLite store
+    connection (works with zero lesson-tagged rows).
+    Postcondition: returns the exact row count matching
+    ``_ELIGIBLE_WHERE`` -- the same eligibility definition the PG twin
+    counts. Read-only.
+    """
+    row = conn.execute(
+        f"SELECT count(*) AS n FROM current_memories m WHERE {_ELIGIBLE_WHERE}"
+    ).fetchone()
+    return int(row["n"]) if row else 0

--- a/tests_py/core/test_causal_graph.py
+++ b/tests_py/core/test_causal_graph.py
@@ -183,6 +183,43 @@ class TestDiscoverCausalEdges:
         strengths = [e["strength"] for e in edges]
         assert strengths == sorted(strengths, reverse=True)
 
+    def test_duplicate_entity_names_do_not_crash_edge_unpack(self):
+        # entities.name carries no UNIQUE constraint (pg_schema.py /
+        # sqlite_schema.py), so a real store can hand this function the
+        # same name twice. Pre-fix, the duplicated name produced the
+        # degenerate skeleton edge frozenset(("A", "A")) == {"A"}: with A
+        # exactly independent of B, the A-B edge is removed at k=0,
+        # leaving {"A"} with no neighbours to condition on, so it
+        # survived to the consumption loop and crashed the 2-tuple
+        # unpack ("not enough values to unpack") — observed on a real
+        # 23k-entity store during setup.
+        pres: list[frozenset[str]] = []
+        for a, b in product((0, 1), repeat=2):
+            for _ in range(6):
+                s: set[str] = set()
+                if a:
+                    s.add("A")
+                if b:
+                    s.add("B")
+                pres.append(frozenset(s))
+
+        edges = discover_causal_edges(["A", "A", "B"], pres, min_observations=3)
+
+        assert all(e["source"] != e["target"] for e in edges)
+
+    def test_duplicate_entity_names_keep_real_edges(self):
+        # Dedup must not lose the genuine A-B dependency.
+        pres = [frozenset(("A", "B")) for _ in range(10)]
+        pres += [frozenset() for _ in range(10)]
+        edges = discover_causal_edges(
+            ["A", "A", "B"],
+            pres,
+            entity_first_seen={"A": "2026-01-01", "B": "2026-01-02"},
+            min_observations=3,
+        )
+        assert len(edges) == 1
+        assert edges[0]["source"] == "A" and edges[0]["target"] == "B"
+
 
 # ── build_presence ────────────────────────────────────────────────────────
 

--- a/tests_py/handlers/test_memory_stats.py
+++ b/tests_py/handlers/test_memory_stats.py
@@ -2,7 +2,9 @@
 
 import asyncio
 
+from mcp_server.handlers import memory_stats
 from mcp_server.handlers.memory_stats import handler, _get_store
+from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
 
 
 class TestMemoryStatsHandler:
@@ -73,3 +75,21 @@ class TestMemoryStatsHandler:
             if kind_stats["last_run_at"] is None:
                 assert kind_stats["stale"] is True
                 assert kind_stats["days_since_last_run"] is None
+
+    def test_works_on_sqlite_backend(self, monkeypatch):
+        """Plugin-default backend: memory_stats must not AttributeError.
+
+        Repro: get_grooming_ages existed only on PgStatsMixin, so this
+        handler crashed on every SQLite install -- observed on a real
+        30k-memory setup run, 2026-07-22."""
+        sqlite_store = SqliteMemoryStore(db_path=":memory:")
+        monkeypatch.setattr(memory_stats, "_store", sqlite_store)
+        try:
+            result = asyncio.run(handler())
+        finally:
+            sqlite_store.close()
+        staleness = result["grooming_staleness"]
+        assert set(staleness.keys()) == {"wiki", "distillation", "promotion"}
+        for kind_stats in staleness.values():
+            assert kind_stats["last_run_at"] is None
+            assert kind_stats["stale"] is True

--- a/tests_py/infrastructure/test_scanner.py
+++ b/tests_py/infrastructure/test_scanner.py
@@ -101,6 +101,49 @@ class TestDiscoverAllMemories:
         memories = discover_all_memories()
         assert isinstance(memories, list)
 
+    def test_parses_legacy_memory_file_with_frontmatter(self, tmp_path, monkeypatch):
+        """parse_yaml_frontmatter returns a NamedTuple; pre-fix the scanner
+        indexed it with strings ("tuple indices must be integers"), so every
+        legacy projects/*/memory/*.md read failed and setup imported zero
+        memory files (each failure swallowed to stderr by the caller)."""
+        monkeypatch.setattr("mcp_server.infrastructure.scanner.CLAUDE_DIR", tmp_path)
+        mem_dir = tmp_path / "projects" / "proj-a" / "memory"
+        mem_dir.mkdir(parents=True)
+        (mem_dir / "auth-decision.md").write_text(
+            "---\n"
+            "name: auth-decision\n"
+            "description: JWT over sessions\n"
+            "type: decision\n"
+            "---\n"
+            "We chose JWT.\n",
+            encoding="utf-8",
+        )
+
+        memories = discover_all_memories()
+
+        assert len(memories) == 1
+        m = memories[0]
+        assert m["name"] == "auth-decision"
+        assert m["description"] == "JWT over sessions"
+        assert m["type"] == "decision"
+        assert m["body"] == "We chose JWT."
+        assert m["project"] == "proj-a"
+
+    def test_parses_memory_file_without_frontmatter(self, tmp_path, monkeypatch):
+        """No-frontmatter files fall back to filename-derived name and the
+        full content as body — same NamedTuple contract, empty meta."""
+        monkeypatch.setattr("mcp_server.infrastructure.scanner.CLAUDE_DIR", tmp_path)
+        mem_dir = tmp_path / "projects" / "proj-b" / "memory"
+        mem_dir.mkdir(parents=True)
+        (mem_dir / "plain-note.md").write_text("just a plain note\n", encoding="utf-8")
+
+        memories = discover_all_memories()
+
+        assert len(memories) == 1
+        assert memories[0]["name"] == "plain-note"
+        assert memories[0]["type"] == "unknown"
+        assert memories[0]["body"] == "just a plain note"
+
 
 class TestDiscoverConversations:
     def test_returns_array(self):

--- a/tests_py/infrastructure/test_sqlite_grooming.py
+++ b/tests_py/infrastructure/test_sqlite_grooming.py
@@ -1,0 +1,125 @@
+"""Tests for grooming-staleness reads on the SQLite backend.
+
+Repro context: ``get_grooming_ages`` existed only on ``PgStatsMixin``,
+so on the SQLite backend (the plugin default) ``memory_stats`` and
+``get_grooming_health`` raised ``AttributeError`` — observed on a real
+30k-memory setup run, 2026-07-22. These tests pin the SQLite mirror:
+``SqliteGroomingMixin.get_grooming_ages`` and
+``sqlite_store_lesson_promotion.count_lesson_promotion_candidates``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
+from mcp_server.infrastructure.sqlite_store_lesson_promotion import (
+    count_lesson_promotion_candidates,
+)
+
+
+@pytest.fixture()
+def store():
+    s = SqliteMemoryStore(db_path=":memory:")
+    yield s
+    s.close()
+
+
+def _set_useful(store: SqliteMemoryStore, memory_id: int) -> None:
+    """Give a memory the usage evidence the eligibility WHERE requires."""
+    store._conn.execute(
+        "UPDATE memories SET useful_count = 1 WHERE id = ?", (memory_id,)
+    )
+    store._conn.commit()
+
+
+class TestGetGroomingAges:
+    def test_returns_the_three_expected_kinds(self, store):
+        ages = store.get_grooming_ages()
+        assert set(ages.keys()) == {"wiki", "distillation", "promotion"}
+        for v in ages.values():
+            assert v is None or isinstance(v, str)
+
+    def test_empty_store_has_no_recorded_ages(self, store):
+        assert store.get_grooming_ages() == {
+            "wiki": None,
+            "distillation": None,
+            "promotion": None,
+        }
+
+    def test_wiki_is_always_none_on_sqlite(self, store):
+        # Documented degradation: the tended index (wiki.pages) is
+        # PG-only; SQLite has no wiki table to record tend timestamps.
+        store.insert_memory({"content": "any", "tags": ["lesson"]})
+        assert store.get_grooming_ages()["wiki"] is None
+
+    def test_distillation_age_advances_after_distill_of_tag(self, store):
+        store.insert_memory(
+            {
+                "content": "root cause: missing transaction boundary.",
+                "tags": ["lesson", "distill-of:cluster-42"],
+            }
+        )
+        ages = store.get_grooming_ages()
+        assert ages["distillation"] is not None
+        # Contract: parseable timestamp (days_since uses fromisoformat).
+        datetime.fromisoformat(ages["distillation"])
+        assert ages["promotion"] is None
+
+    def test_promotion_age_advances_after_promoted_tag(self, store):
+        store.insert_memory(
+            {
+                "content": "always verify provenance before merge.",
+                "tags": ["lesson", "promoted:rule-7"],
+            }
+        )
+        ages = store.get_grooming_ages()
+        assert ages["promotion"] is not None
+        assert ages["distillation"] is None
+
+    def test_prefix_tag_without_lesson_tag_does_not_count(self, store):
+        # The 'lesson' prefilter is semantically required (see the PG
+        # twin's docstring): a distill-of: tag alone is not a
+        # distillation action.
+        store.insert_memory({"content": "x", "tags": ["distill-of:y"]})
+        assert store.get_grooming_ages()["distillation"] is None
+
+
+class TestCountLessonPromotionCandidates:
+    def test_zero_on_empty_store(self, store):
+        assert count_lesson_promotion_candidates(store._conn) == 0
+
+    def test_counts_lesson_with_usage_evidence(self, store):
+        mem_id = store.insert_memory({"content": "a lesson", "tags": ["lesson"]})
+        assert count_lesson_promotion_candidates(store._conn) == 0  # no usage yet
+        _set_useful(store, mem_id)
+        assert count_lesson_promotion_candidates(store._conn) == 1
+
+    def test_already_promoted_is_excluded(self, store):
+        mem_id = store.insert_memory(
+            {"content": "promoted lesson", "tags": ["lesson", "promoted:rule-1"]}
+        )
+        _set_useful(store, mem_id)
+        assert count_lesson_promotion_candidates(store._conn) == 0
+
+    def test_lesson_candidate_tag_qualifies(self, store):
+        mem_id = store.insert_memory(
+            {"content": "candidate", "tags": ["lesson-candidate"]}
+        )
+        _set_useful(store, mem_id)
+        assert count_lesson_promotion_candidates(store._conn) == 1
+
+
+class TestGroomingHealthHandlerDispatch:
+    def test_promotion_count_dispatches_to_sqlite(self, store):
+        # Pre-fix, the handler unconditionally ran the PG jsonb count
+        # against the SQLite compat connection and raised.
+        from mcp_server.handlers.get_grooming_health import (
+            _count_promotion_candidates,
+        )
+
+        mem_id = store.insert_memory({"content": "a lesson", "tags": ["lesson"]})
+        _set_useful(store, mem_id)
+        assert _count_promotion_candidates(store) == 1

--- a/tests_py/invariants/test_I2_canonical_writer.py
+++ b/tests_py/invariants/test_I2_canonical_writer.py
@@ -69,11 +69,11 @@ _ALLOWED_WRITERS: set[tuple[str, int]] = {
     # SQLite parity of the anchor transfer (same transactional rationale).
     # Shifted 389->440 when M-D3 (7.1) added
     # _migrate_homeostatic_state_write_class above it.
-    ("infrastructure/sqlite_store.py", 441),
+    ("infrastructure/sqlite_store.py", 447),
     # SQLite parity: canonical bump_heat_raw / update_memories_heat_batch.
     # Shifted 419->470, 463->534 for the same reason.
-    ("infrastructure/sqlite_store.py", 471),
-    ("infrastructure/sqlite_store.py", 535),
+    ("infrastructure/sqlite_store.py", 477),
+    ("infrastructure/sqlite_store.py", 541),
     # Homeostatic fold (amortized ~once/month per (domain, write_class)).
     # M-D3 (7.1, 2026-07-10): split out of homeostatic.py into
     # homeostatic_apply.py (§4.1 500-line file cap — stratification by


### PR DESCRIPTION
Three bugs hit by a real setup run on a large store (30k memories / 23k entities), each fixed at root cause with a repro test that failed pre-fix:

**1. `causal_graph.py` unpack crash** — `entities.name` has no UNIQUE constraint, so duplicate names reach `pc_skeleton`, where `frozenset((a, b))` collapses a duplicated pair to a 1-element edge; X-vs-X is never independent so the degenerate edge survives to `a, b = sorted(edge)`. Fixed at the source: `discover_causal_edges` establishes PC's distinct-variables precondition (order-preserving dedup) before skeleton learning — duplicates were also fabricating unshielded (X, X, Z) triples for collider orientation.

**2. `SqliteMemoryStore` grooming surface** — `get_grooming_ages` existed only on the PG stats mixin; on the (now default) SQLite backend `memory_stats` and `get_grooming_health` crashed. New SQLite implementations translate the jsonb tag queries via `json_each`; wiki age is an **honest documented degradation** (always `None` — SQLite has no wiki table, and `None` already means "never recorded" to every consumer). The `sqlite_store.py` docstring falsely claiming full PG parity is corrected with the measured 18-method gap inventory.

**3. Legacy memory import silently broken** — `scanner._parse_memory_file` indexed the `FrontmatterResult` NamedTuple as a dict (`parsed["meta"]`), a Node.js-port drift: every `projects/*/memory/*.md` parse raised TypeError, swallowed per-file, so setup imported **zero** legacy memory files while appearing to succeed.

Known follow-up (out of scope, inventoried): `lesson_promotion` handler still PG-only on SQLite.

## Test plan
- [x] Repro tests added for all three (verified failing pre-fix): causal duplicate-names pair, 10-test SQLite grooming suite, SQLite memory_stats, legacy scanner fixtures
- [x] tests_py/core 2787 passed · infrastructure 550 passed · handlers/hooks 115 passed (live PG + model)
- [x] ruff check + format clean (972 files)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)