### PR TITLE
feat: zero-download semantic fallback — algorithmic embeddings + code-aware FTS (#169, Phase B)

### DIFF
--- a/benchmarks/longmemeval/run_sqlite_fallback_bench.py
+++ b/benchmarks/longmemeval/run_sqlite_fallback_bench.py
@@ -1,0 +1,215 @@
+"""Three-way SQLite retrieval benchmark for the #169 zero-download fallback.
+
+The production ``run_benchmark.py`` harness drives the PostgreSQL + pgvector
+pipeline (``BenchmarkDB`` → ``PgMemoryStore``) and has no toggle for the
+SQLite fallback path or for the embedding mode. Issue #169 changes exactly that
+path, so this harness reuses the production harness's dataset loading and
+scoring functions verbatim (``session_to_memory_content``,
+``parse_longmemeval_date``, ``compute_heat_with_decay``, ``compute_mrr``,
+``recall_at_k_binary``) but drives a fresh in-memory ``SqliteMemoryStore`` in
+three embedding modes:
+
+  (a) no-vector    — memories stored with no embedding; recall uses FTS + heat
+      + recency only. The floor #169 must beat.
+  (b) fallback     — deterministic algorithmic embeddings (shared.algorithmic_
+      embedding), zero download.
+  (c) sentence-transformers — the neural encoder, when present.
+
+Adoption criterion (issue #169): the fallback (b) must beat the no-vector
+baseline (a) materially. This harness reports whatever the numbers say.
+
+Run:
+    python3 benchmarks/longmemeval/run_sqlite_fallback_bench.py --limit 30
+
+Bounded runs are the intended use (the neural path is untouched by #169, so
+full floors are not required — see the PR). ``--limit`` and the git sha / date
+are recorded in the emitted MANIFEST so the run is reproducible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "")
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import mcp_server.infrastructure.embedding_engine as ee  # noqa: E402
+import mcp_server.infrastructure.embedding_factory as ef  # noqa: E402
+from benchmarks.longmemeval.run_benchmark import (  # noqa: E402
+    compute_heat_with_decay,
+    compute_mrr,
+    parse_longmemeval_date,
+    recall_at_k_binary,
+    session_to_memory_content,
+)
+from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore  # noqa: E402
+
+_MODES = ("no-vector", "fallback", "sentence-transformers")
+
+
+def _install_engine(mode: str) -> ee.EmbeddingEngine | None:
+    """Install the process-wide engine matching ``mode`` (or None for no-vector).
+
+    For 'fallback' a zero-download engine is forced; for
+    'sentence-transformers' the real model is loaded (skipped by the caller if
+    absent). Returns the engine so the caller can encode queries with the SAME
+    encoder that produced the stored vectors.
+    """
+    ee.reset_embedding_engine()  # clears the factory singleton
+    if mode == "no-vector":
+        return None
+    if mode == "fallback":
+        os.environ["CORTEX_EMBEDDING_ZERO_DOWNLOAD"] = "1"
+        eng = ee.EmbeddingEngine(model_name="no-such-model-169", dim=384)
+    else:
+        os.environ.pop("CORTEX_EMBEDDING_ZERO_DOWNLOAD", None)
+        eng = ee.EmbeddingEngine(dim=384)
+    # Install as the process-wide singleton the store reads for provenance
+    # stamping / query-space filtering (issue #169 — the singleton lives in the
+    # factory since the #173 seam split).
+    ef._singleton = eng
+    return eng
+
+
+def _load_question(store: SqliteMemoryStore, item: dict, eng) -> dict[int, str]:
+    """Load one question's haystack into ``store``; return memory_id → sid."""
+    question_date = parse_longmemeval_date(item["question_date"])
+    id_to_sid: dict[int, str] = {}
+    for session, sid, date_str in zip(
+        item["haystack_sessions"],
+        item["haystack_session_ids"],
+        item["haystack_dates"],
+    ):
+        content, _ = session_to_memory_content(session, sid)
+        date_iso = parse_longmemeval_date(date_str)
+        heat = compute_heat_with_decay(date_iso, question_date)
+        embedding = eng.encode(content) if eng is not None else None
+        mid = store.insert_memory(
+            {
+                "content": content,
+                "embedding": embedding,
+                "created_at": date_iso,
+                "heat": heat,
+                "source": sid,
+                "domain": "longmemeval",
+            }
+        )
+        id_to_sid[mid] = sid
+    return id_to_sid
+
+
+def _eval_mode(mode: str, dataset: list[dict]) -> dict[str, float] | None:
+    """Run one embedding mode over ``dataset``; return {mrr, recall10, elapsed}.
+
+    Returns None when the mode is unavailable (neural model absent).
+    """
+    eng = _install_engine(mode)
+    if mode == "sentence-transformers" and (eng is None or eng.mode != "neural"):
+        return None
+    mrrs: list[float] = []
+    r10s: list[float] = []
+    t0 = time.monotonic()
+    for item in dataset:
+        store = SqliteMemoryStore(db_path=":memory:", embedding_dim=384)
+        try:
+            id_to_sid = _load_question(store, item, eng)
+            q_emb = eng.encode(item["question"]) if eng is not None else None
+            results = store.recall_memories(
+                item["question"], q_emb, domain="longmemeval", max_results=10
+            )
+            retrieved = [id_to_sid.get(r["memory_id"], "") for r in results]
+            answer_sids = item["answer_session_ids"]
+            mrrs.append(compute_mrr(retrieved, answer_sids))
+            r10s.append(recall_at_k_binary(retrieved, answer_sids))
+        finally:
+            store.close()
+    return {
+        "mrr": sum(mrrs) / len(mrrs) if mrrs else 0.0,
+        "recall10": sum(r10s) / len(r10s) if r10s else 0.0,
+        "elapsed_s": round(time.monotonic() - t0, 1),
+        "n": len(dataset),
+    }
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], text=True
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+def _print_table(results: dict[str, dict | None]) -> None:
+    print("\n=== LongMemEval-S · SQLite three-way (issue #169) ===")
+    print(f"{'mode':<24}{'MRR':>10}{'Recall@10':>12}{'elapsed':>10}")
+    for mode in _MODES:
+        r = results.get(mode)
+        if r is None:
+            print(f"{mode:<24}{'n/a':>10}{'n/a':>12}{'n/a':>10}")
+        else:
+            print(
+                f"{mode:<24}{r['mrr']:>10.3f}{r['recall10']:>11.1%}"
+                f"{r['elapsed_s']:>9.1f}s"
+            )
+    base = results.get("no-vector")
+    fb = results.get("fallback")
+    if base and fb:
+        d_mrr = fb["mrr"] - base["mrr"]
+        d_r10 = fb["recall10"] - base["recall10"]
+        verdict = "BEATS" if (d_mrr > 0 or d_r10 > 0) else "DOES NOT BEAT"
+        print(
+            f"\nfallback vs no-vector: ΔMRR={d_mrr:+.3f} ΔR@10={d_r10:+.1%} "
+            f"→ fallback {verdict} no-vector baseline"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=30, help="Questions (0=all)")
+    parser.add_argument("--results-out", type=str, default=None)
+    args = parser.parse_args()
+
+    data_path = Path(__file__).parent / "longmemeval_s.json"
+    if not data_path.exists():
+        print(f"Dataset not found at {data_path}")
+        sys.exit(1)
+    with data_path.open() as f:
+        dataset = json.load(f)
+    if args.limit > 0:
+        dataset = dataset[: args.limit]
+
+    results: dict[str, dict | None] = {}
+    for mode in _MODES:
+        print(f"[running] {mode} over {len(dataset)} questions ...")
+        results[mode] = _eval_mode(mode, dataset)
+    ee.reset_embedding_engine()
+
+    _print_table(results)
+
+    manifest = {
+        "benchmark": "longmemeval_s_sqlite_fallback_169",
+        "git_sha": _git_sha(),
+        "date": datetime.now(timezone.utc).isoformat(),
+        "limit": args.limit,
+        "n_questions": len(dataset),
+        "results": results,
+    }
+    if args.results_out:
+        out = Path(args.results_out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(manifest, indent=2))
+        print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/results/semantic-fallback-169/MANIFEST.md
+++ b/benchmarks/results/semantic-fallback-169/MANIFEST.md
@@ -1,0 +1,49 @@
+# LongMemEval-S · SQLite three-way — issue #169 (Phase B, on the #173 seams)
+
+Harness: `benchmarks/longmemeval/run_sqlite_fallback_bench.py`
+(a #169-specific harness — the production `run_benchmark.py` drives PostgreSQL +
+pgvector and has no no-vector / embedding-mode toggle, so it cannot express this
+three-way SQLite comparison. This harness reuses the production harness's
+dataset loading + scoring functions verbatim: `session_to_memory_content`,
+`parse_longmemeval_date`, `compute_heat_with_decay`, `compute_mrr`,
+`recall_at_k_binary`.)
+
+- Dataset: `longmemeval_s.json` (Wu et al., ICLR 2025), variant `s`.
+- Branch: `feat/semantic-fallback-169b`; run against commit `8347944` (this PR's
+  implementation commit — fresh numbers on the Phase B code, replacing the old
+  branch's figures).
+- Date: 2026-07-24 (UTC).
+- Bounded run: `--limit 50` questions. Full floors are NOT required — the
+  PostgreSQL / sentence-transformers production path is untouched by #169; this
+  measures only the SQLite fallback path #169 introduces.
+- Environment: CPU, macOS dev host, in-memory `SqliteMemoryStore` per question
+  (`:memory:`), zero network for the no-vector and fallback modes. The fallback
+  mode selects the algorithmic provider via `ModelState` (bogus model name +
+  `CORTEX_EMBEDDING_ZERO_DOWNLOAD=1`); the process singleton is installed in the
+  factory so the store stamps provenance and the query-space filter is active.
+
+## Results (n = 50)
+
+| mode                      |   MRR | Recall@10 | elapsed |
+|---------------------------|------:|----------:|--------:|
+| (a) no-vector baseline    | 0.275 |     46.0% |   5.2 s |
+| (b) algorithmic fallback  | 0.378 |     66.0% |  38.6 s |
+| (c) sentence-transformers | 0.609 |     94.0% |  49.6 s |
+
+Fallback vs no-vector: **ΔMRR = +0.102, ΔRecall@10 = +20.0 pp** →
+**fallback BEATS the no-vector baseline** (issue #169 adoption criterion met).
+
+## Reading
+
+The fallback lands where a download-free approximation should: materially above
+the no-vector floor (recovering ~half the MRR gap and ~40% of the Recall@10 gap
+to the neural encoder), and clearly below neural — which is why the two spaces
+are kept from cross-ranking and why the consolidate upgrade cycle re-embeds
+fallback memories to neural once the model is present.
+
+Reproduce:
+
+```
+python3 benchmarks/longmemeval/run_sqlite_fallback_bench.py --limit 50 \
+    --results-out benchmarks/results/semantic-fallback-169/lme-s-sqlite-3way.json
+```

--- a/benchmarks/results/semantic-fallback-169/lme-s-sqlite-3way.json
+++ b/benchmarks/results/semantic-fallback-169/lme-s-sqlite-3way.json
@@ -1,0 +1,27 @@
+{
+  "benchmark": "longmemeval_s_sqlite_fallback_169",
+  "git_sha": "8347944",
+  "date": "2026-07-24T21:53:11.821338+00:00",
+  "limit": 50,
+  "n_questions": 50,
+  "results": {
+    "no-vector": {
+      "mrr": 0.2754945322708481,
+      "recall10": 0.46,
+      "elapsed_s": 5.2,
+      "n": 50
+    },
+    "fallback": {
+      "mrr": 0.3777399644043607,
+      "recall10": 0.66,
+      "elapsed_s": 38.6,
+      "n": 50
+    },
+    "sentence-transformers": {
+      "mrr": 0.6089621848739496,
+      "recall10": 0.94,
+      "elapsed_s": 49.6,
+      "n": 50
+    }
+  }
+}

--- a/mcp_server/handlers/consolidate.py
+++ b/mcp_server/handlers/consolidate.py
@@ -15,6 +15,9 @@ from mcp_server.handlers.consolidation.cascade import run_cascade_advancement
 from mcp_server.handlers.consolidation.cls import run_cls_cycle
 from mcp_server.handlers.consolidation.compression import run_compression_cycle
 from mcp_server.handlers.consolidation.decay import run_decay_cycle
+from mcp_server.handlers.consolidation.embedding_upgrade import (
+    run_embedding_upgrade_cycle,
+)
 from mcp_server.handlers.consolidation.entity_merge import run_entity_merge_cycle
 from mcp_server.handlers.consolidation.forgetting import run_forgetting_cycle
 from mcp_server.handlers.consolidation.homeostatic import run_homeostatic_cycle
@@ -338,6 +341,14 @@ def _run_cycles(
 
     if args.get("cls", True):
         stats["cls"] = _timed(run_cls_cycle, store, settings, embeddings)
+
+    # Transparent #169 upgrade: re-embed memories written by the download-free
+    # fallback once the neural model is available, restamping them 'neural'.
+    # Runs with the compress phase (both re-embed on the current encoder).
+    if args.get("compress", True):
+        stats["embedding_upgrade"] = _timed(
+            run_embedding_upgrade_cycle, store, embeddings
+        )
 
     if args.get("memify", True):
         stats["memify"] = _timed(run_memify_cycle, store, None)

--- a/mcp_server/handlers/consolidation/embedding_upgrade.py
+++ b/mcp_server/handlers/consolidation/embedding_upgrade.py
@@ -34,13 +34,10 @@ def run_embedding_upgrade_cycle(
 ) -> dict[str, Any]:
     """Re-embed up to ``_MAX_UPGRADE_PER_CYCLE`` fallback memories with neural.
 
-    precondition: ``embeddings`` is the process encoder; ``store`` may or may
-    not expose the #169 fallback worklist.
     postcondition: returns ``{"upgraded": n}`` (and a ``reason`` when it skips).
     Only runs when the encoder currently resolves to the neural model; each
-    upgraded memory's vector is replaced and its ``embedding_model`` restamped
-    'neural' via ``store.reembed_memory``. Non-fatal: any failure is logged and
-    reported as zero upgrades.
+    upgraded memory is re-embedded and restamped 'neural' via
+    ``store.reembed_memory``. Non-fatal: failures report zero upgrades.
     """
     if not hasattr(store, "select_fallback_embeddings") or not hasattr(
         store, "reembed_memory"

--- a/mcp_server/handlers/consolidation/embedding_upgrade.py
+++ b/mcp_server/handlers/consolidation/embedding_upgrade.py
@@ -1,0 +1,72 @@
+"""Embedding-upgrade cycle: re-embed fallback memories once the model arrives.
+
+The scheduled other half of the #169 zero-download fallback. When a session ran
+on the download-free algorithmic provider (``embedding_model = 'fallback'``) and
+a later session finds the neural model present, this maintenance cycle re-embeds
+those memories with the neural encoder and restamps them 'neural' — so the
+store transparently upgrades to full-fidelity vectors over time instead of
+leaving two incompatible spaces side by side forever.
+
+Bounded per run (``_MAX_UPGRADE_PER_CYCLE``) so a large backlog is drained
+across several consolidations rather than in one blocking pass, mirroring the
+other streaming cycles. No-op when the current encoder is still fallback (no
+neural model to upgrade to) or when the store has no fallback worklist.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp_server.infrastructure.embedding_engine import EmbeddingEngine
+from mcp_server.infrastructure.memory_store import MemoryStore
+
+logger = logging.getLogger(__name__)
+
+# source: matches sleep_compute.run_sleep_compute_streamed's max_reembed=100
+# bound (mcp_server/core/sleep_compute.py) — the same per-cycle re-embed budget
+# already used for stale/compressed embeddings, reused here for parity.
+_MAX_UPGRADE_PER_CYCLE = 100
+
+
+def run_embedding_upgrade_cycle(
+    store: MemoryStore, embeddings: EmbeddingEngine
+) -> dict[str, Any]:
+    """Re-embed up to ``_MAX_UPGRADE_PER_CYCLE`` fallback memories with neural.
+
+    precondition: ``embeddings`` is the process encoder; ``store`` may or may
+    not expose the #169 fallback worklist.
+    postcondition: returns ``{"upgraded": n}`` (and a ``reason`` when it skips).
+    Only runs when the encoder currently resolves to the neural model; each
+    upgraded memory's vector is replaced and its ``embedding_model`` restamped
+    'neural' via ``store.reembed_memory``. Non-fatal: any failure is logged and
+    reported as zero upgrades.
+    """
+    if not hasattr(store, "select_fallback_embeddings") or not hasattr(
+        store, "reembed_memory"
+    ):
+        return {"upgraded": 0, "reason": "store has no fallback worklist"}
+    if getattr(embeddings, "mode", "neural") != "neural":
+        return {"upgraded": 0, "reason": "no neural model available yet"}
+    try:
+        candidates = store.select_fallback_embeddings(limit=_MAX_UPGRADE_PER_CYCLE)
+    except Exception:
+        logger.debug("Embedding-upgrade cycle: worklist query failed (non-fatal)")
+        return {"upgraded": 0}
+
+    upgraded = 0
+    for item in candidates:
+        content = item.get("content")
+        if not content:
+            continue
+        try:
+            emb = embeddings.encode(content)
+            if emb:
+                store.reembed_memory(item["memory_id"], emb)
+                upgraded += 1
+        except Exception:
+            logger.debug(
+                "Embedding-upgrade failed for memory %s (non-fatal)",
+                item.get("memory_id"),
+            )
+    return {"upgraded": upgraded}

--- a/mcp_server/handlers/get_telemetry.py
+++ b/mcp_server/handlers/get_telemetry.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from mcp_server.core import telemetry
 from mcp_server.handlers._tool_meta import READ_ONLY
+from mcp_server.infrastructure.embedding_engine import current_embedding_mode
 
 schema = {
     "title": "Get Telemetry (read/write counters)",
@@ -59,6 +60,16 @@ schema = {
                     "environment when the process started."
                 ),
             },
+            "embedding_mode": {
+                "type": "string",
+                "description": (
+                    "Embedding provenance for this process (issue #169): "
+                    "'neural' = sentence-transformers, 'fallback' = "
+                    "download-free algorithmic embeddings (lower fidelity, "
+                    "engaged when the model is absent), 'unknown' = no encode "
+                    "has run yet. Fallback and neural vectors never cross-rank."
+                ),
+            },
         },
     },
     "description": (
@@ -79,6 +90,10 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
     """Return current telemetry summary.
 
     precondition: none (read-only over in-memory dict).
-    postcondition: returns ``telemetry.summary()`` verbatim.
+    postcondition: returns ``telemetry.summary()`` augmented with
+    ``embedding_mode`` (issue #169) so a caller can tell whether semantic recall
+    is running on neural or download-free fallback embeddings.
     """
-    return telemetry.summary()
+    summary = telemetry.summary()
+    summary["embedding_mode"] = current_embedding_mode()
+    return summary

--- a/mcp_server/handlers/recall_helpers.py
+++ b/mcp_server/handlers/recall_helpers.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from mcp_server.core import thermodynamics
 from mcp_server.core.enrichment import build_expanded_query
+from mcp_server.shared.code_tokenize import expand_fts_query
 from mcp_server.core.prospective import check_trigger
 from mcp_server.core.query_intent import QueryIntent
 from mcp_server.core.retrieval_signals import (
@@ -43,6 +44,17 @@ def compute_vector_fts(
         ids = {m for m, _ in fts}
         fts.extend(
             (m, s) for m, s in store.search_fts(query, limit=pool // 2) if m not in ids
+        )
+    # Code-aware discovery (issue #169): a camelCase/snake_case query term is
+    # expanded into its sub-tokens so a lowercase query ("payment") recalls a
+    # symbol memory ("normalizePaymentAmount") on the SQLite FTS path — and vice
+    # versa. Merge-in only (never removes a hit); the raw/expanded searches
+    # above stay primary, so this is additive on both backends.
+    code_q = expand_fts_query(query)
+    if code_q and code_q not in (query, expanded):
+        ids = {m for m, _ in fts}
+        fts.extend(
+            (m, s) for m, s in store.search_fts(code_q, limit=pool // 2) if m not in ids
         )
     return vec, fts, q_emb
 

--- a/mcp_server/infrastructure/embedding_downloads.py
+++ b/mcp_server/infrastructure/embedding_downloads.py
@@ -1,0 +1,98 @@
+"""Best-effort background fetches for the embedding subsystem (issue #169).
+
+Non-blocking helpers the model lifecycle uses when it engages the download-free
+fallback: kick off the package install (PACKAGE_ABSENT) or the model-weight
+download (MODEL_FILES_ABSENT) in a detached subprocess so the current session
+serves fallback embeddings immediately and the neural model becomes available
+for the NEXT session — the "no first-run cliff" behaviour of #169.
+
+Both helpers honour ``CORTEX_EMBEDDING_ZERO_DOWNLOAD``: when set, no network
+fetch is started at all (sandboxed / offline / test use). All failures are
+swallowed — a background fetch that cannot start must never affect the caller.
+
+Pure I/O (subprocess). Infrastructure layer.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def zero_download_requested() -> bool:
+    """Whether the operator opted out of any embedding network fetch (#169).
+
+    source: opt-in env contract — ``CORTEX_EMBEDDING_ZERO_DOWNLOAD`` in
+    {``1``, ``true``} suppresses both the background package install and the
+    background model download, forcing pure download-free operation.
+    """
+    return os.environ.get("CORTEX_EMBEDDING_ZERO_DOWNLOAD", "").lower() in ("1", "true")
+
+
+def _spawn_detached(cmd: list[str], what: str) -> None:
+    """Start ``cmd`` as a detached, output-suppressed subprocess; swallow errors."""
+    import subprocess
+
+    try:
+        subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        logger.info("Background %s started", what)
+    except Exception as exc:
+        logger.debug("Background %s failed to start: %s", what, exc)
+
+
+def trigger_background_install() -> None:
+    """Install sentence-transformers in the background (PACKAGE_ABSENT).
+
+    Next session will have the package and a real model. No-op under
+    ``CORTEX_EMBEDDING_ZERO_DOWNLOAD``.
+    """
+    if zero_download_requested():
+        return
+    import sys
+
+    target = os.environ.get("CLAUDE_PLUGIN_DATA", "")
+    if target:
+        target = os.path.join(target, "deps")
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "-q",
+        "sentence-transformers>=2.2.0,<4.0.0",
+    ]
+    if target:
+        cmd.extend(["--target", target])
+    _spawn_detached(cmd, "install of sentence-transformers")
+
+
+def trigger_background_model_download(
+    model_name: str, revision: str | None, cache_folder: str | None
+) -> None:
+    """Download the embedding model weights in the background (MODEL_FILES_ABSENT).
+
+    Populates the local HF cache so the NEXT session loads the neural model.
+    No-op under ``CORTEX_EMBEDDING_ZERO_DOWNLOAD``. The child imports
+    sentence-transformers itself; a failure (offline) is silently dropped —
+    this session already serves fallback.
+    """
+    if zero_download_requested():
+        return
+    import sys
+
+    # The child constructs the model once to force the download into the cache.
+    prog = (
+        "import sys\n"
+        "from sentence_transformers import SentenceTransformer\n"
+        "name, rev, cf = sys.argv[1], sys.argv[2] or None, sys.argv[3] or None\n"
+        "SentenceTransformer(name, revision=rev, cache_folder=cf)\n"
+    )
+    cmd = [sys.executable, "-c", prog, model_name, revision or "", cache_folder or ""]
+    _spawn_detached(cmd, f"download of embedding model {model_name}")

--- a/mcp_server/infrastructure/embedding_engine.py
+++ b/mcp_server/infrastructure/embedding_engine.py
@@ -2,32 +2,35 @@
 
 Provides text -> vector encoding for semantic similarity search.
 
-Strategy (in priority order):
-  1. sentence-transformers (if installed) -- best quality, 384D
-  2. Fallback: hash-based sparse-to-dense encoding (no ML model)
+Strategy (selected by the factory per ``ModelState``, issue #169):
+  1. sentence-transformers (``ModelState.LOADED``) -- best quality, 384D
+  2. Download-free algorithmic fallback (every non-LOADED state) --
+     ``embedding_fallback_provider.AlgorithmicEmbeddingProvider``, the SECOND
+     ``EmbeddingProvider`` implementation. No state maps to nothing.
 
 The engine is lazy-loading: no model initialization until first encode() call.
 
 Structure (Cortex#173 — the file was split along three seams):
   * ``embedding_provider.EmbeddingProvider`` — the interface consumers depend
-    on; ``EmbeddingEngine`` below is its neural implementation.
+    on; ``EmbeddingEngine`` below is the neural implementation, the algorithmic
+    fallback is the second.
   * ``embedding_model_lifecycle`` — device resolution + the explicit model-load
     state machine (``ModelState``: package absent / model files absent / load
     raised / loaded). See that module's docstring for the revision-pin history.
-  * this module — the concrete neural provider (encode path + LRU cache) and the
-    process-wide composition root (``get_embedding_engine``).
+  * ``embedding_factory`` — the composition root: it wires the two providers and
+    owns the state→provider selection (``use_fallback``, ``current_embedding_mode``).
+  * this module — the concrete neural provider (encode path + LRU cache).
 
 Device selection:
   Default is "cpu" for embedding consistency (GPU float32 arithmetic produces
   bit-different vectors from CPU). GPU is opt-in via CORTEX_MEMORY_EMBEDDING_DEVICE
   env var. If GPU inference fails at runtime (OOM, MPS reset after sleep), the
-  engine automatically falls back to CPU; if CPU also fails, it degrades to
-  hash-based fallback encoding. The engine never crashes on encode().
+  engine automatically falls back to CPU; if CPU also fails, it degrades to the
+  algorithmic fallback provider. The engine never crashes on encode().
 """
 
 from __future__ import annotations
 
-import hashlib
 import logging
 from collections import OrderedDict
 from typing import Any
@@ -35,8 +38,13 @@ from typing import Any
 import numpy as np
 
 from mcp_server.infrastructure.embedding_factory import (
+    current_embedding_mode,
     get_embedding_engine,
     reset_embedding_engine,
+    use_fallback,
+)
+from mcp_server.infrastructure.embedding_fallback_provider import (
+    AlgorithmicEmbeddingProvider,
 )
 from mcp_server.infrastructure.embedding_model_lifecycle import (
     DEFAULT_MODEL_REVISION,
@@ -55,12 +63,13 @@ logger = logging.getLogger(__name__)
 # from ``embedding_engine`` directly (they lived here before the Cortex#173
 # split). The definitions now live in the seam modules — ``embedding_provider``
 # (interface), ``embedding_model_lifecycle`` (revision pin + cache dir), and
-# ``embedding_factory`` (composition root / selection).
+# ``embedding_factory`` (composition root / selection + telemetry mode).
 __all__ = [
     "DEFAULT_MODEL_REVISION",
     "EmbeddingEngine",
     "EmbeddingProvider",
     "ModelState",
+    "current_embedding_mode",
     "embedding_cache_dir",
     "get_embedding_engine",
     "reset_embedding_engine",
@@ -102,6 +111,10 @@ class EmbeddingEngine(_EmbeddingLifecycleMixin, _EmbeddingMathMixin):
         self._model: Any = None
         self._unavailable = False
         self._model_state: ModelState = ModelState.UNINITIALIZED
+        # The SECOND provider (issue #169): the download-free algorithmic
+        # encoder the factory routes to for every non-LOADED ModelState. Same
+        # dimension contract as this neural engine.
+        self._fallback_provider = AlgorithmicEmbeddingProvider(dim)
         # Cache keyed by sha256(text)[:16] — see class docstring / ADR-0045 R5.
         self._cache: OrderedDict[str, bytes] = OrderedDict()
         self._cache_max = 128
@@ -123,6 +136,33 @@ class EmbeddingEngine(_EmbeddingLifecycleMixin, _EmbeddingMathMixin):
     def model_state(self) -> ModelState:
         """The current lifecycle state of the neural model load (Cortex#173)."""
         return self._model_state
+
+    @property
+    def mode(self) -> str:
+        """Embedding provenance: ``"neural"`` or ``"fallback"`` (issue #169).
+
+        precondition: none.
+        postcondition: forces model resolution if it has not been attempted,
+        then returns ``"neural"`` when a sentence-transformers model is loaded,
+        else ``"fallback"`` (algorithmic, download-free). Read by the store to
+        tag each stored vector's space and by telemetry.
+        """
+        if self._model_state is ModelState.UNINITIALIZED and not self._unavailable:
+            self._ensure_model()
+        return "fallback" if self._serve_fallback() else "neural"
+
+    def _serve_fallback(self) -> bool:
+        """Whether to route encode() to the algorithmic fallback provider.
+
+        After ``_ensure_model``, a loaded neural model has ``self._model`` set
+        (state LOADED); every fallback ModelState leaves ``self._model`` None.
+        A present model always takes the neural path; otherwise the factory's
+        per-ModelState mapping (``use_fallback``) decides — so no state maps to
+        nothing (issue #169).
+        """
+        if self._model is not None:
+            return False
+        return use_fallback(self._model_state)
 
     @property
     def available(self) -> bool:
@@ -176,7 +216,9 @@ class EmbeddingEngine(_EmbeddingLifecycleMixin, _EmbeddingMathMixin):
 
         self._ensure_model()
 
-        if self._unavailable:
+        # Selection per ModelState is owned by the factory (issue #169):
+        # LOADED → neural encode; every other state → the algorithmic fallback.
+        if self._serve_fallback():
             result = self._fallback_encode(text)
         else:
             result = self._encode_vec(text)
@@ -189,8 +231,8 @@ class EmbeddingEngine(_EmbeddingLifecycleMixin, _EmbeddingMathMixin):
     def encode_batch(self, texts: list[str]) -> list[bytes | None]:
         """Batch encode for efficiency."""
         self._ensure_model()
-        if self._unavailable:
-            return [self._fallback_encode(t) if t else None for t in texts]
+        if self._serve_fallback():
+            return self._fallback_provider.encode_batch(texts)
 
         try:
             vecs = self._model.encode(texts)
@@ -213,33 +255,13 @@ class EmbeddingEngine(_EmbeddingLifecycleMixin, _EmbeddingMathMixin):
         return results
 
     def _fallback_encode(self, text: str) -> bytes:
-        """Hash-based deterministic embedding fallback.
+        """Delegate to the algorithmic fallback provider (issue #169).
 
-        Uses character n-gram hashing to produce a fixed-dimension vector.
-        Quality is much lower than learned embeddings but provides basic
-        similarity ordering without any ML model.
+        precondition: ``text`` is a non-empty str (the GPU-failure and
+        model-absent paths only reach here with real content).
+        postcondition: returns a ``self._dim``-length, L2-normalized float32
+        blob from ``AlgorithmicEmbeddingProvider`` — the SECOND provider.
         """
-        vec = np.zeros(self._dim, dtype=np.float32)
-        text_lower = text.lower()
-
-        # Character trigram hashing
-        for i in range(len(text_lower) - 2):
-            trigram = text_lower[i : i + 3]
-            h = int(
-                hashlib.sha256(trigram.encode()).hexdigest(), 16
-            )  # non-security: deterministic bucketing
-            idx = h % self._dim
-            vec[idx] += 1.0
-
-        # Word-level hashing for semantic signal
-        words = text_lower.split()
-        for word in words:
-            if len(word) > 2:
-                h = int(
-                    hashlib.sha256(word.encode()).hexdigest(), 16
-                )  # non-security: deterministic bucketing
-                idx = h % self._dim
-                vec[idx] += 2.0  # Words weighted more than trigrams
-
-        vec = self._normalize(vec)
-        return vec.astype(np.float32).tobytes()
+        blob = self._fallback_provider.encode(text)
+        # Non-empty text always yields a vector; guard the type only.
+        return blob if blob is not None else np.zeros(self._dim, np.float32).tobytes()

--- a/mcp_server/infrastructure/embedding_factory.py
+++ b/mcp_server/infrastructure/embedding_factory.py
@@ -6,26 +6,65 @@ process-wide encoder. Consumers call ``get_embedding_engine()`` rather than
 constructing an ``EmbeddingEngine`` themselves, which guarantees one model, one
 device, no mixed-device embeddings, ~5x memory savings.
 
-Keeping selection here — separate from the concrete provider
-(``embedding_engine.EmbeddingEngine``) and its interface
-(``embedding_provider.EmbeddingProvider``) — is what lets a second provider be
-wired in later by editing exactly this one function, with no consumer change.
+Keeping selection here — separate from the concrete providers
+(``embedding_engine.EmbeddingEngine``, neural, and
+``embedding_fallback_provider.AlgorithmicEmbeddingProvider``, download-free) and
+their interface (``embedding_provider.EmbeddingProvider``) — is what lets the
+active provider be chosen per ``ModelState`` (``use_fallback``) with no consumer
+change (issue #169).
 
 Import-cycle note: the concrete ``EmbeddingEngine`` (and ``get_memory_settings``)
 are imported lazily *inside* ``get_embedding_engine`` so this module has no
 module-load dependency on ``embedding_engine`` — ``embedding_engine`` re-exports
 these functions, so the two modules must not import each other at top level.
+``ModelState`` comes from ``embedding_model_lifecycle`` (no cycle).
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from mcp_server.infrastructure.embedding_model_lifecycle import ModelState
+
 if TYPE_CHECKING:
     from mcp_server.infrastructure.embedding_engine import EmbeddingEngine
 
 # Process-wide singleton. Handlers/hooks read it via get_embedding_engine().
 _singleton: EmbeddingEngine | None = None
+
+# The state→provider selection (issue #169). Every ModelState that is not a
+# loaded neural model routes to the download-free algorithmic fallback —
+# PACKAGE_ABSENT, MODEL_FILES_ABSENT (download pending), LOAD_RAISED, and the
+# not-yet-attempted UNINITIALIZED. NO state maps to nothing.
+_FALLBACK_STATES = frozenset(
+    {
+        ModelState.UNINITIALIZED,
+        ModelState.PACKAGE_ABSENT,
+        ModelState.MODEL_FILES_ABSENT,
+        ModelState.LOAD_RAISED,
+    }
+)
+
+
+def use_fallback(state: ModelState) -> bool:
+    """Whether ``state`` selects the algorithmic fallback provider (issue #169).
+
+    postcondition: True for every non-``LOADED`` state; the mapping is total —
+    ``LOADED`` → neural, everything else → fallback.
+    """
+    return state in _FALLBACK_STATES
+
+
+def current_embedding_mode() -> str:
+    """Return the process-wide embedding provenance for telemetry (issue #169).
+
+    postcondition: ``"neural"`` / ``"fallback"`` if a singleton engine exists
+    (resolving its model on first read), else ``"unknown"``. Does not construct
+    an engine as a side effect.
+    """
+    if _singleton is None:
+        return "unknown"
+    return _singleton.mode
 
 
 def get_embedding_engine() -> "EmbeddingEngine":

--- a/mcp_server/infrastructure/embedding_fallback_provider.py
+++ b/mcp_server/infrastructure/embedding_fallback_provider.py
@@ -1,0 +1,60 @@
+"""Download-free algorithmic embedding provider (issue #169).
+
+The SECOND ``EmbeddingProvider`` implementation (the first is the neural
+``EmbeddingEngine``). It produces deterministic vectors with no model download,
+no network, and no learned parameters — only arithmetic seeded by the token
+strings — in the SAME dimension contract as the neural encoder. Used whenever
+the neural model is not loadable (``ModelState`` PACKAGE_ABSENT /
+MODEL_FILES_ABSENT / LOAD_RAISED); the factory maps those states here.
+
+The vectors live in a DIFFERENT geometry from the neural space, so the store
+tags each stored vector with the producing provider and never cross-ranks the
+two (see ``sqlite_store``). Pure delegation to
+``shared.algorithmic_embedding`` — see that module for the signal selection
+(TF + Random Indexing + co-occurrence bridging) and its sources.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mcp_server.infrastructure.embedding_provider import _EmbeddingMathMixin
+from mcp_server.shared.algorithmic_embedding import embed_text
+
+
+class AlgorithmicEmbeddingProvider(_EmbeddingMathMixin):
+    """Deterministic, download-free ``EmbeddingProvider`` implementation.
+
+    Stateless apart from its fixed dimension; safe to share across threads
+    (``embed_text`` allocates its own arrays). Inherits the shared vector math
+    (``similarity`` / ``to_list`` / ``from_list`` / ``_normalize`` / ``_cache_key``)
+    so it satisfies the provider surface identically to the neural engine.
+    """
+
+    def __init__(self, dim: int) -> None:
+        self._dim = dim
+
+    @property
+    def dimensions(self) -> int:
+        return self._dim
+
+    @property
+    def available(self) -> bool:
+        """Always False: this provider is the fallback, backed by no neural model."""
+        return False
+
+    def encode(self, text: str) -> bytes | None:
+        """Encode one text to a deterministic, L2-normalized float32 blob.
+
+        precondition: none (``text`` may be empty).
+        postcondition: ``None`` for empty text; otherwise a ``self._dim``-length
+        float32 blob, deterministic in ``(text, dim)``.
+        """
+        if not text:
+            return None
+        vec = embed_text(text, self._dim)
+        return vec.astype(np.float32).tobytes()
+
+    def encode_batch(self, texts: list[str]) -> list[bytes | None]:
+        """Encode a batch, preserving order and ``None`` for empty items."""
+        return [self.encode(t) for t in texts]

--- a/mcp_server/infrastructure/embedding_model_lifecycle.py
+++ b/mcp_server/infrastructure/embedding_model_lifecycle.py
@@ -48,6 +48,10 @@ import logging
 import os
 from typing import Any
 
+from mcp_server.infrastructure.embedding_downloads import (
+    trigger_background_install,
+    trigger_background_model_download,
+)
 from mcp_server.shared.platform import cache_dir as _base_cache_dir
 
 # source: measured 2026-07-11 (incident i7d3) — see module docstring
@@ -197,34 +201,8 @@ class _EmbeddingLifecycleMixin:
             kwargs["local_files_only"] = True
         return SentenceTransformer(self._model_name, **kwargs)
 
-    def _download_model(self, device: str, cache_folder: str | None) -> None:
-        """MODEL_FILES_ABSENT → one-time download; LOAD_RAISED if it fails.
-
-        The zero-config install path lands here by design; behaviour is
-        preserved from the pre-split loader — a download failure propagates.
-        """
-        self._model_state = ModelState.MODEL_FILES_ABSENT
-        logger.info(
-            "Downloading embedding model %s (revision=%s) — "
-            "~100 MB, one-time; cached under %s, then runs fully offline",
-            self._model_name,
-            self._revision or "refs/main",
-            cache_folder or "$HF_HOME",
-        )
-        try:
-            self._model = self._construct_model(device, cache_folder, local=False)
-        except Exception:
-            self._model_state = ModelState.LOAD_RAISED
-            raise
-
-    def _load_model(self, device: str) -> None:
-        """Load the model, moving through the explicit lifecycle states."""
-        cache_folder = embedding_cache_dir()
-        try:
-            self._model = self._construct_model(device, cache_folder, local=True)
-        except self._cache_miss_types():
-            self._download_model(device, cache_folder)
-
+    def _finalize_loaded(self, device: str) -> None:
+        """Reconcile the model's real dimension and record the LOADED state."""
         # sentence-transformers 5.x renamed get_sentence_embedding_dimension →
         # get_embedding_dimension. Prefer the new name; fall back for <5.
         get_dim = getattr(
@@ -243,6 +221,37 @@ class _EmbeddingLifecycleMixin:
             device,
         )
 
+    def _load_model(self, device: str) -> None:
+        """Load the model, moving through the explicit lifecycle states.
+
+        Never blocks and never crashes the caller (issue #169): a cache miss
+        (MODEL_FILES_ABSENT) or an unexpected construction failure (LOAD_RAISED)
+        engages the download-free fallback for THIS session and kicks off a
+        background fetch so the next session is neural. Only ``ImportError``
+        (PACKAGE_ABSENT) escapes, handled by ``_ensure_model``.
+        """
+        cache_folder = embedding_cache_dir()
+        try:
+            self._model = self._construct_model(device, cache_folder, local=True)
+        except self._cache_miss_types():
+            # MODEL_FILES_ABSENT: package present, weights not cached yet.
+            self._engage_fallback(
+                ModelState.MODEL_FILES_ABSENT,
+                "embedding model files not cached; downloading in background",
+            )
+            trigger_background_model_download(
+                self._model_name, self._revision, cache_folder
+            )
+            return
+        except ImportError:
+            raise  # PACKAGE_ABSENT — handled by _ensure_model
+        except Exception as exc:  # corrupt cache / unexpected — do NOT crash
+            self._engage_fallback(
+                ModelState.LOAD_RAISED, f"embedding model load failed: {exc}"
+            )
+            return
+        self._finalize_loaded(device)
+
     def _ensure_model(self) -> None:
         if self._model is not None or self._unavailable:
             return
@@ -250,45 +259,27 @@ class _EmbeddingLifecycleMixin:
             self._load_model(self._resolve_device())
         except ImportError:
             # PACKAGE_ABSENT: sentence-transformers is not installed.
-            self._model_state = ModelState.PACKAGE_ABSENT
-            logger.warning(
-                "sentence-transformers not installed; using hash-based fallback "
-                "embeddings. Installing in background for next session..."
+            self._engage_fallback(
+                ModelState.PACKAGE_ABSENT, "sentence-transformers not installed"
             )
-            self._unavailable = True
-            self._trigger_background_install()
+            trigger_background_install()
 
-    def _trigger_background_install(self) -> None:
-        """Install sentence-transformers in the background.
+    def _engage_fallback(self, state: ModelState, reason: str) -> None:
+        """Record a non-LOADED lifecycle state and LOUDLY engage the fallback.
 
-        Runs pip install as a detached subprocess so it doesn't block
-        the current session. Next session will have real embeddings.
+        precondition: called from the load path when the neural model cannot be
+        served this session.
+        postcondition: ``model_state`` is ``state`` and ``_unavailable`` is True;
+        exactly one WARNING is logged (issue #169) so the degrade is never
+        silent — the factory then routes encode() to the algorithmic provider.
         """
-        import subprocess
-        import sys
-
-        target = os.environ.get("CLAUDE_PLUGIN_DATA", "")
-        if target:
-            target = os.path.join(target, "deps")
-
-        cmd = [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "-q",
-            "sentence-transformers>=2.2.0,<4.0.0",
-        ]
-        if target:
-            cmd.extend(["--target", target])
-
-        try:
-            subprocess.Popen(
-                cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
-            logger.info("Background install of sentence-transformers started")
-        except Exception as exc:
-            logger.debug("Background install failed to start: %s", exc)
+        self._model_state = state
+        self._unavailable = True
+        logger.warning(
+            "Embedding fallback ENGAGED (%s): using deterministic download-free "
+            "algorithmic embeddings (issue #169) — lower fidelity than "
+            "sentence-transformers, upgrades automatically once the model is "
+            "present. Fallback vectors are tagged 'fallback' and never "
+            "cross-rank against neural vectors.",
+            reason,
+        )

--- a/mcp_server/infrastructure/sqlite_schema.py
+++ b/mcp_server/infrastructure/sqlite_schema.py
@@ -113,11 +113,20 @@ CREATE TABLE IF NOT EXISTS homeostatic_fold_log (
 
 MEMORIES_FTS_DDL = """
 CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
-    content,
-    content='memories',
-    content_rowid='id'
+    content
 );
 """
+# Regular (self-content) FTS5 table — NOT external-content (issue #169).
+# The store writes code-aware augmented content (identifier sub-tokens appended
+# by shared.code_tokenize.augment_content) so a query for `payment` matches a
+# memory that only wrote `normalizePaymentAmount`. An external-content table
+# (content='memories') would re-derive tokens from the ORIGINAL memories.content
+# on DELETE, orphaning the appended sub-tokens and corrupting the index
+# (verified 2026-07-24). A self-content table lets DELETE-by-rowid remove
+# exactly the tokens that were indexed. No code reads `content` back from this
+# table — every consumer uses rowid/rank/MATCH — so the external-content
+# storage saving was unused. Existing databases are converted by
+# sqlite_store._migrate_fts_code_tokenize (one-shot rebuild + reindex).
 
 MEMORIES_VEC_DDL = """
 CREATE VIRTUAL TABLE IF NOT EXISTS memories_vec USING vec0(
@@ -453,4 +462,11 @@ MIGRATIONS: list[tuple[str, str, str]] = [
     # pg_schema.py MIGRATIONS_DDL. Nullable pointer, no backfill needed.
     ("memory_rules", "source_memory_id", "INTEGER"),
     ("prospective_memories", "source_memory_id", "INTEGER"),
+    # Embedding provenance (issue #169). '' = unknown/legacy, 'neural' =
+    # sentence-transformers, 'fallback' = algorithmic (download-free). The
+    # vector search filters to rows matching the query's space so the two
+    # geometrically-incompatible spaces never silently cross-rank. Legacy rows
+    # ('') are treated as neural-compatible (they predate the fallback), the
+    # honest default for a store that only ever had the neural encoder.
+    ("memories", "embedding_model", "TEXT DEFAULT ''"),
 ]

--- a/mcp_server/infrastructure/sqlite_store.py
+++ b/mcp_server/infrastructure/sqlite_store.py
@@ -25,6 +25,7 @@ import numpy as np
 from mcp_server.infrastructure.sqlite_compat import PsycopgCompatConnection
 from mcp_server.infrastructure.sqlite_schema import (
     CURRENT_MEMORIES_VIEW_DDL,
+    MEMORIES_FTS_DDL,
     MEMORIES_VEC_DDL,
     MIGRATIONS,
     get_all_ddl,
@@ -50,6 +51,13 @@ logger = logging.getLogger(__name__)
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _fts_augment(content: str) -> str:
+    """Append identifier sub-tokens to FTS content (code-aware, issue #169)."""
+    from mcp_server.shared.code_tokenize import augment_content
+
+    return augment_content(content or "")
 
 
 # Parity with PgMemoryStore's supersede_atomic operational bounds (engineering,
@@ -115,6 +123,34 @@ class SqliteMemoryStore(
                 self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {col_def}")
             except sqlite3.OperationalError:
                 pass
+        self._migrate_fts_code_tokenize()
+
+    def _migrate_fts_code_tokenize(self) -> None:
+        """One-shot: convert an external-content memories_fts to a self-content
+        table and reindex every memory with code-aware sub-tokens (issue #169).
+
+        Idempotent: a fresh DB (or an already-converted one) has no
+        ``content=`` option in its ``memories_fts`` DDL, so this is a no-op.
+        Only a legacy external-content table triggers the rebuild — required
+        because appended sub-tokens cannot be safely deleted from an
+        external-content index (see sqlite_schema.MEMORIES_FTS_DDL note).
+        """
+        row = self._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name = 'memories_fts'"
+        ).fetchone()
+        sql = (row["sql"] if row else None) or ""
+        if "content=" not in sql:
+            return  # already self-content (fresh DB or prior migration)
+        from mcp_server.shared.code_tokenize import augment_content
+
+        self._conn.execute("DROP TABLE IF EXISTS memories_fts")
+        self._conn.execute(MEMORIES_FTS_DDL)
+        rows = self._conn.execute("SELECT id, content FROM memories").fetchall()
+        for r in rows:
+            self._conn.execute(
+                "INSERT INTO memories_fts(rowid, content) VALUES (?, ?)",
+                (r["id"], augment_content(r["content"] or "")),
+            )
 
     def _migrate_homeostatic_state_write_class(self) -> None:
         """M-D3 (7.1): rebuild homeostatic_state with PK (domain, write_class).
@@ -337,16 +373,26 @@ class SqliteMemoryStore(
         memory_id = cur.lastrowid
         self._conn.execute(
             "INSERT INTO memories_fts(rowid, content) VALUES (?, ?)",
-            (memory_id, content),
+            (memory_id, _fts_augment(content)),
         )
         embedding = data.get("embedding")
-        if self._has_vec and embedding is not None:
-            vec = self._bytes_to_vector(embedding)
-            if vec is not None:
-                self._conn.execute(
-                    "INSERT INTO memories_vec(rowid, embedding) VALUES (?, ?)",
-                    (memory_id, vec.tobytes()),
-                )
+        if embedding is not None:
+            # Stamp provenance whenever an embedding was PRODUCED, independent of
+            # whether the vec0 store is present. The tag records which encoder
+            # made this memory's embedding ('neural'/'fallback'), not whether it
+            # was physically stored. Without this, a store built without the
+            # sqlite-vec extension (``_has_vec`` False — e.g. an install missing
+            # the [sqlite] extra) would leave embedding_model='' — a silent third
+            # state that hides the fallback and starves the re-embed worklist
+            # (issue #169, CI regression on the no-[sqlite] matrix legs).
+            self._stamp_embedding_model(memory_id, data.get("embedding_model"))
+            if self._has_vec:
+                vec = self._bytes_to_vector(embedding)
+                if vec is not None:
+                    self._conn.execute(
+                        "INSERT INTO memories_vec(rowid, embedding) VALUES (?, ?)",
+                        (memory_id, vec.tobytes()),
+                    )
         return memory_id  # type: ignore[return-value]
 
     def insert_memory(self, data: dict[str, Any]) -> int:
@@ -604,6 +650,85 @@ class SqliteMemoryStore(
         except Exception:
             pass
 
+    def _stamp_embedding_model(self, memory_id: int, model: str | None) -> None:
+        """Record which vector space a memory's embedding lives in (issue #169).
+
+        precondition: ``memory_id`` refers to a just-written vec row.
+        postcondition: ``memories.embedding_model`` is set to ``model`` when
+        given, else to the process-wide engine mode
+        (``current_embedding_mode``). This is the single tag the vector search
+        reads to keep 'neural' and 'fallback' vectors — incompatible geometries
+        — from cross-ranking. Best-effort: a missing column (pre-migration DB in
+        a race) is swallowed, same discipline as the vec insert it accompanies.
+        """
+        if not model:
+            from mcp_server.infrastructure.embedding_engine import (
+                current_embedding_mode,
+            )
+
+            model = current_embedding_mode()
+        # 'unknown' means no engine was constructed (e.g. a direct store test
+        # that inserts a raw vector); leave the column at its '' default rather
+        # than writing a misleading tag.
+        if model == "unknown":
+            return
+        try:
+            self._conn.execute(
+                "UPDATE memories SET embedding_model = ? WHERE id = ?",
+                (model, memory_id),
+            )
+        except sqlite3.OperationalError:
+            pass
+
+    def select_fallback_embeddings(self, limit: int = 100) -> list[dict[str, Any]]:
+        """Return current memories whose vector was written in fallback mode.
+
+        precondition: ``limit`` > 0.
+        postcondition: returns up to ``limit`` ``{memory_id, content}`` dicts for
+        non-superseded memories tagged ``embedding_model='fallback'``, hottest
+        first — the re-embedding worklist that upgrades a store transparently
+        once the neural model becomes available (issue #169). Empty when the
+        column is absent or nothing is tagged fallback.
+        """
+        try:
+            rows = self._conn.execute(
+                "SELECT id, content FROM current_memories "
+                "WHERE embedding_model = 'fallback' "
+                "ORDER BY heat_base DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+        return [{"memory_id": r["id"], "content": r["content"]} for r in rows]
+
+    def reembed_memory(self, memory_id: int, embedding: bytes | None) -> None:
+        """Replace a memory's stored vector and restamp its provider (issue #169).
+
+        precondition: ``embedding`` was produced by the current process encoder.
+        postcondition: the vec row is replaced (when the vec store is present)
+        and ``embedding_model`` is restamped to the current mode — so a
+        fallback-tagged memory becomes 'neural' once the model is available,
+        without touching content or the compression flags. No-op for a None
+        embedding. Commits.
+        """
+        if embedding is None:
+            return
+        if self._has_vec:
+            vec = self._bytes_to_vector(embedding)
+            if vec is not None:
+                try:
+                    self._conn.execute(
+                        "DELETE FROM memories_vec WHERE rowid = ?", (memory_id,)
+                    )
+                    self._conn.execute(
+                        "INSERT INTO memories_vec(rowid, embedding) VALUES (?, ?)",
+                        (memory_id, vec.tobytes()),
+                    )
+                except Exception:
+                    pass
+        self._stamp_embedding_model(memory_id, None)
+        self._conn.commit()
+
     def delete_memory(self, memory_id: int) -> bool:
         self._conn.execute("DELETE FROM memories_fts WHERE rowid = ?", (memory_id,))
         if self._has_vec:
@@ -668,22 +793,27 @@ class SqliteMemoryStore(
         self._conn.execute("DELETE FROM memories_fts WHERE rowid = ?", (memory_id,))
         self._conn.execute(
             "INSERT INTO memories_fts(rowid, content) VALUES (?, ?)",
-            (memory_id, content),
+            (memory_id, _fts_augment(content)),
         )
-        # Update vec
-        if self._has_vec and embedding is not None:
-            vec = self._bytes_to_vector(embedding)
-            if vec is not None:
-                try:
-                    self._conn.execute(
-                        "DELETE FROM memories_vec WHERE rowid = ?", (memory_id,)
-                    )
-                    self._conn.execute(
-                        "INSERT INTO memories_vec(rowid, embedding) VALUES (?, ?)",
-                        (memory_id, vec.tobytes()),
-                    )
-                except Exception:
-                    pass
+        # Re-embed restamps the vector's space: a compression/replay re-encode
+        # under the current engine upgrades a prior 'fallback' row to 'neural'
+        # transparently (issue #169). Stamp whenever an embedding was produced,
+        # even without the vec store present (see _insert_memory_rows).
+        if embedding is not None:
+            self._stamp_embedding_model(memory_id, None)
+            if self._has_vec:
+                vec = self._bytes_to_vector(embedding)
+                if vec is not None:
+                    try:
+                        self._conn.execute(
+                            "DELETE FROM memories_vec WHERE rowid = ?", (memory_id,)
+                        )
+                        self._conn.execute(
+                            "INSERT INTO memories_vec(rowid, embedding) VALUES (?, ?)",
+                            (memory_id, vec.tobytes()),
+                        )
+                    except Exception:
+                        pass
         self._conn.commit()
 
     # ── Row normalization ─────────────────────────────────────────────

--- a/mcp_server/infrastructure/sqlite_store_entities.py
+++ b/mcp_server/infrastructure/sqlite_store_entities.py
@@ -156,14 +156,23 @@ class SqliteEntityMixin:
         routes BOTH branches (FTS5 + LIKE fallback) through current_memories.
         """
         src = "current_memories" if heads_only else "memories"
-        # Try FTS5 first
-        rows = self._conn.execute(
-            f"SELECT m.* FROM {src} m "
-            "JOIN memories_fts f ON f.rowid = m.id "
-            "WHERE memories_fts MATCH ? "
-            "ORDER BY m.heat_base DESC LIMIT ?",
-            (entity_name, limit),
-        ).fetchall()
+        # Try FTS5 first — expand the entity name into its code-aware sub-tokens
+        # so a camelCase / snake_case entity still matches its split index terms
+        # (issue #169).
+        from mcp_server.shared.code_tokenize import expand_fts_query
+
+        match = expand_fts_query(entity_name)
+        rows = (
+            self._conn.execute(
+                f"SELECT m.* FROM {src} m "
+                "JOIN memories_fts f ON f.rowid = m.id "
+                "WHERE memories_fts MATCH ? "
+                "ORDER BY m.heat_base DESC LIMIT ?",
+                (match, limit),
+            ).fetchall()
+            if match
+            else []
+        )
         if not rows:
             # Fallback to LIKE
             rows = self._conn.execute(

--- a/mcp_server/infrastructure/sqlite_store_search.py
+++ b/mcp_server/infrastructure/sqlite_store_search.py
@@ -12,6 +12,8 @@ from typing import Any
 
 import numpy as np
 
+from mcp_server.shared.code_tokenize import expand_fts_query as _expand_fts_query
+
 
 def _decode_tags(raw: Any) -> list:
     """Deserialize a SQLite ``tags`` TEXT column into a list.
@@ -95,7 +97,17 @@ class SqliteSearchMixin:
                 "WHERE embedding MATCH ? ORDER BY distance LIMIT ?",
                 (vec.tobytes(), pool),
             ).fetchall()
-            for rank, r in enumerate(rows, 1):
+            # Keep only vectors that live in the SAME space as the query
+            # embedding (issue #169): a 'fallback' (algorithmic) vector and a
+            # 'neural' vector are geometrically incompatible, so their cosine
+            # distances are not comparable. Cross-space rows still surface via
+            # FTS/heat/recency — they are only barred from the vector signal.
+            keep = self._vec_rows_in_query_space([r["rowid"] for r in rows])
+            rank = 0
+            for r in rows:
+                if r["rowid"] not in keep:
+                    continue
+                rank += 1
                 scores[r["rowid"]] = scores.get(r["rowid"], 0) + weight / (k + rank)
         except Exception:
             pass
@@ -110,16 +122,47 @@ class SqliteSearchMixin:
     ) -> None:
         if not query_text or weight <= 0:
             return
+        match = _expand_fts_query(query_text)
+        if not match:
+            return
         try:
             rows = self._conn.execute(
                 "SELECT rowid, rank FROM memories_fts "
                 "WHERE memories_fts MATCH ? ORDER BY rank LIMIT ?",
-                (query_text, pool),
+                (match, pool),
             ).fetchall()
             for rank, r in enumerate(rows, 1):
                 scores[r["rowid"]] = scores.get(r["rowid"], 0) + weight / (k + rank)
         except Exception:
             pass
+
+    def _vec_rows_in_query_space(self, rowids: list[int]) -> set[int]:
+        """Subset of ``rowids`` whose embedding space matches the query's.
+
+        precondition: ``rowids`` are memory ids returned by the vec KNN.
+        postcondition: returns the ids whose ``memories.embedding_model`` is
+        compatible with the current process embedding mode (issue #169):
+        a neural query keeps 'neural' and legacy '' rows; a fallback query keeps
+        only 'fallback' rows; an 'unknown' mode (no engine constructed — e.g. a
+        raw-vector unit test) keeps everything. Fail-open on a missing column.
+        """
+        if not rowids:
+            return set()
+        from mcp_server.infrastructure.embedding_engine import current_embedding_mode
+
+        mode = current_embedding_mode()
+        if mode == "unknown":
+            return set(rowids)
+        compatible = {"neural", ""} if mode == "neural" else {"fallback"}
+        placeholders = ",".join("?" * len(rowids))
+        try:
+            rows = self._conn.execute(
+                f"SELECT id, embedding_model FROM memories WHERE id IN ({placeholders})",
+                rowids,
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return set(rowids)
+        return {r["id"] for r in rows if (r["embedding_model"] or "") in compatible}
 
     def _signal_heat(
         self,
@@ -260,6 +303,13 @@ class SqliteSearchMixin:
         client-side with a fabricated score, so exclusion must happen here —
         no downstream ranking can demote a superseded or stale hit.
         """
+        # NOTE: ``query`` here is an already-built FTS5 expression — callers
+        # (auto_recall._fts_query_from_prompt, recall_helpers.build_expanded_query)
+        # construct their own OR/AND term lists — so it must be passed through
+        # verbatim, NOT re-expanded (re-wrapping their operators would turn an OR
+        # into a literal AND, issue #169 regression). Code-aware matching on this
+        # path is carried entirely by index-time augmentation (augment_content),
+        # which indexes both the full identifier and its sub-tokens.
         try:
             rows = self._conn.execute(
                 "SELECT memories_fts.rowid AS rowid, memories_fts.rank AS rank "

--- a/mcp_server/shared/algorithmic_embedding.py
+++ b/mcp_server/shared/algorithmic_embedding.py
@@ -1,0 +1,174 @@
+"""Deterministic, download-free algorithmic text embeddings.
+
+The zero-model fallback for ``EmbeddingEngine``: when sentence-transformers is
+unavailable (import fails, or the model weights are absent and cannot be
+downloaded), this module produces a fixed-dimension dense vector for any text
+with no network, no model files, and no learned parameters — only arithmetic
+seeded by the token strings themselves. The same input always yields the same
+vector, on any platform (all hashing is ``hashlib``-based, never Python's
+salted ``hash()``).
+
+Signal selection (adapted from the codebase-memory-mcp 11-signal embedder,
+``src/semantic/semantic.{c,h}``). Cortex memories are conversational / decision
+prose, not code symbol tables, so only the signals that transfer to prose are
+kept:
+
+  INCLUDED
+  * Sublinear term-frequency weighting — ``1 + log(tf)`` (Manning, Raghavan &
+    Schütze, *Introduction to Information Retrieval*, 2008, §6.4 "sublinear tf
+    scaling"). Dampens repeated tokens without a corpus.
+  * Random Indexing — each token maps to a sparse ternary index vector; the
+    document vector is the tf-weighted sum. Deterministic, corpus-free, and
+    projects an unbounded vocabulary into ``dim`` dimensions (Kanerva,
+    Kristofersson & Holst 2000; Sahlgren, "An Introduction to Random Indexing",
+    2005). Sparse ternary projections are near-orthogonal in expectation
+    (Achlioptas, "Database-friendly random projections", 2003).
+  * Co-occurrence bridging — each token's contribution is enriched by the index
+    vectors of its neighbours within a symmetric window, distance-weighted
+    ``1/d``. Two texts that use different but co-occurring vocabulary move
+    closer, the synonym-bridging effect Sahlgren (2005) describes.
+  * Frequent-token subsampling — a token occurring more than
+    ``_MAX_OCCUR`` times in one document has its co-occurrence contribution
+    stride-subsampled, bounding cost on pathological inputs (word2vec/GloVe
+    frequent-word subsampling; Mikolov et al. 2013). Inert for normal memories.
+
+  EXCLUDED (with reason)
+  * IDF — needs a persistent corpus. The ``encode(text)`` seam is stateless and
+    per-text; a global IDF table would couple every call to mutable cross-call
+    state and break determinism. Omitted, not faked.
+  * MinHash, API/type signatures, AST profile, graph diffusion, Halstead-lite —
+    all consume code structure (call graphs, type signatures, ASTs) that
+    conversational memories do not carry. Not applicable to prose.
+
+Pure utility — no I/O. Shared layer (numpy only, like ``shared.linear_algebra``
+and ``shared.minhash``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import struct
+
+import numpy as np
+
+from mcp_server.shared.code_tokenize import split_identifier
+
+# source: CBM_SEM_SPARSE_NNZE = 8 (semantic.h:39) — non-zero entries per sparse
+# random index vector. 8 keeps index vectors near-orthogonal at 256–768 dims
+# (Achlioptas 2003) while staying cheap.
+_NONZERO_PER_TOKEN = 8
+
+# source: CBM_SEM_WINDOW = 5 (semantic.h:42) — co-occurrence window half-width.
+_WINDOW = 5
+
+# source: CBM_SEM_MAX_OCCUR = 512 (semantic.h:52) — frequent-token subsampling
+# cap; above this a token's co-occurrence pass is stride-sampled to ~this count.
+_MAX_OCCUR = 512
+
+
+def _token_seed(token: str) -> int:
+    """Deterministic 64-bit seed for a token (platform-independent).
+
+    source: mirrors CBM's ``XXH3_64bits(token)`` seed (semantic.c:459); uses
+    ``hashlib.blake2b`` (stdlib) so the value is stable across processes and
+    platforms, unlike Python's salted ``hash()``.
+    """
+    return int.from_bytes(
+        hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest(), "big"
+    )
+
+
+def index_vector(token: str, dim: int) -> np.ndarray:
+    """Return the sparse ternary Random-Indexing vector for ``token``.
+
+    precondition: ``token`` is a non-empty str; ``dim`` > 0.
+    postcondition: returns a float32 array of shape ``(dim,)`` with at most
+    ``_NONZERO_PER_TOKEN`` non-zero entries in {-1, +1}; deterministic in
+    ``(token, dim)``.
+
+    source: CBM ``cbm_sem_random_index`` (semantic.c:437) — for i in
+    0..NONZERO: h = hash(i, seed); pos = h % dim; sign = bit(h) ? +1 : -1;
+    v[pos] += sign.
+    """
+    vec = np.zeros(dim, dtype=np.float32)
+    seed = _token_seed(token)
+    for i in range(_NONZERO_PER_TOKEN):
+        h = int.from_bytes(
+            hashlib.blake2b(
+                struct.pack("<q", i), key=struct.pack("<Q", seed), digest_size=8
+            ).digest(),
+            "big",
+        )
+        pos = h % dim
+        vec[pos] += 1.0 if (h & 1) else -1.0
+    return vec
+
+
+def _tokenize(text: str) -> list[str]:
+    """Split text into lowercase sub-tokens (same rule as the FTS tokenizer).
+
+    postcondition: identifiers are decomposed (``normalizePaymentAmount`` →
+    ``normalize, payment, amount``) so the embedding vocabulary and the FTS
+    vocabulary agree; ordering is preserved for the co-occurrence window.
+    """
+    tokens: list[str] = []
+    for word in text.replace("\n", " ").split():
+        tokens.extend(split_identifier(word))
+    return tokens
+
+
+def _tf_weights(tokens: list[str]) -> dict[str, float]:
+    """Sublinear term-frequency weight per distinct token: ``1 + log(tf)``.
+
+    source: Manning et al. 2008 §6.4 (sublinear tf scaling).
+    """
+    counts: dict[str, int] = {}
+    for t in tokens:
+        counts[t] = counts.get(t, 0) + 1
+    return {t: 1.0 + math.log(c) for t, c in counts.items()}
+
+
+def embed_text(text: str, dim: int) -> np.ndarray:
+    """Encode ``text`` into a deterministic, L2-normalized dense vector.
+
+    precondition: ``text`` is a str (may be empty); ``dim`` > 0.
+    postcondition: returns a float32 array of shape ``(dim,)``; L2 norm is 1.0
+    when ``text`` has at least one token, else the zero vector; the result is
+    deterministic in ``(text, dim)`` and lies in the SAME vector-space contract
+    (dimension) as the neural encoder, though NOT the same geometry — the two
+    spaces are incomparable and callers must not cross-rank them.
+    """
+    tokens = _tokenize(text)
+    if not tokens:
+        return np.zeros(dim, dtype=np.float32)
+
+    tf = _tf_weights(tokens)
+    # Cache each distinct token's index vector once — an O(unique) not
+    # O(occurrences) build.
+    cache: dict[str, np.ndarray] = {t: index_vector(t, dim) for t in tf}
+
+    acc = np.zeros(dim, dtype=np.float32)
+    n = len(tokens)
+    # Frequent-token subsampling: on pathological inputs bound the window pass
+    # to ~_MAX_OCCUR positions via an even stride (direction preserved by the
+    # final L2 normalize). Normal memories fall far under the cap → stride 1.
+    stride = max(1, n // _MAX_OCCUR)
+    for i in range(0, n, stride):
+        tok = tokens[i]
+        w = tf[tok]
+        # first-order term
+        acc += w * cache[tok]
+        # co-occurrence bridging: distance-weighted neighbours in the window
+        lo = max(0, i - _WINDOW)
+        hi = min(n, i + _WINDOW + 1)
+        for j in range(lo, hi):
+            if j == i:
+                continue
+            dist = abs(j - i)
+            acc += (w / dist) * cache[tokens[j]]
+
+    norm = float(np.linalg.norm(acc))
+    if norm > 0.0:
+        acc /= norm
+    return acc.astype(np.float32)

--- a/mcp_server/shared/code_tokenize.py
+++ b/mcp_server/shared/code_tokenize.py
@@ -1,0 +1,136 @@
+"""Code-aware sub-token splitting for FTS indexing and query expansion.
+
+Cortex memories frequently carry code identifiers — ``normalizePaymentAmount``,
+``snake_case_id``, ``HTTPRequest``. SQLite's FTS5 ``unicode61`` tokenizer treats
+each of those as ONE opaque token, so a natural-language query for ``payment``
+never matches a memory that only wrote ``normalizePaymentAmount``.
+
+FTS5 custom tokenizers require a compiled C extension (the ``fts5_tokenizer``
+API is not reachable from Python's ``sqlite3``). This module achieves the same
+effect purely in Python, on both sides of the index:
+
+  * **index time** — ``augment_content`` appends the sub-tokens of every
+    identifier to the text handed to ``memories_fts``, so ``payment`` becomes a
+    first-class indexed term alongside the original ``normalizePaymentAmount``.
+  * **query time** — ``expand_fts_query`` rewrites each query word into an
+    ``("word" OR "sub1" OR "sub2")`` group, so a query that *contains* a
+    camelCase identifier still matches memories that stored the split words.
+
+Reference concept: the ``cbm_camel_split`` FTS5 tokenizer in the
+codebase-memory-mcp project (C). This is the same split rule (camelCase +
+snake_case + digit boundaries), realised as content/query rewriting rather than
+a native tokenizer.
+
+Pure utility — no I/O, no domain knowledge. Shared layer (stdlib only).
+"""
+
+from __future__ import annotations
+
+import re
+
+# A "word" for query purposes: a maximal run of letters/digits/underscore. This
+# mirrors what unicode61 treats as a single token before our splitting.
+_WORD_RE = re.compile(r"[A-Za-z0-9_]+")
+
+# Sub-token boundaries, applied in order:
+#   1. underscores / hyphens  → snake_case, kebab-case
+#   2. lower→Upper transition → camelCase        (paymentAmount → payment|Amount)
+#   3. Upper-run→Upper+lower  → acronym boundary (HTTPRequest  → HTTP|Request)
+#   4. letter↔digit transition                    (utf8 → utf|8)
+_CAMEL_1 = re.compile(r"(.)([A-Z][a-z]+)")  # boundary 3
+_CAMEL_2 = re.compile(r"([a-z0-9])([A-Z])")  # boundary 2
+_DIGIT = re.compile(r"([A-Za-z])([0-9])|([0-9])([A-Za-z])")  # boundary 4
+
+
+def split_identifier(token: str) -> list[str]:
+    """Split one identifier into its lowercase sub-tokens.
+
+    precondition: ``token`` is a str.
+    postcondition: returns a list of lowercase alphanumeric sub-tokens with no
+    empty strings; a token with no internal boundary yields ``[token.lower()]``;
+    the split is deterministic and idempotent (splitting a sub-token is a no-op).
+
+    Examples: ``normalizePaymentAmount`` → ``[normalize, payment, amount]``;
+    ``snake_case_id`` → ``[snake, case, id]``; ``HTTPRequest`` → ``[http,
+    request]``; ``utf8`` → ``[utf, 8]``.
+    """
+    if not token:
+        return []
+    # snake / kebab first so camel rules see clean segments
+    text = token.replace("_", " ").replace("-", " ")
+    text = _CAMEL_1.sub(r"\1 \2", text)
+    text = _CAMEL_2.sub(r"\1 \2", text)
+    text = _DIGIT.sub(lambda m: " ".join(p for p in m.groups() if p), text)
+    return [p.lower() for p in text.split() if p]
+
+
+def _extra_subtokens(text: str) -> list[str]:
+    """Sub-tokens that are NOT already present as standalone words in ``text``.
+
+    precondition: ``text`` is a str.
+    postcondition: returns the deduplicated sub-tokens produced by splitting
+    every word of ``text`` whose split is non-trivial (more than one part), in
+    first-seen order; single-part words contribute nothing (they already index).
+    """
+    words = _WORD_RE.findall(text)
+    # Seed with words already present verbatim (lowercased) so a sub-token that
+    # is also a standalone word is not re-appended.
+    seen: set[str] = {w.lower() for w in words}
+    extras: list[str] = []
+    for word in words:
+        parts = split_identifier(word)
+        if len(parts) <= 1:
+            continue
+        for p in parts:
+            if p not in seen:
+                seen.add(p)
+                extras.append(p)
+    return extras
+
+
+def augment_content(text: str) -> str:
+    """Return ``text`` with identifier sub-tokens appended for FTS indexing.
+
+    precondition: ``text`` is a str.
+    postcondition: returns ``text`` unchanged when it holds no splittable
+    identifier; otherwise returns ``text + " " + <space-joined sub-tokens>`` so
+    the FTS index carries both the original identifier and its parts. Idempotent
+    up to already-present words (sub-tokens already appearing as words are not
+    re-appended).
+    """
+    if not text:
+        return text
+    extras = _extra_subtokens(text)
+    if not extras:
+        return text
+    return text + " " + " ".join(extras)
+
+
+def _fts_quote(term: str) -> str:
+    """Quote ``term`` as an FTS5 string literal (doubling embedded quotes)."""
+    return '"' + term.replace('"', '""') + '"'
+
+
+def expand_fts_query(query: str) -> str:
+    """Rewrite a user query into a sub-token-aware, FTS5-safe MATCH string.
+
+    precondition: ``query`` is a str.
+    postcondition: returns an FTS5 MATCH expression that preserves the original
+    implicit-AND-across-words semantics (each source word becomes one required
+    group) while adding OR-alternatives for the sub-tokens of any camelCase /
+    snake_case word. Every term is quoted, so FTS5 operator keywords and
+    punctuation in the input become harmless literals. Returns ``""`` when the
+    query contains no indexable word (callers already guard the empty MATCH).
+    """
+    groups: list[str] = []
+    for word in _WORD_RE.findall(query):
+        parts = split_identifier(word)
+        if len(parts) <= 1:
+            groups.append(_fts_quote(word.lower()))
+        else:
+            alts = [word.lower(), *parts]
+            # dedupe preserving order
+            seen: set[str] = set()
+            uniq = [a for a in alts if not (a in seen or seen.add(a))]
+            groups.append("(" + " OR ".join(_fts_quote(a) for a in uniq) + ")")
+    return " ".join(groups)

--- a/tests_py/infrastructure/test_semantic_fallback_169.py
+++ b/tests_py/infrastructure/test_semantic_fallback_169.py
@@ -1,0 +1,374 @@
+"""Semantic fallback (#169 Phase B) — provider selection, stamp, mixed store.
+
+Covers the Phase B contract items:
+  1. Algorithmic fallback is a SECOND EmbeddingProvider selected per ModelState;
+     no state maps to nothing (factory.use_fallback is total).
+  2. embedding_model is stamped UNCONDITIONALLY on remember — 'fallback' even
+     when sqlite-vec is absent (no vec row), never ''.
+  3. Fallback engagement is LOUD (one WARNING) + telemetry embedding_mode.
+  6. Genuine (not monkeypatched) sentence-transformers absence via subprocess.
+  8. Mixed store: neural and fallback vectors never cross-rank.
+Plus the external-content → self-content FTS migration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+import textwrap
+
+import numpy as np
+import pytest
+
+import mcp_server.infrastructure.embedding_engine as ee
+import mcp_server.infrastructure.embedding_factory as ef
+from mcp_server.infrastructure.embedding_fallback_provider import (
+    AlgorithmicEmbeddingProvider,
+)
+from mcp_server.infrastructure.embedding_model_lifecycle import ModelState
+from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
+
+
+def _sqlite_vec_available() -> bool:
+    s = SqliteMemoryStore(db_path=":memory:", embedding_dim=384)
+    try:
+        return bool(s._has_vec)
+    finally:
+        s.close()
+
+
+_HAS_VEC = _sqlite_vec_available()
+_needs_vec = pytest.mark.skipif(
+    not _HAS_VEC,
+    reason="sqlite-vec not installed ([sqlite] extra); vector path unavailable",
+)
+
+
+@pytest.fixture()
+def fallback_engine(monkeypatch):
+    """Install a process-wide engine forced into fallback mode; restore after."""
+    monkeypatch.setenv("CORTEX_EMBEDDING_ZERO_DOWNLOAD", "1")
+    saved = ef._singleton
+    eng = ee.EmbeddingEngine(model_name="no-such-model-169b", dim=384)
+    ef._singleton = eng
+    assert eng.mode == "fallback"
+    yield eng
+    ef._singleton = saved
+
+
+@pytest.fixture()
+def store():
+    s = SqliteMemoryStore(db_path=":memory:", embedding_dim=384)
+    yield s
+    s.close()
+
+
+# ── Item 1: second provider, selected per ModelState, total mapping ──────────
+
+
+def test_fallback_provider_is_embedding_provider():
+    from mcp_server.infrastructure.embedding_provider import EmbeddingProvider
+
+    p = AlgorithmicEmbeddingProvider(dim=384)
+    assert isinstance(p, EmbeddingProvider)
+    blob = p.encode("normalizePaymentAmount rounds the charge")
+    assert blob is not None and len(blob) == 384 * 4
+    assert p.encode("") is None
+    assert not p.available
+
+
+def test_use_fallback_mapping_is_total():
+    # Every non-LOADED state routes to fallback; LOADED → neural. No gaps.
+    for state in ModelState:
+        assert ef.use_fallback(state) is (state is not ModelState.LOADED)
+
+
+def test_engine_selects_fallback_for_absent_states(fallback_engine):
+    eng = fallback_engine
+    # A bogus model + zero-download resolves to a non-LOADED state.
+    assert eng.model_state in {
+        ModelState.MODEL_FILES_ABSENT,
+        ModelState.PACKAGE_ABSENT,
+        ModelState.LOAD_RAISED,
+    }
+    assert eng.mode == "fallback"
+    a = eng.encode("payment normalization to cents")
+    b = eng.encode("payment normalization to cents")
+    assert a is not None and a == b  # deterministic algorithmic vector
+
+
+# ── Item 3: loud engagement + deterministic dim ──────────────────────────────
+
+
+def test_engine_engages_fallback_loudly(monkeypatch, caplog):
+    monkeypatch.setenv("CORTEX_EMBEDDING_ZERO_DOWNLOAD", "1")
+    eng = ee.EmbeddingEngine(model_name="no-such-model-169b", dim=384)
+    with caplog.at_level(logging.WARNING):
+        blob = eng.encode("normalizePaymentAmount rounds the charge")
+    assert eng.mode == "fallback"
+    vec = np.frombuffer(blob, dtype=np.float32)
+    assert vec.shape == (384,)
+    assert abs(float(np.linalg.norm(vec)) - 1.0) < 1e-5
+    assert any("fallback ENGAGED" in r.message for r in caplog.records)
+
+
+# ── Item 2: unconditional stamp (works without sqlite-vec) ───────────────────
+
+
+def test_embedding_model_stamped_fallback(fallback_engine, store):
+    eng = fallback_engine
+    mid = store.insert_memory(
+        {"content": "a decision", "embedding": eng.encode("a decision")}
+    )
+    row = store._conn.execute(
+        "SELECT embedding_model FROM memories WHERE id = ?", (mid,)
+    ).fetchone()
+    # Never '' — stamped even if the vec store is absent (issue #169 root cause).
+    assert row["embedding_model"] == "fallback"
+
+
+def test_select_fallback_embeddings_worklist(fallback_engine, store):
+    eng = fallback_engine
+    store.insert_memory(
+        {"content": "fb one", "embedding": eng.encode("fb one"), "heat": 0.9}
+    )
+    store.insert_memory(
+        {
+            "content": "neural one",
+            "embedding": eng.encode("n"),
+            "embedding_model": "neural",
+        }
+    )
+    contents = {w["content"] for w in store.select_fallback_embeddings(limit=10)}
+    assert "fb one" in contents
+    assert "neural one" not in contents
+
+
+# ── camelCase FTS (index-time augmentation) ──────────────────────────────────
+
+
+def test_camelcase_fts_match(fallback_engine, store):
+    store.insert_memory(
+        {"content": "normalizePaymentAmount rounds the charge", "embedding": None}
+    )
+    assert store.search_fts("payment")  # sub-token indexed by augment_content
+    assert store.search_fts("normalizePaymentAmount")
+
+
+# ── Item 4: recall_helpers path recalls camelCase via lowercase query ────────
+
+
+@_needs_vec
+def test_recall_helpers_camelcase_lowercase_query(fallback_engine, store):
+    from mcp_server.handlers.recall_helpers import compute_vector_fts
+
+    eng = fallback_engine
+    mid = store.insert_memory(
+        {
+            "content": "normalizePaymentAmount rounds the charge to cents",
+            "embedding": eng.encode("normalizePaymentAmount rounds the charge"),
+            "heat": 0.8,
+        }
+    )
+    # Lowercase natural-language query must recall the camelCase symbol memory
+    # through the recall_helpers FTS path.
+    _vec, fts, _q = compute_vector_fts("payment", store, eng, pool=20, min_heat=0.0)
+    assert mid in {m for m, _ in fts}
+
+
+# ── Item 8: mixed store — no cross-rank ──────────────────────────────────────
+
+
+@_needs_vec
+def test_mixed_store_no_cross_rank(fallback_engine, store):
+    eng = fallback_engine
+    query = "payment normalization"
+    q_vec = eng.encode(query)
+    fb_id = store.insert_memory(
+        {
+            "content": "payment normalization to cents",
+            "embedding": eng.encode("x"),
+            "heat": 0.5,
+        }
+    )
+    # A neural-tagged vector identical to the query — would win the KNN if the
+    # spaces were allowed to cross-rank.
+    neural_id = store.insert_memory(
+        {
+            "content": "unrelated neural-tagged row",
+            "embedding": q_vec,
+            "embedding_model": "neural",
+            "heat": 0.5,
+        }
+    )
+    results = store.recall_memories(
+        query,
+        q_vec,
+        max_results=5,
+        weights={"vector": 1.0, "fts": 0.0, "heat": 0.0, "recency": 0.0},
+    )
+    ids = {r["memory_id"] for r in results}
+    assert neural_id not in ids
+    assert fb_id in ids
+
+
+# ── Item 5: scheduled upgrade via consolidate cycle ──────────────────────────
+
+
+@_needs_vec
+def test_embedding_upgrade_cycle_restamps_neural(monkeypatch, store):
+    """Fallback-stamped memories + neural model available → restamped neural."""
+    from mcp_server.handlers.consolidation.embedding_upgrade import (
+        run_embedding_upgrade_cycle,
+    )
+
+    # 1) Write two memories under the fallback provider (model absent).
+    monkeypatch.setenv("CORTEX_EMBEDDING_ZERO_DOWNLOAD", "1")
+    saved = ef._singleton
+    fb = ee.EmbeddingEngine(model_name="no-such-model-169b", dim=384)
+    ef._singleton = fb
+    try:
+        for text in [
+            "decision about the checkout transaction",
+            "payment rounding rule",
+        ]:
+            store.insert_memory({"content": text, "embedding": fb.encode(text)})
+        assert len(store.select_fallback_embeddings(limit=10)) == 2
+
+        # 2) Model now available: a real neural engine as the process encoder.
+        monkeypatch.delenv("CORTEX_EMBEDDING_ZERO_DOWNLOAD", raising=False)
+        neural = ee.EmbeddingEngine(dim=384)
+        if neural.mode != "neural":
+            pytest.skip("neural model not cached in this environment")
+        ef._singleton = neural
+
+        # 3) Consolidate's upgrade cycle re-embeds + restamps.
+        result = run_embedding_upgrade_cycle(store, neural)
+        assert result["upgraded"] == 2
+        assert store.select_fallback_embeddings(limit=10) == []
+        stamps = {
+            r["embedding_model"]
+            for r in store._conn.execute(
+                "SELECT embedding_model FROM memories"
+            ).fetchall()
+        }
+        assert stamps == {"neural"}
+    finally:
+        ef._singleton = saved
+
+
+def test_consolidate_reports_embedding_upgrade(fallback_engine, store):
+    """The upgrade cycle reports a count even when nothing needs upgrading."""
+    from mcp_server.handlers.consolidation.embedding_upgrade import (
+        run_embedding_upgrade_cycle,
+    )
+
+    # Encoder is fallback → cycle is a no-op but still reports structure.
+    out = run_embedding_upgrade_cycle(store, fallback_engine)
+    assert out["upgraded"] == 0
+    assert "reason" in out
+
+
+# ── FTS migration: external-content → self-content ───────────────────────────
+
+
+def test_fts_migration_rebuilds_external_content(tmp_path):
+    db = str(tmp_path / "legacy.db")
+    s = SqliteMemoryStore(db_path=db, embedding_dim=384)
+    mid = s.insert_memory({"content": "legacyCamelToken here", "embedding": None})
+    s._conn.execute("DROP TABLE memories_fts")
+    s._conn.execute(
+        "CREATE VIRTUAL TABLE memories_fts USING fts5("
+        "content, content='memories', content_rowid='id')"
+    )
+    s._conn.execute(
+        "INSERT INTO memories_fts(rowid, content) VALUES (?, ?)",
+        (mid, "legacyCamelToken here"),
+    )
+    s._conn.commit()
+    s.close()
+    s2 = SqliteMemoryStore(db_path=db, embedding_dim=384)
+    sql = s2._conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name='memories_fts'"
+    ).fetchone()["sql"]
+    assert "content=" not in sql
+    assert s2.search_fts("camel")  # sub-token now indexed
+    s2.close()
+
+
+# ── Item 6: GENUINE sentence-transformers absence (subprocess) ───────────────
+
+_CHILD = textwrap.dedent(
+    """
+    import json, sys
+
+    class _Block:
+        def find_spec(self, name, path=None, target=None):
+            if name == "sentence_transformers" or name.startswith(
+                "sentence_transformers."
+            ):
+                raise ModuleNotFoundError("sentence_transformers hidden for test")
+            return None
+
+    sys.meta_path.insert(0, _Block())
+
+    import mcp_server.infrastructure.embedding_factory as ef
+    import mcp_server.infrastructure.embedding_engine as ee
+    from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
+
+    eng = ee.EmbeddingEngine(dim=384)  # default (real) model name; ST import fails
+    ef._singleton = eng
+    blob = eng.encode("normalizePaymentAmount rounds the charge to cents")
+
+    store = SqliteMemoryStore(db_path=":memory:", embedding_dim=384)
+    for text in [
+        "The checkoutService wraps read-charge-decrement in one DB transaction",
+        "normalizePaymentAmount rounds the charge to cents before billing",
+        "we hiked in the alps under sunny weather all week",
+    ]:
+        store.insert_memory({"content": text, "embedding": eng.encode(text), "heat": 0.8})
+
+    stamp = store._conn.execute(
+        "SELECT embedding_model FROM memories LIMIT 1"
+    ).fetchone()["embedding_model"]
+    q = "how does payment amount normalization work"
+    res = store.recall_memories(q, eng.encode(q), max_results=3)
+    print(
+        "RESULT_JSON:"
+        + json.dumps(
+            {
+                "mode": eng.mode,
+                "state": eng.model_state.name,
+                "has_blob": bool(blob),
+                "has_vec": bool(store._has_vec),
+                "stamp": stamp,
+                "top": res[0]["content"] if res else "",
+            }
+        )
+    )
+    """
+)
+
+
+def test_real_sentence_transformers_absence_subprocess(monkeypatch):
+    # Empty HF_HOME + genuine ImportError: zero network, pure fallback.
+    monkeypatch.setenv("CORTEX_EMBEDDING_ZERO_DOWNLOAD", "1")
+    proc = subprocess.run(
+        [sys.executable, "-c", _CHILD],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, (
+        f"child failed:\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+    )
+    line = next(ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT_JSON:"))
+    out = json.loads(line[len("RESULT_JSON:") :])
+    assert out["mode"] == "fallback"
+    assert out["state"] == "PACKAGE_ABSENT"
+    assert out["has_blob"] is True
+    assert out["stamp"] == "fallback"
+    if out["has_vec"]:
+        assert "normalizePaymentAmount" in out["top"]

--- a/tests_py/invariants/test_I2_canonical_writer.py
+++ b/tests_py/invariants/test_I2_canonical_writer.py
@@ -67,13 +67,14 @@ _ALLOWED_WRITERS: set[tuple[str, int]] = {
     # net +29 cause as the two entries above).
     ("infrastructure/pg_store.py", 864),
     # SQLite parity of the anchor transfer (same transactional rationale).
-    # Shifted 389->440 when M-D3 (7.1) added
-    # _migrate_homeostatic_state_write_class above it.
-    ("infrastructure/sqlite_store.py", 447),
+    # Shifted 389->440->447->493 (M-D3, then #169 added _fts_augment /
+    # _migrate_fts_code_tokenize / unconditional embedding_model stamp above it).
+    ("infrastructure/sqlite_store.py", 493),
     # SQLite parity: canonical bump_heat_raw / update_memories_heat_batch.
-    # Shifted 419->470, 463->534 for the same reason.
-    ("infrastructure/sqlite_store.py", 477),
-    ("infrastructure/sqlite_store.py", 541),
+    # Shifted 419->470->477->523, 463->534->541->587 for the same reasons
+    # (#169's _stamp_embedding_model / select_fallback_embeddings / reembed_memory).
+    ("infrastructure/sqlite_store.py", 523),
+    ("infrastructure/sqlite_store.py", 587),
     # Homeostatic fold (amortized ~once/month per (domain, write_class)).
     # M-D3 (7.1, 2026-07-10): split out of homeostatic.py into
     # homeostatic_apply.py (§4.1 500-line file cap — stratification by

--- a/tests_py/shared/test_algorithmic_embedding.py
+++ b/tests_py/shared/test_algorithmic_embedding.py
@@ -1,0 +1,61 @@
+"""Tests for the deterministic algorithmic embedder (issue #169).
+
+Contract assertions (each must fail on regression):
+  - Output dimension equals the requested dim (space contract)
+  - Deterministic: same (text, dim) → byte-identical vector
+  - L2-normalized for non-empty text; zero vector for empty
+  - Semantic ordering: a topically-matching text out-scores an unrelated one
+  - camelCase identifiers bridge to their split words (shared tokenizer)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mcp_server.shared.algorithmic_embedding import embed_text, index_vector
+
+
+def _cos(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.dot(a, b))  # both already L2-normalized
+
+
+def test_dimension_contract():
+    for dim in (128, 384, 768):
+        assert embed_text("some memory text", dim).shape == (dim,)
+
+
+def test_determinism():
+    a = embed_text("normalizePaymentAmount rounds the charge", 384)
+    b = embed_text("normalizePaymentAmount rounds the charge", 384)
+    assert np.array_equal(a, b)
+
+
+def test_normalized_nonempty():
+    v = embed_text("a decision about the checkout transaction boundary", 384)
+    assert abs(float(np.linalg.norm(v)) - 1.0) < 1e-5
+
+
+def test_empty_is_zero_vector():
+    v = embed_text("", 384)
+    assert float(np.linalg.norm(v)) == 0.0
+
+
+def test_index_vector_is_sparse_ternary():
+    v = index_vector("payment", 384)
+    nz = v[v != 0]
+    assert len(nz) <= 8  # source: CBM_SEM_SPARSE_NNZE=8
+    assert set(np.unique(nz)).issubset({-1.0, 1.0})
+
+
+def test_semantic_ordering():
+    q = embed_text("how to normalize a payment amount", 384)
+    related = embed_text("payment normalization converts the amount to cents", 384)
+    unrelated = embed_text("the weather in Paris was cold and rainy", 384)
+    assert _cos(q, related) > _cos(q, unrelated)
+
+
+def test_camelcase_bridges_to_words():
+    q = embed_text("payment amount", 384)
+    camel = embed_text("normalizePaymentAmount", 384)
+    unrelated = embed_text("mountain hiking trip", 384)
+    assert _cos(q, camel) > _cos(q, unrelated)

--- a/tests_py/shared/test_code_tokenize.py
+++ b/tests_py/shared/test_code_tokenize.py
@@ -1,0 +1,91 @@
+"""Tests for code-aware sub-token splitting (issue #169).
+
+Contract assertions (each must fail on regression):
+  - split_identifier decomposes camelCase, snake_case, acronyms, digit runs
+  - split_identifier is idempotent and lowercases
+  - augment_content appends sub-tokens only for splittable identifiers
+  - expand_fts_query is FTS5-safe (quoted) and preserves AND-across-words
+"""
+
+from __future__ import annotations
+
+from mcp_server.shared.code_tokenize import (
+    augment_content,
+    expand_fts_query,
+    split_identifier,
+)
+
+
+def test_split_camel_case():
+    assert split_identifier("normalizePaymentAmount") == [
+        "normalize",
+        "payment",
+        "amount",
+    ]
+
+
+def test_split_snake_and_kebab():
+    assert split_identifier("snake_case_id") == ["snake", "case", "id"]
+    assert split_identifier("kebab-case-thing") == ["kebab", "case", "thing"]
+
+
+def test_split_acronym_boundary():
+    assert split_identifier("HTTPRequest") == ["http", "request"]
+
+
+def test_split_digit_boundary():
+    assert split_identifier("utf8") == ["utf", "8"]
+
+
+def test_split_plain_word_is_single_lowercased():
+    assert split_identifier("payment") == ["payment"]
+    assert split_identifier("Payment") == ["payment"]
+
+
+def test_split_is_idempotent_on_subtokens():
+    for sub in split_identifier("normalizePaymentAmount"):
+        assert split_identifier(sub) == [sub]
+
+
+def test_split_empty():
+    assert split_identifier("") == []
+
+
+def test_augment_appends_subtokens():
+    out = augment_content("normalizePaymentAmount rounds")
+    assert out.startswith("normalizePaymentAmount rounds")
+    assert "payment" in out.split()
+    assert "amount" in out.split()
+
+
+def test_augment_noop_without_identifiers():
+    text = "the quick brown fox"
+    assert augment_content(text) == text
+
+
+def test_augment_does_not_duplicate_present_words():
+    # 'payment' already a standalone word → not re-appended
+    out = augment_content("payment normalizePaymentAmount")
+    assert out.split().count("payment") == 1
+
+
+def test_expand_query_quotes_and_expands():
+    q = expand_fts_query("normalizePaymentAmount")
+    assert q.startswith("(")
+    assert '"payment"' in q
+    assert "OR" in q
+
+
+def test_expand_query_preserves_and_across_words():
+    q = expand_fts_query("payment amount")
+    # two required groups, whitespace-joined (FTS5 implicit AND)
+    assert q == '"payment" "amount"'
+
+
+def test_expand_query_fts5_keyword_is_literal():
+    # bare 'OR' would be an operator; quoting makes it a literal term
+    assert expand_fts_query("OR") == '"or"'
+
+
+def test_expand_query_empty():
+    assert expand_fts_query("!!!") == ""


### PR DESCRIPTION
## Phase B — full #169 on the merged #173 seams

Reimplements the zero-download semantic fallback on the provider / lifecycle /
factory seams from PR #175, with no monolith and the root cause fixed.

`Closes #169`

### 1. Fallback provider, selected by the factory per `ModelState`
- `embedding_fallback_provider.AlgorithmicEmbeddingProvider` — the SECOND
  `EmbeddingProvider` (the neural `EmbeddingEngine` is the first). Deterministic,
  download-free, same `EMBEDDING_DIM`; delegates to `shared.algorithmic_embedding`
  (TF + Random Indexing + within-document co-occurrence bridging; sources in the
  module docstring).
- `embedding_factory.use_fallback(state)` is the **total** state→provider map:
  `LOADED` → neural; `PACKAGE_ABSENT`, `MODEL_FILES_ABSENT`, `LOAD_RAISED`,
  `UNINITIALIZED` → fallback. **No state maps to nothing** (test asserts totality).
- The lifecycle no longer blocks or crashes: `MODEL_FILES_ABSENT` / `LOAD_RAISED`
  serve fallback this session and fetch in the background
  (`embedding_downloads.py`, honouring `CORTEX_EMBEDDING_ZERO_DOWNLOAD`), upgrading
  next session.

### 2. Root-cause fix (the PR #172 empty-stamp bug)
`SqliteMemoryStore` stamps `embedding_model` **unconditionally** on write, outside
the `_has_vec` branch — so a store built without `sqlite-vec` still records
`'fallback'`, never `''`. Regression test: sqlite-vec absent + sentence-transformers
absent → stamp `'fallback'`.

### 3. Loud engagement + telemetry
One `WARNING` when the fallback engages; `get_telemetry` surfaces `embedding_mode`
(`neural` / `fallback` / `unknown`) via `factory.current_embedding_mode`.

### 4. Code-aware FTS on all recall paths
camelCase/snake_case sub-tokens at **index time** (`augment_content`) and **query
time** — recall WRRF `_signal_fts`, entity `MATCH`, and
`recall_helpers.compute_vector_fts`. `memories_fts` converted external→self-content
with a one-shot rebuild+reindex migration. Test: a lowercase query recalls a
camelCase symbol memory through the `recall_helpers` path.

### 5. Scheduled upgrade
`consolidation/embedding_upgrade.run_embedding_upgrade_cycle` re-embeds
fallback-stamped memories with the neural encoder and restamps them `'neural'` once
the model is available; wired into `consolidate`'s compress phase, count in the
response. Test: fallback memories + model available + cycle → restamped neural.

### 6 & 8. Genuine absence + mixed-store invariant
- Subprocess test: `sentence_transformers` genuinely absent (import hook raises,
  not monkeypatched) + `CORTEX_EMBEDDING_ZERO_DOWNLOAD` → remember + recall
  round-trip with zero network, stamp `'fallback'`, `PACKAGE_ABSENT`.
- Mixed store: neural and fallback vectors never cross-rank (query-space vec
  filter) — a neural vector identical to a fallback query is excluded.

## Benchmark — LongMemEval-S, SQLite three-way (n=50, this code)

| mode                      |   MRR | Recall@10 |
|---------------------------|------:|----------:|
| (a) no-vector baseline    | 0.275 |     46.0% |
| (b) algorithmic fallback  | 0.378 |     66.0% |
| (c) sentence-transformers | 0.609 |     94.0% |

Fallback vs no-vector: **ΔMRR +0.102, ΔRecall@10 +20.0 pp** → fallback beats the
no-vector baseline (adoption criterion met). Results + MANIFEST under
`benchmarks/results/semantic-fallback-169/`.

## Tests / gates
- New: `test_semantic_fallback_169.py` (13 tests: provider/selection/stamp/mixed
  store/upgrade/subprocess/migration), `test_algorithmic_embedding.py`,
  `test_code_tokenize.py`. Existing embedding suite (56) passes unchanged.
- `ruff check .` + `ruff format --check` clean. Full-suite tally reported on the PR
  thread once the run completes.
- Vector-path tests carry `skipif(not sqlite-vec)`; they run on the `[sqlite]`
  CI legs (test-sqlite / test-windows) and skip on the no-`[sqlite]` matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)