### PR TITLE
refactor(embedding): split embedding_engine.py along three seams (#173)

### DIFF
--- a/mcp_server/infrastructure/embedding_engine.py
+++ b/mcp_server/infrastructure/embedding_engine.py
@@ -8,102 +8,60 @@ Strategy (in priority order):
 
 The engine is lazy-loading: no model initialization until first encode() call.
 
+Structure (Cortex#173 — the file was split along three seams):
+  * ``embedding_provider.EmbeddingProvider`` — the interface consumers depend
+    on; ``EmbeddingEngine`` below is its neural implementation.
+  * ``embedding_model_lifecycle`` — device resolution + the explicit model-load
+    state machine (``ModelState``: package absent / model files absent / load
+    raised / loaded). See that module's docstring for the revision-pin history.
+  * this module — the concrete neural provider (encode path + LRU cache) and the
+    process-wide composition root (``get_embedding_engine``).
+
 Device selection:
   Default is "cpu" for embedding consistency (GPU float32 arithmetic produces
   bit-different vectors from CPU). GPU is opt-in via CORTEX_MEMORY_EMBEDDING_DEVICE
-  env var. Switching devices mid-deployment means new embeddings won't be
-  bit-identical to existing ones -- cosine similarity degradation is small
-  (~1e-7) but retrieval ranking can shift for borderline results.
-
-  If GPU inference fails at runtime (OOM, MPS reset after sleep), the engine
-  automatically falls back to CPU. If CPU also fails, it degrades to hash-based
-  fallback encoding. The engine never crashes on encode().
-
-Model revision pin (reproducibility gap closed 2026-07-11, incident i7d3):
-  ``huggingface_hub`` resolves an unpinned model name against the repo's
-  moving ``refs/main`` pointer. Root-cause investigation of a benchmark
-  regression found TWO snapshots cached locally for
-  ``sentence-transformers/all-MiniLM-L6-v2`` (``c9745ed1...`` from
-  2026-04-04 and ``1110a243...`` from 2026-06-09) — ``refs/main`` had moved
-  between them. In that specific incident the underlying
-  ``model.safetensors``/``config.json``/``tokenizer.json`` blobs were
-  confirmed BYTE-IDENTICAL across both snapshots (same SHA256 content
-  hash) by direct cache inspection, so it was not the cause of THAT
-  regression — but the gap itself is real and unbounded: nothing stops a
-  future upstream repo change (a genuine weight update, not just a
-  metadata/README commit) from silently altering embeddings for every
-  caller that resolves ``main`` at load time, with no signal in
-  ``uv.lock`` (which pins the Python package, not the HF model weights).
-  ``DEFAULT_MODEL_REVISION`` below pins the exact snapshot verified during
-  that investigation; ``EmbeddingEngine`` uses it whenever the caller does
-  not supply an explicit ``revision``. source: measured on 2026-07-11 via
-  ``~/.cache/huggingface/hub/models--sentence-transformers--all-MiniLM-L6-v2/refs/main``
-  and blob-hash comparison of the two cached snapshots.
+  env var. If GPU inference fails at runtime (OOM, MPS reset after sleep), the
+  engine automatically falls back to CPU; if CPU also fails, it degrades to
+  hash-based fallback encoding. The engine never crashes on encode().
 """
 
 from __future__ import annotations
 
 import hashlib
 import logging
-import os
 from collections import OrderedDict
 from typing import Any
 
 import numpy as np
 
+from mcp_server.infrastructure.embedding_model_lifecycle import (
+    DEFAULT_MODEL_REVISION,
+    ModelState,
+    _EmbeddingLifecycleMixin,
+    embedding_cache_dir,
+)
 from mcp_server.infrastructure.embedding_provider import (
     EmbeddingProvider,
     _EmbeddingMathMixin,
 )
-from mcp_server.shared.platform import cache_dir as _base_cache_dir
-
-# source: measured 2026-07-11 (incident i7d3) — see module docstring
-# "Model revision pin" section for the full derivation and the blob-hash
-# verification that this snapshot's weights are byte-identical to the
-# immediately-prior cached snapshot.
-DEFAULT_MODEL_REVISION = "1110a243fdf4706b3f48f1d95db1a4f5529b4d41"
 
 logger = logging.getLogger(__name__)
 
+# Re-exported for backward compatibility: callers and tests import these names
+# from ``embedding_engine`` directly (they lived here before the Cortex#173
+# split). The definitions now live in ``embedding_model_lifecycle``.
 __all__ = [
     "DEFAULT_MODEL_REVISION",
     "EmbeddingEngine",
     "EmbeddingProvider",
+    "ModelState",
     "embedding_cache_dir",
     "get_embedding_engine",
     "reset_embedding_engine",
 ]
 
 
-def embedding_cache_dir() -> str | None:
-    """Resolve the ``cache_folder`` to pass to ``SentenceTransformer``.
-
-    Mirrors ``mcp_server.core.reranker.reranker_cache_dir`` (hardened
-    after the FlashRank /tmp incident, commit bb1c581f): same shared,
-    XDG-aware ``mcp_server.shared.platform.cache_dir()`` base, laid out
-    under ``huggingface/hub`` to match the directory
-    ``sentence-transformers``/``huggingface_hub`` already write
-    ``models--org--name`` snapshots into by default (``$HF_HOME/hub``).
-
-    Precedence, decided for consistency with how ``huggingface_hub``
-    itself resolves its cache (``cache_folder`` passed to
-    ``SentenceTransformer`` takes priority over both env vars inside the
-    library, so passing one unconditionally would silently override a
-    choice the user already made): if ``HF_HOME`` or
-    ``SENTENCE_TRANSFORMERS_HOME`` is set in the environment, return
-    ``None`` and let the library resolve its own default from that env
-    var. Otherwise return our durable, shared cache path so a caller who
-    set neither var still gets a deterministic, XDG-aware location
-    instead of depending entirely on ``huggingface_hub``'s built-in
-    resolution (issue #124 — the reranker was hardened this way in
-    bb1c581f; embeddings had no equivalent).
-    """
-    if os.environ.get("HF_HOME") or os.environ.get("SENTENCE_TRANSFORMERS_HOME"):
-        return None
-    return str(_base_cache_dir() / "huggingface" / "hub")
-
-
-# ── Process-wide singleton ────────────────────────────────────────────
+# ── Process-wide singleton (composition root) ─────────────────────────
 # One EmbeddingEngine per process. Handlers call get_embedding_engine()
 # instead of creating their own instances. This guarantees: one model,
 # one device, no mixed-device embeddings, ~5x memory savings.
@@ -127,13 +85,12 @@ def reset_embedding_engine() -> None:
     _singleton = None
 
 
-class EmbeddingEngine(_EmbeddingMathMixin):
-    """Lazy-loading embedding engine with graceful fallback.
+class EmbeddingEngine(_EmbeddingLifecycleMixin, _EmbeddingMathMixin):
+    """Lazy-loading neural embedding provider with graceful fallback.
 
-    Implements ``EmbeddingProvider`` (embedding_provider.py) and mixes in the
-    shared vector math (``_EmbeddingMathMixin``) so ``_cache_key`` /
-    ``similarity`` / ``to_list`` / ``from_list`` / ``_normalize`` stay on the
-    class exactly as before.
+    Implements ``EmbeddingProvider`` (embedding_provider.py). Composes the model
+    lifecycle (``_EmbeddingLifecycleMixin``) and shared vector math
+    (``_EmbeddingMathMixin``); this class owns the encode path and the LRU cache.
 
     Cache key discipline (ADR-0045 R5): the LRU cache is keyed by
     ``sha256(text)[:16]`` (16 hex chars = 8 bytes of entropy), never by
@@ -158,10 +115,11 @@ class EmbeddingEngine(_EmbeddingMathMixin):
         # revision=None means "resolve refs/main at load time" (the
         # pre-i7d3 unpinned behavior) — an explicit opt-out for callers
         # that pass a different model_name this pin was never verified
-        # against. See module docstring "Model revision pin".
+        # against. See embedding_model_lifecycle "Model revision pin".
         self._revision = revision
         self._model: Any = None
         self._unavailable = False
+        self._model_state: ModelState = ModelState.UNINITIALIZED
         # Cache keyed by sha256(text)[:16] — see class docstring / ADR-0045 R5.
         self._cache: OrderedDict[str, bytes] = OrderedDict()
         self._cache_max = 128
@@ -180,6 +138,11 @@ class EmbeddingEngine(_EmbeddingMathMixin):
         return self._dim
 
     @property
+    def model_state(self) -> ModelState:
+        """The current lifecycle state of the neural model load (Cortex#173)."""
+        return self._model_state
+
+    @property
     def available(self) -> bool:
         """Check if a real embedding model is available (without loading it)."""
         if self._model is not None:
@@ -192,175 +155,6 @@ class EmbeddingEngine(_EmbeddingMathMixin):
             return True
         except ImportError:
             return False
-
-    # ── Device detection ──────────────────────────────────────────────
-
-    @staticmethod
-    def _detect_device() -> str:
-        """Probe hardware: CUDA > MPS > CPU."""
-        try:
-            import torch
-
-            if torch.cuda.is_available():
-                logger.info("GPU auto-detect: CUDA available")
-                return "cuda"
-            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                logger.info("GPU auto-detect: MPS available")
-                return "mps"
-        except ImportError:
-            logger.debug("GPU auto-detect: torch not available, using cpu")
-        return "cpu"
-
-    def _resolve_device(self) -> str:
-        """Resolve and cache the target device. Called once per instance."""
-        if self._device is not None:
-            return self._device
-        requested = self._device_requested
-        if requested == "auto":
-            self._device = self._detect_device()
-        elif requested in ("cpu", "cuda", "mps"):
-            self._device = requested
-        else:
-            logger.warning("Unknown embedding device %r, using cpu", requested)
-            self._device = "cpu"
-        logger.info("Embedding device: %s (requested: %s)", self._device, requested)
-        return self._device
-
-    def _fallback_to_cpu(self) -> None:
-        """Reload model on CPU after GPU failure."""
-        logger.warning(
-            "GPU inference failed (device=%s) — reloading on CPU", self._device
-        )
-        self._device = "cpu"
-        self._model = None
-        self._ensure_model()
-
-    # ── Model loading ─────────────────────────────────────────────────
-
-    def _ensure_model(self) -> None:
-        if self._model is not None or self._unavailable:
-            return
-        try:
-            # Collect cache-miss exception types: OSError covers transformers'
-            # config loader; LocalEntryNotFoundError covers huggingface_hub
-            # (>=0.22) which raises a non-OSError on local-only cache miss.
-            _cache_miss: tuple[type[Exception], ...] = (OSError,)
-            try:
-                from huggingface_hub.errors import LocalEntryNotFoundError
-
-                _cache_miss = (OSError, LocalEntryNotFoundError)
-            except ImportError:
-                pass
-
-            device = self._resolve_device()
-            from sentence_transformers import SentenceTransformer
-
-            # cache_folder: explicit, XDG-aware default (mirrors the
-            # reranker's /tmp-incident hardening, bb1c581f) unless the
-            # user already set HF_HOME / SENTENCE_TRANSFORMERS_HOME, in
-            # which case we pass None and defer to their choice. See
-            # embedding_cache_dir() docstring for the full precedence
-            # rationale (issue #124).
-            cache_folder = embedding_cache_dir()
-
-            # local_files_only=True keeps the load hermetic (no HF Hub
-            # requests) whenever the model is already cached. It must be
-            # an explicit argument, not the HF_HUB_OFFLINE env var: hub
-            # freezes that env var into module constants at first import,
-            # so the previous unset-env-and-retry fallback still ran
-            # offline, leaving the download path unreachable on a fresh
-            # install (reproduced 2026-07-03, clean-env harness run).
-            # source: kwarg added in sentence-transformers v3.0.0
-            # (absent in v2.3.0 SentenceTransformer.py; pyproject floor
-            # raised to match).
-            try:
-                self._model = SentenceTransformer(
-                    self._model_name,
-                    device=device,
-                    local_files_only=True,
-                    revision=self._revision,
-                    cache_folder=cache_folder,
-                )
-            except _cache_miss:
-                # Model not in local cache (at all, or not at the pinned
-                # revision) — download it once. First use on the
-                # zero-config install path lands here by design: the
-                # plugin postInstall deliberately skips the eager
-                # pre-cache (scripts/setup.py SQLite mode). Size figure
-                # per PRIVACY.md "one-time model download" / the
-                # pre-cache step it replaces (scripts/setup.sh step 5).
-                logger.info(
-                    "Downloading embedding model %s (revision=%s) — "
-                    "~100 MB, one-time; cached under %s, then runs fully offline",
-                    self._model_name,
-                    self._revision or "refs/main",
-                    cache_folder or "$HF_HOME",
-                )
-                self._model = SentenceTransformer(
-                    self._model_name,
-                    device=device,
-                    revision=self._revision,
-                    cache_folder=cache_folder,
-                )
-
-            # sentence-transformers 5.x renamed get_sentence_embedding_dimension
-            # → get_embedding_dimension. Prefer the new name; fall back for <5.
-            get_dim = getattr(
-                self._model,
-                "get_embedding_dimension",
-                self._model.get_sentence_embedding_dimension,
-            )
-            actual_dim = get_dim()
-            if actual_dim != self._dim:
-                self._dim = actual_dim
-            logger.info(
-                "Loaded embedding model: %s (%dD, device=%s)",
-                self._model_name,
-                self._dim,
-                device,
-            )
-        except ImportError:
-            logger.warning(
-                "sentence-transformers not installed; using hash-based fallback "
-                "embeddings. Installing in background for next session..."
-            )
-            self._unavailable = True
-            self._trigger_background_install()
-
-    def _trigger_background_install(self) -> None:
-        """Install sentence-transformers in the background.
-
-        Runs pip install as a detached subprocess so it doesn't block
-        the current session. Next session will have real embeddings.
-        """
-        import subprocess
-        import sys
-
-        target = os.environ.get("CLAUDE_PLUGIN_DATA", "")
-        if target:
-            target = os.path.join(target, "deps")
-
-        cmd = [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "-q",
-            "sentence-transformers>=2.2.0,<4.0.0",
-        ]
-        if target:
-            cmd.extend(["--target", target])
-
-        try:
-            subprocess.Popen(
-                cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
-            logger.info("Background install of sentence-transformers started")
-        except Exception as exc:
-            logger.debug("Background install failed to start: %s", exc)
 
     # ── Encoding ──────────────────────────────────────────────────────
 

--- a/mcp_server/infrastructure/embedding_engine.py
+++ b/mcp_server/infrastructure/embedding_engine.py
@@ -4,7 +4,7 @@ Provides text -> vector encoding for semantic similarity search.
 
 Strategy (in priority order):
   1. sentence-transformers (if installed) -- best quality, 384D
-  2. Fallback: TF-IDF-like sparse-to-dense via Cortex's own text utilities
+  2. Fallback: hash-based sparse-to-dense encoding (no ML model)
 
 The engine is lazy-loading: no model initialization until first encode() call.
 
@@ -51,6 +51,10 @@ from typing import Any
 
 import numpy as np
 
+from mcp_server.infrastructure.embedding_provider import (
+    EmbeddingProvider,
+    _EmbeddingMathMixin,
+)
 from mcp_server.shared.platform import cache_dir as _base_cache_dir
 
 # source: measured 2026-07-11 (incident i7d3) — see module docstring
@@ -60,6 +64,15 @@ from mcp_server.shared.platform import cache_dir as _base_cache_dir
 DEFAULT_MODEL_REVISION = "1110a243fdf4706b3f48f1d95db1a4f5529b4d41"
 
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_MODEL_REVISION",
+    "EmbeddingEngine",
+    "EmbeddingProvider",
+    "embedding_cache_dir",
+    "get_embedding_engine",
+    "reset_embedding_engine",
+]
 
 
 def embedding_cache_dir() -> str | None:
@@ -114,8 +127,13 @@ def reset_embedding_engine() -> None:
     _singleton = None
 
 
-class EmbeddingEngine:
+class EmbeddingEngine(_EmbeddingMathMixin):
     """Lazy-loading embedding engine with graceful fallback.
+
+    Implements ``EmbeddingProvider`` (embedding_provider.py) and mixes in the
+    shared vector math (``_EmbeddingMathMixin``) so ``_cache_key`` /
+    ``similarity`` / ``to_list`` / ``from_list`` / ``_normalize`` stay on the
+    class exactly as before.
 
     Cache key discipline (ADR-0045 R5): the LRU cache is keyed by
     ``sha256(text)[:16]`` (16 hex chars = 8 bytes of entropy), never by
@@ -123,8 +141,7 @@ class EmbeddingEngine:
     100 KB of key bytes — at ``_cache_max = 128`` this bounds cache key
     memory to ~2 KB regardless of input size. A 16-char SHA256 prefix
     has 2^64 possible values; the birthday-bound collision probability
-    at 128 cached entries is ~4.6e-16 (negligible). See
-    ``_cache_key`` for the single point of truth.
+    at 128 cached entries is ~4.6e-16 (negligible).
     """
 
     def __init__(
@@ -148,23 +165,6 @@ class EmbeddingEngine:
         # Cache keyed by sha256(text)[:16] — see class docstring / ADR-0045 R5.
         self._cache: OrderedDict[str, bytes] = OrderedDict()
         self._cache_max = 128
-
-    # ── Cache key (ADR-0045 R5) ───────────────────────────────────────
-
-    @staticmethod
-    def _cache_key(text: str) -> str:
-        """Return the SHA256[:16] cache key for ``text``.
-
-        precondition: ``text`` is a non-empty str.
-        postcondition: returns a 16-char lowercase hex string; the same
-        input always produces the same key; key length is independent of
-        ``len(text)``.
-
-        Source: ADR-0045 R5 — ``hashlib.sha256(text.encode()).hexdigest()[:16]``
-        is the mandated cache-key form for any memoization layer over
-        user-provided strings.
-        """
-        return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
 
     @property
     def model_name(self) -> str:
@@ -223,18 +223,13 @@ class EmbeddingEngine:
         else:
             logger.warning("Unknown embedding device %r, using cpu", requested)
             self._device = "cpu"
-        logger.info(
-            "Embedding device: %s (requested: %s)",
-            self._device,
-            requested,
-        )
+        logger.info("Embedding device: %s (requested: %s)", self._device, requested)
         return self._device
 
     def _fallback_to_cpu(self) -> None:
         """Reload model on CPU after GPU failure."""
         logger.warning(
-            "GPU inference failed (device=%s) — reloading on CPU",
-            self._device,
+            "GPU inference failed (device=%s) — reloading on CPU", self._device
         )
         self._device = "cpu"
         self._model = None
@@ -326,8 +321,8 @@ class EmbeddingEngine:
             )
         except ImportError:
             logger.warning(
-                "sentence-transformers not installed; using hash-based fallback embeddings. "
-                "Installing in background for next session..."
+                "sentence-transformers not installed; using hash-based fallback "
+                "embeddings. Installing in background for next session..."
             )
             self._unavailable = True
             self._trigger_background_install()
@@ -338,7 +333,6 @@ class EmbeddingEngine:
         Runs pip install as a detached subprocess so it doesn't block
         the current session. Next session will have real embeddings.
         """
-        import os
         import subprocess
         import sys
 
@@ -441,37 +435,6 @@ class EmbeddingEngine:
             arr = self._normalize(np.asarray(v, dtype=np.float32))
             results.append(arr.tobytes())
         return results
-
-    def similarity(self, embedding_a: bytes, embedding_b: bytes) -> float:
-        """Cosine similarity between two embedding blobs."""
-        a = np.frombuffer(embedding_a, dtype=np.float32)
-        b = np.frombuffer(embedding_b, dtype=np.float32)
-        if len(a) != len(b):
-            return 0.0
-        dot = float(np.dot(a, b))
-        norm = float(np.linalg.norm(a) * np.linalg.norm(b))
-        if norm == 0:
-            return 0.0
-        return dot / norm
-
-    @staticmethod
-    def to_list(embedding: bytes) -> list[float]:
-        """Convert embedding blob to Python float list."""
-        arr = np.frombuffer(embedding, dtype=np.float32)
-        return arr.tolist()
-
-    @staticmethod
-    def from_list(values: list[float]) -> bytes:
-        """Convert float list to embedding blob."""
-        arr = np.asarray(values, dtype=np.float32)
-        return arr.tobytes()
-
-    @staticmethod
-    def _normalize(arr: np.ndarray) -> np.ndarray:
-        norm = np.linalg.norm(arr)
-        if norm > 0:
-            arr = arr / norm
-        return arr
 
     def _fallback_encode(self, text: str) -> bytes:
         """Hash-based deterministic embedding fallback.

--- a/mcp_server/infrastructure/embedding_engine.py
+++ b/mcp_server/infrastructure/embedding_engine.py
@@ -34,6 +34,10 @@ from typing import Any
 
 import numpy as np
 
+from mcp_server.infrastructure.embedding_factory import (
+    get_embedding_engine,
+    reset_embedding_engine,
+)
 from mcp_server.infrastructure.embedding_model_lifecycle import (
     DEFAULT_MODEL_REVISION,
     ModelState,
@@ -49,7 +53,9 @@ logger = logging.getLogger(__name__)
 
 # Re-exported for backward compatibility: callers and tests import these names
 # from ``embedding_engine`` directly (they lived here before the Cortex#173
-# split). The definitions now live in ``embedding_model_lifecycle``.
+# split). The definitions now live in the seam modules — ``embedding_provider``
+# (interface), ``embedding_model_lifecycle`` (revision pin + cache dir), and
+# ``embedding_factory`` (composition root / selection).
 __all__ = [
     "DEFAULT_MODEL_REVISION",
     "EmbeddingEngine",
@@ -59,30 +65,6 @@ __all__ = [
     "get_embedding_engine",
     "reset_embedding_engine",
 ]
-
-
-# ── Process-wide singleton (composition root) ─────────────────────────
-# One EmbeddingEngine per process. Handlers call get_embedding_engine()
-# instead of creating their own instances. This guarantees: one model,
-# one device, no mixed-device embeddings, ~5x memory savings.
-_singleton: EmbeddingEngine | None = None
-
-
-def get_embedding_engine() -> "EmbeddingEngine":
-    """Return the process-wide EmbeddingEngine singleton."""
-    global _singleton
-    if _singleton is None:
-        from mcp_server.infrastructure.memory_config import get_memory_settings
-
-        s = get_memory_settings()
-        _singleton = EmbeddingEngine(dim=s.EMBEDDING_DIM, device=s.EMBEDDING_DEVICE)
-    return _singleton
-
-
-def reset_embedding_engine() -> None:
-    """Clear singleton (for testing only)."""
-    global _singleton
-    _singleton = None
 
 
 class EmbeddingEngine(_EmbeddingLifecycleMixin, _EmbeddingMathMixin):

--- a/mcp_server/infrastructure/embedding_factory.py
+++ b/mcp_server/infrastructure/embedding_factory.py
@@ -1,0 +1,52 @@
+"""Composition root for the embedding subsystem (Cortex#173, seam 3).
+
+This is the "engine selection / wiring" seam: the single place that reads the
+runtime settings (``EMBEDDING_DIM`` / ``EMBEDDING_DEVICE``) and assembles the
+process-wide encoder. Consumers call ``get_embedding_engine()`` rather than
+constructing an ``EmbeddingEngine`` themselves, which guarantees one model, one
+device, no mixed-device embeddings, ~5x memory savings.
+
+Keeping selection here — separate from the concrete provider
+(``embedding_engine.EmbeddingEngine``) and its interface
+(``embedding_provider.EmbeddingProvider``) — is what lets a second provider be
+wired in later by editing exactly this one function, with no consumer change.
+
+Import-cycle note: the concrete ``EmbeddingEngine`` (and ``get_memory_settings``)
+are imported lazily *inside* ``get_embedding_engine`` so this module has no
+module-load dependency on ``embedding_engine`` — ``embedding_engine`` re-exports
+these functions, so the two modules must not import each other at top level.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mcp_server.infrastructure.embedding_engine import EmbeddingEngine
+
+# Process-wide singleton. Handlers/hooks read it via get_embedding_engine().
+_singleton: EmbeddingEngine | None = None
+
+
+def get_embedding_engine() -> "EmbeddingEngine":
+    """Return the process-wide EmbeddingEngine singleton, building it once.
+
+    precondition: none.
+    postcondition: the same instance is returned for every call until
+    ``reset_embedding_engine`` clears it; the instance is constructed from the
+    current ``MemorySettings`` (dimension + device).
+    """
+    global _singleton
+    if _singleton is None:
+        from mcp_server.infrastructure.embedding_engine import EmbeddingEngine
+        from mcp_server.infrastructure.memory_config import get_memory_settings
+
+        s = get_memory_settings()
+        _singleton = EmbeddingEngine(dim=s.EMBEDDING_DIM, device=s.EMBEDDING_DEVICE)
+    return _singleton
+
+
+def reset_embedding_engine() -> None:
+    """Clear the singleton (for testing only)."""
+    global _singleton
+    _singleton = None

--- a/mcp_server/infrastructure/embedding_model_lifecycle.py
+++ b/mcp_server/infrastructure/embedding_model_lifecycle.py
@@ -1,0 +1,294 @@
+"""Model lifecycle for the embedding engine — device + load state machine.
+
+Split out of ``embedding_engine.py`` (Cortex#173) so the download/cache/load
+lifecycle is an explicit, testable seam rather than an inline tangle. The
+``ModelState`` enum names the distinct outcomes the loader can reach — the
+state space where a silent-degradation bug can hide:
+
+  * ``UNINITIALIZED``       — no load attempted yet (lazy engine).
+  * ``LOADED``              — a neural model is in hand.
+  * ``PACKAGE_ABSENT``      — ``import sentence_transformers`` failed; the
+                              package is not installed at all.
+  * ``MODEL_FILES_ABSENT``  — the package is present but the weights are not in
+                              the local cache; a one-time download is attempted.
+  * ``LOAD_RAISED``         — construction raised (corrupt cache, or an offline
+                              download attempt failed).
+
+Behaviour is preserved verbatim from the pre-split ``_ensure_model``:
+``PACKAGE_ABSENT`` degrades to the hash fallback + a background install;
+``MODEL_FILES_ABSENT`` downloads; ``LOAD_RAISED`` propagates. The states are now
+*named*, which is the seam a second (download-free) encoder plugs into later.
+
+Model revision pin (reproducibility gap closed 2026-07-11, incident i7d3):
+  ``huggingface_hub`` resolves an unpinned model name against the repo's
+  moving ``refs/main`` pointer. Root-cause investigation of a benchmark
+  regression found TWO snapshots cached locally for
+  ``sentence-transformers/all-MiniLM-L6-v2`` (``c9745ed1...`` from
+  2026-04-04 and ``1110a243...`` from 2026-06-09) — ``refs/main`` had moved
+  between them. In that specific incident the underlying
+  ``model.safetensors``/``config.json``/``tokenizer.json`` blobs were
+  confirmed BYTE-IDENTICAL across both snapshots (same SHA256 content
+  hash) by direct cache inspection, so it was not the cause of THAT
+  regression — but the gap itself is real and unbounded: nothing stops a
+  future upstream repo change (a genuine weight update, not just a
+  metadata/README commit) from silently altering embeddings for every
+  caller that resolves ``main`` at load time, with no signal in
+  ``uv.lock`` (which pins the Python package, not the HF model weights).
+  ``DEFAULT_MODEL_REVISION`` below pins the exact snapshot verified during
+  that investigation; ``EmbeddingEngine`` uses it whenever the caller does
+  not supply an explicit ``revision``. source: measured on 2026-07-11 via
+  ``~/.cache/huggingface/hub/models--sentence-transformers--all-MiniLM-L6-v2/refs/main``
+  and blob-hash comparison of the two cached snapshots.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import os
+from typing import Any
+
+from mcp_server.shared.platform import cache_dir as _base_cache_dir
+
+# source: measured 2026-07-11 (incident i7d3) — see module docstring
+# "Model revision pin" section for the full derivation and the blob-hash
+# verification that this snapshot's weights are byte-identical to the
+# immediately-prior cached snapshot.
+DEFAULT_MODEL_REVISION = "1110a243fdf4706b3f48f1d95db1a4f5529b4d41"
+
+logger = logging.getLogger(__name__)
+
+
+class ModelState(enum.Enum):
+    """Explicit lifecycle states of the neural model load (Cortex#173)."""
+
+    UNINITIALIZED = enum.auto()
+    LOADED = enum.auto()
+    PACKAGE_ABSENT = enum.auto()
+    MODEL_FILES_ABSENT = enum.auto()
+    LOAD_RAISED = enum.auto()
+
+
+def embedding_cache_dir() -> str | None:
+    """Resolve the ``cache_folder`` to pass to ``SentenceTransformer``.
+
+    Mirrors ``mcp_server.core.reranker.reranker_cache_dir`` (hardened
+    after the FlashRank /tmp incident, commit bb1c581f): same shared,
+    XDG-aware ``mcp_server.shared.platform.cache_dir()`` base, laid out
+    under ``huggingface/hub`` to match the directory
+    ``sentence-transformers``/``huggingface_hub`` already write
+    ``models--org--name`` snapshots into by default (``$HF_HOME/hub``).
+
+    Precedence, decided for consistency with how ``huggingface_hub``
+    itself resolves its cache (``cache_folder`` passed to
+    ``SentenceTransformer`` takes priority over both env vars inside the
+    library, so passing one unconditionally would silently override a
+    choice the user already made): if ``HF_HOME`` or
+    ``SENTENCE_TRANSFORMERS_HOME`` is set in the environment, return
+    ``None`` and let the library resolve its own default from that env
+    var. Otherwise return our durable, shared cache path so a caller who
+    set neither var still gets a deterministic, XDG-aware location
+    instead of depending entirely on ``huggingface_hub``'s built-in
+    resolution (issue #124 — the reranker was hardened this way in
+    bb1c581f; embeddings had no equivalent).
+    """
+    if os.environ.get("HF_HOME") or os.environ.get("SENTENCE_TRANSFORMERS_HOME"):
+        return None
+    return str(_base_cache_dir() / "huggingface" / "hub")
+
+
+class _EmbeddingLifecycleMixin:
+    """Device resolution + the neural-model load state machine.
+
+    A mixin so ``EmbeddingEngine`` keeps exposing ``_detect_device`` /
+    ``_resolve_device`` / ``_ensure_model`` on the class (the tests patch and
+    call them there). Reads/writes the engine attributes declared below, all
+    owned by ``EmbeddingEngine.__init__``.
+    """
+
+    _model: Any
+    _model_name: str
+    _dim: int
+    _revision: str | None
+    _device: str | None
+    _device_requested: str
+    _unavailable: bool
+    _model_state: ModelState
+
+    # ── Device detection ──────────────────────────────────────────────
+
+    @staticmethod
+    def _detect_device() -> str:
+        """Probe hardware: CUDA > MPS > CPU."""
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                logger.info("GPU auto-detect: CUDA available")
+                return "cuda"
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                logger.info("GPU auto-detect: MPS available")
+                return "mps"
+        except ImportError:
+            logger.debug("GPU auto-detect: torch not available, using cpu")
+        return "cpu"
+
+    def _resolve_device(self) -> str:
+        """Resolve and cache the target device. Called once per instance."""
+        if self._device is not None:
+            return self._device
+        requested = self._device_requested
+        if requested == "auto":
+            self._device = self._detect_device()
+        elif requested in ("cpu", "cuda", "mps"):
+            self._device = requested
+        else:
+            logger.warning("Unknown embedding device %r, using cpu", requested)
+            self._device = "cpu"
+        logger.info("Embedding device: %s (requested: %s)", self._device, requested)
+        return self._device
+
+    def _fallback_to_cpu(self) -> None:
+        """Reload model on CPU after GPU failure."""
+        logger.warning(
+            "GPU inference failed (device=%s) — reloading on CPU", self._device
+        )
+        self._device = "cpu"
+        self._model = None
+        self._ensure_model()
+
+    # ── Model loading (state machine) ─────────────────────────────────
+
+    @staticmethod
+    def _cache_miss_types() -> tuple[type[Exception], ...]:
+        """Exception types that mean 'weights not in local cache'.
+
+        OSError covers transformers' config loader; ``LocalEntryNotFoundError``
+        covers huggingface_hub (>=0.22), which raises a non-OSError on a
+        local-only cache miss.
+        """
+        try:
+            from huggingface_hub.errors import LocalEntryNotFoundError
+
+            return (OSError, LocalEntryNotFoundError)
+        except ImportError:
+            return (OSError,)
+
+    def _construct_model(self, device: str, cache_folder: str | None, local: bool):
+        """Build one ``SentenceTransformer``. Import is at call time so the
+        ``sentence_transformers.SentenceTransformer`` patch point still works.
+
+        ``local`` toggles ``local_files_only=True`` — hermetic (no HF Hub
+        requests) when the model is already cached. It must be an explicit
+        kwarg, not HF_HUB_OFFLINE, which hub freezes into module constants at
+        first import (reproduced 2026-07-03). source: kwarg added in
+        sentence-transformers v3.0.0.
+        """
+        from sentence_transformers import SentenceTransformer
+
+        kwargs: dict[str, Any] = {
+            "device": device,
+            "revision": self._revision,
+            # explicit, XDG-aware default (mirrors reranker bb1c581f) unless the
+            # user already set HF_HOME / SENTENCE_TRANSFORMERS_HOME (issue #124).
+            "cache_folder": cache_folder,
+        }
+        if local:
+            kwargs["local_files_only"] = True
+        return SentenceTransformer(self._model_name, **kwargs)
+
+    def _download_model(self, device: str, cache_folder: str | None) -> None:
+        """MODEL_FILES_ABSENT → one-time download; LOAD_RAISED if it fails.
+
+        The zero-config install path lands here by design; behaviour is
+        preserved from the pre-split loader — a download failure propagates.
+        """
+        self._model_state = ModelState.MODEL_FILES_ABSENT
+        logger.info(
+            "Downloading embedding model %s (revision=%s) — "
+            "~100 MB, one-time; cached under %s, then runs fully offline",
+            self._model_name,
+            self._revision or "refs/main",
+            cache_folder or "$HF_HOME",
+        )
+        try:
+            self._model = self._construct_model(device, cache_folder, local=False)
+        except Exception:
+            self._model_state = ModelState.LOAD_RAISED
+            raise
+
+    def _load_model(self, device: str) -> None:
+        """Load the model, moving through the explicit lifecycle states."""
+        cache_folder = embedding_cache_dir()
+        try:
+            self._model = self._construct_model(device, cache_folder, local=True)
+        except self._cache_miss_types():
+            self._download_model(device, cache_folder)
+
+        # sentence-transformers 5.x renamed get_sentence_embedding_dimension →
+        # get_embedding_dimension. Prefer the new name; fall back for <5.
+        get_dim = getattr(
+            self._model,
+            "get_embedding_dimension",
+            self._model.get_sentence_embedding_dimension,
+        )
+        actual_dim = get_dim()
+        if actual_dim != self._dim:
+            self._dim = actual_dim
+        self._model_state = ModelState.LOADED
+        logger.info(
+            "Loaded embedding model: %s (%dD, device=%s)",
+            self._model_name,
+            self._dim,
+            device,
+        )
+
+    def _ensure_model(self) -> None:
+        if self._model is not None or self._unavailable:
+            return
+        try:
+            self._load_model(self._resolve_device())
+        except ImportError:
+            # PACKAGE_ABSENT: sentence-transformers is not installed.
+            self._model_state = ModelState.PACKAGE_ABSENT
+            logger.warning(
+                "sentence-transformers not installed; using hash-based fallback "
+                "embeddings. Installing in background for next session..."
+            )
+            self._unavailable = True
+            self._trigger_background_install()
+
+    def _trigger_background_install(self) -> None:
+        """Install sentence-transformers in the background.
+
+        Runs pip install as a detached subprocess so it doesn't block
+        the current session. Next session will have real embeddings.
+        """
+        import subprocess
+        import sys
+
+        target = os.environ.get("CLAUDE_PLUGIN_DATA", "")
+        if target:
+            target = os.path.join(target, "deps")
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-q",
+            "sentence-transformers>=2.2.0,<4.0.0",
+        ]
+        if target:
+            cmd.extend(["--target", target])
+
+        try:
+            subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            logger.info("Background install of sentence-transformers started")
+        except Exception as exc:
+            logger.debug("Background install failed to start: %s", exc)

--- a/mcp_server/infrastructure/embedding_provider.py
+++ b/mcp_server/infrastructure/embedding_provider.py
@@ -1,0 +1,115 @@
+"""Encoder-provider seam for the embedding subsystem (Cortex#173).
+
+This module defines the interface the rest of the system consumes to turn text
+into vectors, decoupled from *which* encoder produces them:
+
+  * ``EmbeddingProvider`` — the ``Protocol`` the store, handlers, and hooks
+    depend on. ``EmbeddingEngine`` (the neural encoder in
+    ``embedding_engine.py``) is its first and, today, only implementation. A
+    future download-free encoder (issue #169) plugs in here as a second
+    implementation without any consumer change.
+  * ``_EmbeddingMathMixin`` — the stateless vector arithmetic shared by any
+    provider (cache key, L2 normalize, cosine similarity, blob⇄list). Kept as a
+    mixin so ``EmbeddingEngine`` exposes these on the class exactly as before
+    (``EmbeddingEngine._cache_key`` etc. — the tests pin them there).
+
+Pure infrastructure: no model, no I/O. Split out of ``embedding_engine.py`` to
+bring that file under the 300-line cap and to make the provider boundary
+explicit. Behaviour is unchanged — the methods below are moved verbatim.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+
+@runtime_checkable
+class EmbeddingProvider(Protocol):
+    """The text→vector interface consumers depend on (Cortex#173 seam).
+
+    Any implementation returns L2-normalized ``float32`` blobs of ``dimensions``
+    length (or ``None`` for empty text). ``EmbeddingEngine`` is the neural
+    implementation; the seam lets a second encoder be substituted without
+    touching a single caller.
+    """
+
+    @property
+    def dimensions(self) -> int:
+        """Vector dimension of the blobs this provider emits."""
+        ...
+
+    @property
+    def available(self) -> bool:
+        """Whether a real (neural) model backs this provider right now."""
+        ...
+
+    def encode(self, text: str) -> bytes | None:
+        """Encode one text to a float32 blob (``None`` for empty input)."""
+        ...
+
+    def encode_batch(self, texts: list[str]) -> list[bytes | None]:
+        """Encode a batch, preserving order and ``None`` for empty items."""
+        ...
+
+    def similarity(self, embedding_a: bytes, embedding_b: bytes) -> float:
+        """Cosine similarity between two blobs from this provider."""
+        ...
+
+
+class _EmbeddingMathMixin:
+    """Stateless vector arithmetic shared by every embedding provider.
+
+    A mixin (not free functions) so the concrete provider keeps exposing these
+    as class/instance methods — ``EmbeddingEngine._cache_key``,
+    ``engine.similarity``, ``engine.to_list`` — the exact surface the existing
+    tests exercise.
+    """
+
+    @staticmethod
+    def _cache_key(text: str) -> str:
+        """Return the SHA256[:16] cache key for ``text``.
+
+        precondition: ``text`` is a non-empty str.
+        postcondition: returns a 16-char lowercase hex string; the same
+        input always produces the same key; key length is independent of
+        ``len(text)``.
+
+        Source: ADR-0045 R5 — ``hashlib.sha256(text.encode()).hexdigest()[:16]``
+        is the mandated cache-key form for any memoization layer over
+        user-provided strings.
+        """
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+    @staticmethod
+    def _normalize(arr: np.ndarray) -> np.ndarray:
+        norm = np.linalg.norm(arr)
+        if norm > 0:
+            arr = arr / norm
+        return arr
+
+    def similarity(self, embedding_a: bytes, embedding_b: bytes) -> float:
+        """Cosine similarity between two embedding blobs."""
+        a = np.frombuffer(embedding_a, dtype=np.float32)
+        b = np.frombuffer(embedding_b, dtype=np.float32)
+        if len(a) != len(b):
+            return 0.0
+        dot = float(np.dot(a, b))
+        norm = float(np.linalg.norm(a) * np.linalg.norm(b))
+        if norm == 0:
+            return 0.0
+        return dot / norm
+
+    @staticmethod
+    def to_list(embedding: bytes) -> list[float]:
+        """Convert embedding blob to Python float list."""
+        arr = np.frombuffer(embedding, dtype=np.float32)
+        return arr.tolist()
+
+    @staticmethod
+    def from_list(values: list[float]) -> bytes:
+        """Convert float list to embedding blob."""
+        arr = np.asarray(values, dtype=np.float32)
+        return arr.tobytes()


### PR DESCRIPTION
## Phase A — pure refactoring, zero feature change

Splits `infrastructure/embedding_engine.py` (506 lines on main) into
behaviour-preserving modules along the three real seams, so a second encoder
(the #169 download-free fallback) can later plug in as a *second implementation*
without touching the monolith. No fallback embedder is added here.

`Closes #173`

## Seam design

**Seam 1 — encoder provider interface** (`embedding_provider.py`, 115 lines)
- `EmbeddingProvider` — a `runtime_checkable` `Protocol`: the text→vector
  interface the store, handlers, and hooks depend on, decoupled from *which*
  encoder produces the vectors. `EmbeddingEngine` is its first (neural)
  implementation and structurally satisfies it (asserted in a smoke check).
- `_EmbeddingMathMixin` — the stateless vector arithmetic shared by any provider
  (cache key, L2 normalize, cosine similarity, blob⇄list), kept as a mixin so
  `EmbeddingEngine._cache_key` / `.similarity` / `.to_list` stay on the class.

**Seam 2 — model lifecycle state machine** (`embedding_model_lifecycle.py`, 294 lines)
- `ModelState` enum makes the load state space **explicit** — this is exactly
  where a silent-degradation bug can hide:
  - `UNINITIALIZED` — no load attempted (lazy engine)
  - `LOADED` — a neural model is in hand
  - `PACKAGE_ABSENT` — `import sentence_transformers` failed (not installed)
  - `MODEL_FILES_ABSENT` — package present, weights not cached → download attempted
  - `LOAD_RAISED` — construction raised (corrupt cache / offline download failure)
- `_EmbeddingLifecycleMixin` owns device detection/resolution and the load path
  (`_ensure_model` decomposed into `_construct_model` / `_download_model` /
  `_load_model`, each ≤40 lines). Behaviour is preserved verbatim:
  `PACKAGE_ABSENT` → hash fallback + background install; `MODEL_FILES_ABSENT` →
  download; `LOAD_RAISED` → propagates.
- The revision-pin history (incident i7d3) and `embedding_cache_dir` move here.

**Seam 3 — engine selection / composition root** (`embedding_factory.py`, 52 lines)
- `get_embedding_engine` / `reset_embedding_engine` — the single place that reads
  `EMBEDDING_DIM` / `EMBEDDING_DEVICE` and assembles the process-wide encoder.
  Lazy internal import of `EmbeddingEngine` avoids an import cycle (verified in
  both import orders). `embedding_engine` re-exports these so every existing
  consumer import keeps working.

**Concrete provider** (`embedding_engine.py`, 245 lines) — the neural
`EmbeddingEngine`: encode path + LRU cache, composing the two mixins. Re-exports
`DEFAULT_MODEL_REVISION`, `embedding_cache_dir`, `EmbeddingProvider`,
`ModelState`, `get_embedding_engine`, `reset_embedding_engine` for import
compatibility.

## Proof of behaviour preservation

- The existing embedding test suite (`test_embedding_engine.py`,
  `test_embedding_cache.py`, 56 tests) passes **unchanged** — no test edited.
- Full suite: **5299 passed, 9 skipped, 3 failed**. The 3 failures are the
  documented pre-existing #174 `test_rebuild_profiles` failures (depend on live
  `~/.claude` data; reproduce identically on `main`) — unrelated to this PR.
- `ruff check .` and `ruff format --check` clean.
- File sizes: 115 / 294 / 52 / 245 — all ≤300; every method ≤40 lines.

One concern per commit (Fowler Extract Class ×2 + Move Function):
1. extract encoder-provider seam
2. extract model-lifecycle state machine
3. extract composition-root/selection seam

🤖 Generated with [Claude Code](https://claude.com/claude-code)