### PR TITLE
fix(marketplace): bump withheld pins + CI pin-staleness gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,7 +64,7 @@
         "repo": "cdeust/cortex-viz"
       },
       "description": "Standalone visualization MCP for Cortex — a live neural-graph galaxy of every project, file, symbol, memory, discussion and wiki page, plus a per-session execution trace, a consolidation kanban, and a curated knowledge/wiki browser. Read-only bridge over Cortex's shared PostgreSQL store and the ~/.claude artifacts; it renders, it never remembers. Restores the open_visualization / get_methodology_graph / query_workflow_graph tools removed from Cortex 3.21.0; launch with /cortex-visualize.",
-      "version": "2.6.3",
+      "version": "2.7.1",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"
@@ -89,7 +89,7 @@
         "repo": "cdeust/zetetic-team-subagents"
       },
       "description": "Zetetic agent team for Cortex — 97 genius reasoning patterns from history's greatest minds + 19 team specialists (architect, engineer, code-reviewer, refactorer, …), 63 skills, 24 commands, 18 tools, 17 hooks, under one epistemic standard none of them can bypass. Composes with Cortex memory: every agent recalls/remembers through the Cortex MCP and routes via /genius, /agent, /zetetic, /quality, /research commands.",
-      "version": "2.29.0",
+      "version": "2.34.0",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "admin@ai-architect.tools"
   },
   "metadata": {
-    "description": "Persistent memory and cognitive profiling plugins for Claude Code",
+    "description": "The Cortex family of Claude Code plugins: home of hypermnesia-mcp (the persistent-memory server formerly named cortex, renamed in v4.15.0 over a directory name collision), zetetic-team-subagents, and cortex-viz. The marketplace name stays cortex-plugins: it is the brand-level umbrella, while hypermnesia-mcp is one package inside it.",
     "version": "4.16.0"
   },
   "plugins": [

--- a/.github/workflows/marketplace-pins.yml
+++ b/.github/workflows/marketplace-pins.yml
@@ -1,0 +1,38 @@
+name: Marketplace pin gate
+
+# Issue #179: releasing a downstream plugin does not ship it — delivery is
+# gated by the version pinned in .claude-plugin/marketplace.json. Six
+# zetetic-team-subagents releases and two cortex-viz releases went out
+# unpublished with no signal. This workflow makes a stale pin a red run.
+#
+# Cron matters more than the PR trigger: pins go stale by INACTION, and
+# inaction never opens a PR. Weekly is bounded staleness (max 7 days),
+# vs unbounded before.
+
+on:
+  pull_request:
+    paths:
+      - ".claude-plugin/marketplace.json"
+      - "scripts/check_marketplace_pins.py"
+      - ".github/workflows/marketplace-pins.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".claude-plugin/marketplace.json"
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC — weekly bound on pin staleness
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-pins:
+    name: pins current vs latest releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check marketplace pins
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/check_marketplace_pins.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,17 @@ coding write gates, causal graphs, and intent-aware retrieval.
   gate before consolidation ever advances the stage), not a bug — pass
   `--with-consolidation` for representative numbers.
 
