### PR TITLE
test(cold-start): hermetic SessionStart banner — kill live-env dependency (#174 follow-up)

### DIFF
--- a/tests_py/integration/test_cold_start.py
+++ b/tests_py/integration/test_cold_start.py
@@ -41,57 +41,58 @@ def _pg_reachable() -> bool:
 class TestSessionStartHook:
     """Test session_start.py outputs correct context for different DB states."""
 
-    def _run_hook(self, env_overrides: dict | None = None) -> str:
-        """Run session_start.py as subprocess and capture stdout."""
-        hook_path = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "mcp_server",
-            "hooks",
-            "session_start.py",
-        )
-        hook_path = os.path.abspath(hook_path)
-        env = {**os.environ, **(env_overrides or {})}
-        result = subprocess.run(
-            [sys.executable, hook_path],
-            capture_output=True,
-            text=True,
-            timeout=15,
-            env=env,
-        )
-        return result.stdout.strip()
+    def test_normal_session_with_memories(self, tmp_path, monkeypatch, capsys):
+        """When the store has memories, the banner injects context (not cold start).
 
-    def test_normal_session_with_memories(self):
-        """When DB has memories, hook should inject memory context."""
-        from mcp_server.handlers.remember import handler as remember
-        import asyncio
+        Hermetic (issue #174 family — hidden live-environment dependency).
+        The prior version ran ``session_start.py`` as a subprocess with the
+        inherited real environment: the SessionStart backend gate reads the
+        developer's live backend marker (``~/.claude/methodology/backend.json``),
+        the banner then reads the real ``~/.claude/methodology/memory.db`` (or a
+        live PostgreSQL), and the subprocess also spawned detached
+        background consolidate/reanalyze workers against the real HOME. The
+        in-process ``remember`` write landed in the per-process test DB while
+        the subprocess read a *different* live store, so the assertion outcome
+        depended on whose machine ran it — and the raw ``UPDATE ... NOW()`` seed
+        is PostgreSQL-only, silently mismatched under the SQLite default.
 
-        # Store a test memory
-        asyncio.run(
-            remember(
+        Rewritten to the canonical hermetic pattern already used by
+        ``tests_py/hooks/test_sqlite_hook_paths.py``: seed an ephemeral
+        ``SqliteMemoryStore`` in ``tmp_path`` and drive the SQLite banner path
+        (``_sqlite_context``) in-process, asserting the seeded memory is
+        injected and no PostgreSQL install guidance leaks in.
+        """
+        from mcp_server.hooks import session_start
+        from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
+
+        monkeypatch.setenv("CORTEX_MEMORY_STORE_BACKEND", "sqlite")
+        store = SqliteMemoryStore(db_path=str(tmp_path / "memory.db"))
+        try:
+            store.insert_memory(
                 {
                     "content": "Critical architecture: use PostgreSQL for all storage",
-                    "force": True,
+                    "heat": 1.0,
+                    "is_protected": True,
                     "tags": ["_anchor", "architecture"],
                 }
             )
-        )
-        # Mark it as protected/anchored
-        from mcp_server.infrastructure.memory_store import MemoryStore
+            monkeypatch.setattr(
+                "mcp_server.infrastructure.memory_store.get_shared_store",
+                lambda: store,
+            )
+            monkeypatch.setattr(session_start, "_print_external_sources", lambda: None)
 
-        store = MemoryStore()
-        store._conn.execute(
-            "UPDATE memories SET is_protected = TRUE, heat_base = 1.0, "
-            "heat_base_set_at = NOW() "
-            "WHERE content LIKE '%Critical architecture%'"
-        )
-        store.close()
+            session_start._sqlite_context(
+                {"transcript_path": str(tmp_path / "session.jsonl")}
+            )
+        finally:
+            store.close()
 
-        output = self._run_hook()
-        # Should contain memory context, not cold start message
+        output = capsys.readouterr().out
+        # Memory context injected, not a cold-start message.
         assert "Cortex" in output
-        # Should NOT contain setup instructions
+        assert "Critical architecture" in output
+        # And never the PostgreSQL install guidance.
         assert "brew install" not in output
 
     def test_empty_db_with_session_files_auto_backfills(self):


### PR DESCRIPTION
Follow-up to #174 / #180 (merged). The first full-suite run after #180 surfaced two more failures in the same test-isolation family; this PR fixes the one that is a genuine test defect.

## `test_cold_start.py::test_normal_session_with_memories` — live-environment dependency

Root cause: the test ran `session_start.py` as a **subprocess under the inherited real environment**. The SessionStart backend gate reads the developer's live backend marker (`~/.claude/methodology/backend.json`); the banner then reads the real `~/.claude/methodology/memory.db` (or a live PostgreSQL); and the subprocess additionally spawned detached consolidate/reanalyze workers against the real HOME and repo. The in-process `remember` seed landed in the per-process test DB while the subprocess read a *different* live store — so the assertion outcome depended on whose machine ran it (failed on this developer's populated home, passed on an empty CI home). The seed's raw `UPDATE ... NOW()` is also PostgreSQL-only, silently mismatched under the SQLite default.

Fix (test-side — the SQLite banner path itself is already proven correct by `tests_py/hooks/test_sqlite_hook_paths.py`): rewritten to the canonical hermetic pattern — seed an ephemeral `SqliteMemoryStore` in `tmp_path` and drive `_sqlite_context` in-process via a monkeypatched `get_shared_store`, asserting the seeded memory is injected and no PostgreSQL install guidance leaks. Deterministic and environment-independent; same behavior verified (DB has memories -> banner injected, not cold start).

## The second failure — `test_I2_no_unauthorized_heat_writes` — is NOT a code defect

`test_I2` is a stateless static source scan (`rglob mcp_server/**/*.py`, compare `SET heat_base` sites to a line-pinned allow-list). It holds no runtime state, so it cannot carry hidden shared state between tests. Its one observed failure occurred in a working tree a **second concurrent agent was actively mutating** (running its own `pytest tests_py/` and editing `test_I2` + `pg_store.py`/`sqlite_store.py` on another branch in the same checkout); a `git checkout`/edit landing mid-run shifts the pinned offsets so the scan reads source that no longer matches the allow-list. It passes standalone and in every controlled/isolated run — no code change is warranted (hardening the scan against a concurrently-mutated tree would only weaken the invariant it guards).

Gates: `ruff check` + `ruff format --check` pass. Full suite verified green in an isolated worktree (own source via PYTHONPATH, own throwaway DB via conftest), immune to the concurrent agent's mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)