### PR TITLE
feat(prose-redaction): native AI-writing-tell inventory for generated prose

### DIFF
--- a/mcp_server/core/auto_curator.py
+++ b/mcp_server/core/auto_curator.py
@@ -32,6 +32,8 @@ References (the user-quoted directives this module exists to satisfy):
 
 from __future__ import annotations
 
+from mcp_server.core.prose_redaction import REDACTION_CONVENTIONS
+
 import re
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
@@ -498,6 +500,7 @@ audience: [developer, ...]
 - Don't repeat what's already in [[reference/{domain}/architecture-overview]] — link to it.
 - Each diagram must add information that the table or prose cannot convey efficiently.
 - No phrases like "in this section we will" — just say it.
+{redaction_conventions}
 - Mandatory elements means *constraints*, not steps. A constraint says "MUST honour X"; a step says "did X".
 
 # The cluster
@@ -564,6 +567,7 @@ scope: {scope_name}
 5. **## Source files** — the files in the codebase a reader should open to verify what this page says. Full paths.
 
 # Conventions
+{redaction_conventions}
 
 - Walk the source tree if you need to ground the content; the wiki must reflect the codebase as it is, not as it was.
 - When a number is given, name its source.
@@ -650,6 +654,7 @@ def build_authoring_prompt(
     """
     today = today or "2026-05-18"
     return WIKI_AUTHORING_PROMPT.format(
+        redaction_conventions=REDACTION_CONVENTIONS,
         kind=cluster.suggested_kind,
         domain=cluster.domain,
         today=today,
@@ -685,6 +690,7 @@ def build_coverage_prompt(
     """
     today = today or "2026-05-18"
     return WIKI_COVERAGE_PROMPT.format(
+        redaction_conventions=REDACTION_CONVENTIONS,
         scope_name=scope_name,
         scope_title=scope_title,
         scope_description=scope_description,
@@ -740,6 +746,7 @@ Output ONLY the wiki page body, starting with YAML frontmatter, then the body. N
 ```
 
 # Conventions
+{redaction_conventions}
 
 - Same conventions as a fresh authoring job: authoritative declarative prose, citations with full paths, mermaid diagrams where dataflow benefits from one, no filler phrases.
 - "Refine and verify and update" means: cross-check claims against the current source. If a paragraph says "implemented via X" and X no longer exists, the paragraph is wrong — rewrite it from what actually exists.
@@ -807,6 +814,7 @@ def build_reauthor_prompt(
     summary = "\n".join(drift_lines) if drift_lines else "(none recorded)"
 
     return WIKI_REAUTHOR_PROMPT.format(
+        redaction_conventions=REDACTION_CONVENTIONS,
         drift_summary=summary,
         wiki_path=drift.wiki_path,
         kind=drift.kind or "explanation",

--- a/mcp_server/core/prose_redaction.py
+++ b/mcp_server/core/prose_redaction.py
@@ -11,12 +11,18 @@ style, not data protection.
 
 Sources (zetetic standard — inventory informed by, implementation ours):
   - Wikipedia, "Signs of AI writing" (WikiProject AI Cleanup) — the
-    maintained public catalog of the patterns detected here.
+    maintained public catalog; section names cited per pattern below.
   - Method prior art: blader/humanizer v2.9.1, petergyang/no-ai-slop
     (both MIT) — pattern-inventory editing and quoted-evidence detection.
   - House rules (ai-architect.tools redaction practice, 2026): zero em
     dashes in published copy; unsourced attribution is a violation of the
     project's own evidence discipline (CLAUDE.md zetetic standard).
+
+Only patterns with near-zero false-positive rates on technical prose are
+detected mechanically; judgment-level tells (synonym cycling, rule of
+three, robotic rhythm) are handled at prompt time via
+``REDACTION_CONVENTIONS``. FP guards live in the test suite: an inventory
+extension that fires on ordinary technical prose is a regression.
 """
 
 from __future__ import annotations
@@ -24,59 +30,172 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-# ── Inventory (mechanically detectable subset) ─────────────────────────
-# Judgment-level tells (importance puffery in context, colon reveals,
-# synonym cycling) are handled at prompt time via REDACTION_CONVENTIONS;
-# regexes below only carry patterns with near-zero false-positive rates
-# on technical prose.
-
-# source: house rule (ai-architect.tools). Em dash as rhythm crutch is the
-# single strongest tell; policy for generated copy is zero.
-_EM_DASH = re.compile("—")
-
-# source: Wikipedia "Signs of AI writing" § Overused vocabulary.
-_BANNED_WORDS = re.compile(
-    r"\b(delve|foster(?:s|ing)?|leverag(?:e|es|ing)|utiliz(?:e|es|ing)"
-    r"|facilitat(?:e|es|ing)|empower(?:s|ing)?|streamlin(?:e|es|ing)"
-    r"|cutting-edge|paradigm shift|game.chang(?:er|ing)|tapestry"
-    r"|multifaceted|paramount|transformative|embark(?:s|ing)?"
-    r"|supercharg(?:e|es|ing)|ever-evolving)\b",
-    re.IGNORECASE,
-)
-
-# source: Wikipedia "Signs of AI writing" § Weasel wording / vague
-# attribution; escalated to a violation by the project's zetetic standard
-# (name the source or cut the claim).
-_WEASEL = re.compile(
-    r"(studies show|experts (?:agree|argue|believe)|industry reports"
-    r"|widely regarded|it'?s worth noting|it'?s important to note"
-    r"|in today'?s world|at the end of the day|let'?s dive in)",
-    re.IGNORECASE,
-)
-
-# source: Wikipedia "Signs of AI writing" § Superficial analyses — a
-# trailing present-participle clause tacked onto a sentence to fake depth.
-# Detected only in the narrow ", <-ing verb of the known set>" form to
-# keep false positives near zero on technical prose.
-_ING_TACKON = re.compile(
-    r",\s+(highlighting|underscoring|showcasing|emphasizing|reflecting"
-    r"|symbolizing|demonstrating its|cementing|solidifying)\b",
-    re.IGNORECASE,
-)
-
-_FENCE = re.compile(r"^\s*(```|~~~)")
-
 CATEGORY_EM_DASH = "em_dash"
 CATEGORY_BANNED_WORD = "banned_word"
 CATEGORY_WEASEL = "weasel_attribution"
+CATEGORY_FILLER = "filler_phrase"
 CATEGORY_ING_TACKON = "ing_tackon"
+CATEGORY_BINARY_CONTRAST = "binary_contrast"
+CATEGORY_NEGATIVE_LISTING = "negative_listing"
+CATEGORY_THROAT_CLEARING = "throat_clearing"
+CATEGORY_FAUX_INSIGHT = "faux_insight"
+CATEGORY_PUFFERY = "importance_puffery"
+CATEGORY_PROMOTIONAL = "promotional"
+CATEGORY_FAKE_VERB = "fake_strong_verb"
+CATEGORY_AI_ARTIFACT = "ai_conversation_artifact"
+CATEGORY_SIGNPOST = "signposting"
+CATEGORY_RHETORICAL = "rhetorical_setup"
+CATEGORY_DRAMATIC_FRAGMENT = "dramatic_fragment"
 
+# (category, pattern) — one compiled regex per class, source-annotated.
 _CHECKS: tuple[tuple[str, re.Pattern[str]], ...] = (
-    (CATEGORY_EM_DASH, _EM_DASH),
-    (CATEGORY_BANNED_WORD, _BANNED_WORDS),
-    (CATEGORY_WEASEL, _WEASEL),
-    (CATEGORY_ING_TACKON, _ING_TACKON),
+    # source: house rule (ai-architect.tools) — zero em dashes in generated copy.
+    (CATEGORY_EM_DASH, re.compile("—")),
+    # source: Wikipedia "Signs of AI writing" § Overused vocabulary.
+    (
+        CATEGORY_BANNED_WORD,
+        re.compile(
+            r"\b(delve|foster(?:s|ing)?|leverag(?:e|es|ing)|utiliz(?:e|es|ing)"
+            r"|facilitat(?:e|es|ing)|empower(?:s|ing)?|streamlin(?:e|es|ing)"
+            r"|cutting-edge|paradigm shift|game.chang(?:er|ing)|tapestry"
+            r"|multifaceted|paramount|transformative|embark(?:s|ing)?"
+            r"|supercharg(?:e|es|ing)|ever-evolving)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: Wikipedia § Vague attributions / weasel wording; escalated by
+    # the project's zetetic standard (name the source or cut the claim).
+    (
+        CATEGORY_WEASEL,
+        re.compile(
+            r"(studies show|experts (?:agree|argue|believe)|industry reports"
+            r"|widely regarded|many argue)",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: Wikipedia § Filler phrases; no-ai-slop "often-empty phrases".
+    (
+        CATEGORY_FILLER,
+        re.compile(
+            r"(it'?s worth noting|it'?s important to note|in today'?s world"
+            r"|at the end of the day|let'?s dive in|when it comes to"
+            r"|at its core|in the age of|in the world of|going forward"
+            r"|needless to say|the reality is)",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: Wikipedia § Superficial analyses — trailing present-participle
+    # clause faking depth. Narrow verb set keeps FP near zero.
+    (
+        CATEGORY_ING_TACKON,
+        re.compile(
+            r",\s+(highlighting|underscoring|showcasing|emphasizing"
+            r"|reflecting|symbolizing|demonstrating its|cementing"
+            r"|solidifying)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: no-ai-slop "binary contrasts"; humanizer § Negative
+    # parallelisms. Both the two-sentence and the not-just-X-but-Y forms.
+    (
+        CATEGORY_BINARY_CONTRAST,
+        re.compile(
+            r"((?:It|This|That)(?:'s| is) not [^.]{2,60}\.\s*(?:It|This|That)(?:'s| is)\b"
+            r"|\bnot just [^,.;]{2,40}, but\b"
+            r"|\b(?:question|problem|point|issue) (?:is|was)n'?t [^.]{2,40}[.,]\s*(?:it|It)(?:'s| is)\b)",
+        ),
+    ),
+    # source: no-ai-slop "negative listing" ("Not a X. Not a Y. A Z.").
+    (
+        CATEGORY_NEGATIVE_LISTING,
+        re.compile(r"\bNot (?:a|an|the) [^.]{1,40}\.\s*Not (?:a|an|the)\b"),
+    ),
+    # source: no-ai-slop "throat-clearing openers".
+    (
+        CATEGORY_THROAT_CLEARING,
+        re.compile(
+            r"(here'?s the thing|let me be clear|let'?s be honest"
+            r"|to be clear,|the (?:uncomfortable |hard |simple )?truth is"
+            r"|here'?s what I mean)",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: no-ai-slop "faux-insight setups".
+    (
+        CATEGORY_FAUX_INSIGHT,
+        re.compile(
+            r"(what nobody tells you|what most people (?:miss|get wrong|skip)"
+            r"|the part everyone misses|here'?s what nobody)",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: Wikipedia § Undue emphasis on significance/legacy.
+    (
+        CATEGORY_PUFFERY,
+        re.compile(
+            r"(testament to|pivotal moment|(?:vital|crucial|key) role"
+            r"|underscor(?:es|ing) (?:its|the) (?:significance|importance)"
+            r"|marks a (?:pivotal|significant)|solidif(?:y|ies) its position"
+            r"|indelible mark|evolving landscape|sets? the stage for)",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: Wikipedia § Promotional and advertisement-like language.
+    (
+        CATEGORY_PROMOTIONAL,
+        re.compile(
+            r"\b(nestled|boasts? a|vibrant|breathtaking|stunning|must-visit"
+            r"|renowned|rich (?:cultural )?heritage|in the heart of)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: humanizer § Copula avoidance; no-ai-slop "fake-strong verbs".
+    (
+        CATEGORY_FAKE_VERB,
+        re.compile(
+            r"\b(serves as (?:a|an|the)|stands as|functions as (?:a|an|the)"
+            r"|acts as (?:a|an|the) (?:hub|beacon|cornerstone))\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: humanizer § Collaborative communication artifacts,
+    # knowledge-cutoff disclaimers, sycophancy.
+    (
+        CATEGORY_AI_ARTIFACT,
+        re.compile(
+            r"(as an AI\b|knowledge cutoff|I hope this helps"
+            r"|let me know if you|I'?d be happy to|great question"
+            r"|certainly!)",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: humanizer § Signposting and announcements; § Generic
+    # positive/summary conclusions.
+    (
+        CATEGORY_SIGNPOST,
+        re.compile(
+            r"(in this (?:article|section|page|document)|we will explore"
+            r"|let'?s explore|in conclusion|in summary,)",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: no-ai-slop "rhetorical setups" and "colon reveals" (stock forms).
+    (
+        CATEGORY_RHETORICAL,
+        re.compile(
+            r"(what if I told you|plot twist:|think about it:"
+            r"|the (?:best|craziest|wildest) part[:?])",
+            re.IGNORECASE,
+        ),
+    ),
+    # source: no-ai-slop "dramatic fragmentation".
+    (
+        CATEGORY_DRAMATIC_FRAGMENT,
+        re.compile(r"That'?s it\.\s*That'?s\b", re.IGNORECASE),
+    ),
 )
+
+_FENCE = re.compile(r"^\s*(```|~~~)")
 
 _EXCERPT_MAX = 80  # source: keeps a finding to one terminal line; excerpt is a locator, not the evidence itself
 
@@ -146,7 +265,7 @@ def _count_by_category(findings: list[ProseFinding]) -> dict[str, int]:
 
 # Injected into every wiki-authoring prompt (auto_curator prompts) so the
 # tells are avoided at generation time; scan_prose measures what slipped
-# through at write time.
+# through at write time. Judgment-level rules live here only.
 REDACTION_CONVENTIONS = """\
 - Redaction pass (write like a person, not a press release):
   * No em dashes anywhere in the page. Use commas, periods, or parentheses.
@@ -157,7 +276,15 @@ multifaceted, paramount, transformative, ever-evolving.
 regarded"): name the memory, benchmark, or paper, or cut the claim.
   * No trailing "-ing" analysis clauses ("..., highlighting the team's \
 commitment"): state the concrete mechanism or consequence instead.
-  * No importance puffery ("pivotal", "testament to", "vital role"): state \
-the fact and let the reader judge.
+  * No importance puffery ("pivotal", "testament to", "vital role") and no \
+promotional adjectives: state the fact and let the reader judge.
+  * No binary contrasts ("It's not X. It's Y."), no negative listing \
+("Not a X. Not a Y."), no rule-of-three rhythm, no colon reveals \
+("The best part: ..."): state the point directly, vary sentence shapes.
+  * No throat-clearing ("Here's the thing"), faux insight ("what nobody \
+tells you"), signposting ("in this section"), or rhetorical setups \
+("What if I told you"): the first sentence carries the point.
+  * Repeat the clear word instead of cycling synonyms; prefer "is"/"has" \
+over "serves as"/"stands as".
   * No summary-recap ending and no aphorism kicker: end on the last \
 concrete point, limitation, or next action."""

--- a/mcp_server/core/prose_redaction.py
+++ b/mcp_server/core/prose_redaction.py
@@ -1,0 +1,163 @@
+"""Prose redaction — native inventory of AI-writing tells for generated prose.
+
+Cortex manufactures reader-facing prose (curated wiki pages, narratives,
+briefings). This module owns the pattern inventory used to (a) instruct the
+authoring LLM at prompt time and (b) measure authored pages at write time.
+Findings are advisory: the write path never blocks on them (generated prose
+only gets measured; user-authored content is out of scope — issue #166).
+
+Distinct from secret/PII redaction (``core/redaction*``): this is prose
+style, not data protection.
+
+Sources (zetetic standard — inventory informed by, implementation ours):
+  - Wikipedia, "Signs of AI writing" (WikiProject AI Cleanup) — the
+    maintained public catalog of the patterns detected here.
+  - Method prior art: blader/humanizer v2.9.1, petergyang/no-ai-slop
+    (both MIT) — pattern-inventory editing and quoted-evidence detection.
+  - House rules (ai-architect.tools redaction practice, 2026): zero em
+    dashes in published copy; unsourced attribution is a violation of the
+    project's own evidence discipline (CLAUDE.md zetetic standard).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# ── Inventory (mechanically detectable subset) ─────────────────────────
+# Judgment-level tells (importance puffery in context, colon reveals,
+# synonym cycling) are handled at prompt time via REDACTION_CONVENTIONS;
+# regexes below only carry patterns with near-zero false-positive rates
+# on technical prose.
+
+# source: house rule (ai-architect.tools). Em dash as rhythm crutch is the
+# single strongest tell; policy for generated copy is zero.
+_EM_DASH = re.compile("—")
+
+# source: Wikipedia "Signs of AI writing" § Overused vocabulary.
+_BANNED_WORDS = re.compile(
+    r"\b(delve|foster(?:s|ing)?|leverag(?:e|es|ing)|utiliz(?:e|es|ing)"
+    r"|facilitat(?:e|es|ing)|empower(?:s|ing)?|streamlin(?:e|es|ing)"
+    r"|cutting-edge|paradigm shift|game.chang(?:er|ing)|tapestry"
+    r"|multifaceted|paramount|transformative|embark(?:s|ing)?"
+    r"|supercharg(?:e|es|ing)|ever-evolving)\b",
+    re.IGNORECASE,
+)
+
+# source: Wikipedia "Signs of AI writing" § Weasel wording / vague
+# attribution; escalated to a violation by the project's zetetic standard
+# (name the source or cut the claim).
+_WEASEL = re.compile(
+    r"(studies show|experts (?:agree|argue|believe)|industry reports"
+    r"|widely regarded|it'?s worth noting|it'?s important to note"
+    r"|in today'?s world|at the end of the day|let'?s dive in)",
+    re.IGNORECASE,
+)
+
+# source: Wikipedia "Signs of AI writing" § Superficial analyses — a
+# trailing present-participle clause tacked onto a sentence to fake depth.
+# Detected only in the narrow ", <-ing verb of the known set>" form to
+# keep false positives near zero on technical prose.
+_ING_TACKON = re.compile(
+    r",\s+(highlighting|underscoring|showcasing|emphasizing|reflecting"
+    r"|symbolizing|demonstrating its|cementing|solidifying)\b",
+    re.IGNORECASE,
+)
+
+_FENCE = re.compile(r"^\s*(```|~~~)")
+
+CATEGORY_EM_DASH = "em_dash"
+CATEGORY_BANNED_WORD = "banned_word"
+CATEGORY_WEASEL = "weasel_attribution"
+CATEGORY_ING_TACKON = "ing_tackon"
+
+_CHECKS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (CATEGORY_EM_DASH, _EM_DASH),
+    (CATEGORY_BANNED_WORD, _BANNED_WORDS),
+    (CATEGORY_WEASEL, _WEASEL),
+    (CATEGORY_ING_TACKON, _ING_TACKON),
+)
+
+_EXCERPT_MAX = 80  # source: keeps a finding to one terminal line; excerpt is a locator, not the evidence itself
+
+
+@dataclass(frozen=True)
+class ProseFinding:
+    """One detected AI-writing tell in a piece of generated prose."""
+
+    line: int
+    category: str
+    match: str
+    excerpt: str
+
+
+def scan_prose(text: str) -> list[ProseFinding]:
+    """Scan generated prose for the mechanical inventory.
+
+    Fenced code blocks are skipped (code is not copy). YAML frontmatter is
+    scanned — titles and descriptions are reader-facing.
+    """
+    findings: list[ProseFinding] = []
+    in_fence = False
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if _FENCE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        for category, pattern in _CHECKS:
+            hit = pattern.search(line)
+            if hit is None:
+                continue
+            findings.append(
+                ProseFinding(
+                    line=lineno,
+                    category=category,
+                    match=hit.group(0),
+                    excerpt=line.strip()[:_EXCERPT_MAX],
+                )
+            )
+    return findings
+
+
+def summarize_findings(findings: list[ProseFinding], cap: int = 10) -> dict:
+    """Advisory summary for tool responses (never blocks a write)."""
+    return {
+        "count": len(findings),
+        "by_category": _count_by_category(findings),
+        "first": [
+            {
+                "line": f.line,
+                "category": f.category,
+                "match": f.match,
+                "excerpt": f.excerpt,
+            }
+            for f in findings[:cap]
+        ],
+    }
+
+
+def _count_by_category(findings: list[ProseFinding]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for f in findings:
+        counts[f.category] = counts.get(f.category, 0) + 1
+    return counts
+
+
+# Injected into every wiki-authoring prompt (auto_curator prompts) so the
+# tells are avoided at generation time; scan_prose measures what slipped
+# through at write time.
+REDACTION_CONVENTIONS = """\
+- Redaction pass (write like a person, not a press release):
+  * No em dashes anywhere in the page. Use commas, periods, or parentheses.
+  * No filler vocabulary: delve, leverage, utilize, facilitate, empower, \
+streamline, cutting-edge, paradigm shift, game changer, tapestry, \
+multifaceted, paramount, transformative, ever-evolving.
+  * No unsourced attribution ("studies show", "experts agree", "widely \
+regarded"): name the memory, benchmark, or paper, or cut the claim.
+  * No trailing "-ing" analysis clauses ("..., highlighting the team's \
+commitment"): state the concrete mechanism or consequence instead.
+  * No importance puffery ("pivotal", "testament to", "vital role"): state \
+the fact and let the reader judge.
+  * No summary-recap ending and no aphorism kicker: end on the last \
+concrete point, limitation, or next action."""

--- a/mcp_server/handlers/wiki_write.py
+++ b/mcp_server/handlers/wiki_write.py
@@ -32,6 +32,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from mcp_server.core.prose_redaction import scan_prose, summarize_findings
 from mcp_server.core.wiki_frontmatter_validation import UnclosedFrontmatterError
 from mcp_server.core.wiki_layout import page_path
 from mcp_server.core.wiki_pages import (
@@ -310,7 +311,11 @@ async def write_governed_page(
 
     citations_written = _sync_page_and_cite(rel_path, content, memory_ids or [])
 
-    return {
+    # Advisory prose measurement (issue #166): generated pages carry an
+    # AI-writing-tell report so authoring quality is visible at write time.
+    # Never blocks the write; empty report is omitted to keep responses lean.
+    findings = scan_prose(content)
+    response: dict[str, Any] = {
         "path": result.path,
         "mode": result.mode,
         "created": result.created,
@@ -318,6 +323,9 @@ async def write_governed_page(
         "root": str(root),
         "citations_written": citations_written,
     }
+    if findings:
+        response["redaction_findings"] = summarize_findings(findings)
+    return response
 
 
 async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/tests_py/core/test_prose_redaction.py
+++ b/tests_py/core/test_prose_redaction.py
@@ -1,0 +1,99 @@
+"""Tests for core/prose_redaction.py — the native AI-writing-tell inventory (issue #166)."""
+
+from __future__ import annotations
+
+from mcp_server.core.prose_redaction import (
+    CATEGORY_BANNED_WORD,
+    CATEGORY_EM_DASH,
+    CATEGORY_ING_TACKON,
+    CATEGORY_WEASEL,
+    REDACTION_CONVENTIONS,
+    scan_prose,
+    summarize_findings,
+)
+
+
+class TestScanProse:
+    def test_clean_technical_prose_yields_no_findings(self):
+        text = (
+            "The recall path fuses vector, FTS, and trigram signals.\n"
+            "p50 latency is 125ms, measured in benchmarks/longmemeval "
+            "(2026-04 run).\n"
+        )
+        assert scan_prose(text) == []
+
+    def test_em_dash_flagged_with_line_number(self):
+        findings = scan_prose("First line is fine.\nThe store is fast — very fast.")
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.category == CATEGORY_EM_DASH
+        assert f.line == 2
+
+    def test_banned_vocabulary_flagged(self):
+        findings = scan_prose("We leverage a transformative pipeline.")
+        cats = [f.category for f in findings]
+        assert cats.count(CATEGORY_BANNED_WORD) >= 1
+
+    def test_weasel_attribution_flagged(self):
+        findings = scan_prose("Studies show this approach wins.")
+        assert [f.category for f in findings] == [CATEGORY_WEASEL]
+
+    def test_ing_tackon_flagged(self):
+        text = "The launch adds file search, highlighting the team's commitment."
+        findings = scan_prose(text)
+        assert [f.category for f in findings] == [CATEGORY_ING_TACKON]
+
+    def test_plain_participle_clause_not_flagged(self):
+        # An -ing verb outside the tack-on set must not fire (false-positive guard).
+        assert scan_prose("The worker keeps polling, retrying on timeouts.") == []
+
+    def test_fenced_code_blocks_skipped(self):
+        text = (
+            "Real prose line.\n```\nx = 'studies show — leverage'\n```\nMore prose.\n"
+        )
+        assert scan_prose(text) == []
+
+    def test_frontmatter_is_scanned(self):
+        # Titles/descriptions are reader-facing; the fence regex must not
+        # treat YAML '---' as a code fence.
+        text = "---\ntitle: A transformative journey\n---\nBody.\n"
+        findings = scan_prose(text)
+        assert [f.category for f in findings] == [CATEGORY_BANNED_WORD]
+
+    def test_excerpt_bounded(self):
+        long_line = "delve " + "x" * 300
+        (finding,) = scan_prose(long_line)
+        assert len(finding.excerpt) <= 80
+
+
+class TestSummarizeFindings:
+    def test_summary_shape_and_cap(self):
+        text = "\n".join("We delve deeper — again." for _ in range(15))
+        summary = summarize_findings(scan_prose(text), cap=10)
+        assert summary["count"] == 30  # em dash + banned word per line
+        assert summary["by_category"][CATEGORY_EM_DASH] == 15
+        assert summary["by_category"][CATEGORY_BANNED_WORD] == 15
+        assert len(summary["first"]) == 10
+        first = summary["first"][0]
+        assert set(first) == {"line", "category", "match", "excerpt"}
+
+    def test_empty_findings_summary(self):
+        summary = summarize_findings([])
+        assert summary == {"count": 0, "by_category": {}, "first": []}
+
+
+class TestPromptIntegration:
+    def test_conventions_block_is_nonempty_and_em_dash_free(self):
+        assert "No em dashes" in REDACTION_CONVENTIONS
+        assert "—" not in REDACTION_CONVENTIONS
+
+    def test_authoring_prompts_carry_the_conventions(self):
+        from mcp_server.core import auto_curator
+
+        for name in (
+            "WIKI_AUTHORING_PROMPT",
+            "WIKI_COVERAGE_PROMPT",
+            "WIKI_REAUTHOR_PROMPT",
+        ):
+            template = getattr(auto_curator, name)
+            assert "{redaction_conventions}" in template, name

--- a/tests_py/core/test_prose_redaction.py
+++ b/tests_py/core/test_prose_redaction.py
@@ -3,14 +3,30 @@
 from __future__ import annotations
 
 from mcp_server.core.prose_redaction import (
+    CATEGORY_AI_ARTIFACT,
     CATEGORY_BANNED_WORD,
+    CATEGORY_BINARY_CONTRAST,
+    CATEGORY_DRAMATIC_FRAGMENT,
     CATEGORY_EM_DASH,
+    CATEGORY_FAKE_VERB,
+    CATEGORY_FAUX_INSIGHT,
+    CATEGORY_FILLER,
     CATEGORY_ING_TACKON,
+    CATEGORY_NEGATIVE_LISTING,
+    CATEGORY_PROMOTIONAL,
+    CATEGORY_PUFFERY,
+    CATEGORY_RHETORICAL,
+    CATEGORY_SIGNPOST,
+    CATEGORY_THROAT_CLEARING,
     CATEGORY_WEASEL,
     REDACTION_CONVENTIONS,
     scan_prose,
     summarize_findings,
 )
+
+
+def _categories(text: str) -> list[str]:
+    return [f.category for f in scan_prose(text)]
 
 
 class TestScanProse:
@@ -64,6 +80,84 @@ class TestScanProse:
         long_line = "delve " + "x" * 300
         (finding,) = scan_prose(long_line)
         assert len(finding.excerpt) <= 80
+
+
+class TestExpandedInventory:
+    """The full mechanical set beyond the initial four classes (issue #166)."""
+
+    def test_binary_contrast_two_sentence_form(self):
+        assert _categories("It's not the model. It's the eval.") == [
+            CATEGORY_BINARY_CONTRAST
+        ]
+
+    def test_binary_contrast_not_just_but_form(self):
+        assert CATEGORY_BINARY_CONTRAST in _categories(
+            "This is not just retrieval, but a full memory system."
+        )
+
+    def test_negative_listing(self):
+        assert _categories("Not a cache. Not a database. A memory.") == [
+            CATEGORY_NEGATIVE_LISTING
+        ]
+
+    def test_throat_clearing(self):
+        assert _categories("Here's the thing about consolidation.") == [
+            CATEGORY_THROAT_CLEARING
+        ]
+
+    def test_faux_insight(self):
+        assert _categories("What nobody tells you about vector search.") == [
+            CATEGORY_FAUX_INSIGHT
+        ]
+
+    def test_puffery(self):
+        assert _categories("This marks a pivotal moment for the wiki.") == [
+            CATEGORY_PUFFERY
+        ]
+
+    def test_promotional(self):
+        assert CATEGORY_PROMOTIONAL in _categories(
+            "A vibrant ecosystem nestled in the heart of the repo."
+        )
+
+    def test_fake_strong_verb(self):
+        assert _categories("The handler serves as a centralized hub.") == [
+            CATEGORY_FAKE_VERB
+        ]
+
+    def test_ai_conversation_artifact(self):
+        assert _categories("I hope this helps with your setup.") == [
+            CATEGORY_AI_ARTIFACT
+        ]
+
+    def test_signposting(self):
+        assert _categories("In this section we will explore recall.") == [
+            CATEGORY_SIGNPOST
+        ]
+
+    def test_rhetorical_setup(self):
+        assert _categories("Plot twist: the cache was cold.") == [CATEGORY_RHETORICAL]
+
+    def test_dramatic_fragment(self):
+        assert _categories("That's it. That's the whole design.") == [
+            CATEGORY_DRAMATIC_FRAGMENT
+        ]
+
+    def test_filler_phrase(self):
+        assert _categories("At its core, the gate is a filter.") == [CATEGORY_FILLER]
+
+    def test_false_positive_guards_on_technical_prose(self):
+        # Ordinary technical sentences that brush against pattern shapes
+        # must stay silent — an inventory extension that fires here is a
+        # regression, not a catch.
+        clean = (
+            "The store is not thread-safe; callers hold the lock.\n"
+            "Serves requests from the read replica after failover.\n"
+            "The problem is the cache TTL, not the index.\n"
+            "We explore the graph via BFS from the seed entity.\n"
+            "In summary tables, counts are measured, not estimated.\n"
+        )
+        assert scan_prose(clean) == []
 
 
 class TestSummarizeFindings:


### PR DESCRIPTION
Implements #166 — the redaction mechanism as a native Cortex capability, no cross-repo dependency (the agent-surface implementation lives independently in zetetic-team-subagents).

## What

1. **`mcp_server/core/prose_redaction.py`** (pure core, stdlib-only) — the mechanical inventory with per-pattern `# source:` annotations (Wikipedia "Signs of AI writing" / WikiProject AI Cleanup; house rules): em dashes (zero-tolerance policy for generated copy), banned vocabulary, weasel attribution (escalated to a violation by the project's own zetetic standard), and trailing `-ing` tack-on analyses (narrow verb set, near-zero false positives on technical prose). `scan_prose()` skips fenced code, scans frontmatter (titles are reader-facing). `REDACTION_CONVENTIONS` is the prompt-time block.
2. **Authoring prompts** — all three auto-curator templates (authoring, coverage, re-author) now carry the redaction conventions, so pages avoid the tells at generation time.
3. **`wiki_write`** — advisory `redaction_findings` summary (count, by-category, first 10 with line + excerpt) on every written page; never blocks; omitted when clean. Generated prose gets measured at the exact point it becomes durable.

## Tests

13 new tests: every pattern class, the false-positive guard (ordinary participle clauses stay silent), fence/frontmatter behavior, summary shape, and an integration check that all three prompts carry the conventions. One meta-result worth recording: the eval initially failed because the conventions block itself contained an em dash — caught by its own test.

Affected suites green locally: prose_redaction 13/13, wiki_write 16/16, auto_curator/curate_wiki 9/9. `ruff check` + `format` clean.

## Done criteria from #166

- Inventory carries per-pattern sources: done.
- Conventions in wiki authoring paths: done (all three prompt templates).
- Write-time measurement: done (`redaction_findings`).
- Remaining (follow-up): regenerated before/after anchor page, and the week-of-autonomous-cycle zero-hits observation — both need live wiki cycles, not code.

Closes #166 (code half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)