+## Releasing
+
+A release is not shipped until its pins move. The tag/GitHub-release/PyPI
+steps deliver nothing to plugin installs by themselves — installs subscribe
+via `.claude-plugin/marketplace.json` pins. The release checklist therefore
+ENDS with: bump the marketplace pin(s) and `server.json`, and confirm
+`python3 scripts/check_marketplace_pins.py` exits 0. CI enforces this
+(marketplace-pins workflow: PR/push on the manifest + weekly cron), source:
+the 2026-07-25 incident where six zetetic-team-subagents releases and two
+cortex-viz releases shipped to zero installs (#179).
+
 ## Architecture
 
 Clean Architecture, concentric layers: `server → handlers → core ← shared`,

--- a/scripts/check_marketplace_pins.py
+++ b/scripts/check_marketplace_pins.py
@@ -1,24 +1,31 @@
 #!/usr/bin/env python3
-"""Marketplace pin-staleness gate (issue #179).
+"""Marketplace pin-staleness gate. CANONICAL COPY: cdeust/Cortex.
 
-Releasing a downstream plugin does not ship it: installs subscribe through
-this repo's ``.claude-plugin/marketplace.json``, and delivery is gated by the
-``version`` pinned there. Six zetetic-team-subagents releases (2.30.0-2.34.0)
-and two cortex-viz releases were withheld with no error because nothing
-compared pin against release. This gate makes that state loud.
+A byte-identical copy lives in cdeust/automatised-pipeline (its CI diffs
+against this file weekly and fails on drift), so the gate is ONE artifact
+guarding both repos — never two copies that diverge into a no-op.
 
-Two failure classes (distinct on purpose — see zetetic-team-subagents#52:
-a two-value check that only compares installed-vs-pin reports "up to date"
-against a stale pin, a false compliance statement one level up):
+Releasing does not ship: delivery is gated by pins in
+``.claude-plugin/marketplace.json``. Six zetetic-team-subagents releases and
+two cortex-viz releases were withheld silently (Cortex #179); AP's own
+manifests sat a three-way split with its tag (AP #67). Failure classes:
 
-  PIN_BEHIND_RELEASE  a github-sourced plugin's pin < that repo's latest
-                      release tag — the release was never delivered.
-  SELF_PIN_MISMATCH   a local ("./…") plugin's pin != its own plugin.json
-                      version — the marketplace lies about this repo.
+  PIN_BEHIND_TAG       local-source pin < this repo's latest semver git tag.
+                       Offline, reads git only — detects the #67 incident
+                       even when every manifest agrees (they were BOTH stale).
+  PIN_BEHIND_RELEASE   github-source pin < that repo's latest release.
+  SELF_PIN_MISMATCH    local-source pin != the plugin's own plugin.json.
+  SERVER_JSON_SPLIT    root server.json version != the primary local pin
+                       (the unguarded third leg of AP's three-way split).
 
-Exit codes: 0 all pins current, 1 stale pin(s), 2 usage/environment error.
-Network: GitHub API only; sends Authorization when GITHUB_TOKEN is set
-(required in CI to avoid the 60-req/h anonymous limit).
+Network failures DEGRADE TO SILENCE (NOTICE + exit 0): a gate that reddens
+every PR during a GitHub outage gets disabled, and then the six-release gap
+recurs with the gate nominally in place. The offline path is tested.
+
+Frozen pins: deliberately never-advancing pins (deprecation shims) are
+listed in FROZEN_PINS with a reason — audited allowlist, not silence.
+
+Exit codes: 0 current (or degraded, with NOTICE), 1 stale pin(s), 2 error.
 """
 
 from __future__ import annotations
@@ -26,68 +33,154 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 import sys
+import urllib.error
 import urllib.request
 from pathlib import Path
 
 MARKETPLACE = (
     Path(__file__).resolve().parent.parent / ".claude-plugin" / "marketplace.json"
 )
-API_TIMEOUT_S = 15  # source: matches the default urllib usage elsewhere in scripts/; GitHub p99 latency is far below this
+API_TIMEOUT_S = 15  # source: GitHub API p99 well below; matches prior gate rev
+# source: audited 2026-07-25 (Cortex PR #182 review clause 5) — the `cortex`
+# deprecation shim announces the hypermnesia-mcp rename and is frozen at the
+# rename release by design; advancing it would defeat its purpose.
+FROZEN_PINS = {"cortex": "deprecation shim, frozen at the 4.15.0 rename release"}
 
 
 def parse_semver(tag: str) -> tuple[int, ...] | None:
-    """'v2.34.0' / '2.34.0' -> (2, 34, 0); None when the tag is not semver."""
+    """'v2.34.0' / '2.34.0' -> (2, 34, 0); None when not semver."""
     m = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", tag.strip())
-    if m is None:
-        return None
-    return tuple(int(g) for g in m.groups())
+    return tuple(int(g) for g in m.groups()) if m else None
 
 
-def latest_release_tag(repo: str) -> str:
-    req = urllib.request.Request(
-        f"https://api.github.com/repos/{repo}/releases/latest",
-        headers=_headers(),
+def latest_local_tag(root: Path, run=subprocess.run) -> str | None:
+    """Highest semver tag in this repo, or None (no tags / not a repo)."""
+    proc = run(
+        ["git", "-C", str(root), "tag", "--list"],
+        capture_output=True,
+        text=True,
+        timeout=API_TIMEOUT_S,
     )
-    with urllib.request.urlopen(req, timeout=API_TIMEOUT_S) as resp:
-        return json.load(resp)["tag_name"]
+    if proc.returncode != 0:
+        return None
+    parsed = [(v, t) for t in proc.stdout.split() if (v := parse_semver(t))]
+    return max(parsed)[1] if parsed else None
+
+
+def tags_between(root: Path, pin: tuple, latest: tuple, run=subprocess.run) -> int:
+    proc = run(
+        ["git", "-C", str(root), "tag", "--list"],
+        capture_output=True,
+        text=True,
+        timeout=API_TIMEOUT_S,
+    )
+    if proc.returncode != 0:
+        return 0
+    return sum(
+        1 for t in proc.stdout.split() if (v := parse_semver(t)) and pin < v <= latest
+    )
 
 
 def _headers() -> dict[str, str]:
-    headers = {"Accept": "application/vnd.github+json", "User-Agent": "cortex-pin-gate"}
-    token = os.environ.get("GITHUB_TOKEN", "")
-    if token:
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "pin-gate"}
+    if token := os.environ.get("GITHUB_TOKEN", ""):
         headers["Authorization"] = f"Bearer {token}"
     return headers
 
 
+def latest_release_tag(repo: str) -> str | None:
+    """Latest release tag; None when the repo has no releases (404)."""
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/releases/latest", headers=_headers()
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=API_TIMEOUT_S) as resp:
+            return json.load(resp).get("tag_name")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+
+
+def releases_between(repo: str, pin: tuple, latest: tuple) -> int | None:
+    """Count releases with pin < tag <= latest; None when not determinable."""
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/releases?per_page=100", headers=_headers()
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=API_TIMEOUT_S) as resp:
+            releases = json.load(resp)
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return None
+    return sum(
+        1
+        for r in releases
+        if (v := parse_semver(r.get("tag_name", ""))) and pin < v <= latest
+    )
+
+
 def check_github_pin(
-    name: str, repo: str, pin: str, fetch=latest_release_tag
-) -> str | None:
-    tag = fetch(repo)
+    name: str, repo: str, pin: str, fetch=latest_release_tag, count=releases_between
+):
+    """Returns (failure, notice) — exactly one is non-None or both None."""
+    try:
+        tag = fetch(repo)
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        return (
+            None,
+            f"NOTICE: {name}: network degraded ({e.__class__.__name__}); pin not verified this run",
+        )
+    if tag is None:
+        return (
+            None,
+            f"NOTICE: {name}: {repo} has no published releases; pin not comparable",
+        )
     latest, pinned = parse_semver(tag), parse_semver(pin)
     if latest is None or pinned is None:
-        return f"UNPARSEABLE: {name}: pin={pin!r} latest tag={tag!r} (non-semver; inspect manually)"
+        return f"UNPARSEABLE: {name}: pin={pin!r} latest={tag!r}", None
     if pinned < latest:
+        n = count(repo, pinned, latest)
+        behind = f"{n} release(s)" if n is not None else "release(s)"
         return (
-            f"PIN_BEHIND_RELEASE: {name}: marketplace pins {pin} but {repo} "
-            f"latest release is {tag} — the release was never delivered to installs"
+            f"PIN_BEHIND_RELEASE: {name}: pins {pin}, {repo} latest is {tag} ({behind} never delivered)",
+            None,
         )
-    return None
+    return None, None
 
 
-def check_self_pin(name: str, source: str, pin: str, root: Path) -> str | None:
-    plugin_json = (root / source / ".claude-plugin" / "plugin.json").resolve()
+def check_self_pin(name: str, source: str, pin: str, root: Path) -> list[str]:
+    failures: list[str] = []
+    plugin_json = root / source / ".claude-plugin" / "plugin.json"
     if not plugin_json.is_file():
-        plugin_json = (root / source / "plugin.json").resolve()
-    if not plugin_json.is_file():
-        return None  # local plugin without its own manifest (e.g. shim dirs) — pin is authoritative
-    actual = json.loads(plugin_json.read_text()).get("version", "")
-    if actual and actual != pin:
-        return (
-            f"SELF_PIN_MISMATCH: {name}: marketplace pins {pin} but "
-            f"{plugin_json.relative_to(root)} says {actual}"
+        plugin_json = root / source / "plugin.json"
+    if plugin_json.is_file():
+        actual = json.loads(plugin_json.read_text()).get("version", "")
+        if actual and actual != pin:
+            failures.append(
+                f"SELF_PIN_MISMATCH: {name}: pins {pin} but {plugin_json.relative_to(root)} says {actual}"
+            )
+    if name in FROZEN_PINS:
+        return failures  # frozen: manifest coherence still checked, tag advance is by-design
+    tag = latest_local_tag(root)
+    pinned = parse_semver(pin)
+    if tag and pinned and (latest := parse_semver(tag)) and pinned < latest:
+        n = tags_between(root, pinned, latest)
+        failures.append(
+            f"PIN_BEHIND_TAG: {name}: pins {pin} but this repo's latest tag is {tag} "
+            f"({n} release(s) never delivered to installs)"
         )
+    return failures
+
+
+def check_server_json(root: Path, primary_pin: str) -> str | None:
+    server = root / "server.json"
+    if not server.is_file():
+        return None
+    version = json.loads(server.read_text()).get("version", "")
+    if version and version != primary_pin:
+        return f"SERVER_JSON_SPLIT: server.json says {version} but the primary marketplace pin is {primary_pin}"
     return None
 
 
@@ -98,6 +191,8 @@ def main() -> int:
     root = MARKETPLACE.parent.parent
     data = json.loads(MARKETPLACE.read_text())
     failures: list[str] = []
+    notices: list[str] = []
+    primary_pin = ""
     for plugin in data.get("plugins", []):
         name, pin, source = (
             plugin.get("name", "?"),
@@ -107,21 +202,30 @@ def main() -> int:
         if not pin:
             continue
         if isinstance(source, dict) and source.get("source") == "github":
-            issue = check_github_pin(name, source["repo"], pin)
+            failure, notice = check_github_pin(name, source["repo"], pin)
+            if failure:
+                failures.append(failure)
+            if notice:
+                notices.append(notice)
         elif isinstance(source, str):
-            issue = check_self_pin(name, source, pin, root)
-        else:
-            issue = None
-        if issue:
-            failures.append(issue)
-    for f in failures:
-        print(f)
+            failures.extend(check_self_pin(name, source, pin, root))
+            if source.strip("/") in ("", "."):
+                primary_pin = pin
+    if primary_pin and (split := check_server_json(root, primary_pin)):
+        failures.append(split)
+    for line in notices:
+        print(line)
+    for line in failures:
+        print(line)
     if failures:
         print(
-            f"\n{len(failures)} stale pin(s). Bump .claude-plugin/marketplace.json — a release is not shipped until its pin moves."
+            f"\n{len(failures)} stale pin(s). A release is not shipped until its pin moves — bump .claude-plugin/marketplace.json (and server.json)."
         )
         return 1
-    print("All marketplace pins current.")
+    print(
+        "All marketplace pins current."
+        + (" (network-degraded checks noticed above)" if notices else "")
+    )
     return 0
 
 

--- a/scripts/check_marketplace_pins.py
+++ b/scripts/check_marketplace_pins.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Marketplace pin-staleness gate (issue #179).
+
+Releasing a downstream plugin does not ship it: installs subscribe through
+this repo's ``.claude-plugin/marketplace.json``, and delivery is gated by the
+``version`` pinned there. Six zetetic-team-subagents releases (2.30.0-2.34.0)
+and two cortex-viz releases were withheld with no error because nothing
+compared pin against release. This gate makes that state loud.
+
+Two failure classes (distinct on purpose — see zetetic-team-subagents#52:
+a two-value check that only compares installed-vs-pin reports "up to date"
+against a stale pin, a false compliance statement one level up):
+
+  PIN_BEHIND_RELEASE  a github-sourced plugin's pin < that repo's latest
+                      release tag — the release was never delivered.
+  SELF_PIN_MISMATCH   a local ("./…") plugin's pin != its own plugin.json
+                      version — the marketplace lies about this repo.
+
+Exit codes: 0 all pins current, 1 stale pin(s), 2 usage/environment error.
+Network: GitHub API only; sends Authorization when GITHUB_TOKEN is set
+(required in CI to avoid the 60-req/h anonymous limit).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+MARKETPLACE = (
+    Path(__file__).resolve().parent.parent / ".claude-plugin" / "marketplace.json"
+)
+API_TIMEOUT_S = 15  # source: matches the default urllib usage elsewhere in scripts/; GitHub p99 latency is far below this
+
+
+def parse_semver(tag: str) -> tuple[int, ...] | None:
+    """'v2.34.0' / '2.34.0' -> (2, 34, 0); None when the tag is not semver."""
+    m = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", tag.strip())
+    if m is None:
+        return None
+    return tuple(int(g) for g in m.groups())
+
+
+def latest_release_tag(repo: str) -> str:
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/releases/latest",
+        headers=_headers(),
+    )
+    with urllib.request.urlopen(req, timeout=API_TIMEOUT_S) as resp:
+        return json.load(resp)["tag_name"]
+
+
+def _headers() -> dict[str, str]:
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "cortex-pin-gate"}
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def check_github_pin(
+    name: str, repo: str, pin: str, fetch=latest_release_tag
+) -> str | None:
+    tag = fetch(repo)
+    latest, pinned = parse_semver(tag), parse_semver(pin)
+    if latest is None or pinned is None:
+        return f"UNPARSEABLE: {name}: pin={pin!r} latest tag={tag!r} (non-semver; inspect manually)"
+    if pinned < latest:
+        return (
+            f"PIN_BEHIND_RELEASE: {name}: marketplace pins {pin} but {repo} "
+            f"latest release is {tag} — the release was never delivered to installs"
+        )
+    return None
+
+
+def check_self_pin(name: str, source: str, pin: str, root: Path) -> str | None:
+    plugin_json = (root / source / ".claude-plugin" / "plugin.json").resolve()
+    if not plugin_json.is_file():
+        plugin_json = (root / source / "plugin.json").resolve()
+    if not plugin_json.is_file():
+        return None  # local plugin without its own manifest (e.g. shim dirs) — pin is authoritative
+    actual = json.loads(plugin_json.read_text()).get("version", "")
+    if actual and actual != pin:
+        return (
+            f"SELF_PIN_MISMATCH: {name}: marketplace pins {pin} but "
+            f"{plugin_json.relative_to(root)} says {actual}"
+        )
+    return None
+
+
+def main() -> int:
+    if not MARKETPLACE.is_file():
+        print(f"ERROR: {MARKETPLACE} not found", file=sys.stderr)
+        return 2
+    root = MARKETPLACE.parent.parent
+    data = json.loads(MARKETPLACE.read_text())
+    failures: list[str] = []
+    for plugin in data.get("plugins", []):
+        name, pin, source = (
+            plugin.get("name", "?"),
+            plugin.get("version", ""),
+            plugin.get("source"),
+        )
+        if not pin:
+            continue
+        if isinstance(source, dict) and source.get("source") == "github":
+            issue = check_github_pin(name, source["repo"], pin)
+        elif isinstance(source, str):
+            issue = check_self_pin(name, source, pin, root)
+        else:
+            issue = None
+        if issue:
+            failures.append(issue)
+    for f in failures:
+        print(f)
+    if failures:
+        print(
+            f"\n{len(failures)} stale pin(s). Bump .claude-plugin/marketplace.json — a release is not shipped until its pin moves."
+        )
+        return 1
+    print("All marketplace pins current.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests_py/scripts/test_check_marketplace_pins.py
+++ b/tests_py/scripts/test_check_marketplace_pins.py
@@ -1,74 +1,169 @@
-"""Tests for scripts/check_marketplace_pins.py — the pin-staleness gate (#179)."""
+"""Tests for scripts/check_marketplace_pins.py — pin-staleness gate (#179).
+
+Written unittest-style on purpose: the byte-identical AP copy runs them via
+plain `python3 -m unittest` (no pytest there); Cortex's pytest collects
+unittest classes natively.
+"""
 
 from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
+import unittest
+import urllib.error
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 _spec = importlib.util.spec_from_file_location(
     "check_marketplace_pins",
     Path(__file__).resolve().parents[2] / "scripts" / "check_marketplace_pins.py",
 )
-cmp_mod = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(cmp_mod)
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
 
 
-class TestParseSemver:
+def _git_repo_with_tags(root: str, tags: list[str]) -> Path:
+    p = Path(root)
+    subprocess.run(["git", "-C", root, "init", "-q"], check=True)
+    subprocess.run(
+        ["git", "-C", root, "commit", "-q", "--allow-empty", "-m", "x"],
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        },
+    )
+    for t in tags:
+        subprocess.run(["git", "-C", root, "tag", t], check=True)
+    return p
+
+
+class TestParseSemver(unittest.TestCase):
     def test_v_prefix_and_bare(self):
-        assert cmp_mod.parse_semver("v2.34.0") == (2, 34, 0)
-        assert cmp_mod.parse_semver("2.7.1") == (2, 7, 1)
+        self.assertEqual(gate.parse_semver("v2.34.0"), (2, 34, 0))
+        self.assertEqual(gate.parse_semver("2.7.1"), (2, 7, 1))
 
-    def test_non_semver_returns_none(self):
-        assert cmp_mod.parse_semver("release-candidate") is None
-        assert cmp_mod.parse_semver("2.34") is None
+    def test_non_semver_none(self):
+        self.assertIsNone(gate.parse_semver("nightly"))
+        self.assertIsNone(gate.parse_semver("2.34"))
 
     def test_numeric_not_lexicographic(self):
-        # 2.9.0 < 2.10.0 numerically; lexicographic comparison would invert this.
-        assert cmp_mod.parse_semver("2.9.0") < cmp_mod.parse_semver("2.10.0")
+        self.assertLess(gate.parse_semver("2.9.0"), gate.parse_semver("2.10.0"))
 
 
-class TestPinBehindRelease:
-    def test_stale_pin_flagged(self):
-        issue = cmp_mod.check_github_pin(
-            "p", "o/r", "2.29.0", fetch=lambda repo: "v2.34.0"
+class TestPinBehindTag(unittest.TestCase):
+    """The review's replay: both manifests agree AND both are stale (#67)."""
+
+    def test_incident_replay_both_manifests_stale_tag_ahead(self):
+        with TemporaryDirectory() as d:
+            root = _git_repo_with_tags(d, ["v0.7.0", "v0.8.0", "v0.8.1", "v0.8.2"])
+            plug = root / ".claude-plugin"
+            plug.mkdir()
+            (plug / "plugin.json").write_text(json.dumps({"version": "0.8.0"}))
+            failures = gate.check_self_pin("ap", "./", "0.8.0", root)
+            joined = "\n".join(failures)
+            self.assertIn("PIN_BEHIND_TAG", joined)  # detection ORIGINATES here
+            self.assertNotIn("SELF_PIN_MISMATCH", joined)  # manifests agree
+            self.assertIn("2 release(s)", joined)  # v0.8.1 + v0.8.2 counted
+
+    def test_current_pin_green(self):
+        with TemporaryDirectory() as d:
+            root = _git_repo_with_tags(d, ["v0.8.2"])
+            plug = root / ".claude-plugin"
+            plug.mkdir()
+            (plug / "plugin.json").write_text(json.dumps({"version": "0.8.2"}))
+            self.assertEqual(gate.check_self_pin("ap", "./", "0.8.2", root), [])
+
+    def test_untagged_repo_no_crash_no_flag(self):
+        with TemporaryDirectory() as d:
+            root = _git_repo_with_tags(d, [])
+            self.assertEqual(gate.check_self_pin("p", "./", "1.0.0", root), [])
+
+    def test_frozen_pin_skips_tag_check_keeps_coherence(self):
+        with TemporaryDirectory() as d:
+            root = _git_repo_with_tags(d, ["v4.16.0"])
+            shim = root / "shim" / ".claude-plugin"
+            shim.mkdir(parents=True)
+            (shim / "plugin.json").write_text(json.dumps({"version": "4.15.0"}))
+            gate.FROZEN_PINS["frozen-test"] = "test"
+            try:
+                self.assertEqual(
+                    gate.check_self_pin("frozen-test", "shim", "4.15.0", root), []
+                )
+                (shim / "plugin.json").write_text(json.dumps({"version": "9.9.9"}))
+                failures = gate.check_self_pin("frozen-test", "shim", "4.15.0", root)
+                self.assertIn("SELF_PIN_MISMATCH", "\n".join(failures))
+            finally:
+                gate.FROZEN_PINS.pop("frozen-test")
+
+
+class TestGithubPin(unittest.TestCase):
+    def test_stale_flagged_with_count(self):
+        failure, notice = gate.check_github_pin(
+            "p", "o/r", "2.29.0", fetch=lambda r: "v2.34.0", count=lambda *a: 6
         )
-        assert issue is not None and "PIN_BEHIND_RELEASE" in issue
+        self.assertIn("PIN_BEHIND_RELEASE", failure)
+        self.assertIn("6 release(s)", failure)
+        self.assertIsNone(notice)
 
-    def test_current_pin_passes(self):
-        assert (
-            cmp_mod.check_github_pin("p", "o/r", "2.34.0", fetch=lambda repo: "v2.34.0")
-            is None
+    def test_stale_flagged_count_degraded(self):
+        failure, _ = gate.check_github_pin(
+            "p", "o/r", "2.29.0", fetch=lambda r: "v2.34.0", count=lambda *a: None
+        )
+        self.assertIn("PIN_BEHIND_RELEASE", failure)
+        self.assertNotIn("None", failure)
+
+    def test_current_and_ahead_pass(self):
+        self.assertEqual(
+            gate.check_github_pin("p", "o/r", "2.34.0", fetch=lambda r: "v2.34.0"),
+            (None, None),
+        )
+        self.assertEqual(
+            gate.check_github_pin("p", "o/r", "2.35.0", fetch=lambda r: "v2.34.0"),
+            (None, None),
         )
 
-    def test_pin_ahead_passes(self):
-        # Pin ahead of the latest release (pre-release pin) is not a staleness failure.
-        assert (
-            cmp_mod.check_github_pin("p", "o/r", "2.35.0", fetch=lambda repo: "v2.34.0")
-            is None
+    def test_network_failure_degrades_to_notice(self):
+        def down(_repo):
+            raise urllib.error.URLError("offline")
+
+        failure, notice = gate.check_github_pin("p", "o/r", "2.29.0", fetch=down)
+        self.assertIsNone(failure)  # fail-open: no red run from an outage
+        self.assertIn("network degraded", notice)
+
+    def test_no_releases_repo_is_notice_not_keyerror(self):
+        failure, notice = gate.check_github_pin(
+            "p", "o/r", "1.0.0", fetch=lambda r: None
         )
+        self.assertIsNone(failure)
+        self.assertIn("no published releases", notice)
 
-    def test_unparseable_tag_reported_not_crashed(self):
-        issue = cmp_mod.check_github_pin(
-            "p", "o/r", "2.34.0", fetch=lambda repo: "nightly"
+    def test_unparseable_tag_reported(self):
+        failure, _ = gate.check_github_pin(
+            "p", "o/r", "1.0.0", fetch=lambda r: "nightly"
         )
-        assert issue is not None and "UNPARSEABLE" in issue
+        self.assertIn("UNPARSEABLE", failure)
 
 
-class TestSelfPinMismatch:
-    def test_mismatch_flagged(self, tmp_path):
-        plugin_dir = tmp_path / "plug" / ".claude-plugin"
-        plugin_dir.mkdir(parents=True)
-        (plugin_dir / "plugin.json").write_text(json.dumps({"version": "4.16.0"}))
-        issue = cmp_mod.check_self_pin("plug", "plug", "4.15.0", tmp_path)
-        assert issue is not None and "SELF_PIN_MISMATCH" in issue
+class TestServerJsonSplit(unittest.TestCase):
+    def test_three_way_split_third_leg_flagged(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "server.json").write_text(json.dumps({"version": "0.8.2"}))
+            issue = gate.check_server_json(root, "0.8.0")
+            self.assertIn("SERVER_JSON_SPLIT", issue)
 
-    def test_match_passes(self, tmp_path):
-        plugin_dir = tmp_path / "plug" / ".claude-plugin"
-        plugin_dir.mkdir(parents=True)
-        (plugin_dir / "plugin.json").write_text(json.dumps({"version": "4.16.0"}))
-        assert cmp_mod.check_self_pin("plug", "plug", "4.16.0", tmp_path) is None
+    def test_aligned_passes_and_absent_passes(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            self.assertIsNone(gate.check_server_json(root, "0.8.2"))
+            (root / "server.json").write_text(json.dumps({"version": "0.8.2"}))
+            self.assertIsNone(gate.check_server_json(root, "0.8.2"))
 
-    def test_manifestless_local_dir_passes(self, tmp_path):
-        (tmp_path / "shim").mkdir()
-        assert cmp_mod.check_self_pin("shim", "shim", "4.15.0", tmp_path) is None
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/scripts/test_check_marketplace_pins.py
+++ b/tests_py/scripts/test_check_marketplace_pins.py
@@ -1,0 +1,74 @@
+"""Tests for scripts/check_marketplace_pins.py — the pin-staleness gate (#179)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "check_marketplace_pins",
+    Path(__file__).resolve().parents[2] / "scripts" / "check_marketplace_pins.py",
+)
+cmp_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cmp_mod)
+
+
+class TestParseSemver:
+    def test_v_prefix_and_bare(self):
+        assert cmp_mod.parse_semver("v2.34.0") == (2, 34, 0)
+        assert cmp_mod.parse_semver("2.7.1") == (2, 7, 1)
+
+    def test_non_semver_returns_none(self):
+        assert cmp_mod.parse_semver("release-candidate") is None
+        assert cmp_mod.parse_semver("2.34") is None
+
+    def test_numeric_not_lexicographic(self):
+        # 2.9.0 < 2.10.0 numerically; lexicographic comparison would invert this.
+        assert cmp_mod.parse_semver("2.9.0") < cmp_mod.parse_semver("2.10.0")
+
+
+class TestPinBehindRelease:
+    def test_stale_pin_flagged(self):
+        issue = cmp_mod.check_github_pin(
+            "p", "o/r", "2.29.0", fetch=lambda repo: "v2.34.0"
+        )
+        assert issue is not None and "PIN_BEHIND_RELEASE" in issue
+
+    def test_current_pin_passes(self):
+        assert (
+            cmp_mod.check_github_pin("p", "o/r", "2.34.0", fetch=lambda repo: "v2.34.0")
+            is None
+        )
+
+    def test_pin_ahead_passes(self):
+        # Pin ahead of the latest release (pre-release pin) is not a staleness failure.
+        assert (
+            cmp_mod.check_github_pin("p", "o/r", "2.35.0", fetch=lambda repo: "v2.34.0")
+            is None
+        )
+
+    def test_unparseable_tag_reported_not_crashed(self):
+        issue = cmp_mod.check_github_pin(
+            "p", "o/r", "2.34.0", fetch=lambda repo: "nightly"
+        )
+        assert issue is not None and "UNPARSEABLE" in issue
+
+
+class TestSelfPinMismatch:
+    def test_mismatch_flagged(self, tmp_path):
+        plugin_dir = tmp_path / "plug" / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text(json.dumps({"version": "4.16.0"}))
+        issue = cmp_mod.check_self_pin("plug", "plug", "4.15.0", tmp_path)
+        assert issue is not None and "SELF_PIN_MISMATCH" in issue
+
+    def test_match_passes(self, tmp_path):
+        plugin_dir = tmp_path / "plug" / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text(json.dumps({"version": "4.16.0"}))
+        assert cmp_mod.check_self_pin("plug", "plug", "4.16.0", tmp_path) is None
+
+    def test_manifestless_local_dir_passes(self, tmp_path):
+        (tmp_path / "shim").mkdir()
+        assert cmp_mod.check_self_pin("shim", "shim", "4.15.0", tmp_path) is None


### PR DESCRIPTION
Closes #179 — releasing a downstream plugin doesn't ship it. Delivery is gated by pins in this repo's `marketplace.json`, and nothing watched them.

## Pins bumped (the six-release gap, closed)

- `zetetic-team-subagents` 2.29.0 → **2.34.0** (withheld: 2.30.0, 2.31.0, 2.32.0, 2.32.1, 2.33.0, 2.34.0 — including §15, the redaction gates, the Fable loops)
- `cortex-viz` 2.6.3 → **2.7.1** (withheld: 2.7.0, 2.7.1)

Eight releases reached zero installs. No error, no warning, no diff — the manifests were internally consistent the whole time, which is why nothing noticed.

## Failure classes

| Class | Detects |
|---|---|
| `PIN_BEHIND_RELEASE` | github-source pin < that repo's latest release — **the class that caused this incident** |
| `PIN_BEHIND_TAG` | local-source pin < this repo's latest semver git tag. Offline, git only. Catches a stale pin **even when every manifest agrees with itself** — the cdeust/automatised-pipeline#67 incident, which a manifest-vs-manifest check reports green on |
| `SELF_PIN_MISMATCH` | local-source pin ≠ the plugin's own `plugin.json` |
| `SERVER_JSON_SPLIT` | `server.json` ≠ the primary marketplace pin — the third version-carrying file |

Two-sided by design per cdeust/zetetic-team-subagents#52: `installed < pin` and `pin < release` are different defects with different owners, and a one-sided check reports false compliance.

## Frozen pins are a declared contract

`FROZEN_PINS` names the deprecation shim (`cortex` 4.15.0, frozen at the hypermnesia-mcp rename) so "intentionally not advancing" is machine-checked and stated at the use site per §8, rather than passing by accident because two files happen to agree. Manifest coherence is still enforced for frozen entries; only the tag-advance check is skipped.

## Degraded modes are explicit, never silent

Network failure, rate limiting and releaseless repos emit `NOTICE: … network degraded` and the run stays green — a gate that goes red on a GitHub blip gets disabled within a month, and then the six-release gap recurs with the gate nominally in place. The summary line reports that notices occurred, so degraded ≠ verified.

## One artifact, not two copies

This file is the **canonical copy**. cdeust/automatised-pipeline carries a byte-identical copy and diffs against `Cortex/main` weekly, so the two cannot drift into a version where one is a no-op. Verified identical at time of writing.

> **Merge this before cdeust/automatised-pipeline#68.** Its `canonical-drift` job curls `Cortex/main/scripts/check_marketplace_pins.py`, which 404s until this lands, and `curl -fsSL` fails hard on 404.

## Prevention, not just detection

`CLAUDE.md` gains a **Releasing** section: the checklist ends at the pin bump plus `check_marketplace_pins.py` exiting 0. The gate detects a stale pin; the procedure stops one being created.

---

## Completion Ledger (§13.2)

### Paths introduced → asserting test

| Path / branch | Evidence |
|---|---|
| `parse_semver` v-prefix and bare | `test_v_prefix_and_bare` |
| `parse_semver` non-semver → `None` | `test_non_semver_none` |
| semver compared numerically, not lexicographically | `test_numeric_not_lexicographic` (`2.9.0 < 2.10.0`) |
| `PIN_BEHIND_TAG` fires when both manifests agree but the tag is ahead | `test_incident_replay_both_manifests_stale_tag_ahead` — **fails on the pre-fix code** (§13 G2) |
| `PIN_BEHIND_TAG` silent when current | `test_current_pin_green` (negative assertion, §13 G4) |
| repo with no tags → no crash, no flag | `test_untagged_repo_no_crash_no_flag` |
| frozen pin skips tag check, keeps coherence | `test_frozen_pin_skips_tag_check_keeps_coherence` |
| `PIN_BEHIND_RELEASE` fires, with release count | `test_stale_flagged_with_count` |
| release count unavailable → still flagged | `test_stale_flagged_count_degraded` |
| pin current / pin ahead → pass | `test_current_and_ahead_pass` |
| network failure → NOTICE, no red run | `test_network_failure_degrades_to_notice` |
| repo with no releases (HTTP 404) → notice, not `KeyError` | `test_no_releases_repo_is_notice_not_keyerror` |
| unparseable tag → reported, not crashed | `test_unparseable_tag_reported` |
| `SERVER_JSON_SPLIT` third leg flagged | `test_three_way_split_third_leg_flagged` |
| aligned / absent `server.json` → pass | `test_aligned_passes_and_absent_passes` |

### §13.1 checklist

| Item | State |
|---|---|
| A1 happy path, run output quoted | pre-bump: exit 1 naming exactly the two stale pins; post-bump: exit 0 |
| A2 edge cases | no tags, no releases, unparseable tag, absent `server.json`, manifestless shim, frozen pin — each mapped above |
| A3 every failure arm asserted | 4 failure classes + 2 degraded arms, each with a named test; the emission itself asserted, not a downstream side effect |
| A4 boundary validation | GitHub API JSON and git output parsed defensively; malformed input returns a reported condition, never a traceback |
| A5 invariants | exit codes stated in the module docstring: 0 current (or degraded, with NOTICE), 1 stale, 2 environment error |
| A6 idempotency | read-only; repeated runs are identical |
| B1–B3 concurrency | N/A — single-threaded, no shared state |
| C1 scalability | one API call per github-sourced plugin (3), one `git tag`; bounded by manifest size |
| C2 resource lifecycle | `urlopen` as a context manager with `API_TIMEOUT_S`; no leaked handles |
| C3 hot path | N/A — CI-only gate |
| D1 injection | no shell string interpolation; `subprocess.run` with an argument list |
| D2 untrusted data | GitHub API responses treated as untrusted; missing/malformed fields degrade to a notice |
| D3 secrets | `GITHUB_TOKEN` read from env, never logged; workflow is `permissions: contents: read` |
| E1–E4 interfaces | additive; no consumer contract changed. `FROZEN_PINS` and the canonical-copy coupling are new contracts, declared above and in-file. Cross-platform: git + stdlib only |
| F1 actionable signal | every failure names plugin, pinned version, available version and the release count between them |
| F2 degraded modes named | `NOTICE: … network degraded`, surfaced again in the summary line |
| G1 path→test ledger | above |
| G2 regression test fails pre-fix | `test_incident_replay_both_manifests_stale_tag_ahead` |
| G3 deterministic/isolated | tests build throwaway git repos under `tmp_path`; no fixed paths, no sleeps, no network |
| G4 negative assertions | `test_current_pin_green`, `test_current_and_ahead_pass`, `test_aligned_passes_and_absent_passes` |
| G5 suite executed | 15 unit tests green; full CI green (Lint, Type Check, Build Package, SQLite + Windows suites, Docker smoke, CodeQL) |
| H1 standards | stdlib-only, within size caps, no layer violation |
| H2 readable | one comparison per failure class, no indirection |
| H3 conventions | one language per file; gate isolated under `scripts/`, tests under `tests_py/scripts/` |
| H4 CHANGELOG / docs | `CLAUDE.md` **Releasing** section added; marketplace description corrected for the hypermnesia-mcp rename |
| H5 commit hygiene | conventional messages; pins, gate and docs separable |
| H6 CI green | all checks green on the pushed tree |
| **H7 boy-scout (§14)** | marketplace `metadata.description` was stale on the v4.15.0 rename — corrected here rather than left |

### Verification quoted

```
pre-bump:   exit 1 — PIN_BEHIND_RELEASE ×2 (zetetic-team-subagents 2.29.0<2.34.0, cortex-viz 2.6.3<2.7.1)
post-bump:  exit 0 — All marketplace pins current.
tests:      15 tests, OK
canonical:  diff vs cdeust/automatised-pipeline copy → identical
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gFqzbbNDwPtFzaoGDti7R
