### PR TITLE
fix: rebuild_profiles hermeticity + bridge_finder ValueError on real session data (#174)

### DIFF
--- a/mcp_server/core/bridge_finder.py
+++ b/mcp_server/core/bridge_finder.py
@@ -216,17 +216,46 @@ def _merge_analogical_bridges(
             )
 
 
+def _index_memories(memories: dict | list | None) -> dict[str, dict]:
+    """Coerce a memory collection into an id -> record map.
+
+    Two producers feed this function with different shapes:
+      - ``brain_index["memories"]`` is already an id-keyed ``dict``.
+      - ``scanner.discover_all_memories()`` returns a ``list`` of records
+        (``file``/``path``/``project``/``body``/... — see
+        ``scanner._parse_memory_file``). Passing that list straight into
+        ``dict.update`` raised ``ValueError: dictionary update sequence
+        element #0 has length 9; 2 is required`` whenever the live home held
+        real memory files (issue #174) — empty homes skipped the branch, so
+        the defect only surfaced against production data.
+
+    A ``dict`` is returned unchanged. A ``list`` is keyed by the record's
+    stable ``path`` (fallback ``file`` then ``name``); records that carry no
+    identifier are keyed by object identity so distinct records never collide.
+    """
+    if not memories:
+        return {}
+    if isinstance(memories, dict):
+        return memories
+    indexed: dict[str, dict] = {}
+    for record in memories:
+        if not isinstance(record, dict):
+            continue
+        key = record.get("path") or record.get("file") or record.get("name")
+        indexed[str(key) if key is not None else f"mem:{id(record)}"] = record
+    return indexed
+
+
 def find_bridges(
     profiles: dict | None,
     brain_index: dict | None,
-    memories: dict | None = None,
+    memories: dict | list | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     """Find cross-domain bridges from structural edges and analogical text."""
-    all_memories = {}
+    all_memories: dict[str, dict] = {}
     if brain_index and brain_index.get("memories"):
         all_memories.update(brain_index["memories"])
-    if memories:
-        all_memories.update(memories)
+    all_memories.update(_index_memories(memories))
 
     all_conversations = (brain_index or {}).get("conversations") or {}
     project_domain_map = _build_project_domain_map(profiles)

--- a/mcp_server/core/profile_assembler.py
+++ b/mcp_server/core/profile_assembler.py
@@ -239,7 +239,7 @@ def _apply_cross_domain_analysis(
     domain_conversations: dict[str, dict],
     conversations: list[dict],
     brain_index: dict | None,
-    memories: dict | None,
+    memories: dict | list[dict] | None,
 ) -> None:
     """Attach bridges, blind spots, features, and persistent features."""
     bridges = find_bridges(profiles, brain_index, memories)
@@ -280,7 +280,7 @@ def build_domain_profiles(
     *,
     existing_profiles: dict,
     conversations: list[dict],
-    memories: dict | None,
+    memories: dict | list[dict] | None,
     brain_index: dict | None,
     by_project: dict[str, list[dict]],
     target_domain: str | None = None,

--- a/tests_py/core/test_bridge_finder.py
+++ b/tests_py/core/test_bridge_finder.py
@@ -292,3 +292,88 @@ class TestFindBridges:
         )
         assert len(alpha_bridge["examples"]) <= 5
         assert alpha_bridge["edgeCount"] == 10
+
+
+def _scanner_memory_record(project: str, body: str = "") -> dict:
+    """A memory record in the exact 9-key shape emitted by the scanner.
+
+    Mirrors ``scanner._parse_memory_file`` — the production producer whose
+    list output reached ``find_bridges`` and blew up in issue #174.
+    """
+    return {
+        "file": "note.md",
+        "path": f"/home/u/.claude/projects/{project}/memory/note.md",
+        "project": project,
+        "name": "note",
+        "description": "",
+        "type": "note",
+        "body": body,
+        "modifiedAt": "2026-07-23T02:57:21.806511Z",
+        "createdAt": "2026-07-23T02:57:21.806511Z",
+    }
+
+
+class TestFindBridgesScannerListShape:
+    """Regression pin for issue #174.
+
+    ``discover_all_memories()`` returns a ``list`` of records, but
+    ``find_bridges`` fed it straight into ``dict.update``. A non-empty list of
+    records (each with 9 keys) raised ``ValueError: dictionary update sequence
+    element #0 has length 9; 2 is required``. Empty homes skipped the branch,
+    so CI stayed green while every real ``~/.claude`` failed.
+    """
+
+    def test_minimized_failing_input_no_longer_raises(self):
+        # source: minimized from the live-home stack captured on 2026-07-24
+        # (issue #174); a single 9-key scanner record is the smallest input
+        # that reproduces the ValueError.
+        profiles = _make_profiles({"alpha": _make_domain(projects=["proj-a"])})
+        memories = [_scanner_memory_record("proj-a")]
+
+        result = find_bridges(profiles, None, memories)
+
+        assert isinstance(result, dict)
+
+    def test_scanner_list_yields_analogical_bridge(self):
+        profiles = _make_profiles(
+            {
+                "alpha": _make_domain(projects=["proj-a"]),
+                "beta": _make_domain(projects=["proj-b"]),
+            }
+        )
+        memories = [
+            _scanner_memory_record(
+                "proj-a", body="the write gate works just as a free energy filter"
+            ),
+        ]
+
+        result = find_bridges(profiles, None, memories)
+
+        assert "alpha" in result
+        analog = next(b for b in result["alpha"] if b["toDomain"] == "text-analogy")
+        assert analog["pattern"] == "just as"
+
+    def test_scanner_list_and_brain_index_dict_merge(self):
+        profiles = _make_profiles(
+            {
+                "alpha": _make_domain(projects=["proj-a"]),
+                "beta": _make_domain(projects=["proj-b"]),
+            }
+        )
+        brain_index = {
+            "memories": {
+                "m1": {"projectId": "proj-a", "body": "", "crossRefs": ["m2"]},
+                "m2": {"projectId": "proj-b", "body": "", "crossRefs": []},
+            },
+            "conversations": {},
+        }
+        list_memories = [_scanner_memory_record("proj-a", body="")]
+
+        result = find_bridges(profiles, brain_index, list_memories)
+
+        assert "alpha" in result
+        assert any(b["pattern"] == "structural-edge" for b in result["alpha"])
+
+    def test_empty_list_is_noop(self):
+        profiles = _make_profiles({"alpha": _make_domain(projects=["proj-a"])})
+        assert find_bridges(profiles, None, []) == {}

--- a/tests_py/handlers/test_rebuild_profiles.py
+++ b/tests_py/handlers/test_rebuild_profiles.py
@@ -1,27 +1,117 @@
 """Tests for mcp_server.handlers.rebuild_profiles — ported from rebuild-profiles.test.js."""
 
 import asyncio
+import json
 from datetime import datetime, timezone, timedelta
 from unittest.mock import patch
+
+import pytest
 
 from mcp_server.handlers.rebuild_profiles import handler
 
 
+def _write_session(proj_dir, name="s1.jsonl"):
+    """Write a minimal-but-real JSONL session (scanner convention)."""
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps(
+            {
+                "type": "user",
+                "slug": "s",
+                "cwd": str(proj_dir),
+                "timestamp": "2026-01-01T00:00:00Z",
+                "message": {"content": "fix the bug please"},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-01-01T00:05:00Z",
+                "message": {
+                    "content": [{"type": "tool_use", "name": "Read", "input": {}}]
+                },
+            }
+        ),
+    ]
+    (proj_dir / name).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_memory(proj_dir, name="note.md", body="We chose JWT over sessions."):
+    """Write a real memory .md so the scanner emits a 9-key record.
+
+    That list-of-records shape is precisely what triggered the issue #174
+    ValueError once it reached ``bridge_finder.find_bridges`` — pinning it
+    through the real pipeline is the point of this fixture.
+    """
+    mem_dir = proj_dir / "memory"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    (mem_dir / name).write_text(
+        "---\nname: note\ntype: decision\n---\n" + body + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def hermetic_claude_home(tmp_path, monkeypatch):
+    """Redirect every ~/.claude path constant the handler touches at a
+    synthetic tmp dir, so the rebuild runs against fixture data — never the
+    developer's live session history (issue #174 isolation violation).
+
+    Seeds two real projects, each with a session and a memory file, so the
+    scanner yields a non-empty ``list`` of memory records and the full
+    scan → group → assemble → bridge pipeline executes for real.
+    """
+    projects = tmp_path / "projects"
+    _write_session(projects / "proj-a")
+    _write_memory(projects / "proj-a", body="cache works just as a free energy filter")
+    _write_session(projects / "proj-b")
+    _write_memory(projects / "proj-b", body="a second decision note")
+
+    methodology = tmp_path / "methodology"
+    domains = methodology / "domains"
+    monkeypatch.setattr("mcp_server.infrastructure.scanner.CLAUDE_DIR", tmp_path)
+    monkeypatch.setattr(
+        "mcp_server.infrastructure.brain_index_store.BRAIN_INDEX_PATH",
+        tmp_path / "brain-index.json",
+    )
+    monkeypatch.setattr(
+        "mcp_server.infrastructure.profile_store.PROFILES_PATH",
+        methodology / "profiles.json",
+    )
+    monkeypatch.setattr(
+        "mcp_server.infrastructure.profile_store.METHODOLOGY_DIR", methodology
+    )
+    monkeypatch.setattr("mcp_server.infrastructure.profile_store.DOMAINS_DIR", domains)
+    monkeypatch.setattr(
+        "mcp_server.infrastructure.profile_store.INDEX_PATH",
+        methodology / "index.json",
+    )
+    monkeypatch.setattr(
+        "mcp_server.infrastructure.profile_store.LEGACY_BACKUP_PATH",
+        methodology / "profiles.json.v1_backup",
+    )
+    return tmp_path
+
+
 class TestRebuildProfilesHandler:
-    def test_returns_domains_array_with_force(self):
+    def test_returns_domains_array_with_force(self, hermetic_claude_home):
         result = asyncio.run(handler({"force": True}))
         assert result is not None
         assert "domains" in result
         assert isinstance(result["domains"], list)
 
-    def test_includes_total_sessions_and_memories(self):
+    def test_includes_total_sessions_and_memories(self, hermetic_claude_home):
         result = asyncio.run(handler({"force": True}))
         assert "totalSessions" in result
         assert "totalMemories" in result
         assert isinstance(result["totalSessions"], (int, float))
         assert isinstance(result["totalMemories"], (int, float))
+        # The fixture seeds two real memory files; the scan must find them —
+        # proving the pipeline consumed a non-empty list of scanner records
+        # (the shape that raised the issue #174 ValueError) without erroring.
+        assert result["totalMemories"] == 2
 
-    def test_includes_duration_metric(self):
+    def test_includes_duration_metric(self, hermetic_claude_home):
         result = asyncio.run(handler({"force": True}))
         assert "duration" in result
         assert isinstance(result["duration"], (int, float))


### PR DESCRIPTION
Closes #174

## The defect, two layers

**1. Real bug (production data path).** `scanner.discover_all_memories()` returns a `list[dict]` of memory records, but `bridge_finder.find_bridges` fed that list straight into `dict.update`. A non-empty list of 9-key records raises:

```
ValueError: dictionary update sequence element #0 has length 9; 2 is required
```

Empty homes skip the `if memories:` branch, so CI (empty `$HOME`) stayed green while every developer machine with real `~/.claude` memory files failed. This is a type-contract mismatch reached by legitimate production data — classified as a real bug, not flakiness.

**2. Test isolation (hidden shared state).** Three `test_rebuild_profiles` cases called `handler({"force": True})` with no mocking, reading the developer's live `~/.claude` session history. Results depended on whose machine ran them.

## Minimized failing input

A single scanner-shaped record (the 9 keys `file, path, project, name, description, type, body, modifiedAt, createdAt`) wrapped in a list:

```python
find_bridges(profiles, None, [{"file": "note.md", "path": "...", "project": "proj-a",
    "name": "note", "description": "", "type": "note", "body": "",
    "modifiedAt": "...", "createdAt": "..."}])   # -> ValueError pre-fix
```

## Root-cause classification

`bridge_finder` **should** handle that shape — it is exactly what the production producer (`discover_all_memories`) emits. Fixed there, not by rejecting the data.

## What changed

- `core/bridge_finder.py`: new `_index_memories()` normalizes the scanner `list` into an id-keyed map (keyed by `path`/`file`/`name`); the `brain_index` `dict` shape is passed through unchanged. Signature widened to `dict | list | None`.
- `core/profile_assembler.py`: annotations corrected to the honest `dict | list[dict] | None` through the call chain.
- `tests_py/core/test_bridge_finder.py`: `TestFindBridgesScannerListShape` pins the minimized 9-key record and the list+brain_index merge.
- `tests_py/handlers/test_rebuild_profiles.py`: `hermetic_claude_home` fixture redirects every `~/.claude` path constant at a synthetic `tmp_path` seeded with real sessions + memory files; the three previously-live-home tests now drive the full pipeline against fixtures and consume the list-of-records shape that triggered the ValueError.

## Gates (on this machine, live `~/.claude` present)

- `ruff check` + `ruff format --check`: pass.
- Full `pytest`: **5304 passed**, 9 skipped. The 3 previously-failing `test_rebuild_profiles` cases are green. Two unrelated pre-existing failures (`test_cold_start` real-DB SessionStart hook; `test_I2_canonical_writer` order-dependent, passes in isolation) reproduce on clean `main` without this change and are out of scope for #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)