### PR TITLE
feat(response): opt-in tabular encoding for recall responses (#170)

### DIFF
--- a/benchmarks/results/tabular-170/MANIFEST.json
+++ b/benchmarks/results/tabular-170/MANIFEST.json
@@ -1,0 +1,11 @@
+{
+  "issue": 170,
+  "generated_at": "2026-07-25T11:52:46Z",
+  "git_commit": "8817374cfc02bdf50e15810ca1409c8bd7a04e1e",
+  "method": "encode_within_budget(json) vs encode_within_budget(tabular) over recall-shaped memory dicts built from longmemeval haystack turns; size via response_budget.serialized_length; tokens via chars/4 (Claude Code host estimator).",
+  "script": "benchmarks/tabular_170/measure.py",
+  "script_sha256": "501e179e3ba80bd10fb8ba3fbd34f274f4bcbd50414cee467299dd47ff9ad621",
+  "fixture": "benchmarks/longmemeval/longmemeval_s.json",
+  "fixture_sha256": "08d8dad4be43ee2049a22ff5674eb86725d0ce5ff434cde2627e5e8e7e117894",
+  "result": "result.json"
+}

--- a/benchmarks/results/tabular-170/README.md
+++ b/benchmarks/results/tabular-170/README.md
@@ -1,0 +1,50 @@
+# Tabular response encoding — token-delta measurement (issue #170)
+
+Reproduce: `PYTHONPATH=. python3 benchmarks/tabular_170/measure.py`
+
+## Gate
+
+Issue #170: on a fixed recall corpus, tabular encoding that cuts serialized
+size by **≥ 25%** vs current JSON → ship tabular as the default; otherwise keep
+it an opt-in `format` param. See `MANIFEST.json` for sha/date/method and
+`result.json` for the full numbers.
+
+## Result
+
+Corpus: `benchmarks/longmemeval/longmemeval_s.json` haystack turns as recall
+memory bodies, 100 queries × 10 memories, recall's real field set (id, content,
+score, heat, domain, tags, created_at, source). Size = `serialized_length`
+(host char count); tokens = chars/4 (host estimator).
+
+| Encoding | chars | tokens (est) |
+|---|---|---|
+| JSON | 1,146,694 | 286,674 |
+| tabular | 1,086,994 | 271,749 |
+| **reduction** | **5.21%** | **5.21%** |
+
+**Decision: opt-in.** 5.21% ≪ 25%, so tabular is an opt-in `format: "tabular"`
+param; the default stays `format: "json"`.
+
+## Why so much smaller than AP's 48%
+
+Tabular's saving is the fixed field-name overhead removed per item; its
+*fraction* of the payload falls as content grows. AP's 48% was on short symbol
+rows (`qualified_name`/`kind`/`score`) that are almost entirely field names.
+Cortex recall memories carry long prose bodies (fixture median ~376 chars), so
+the content dominates and the field-name dedup is a small fraction.
+
+Sensitivity sweep (10 memories, uniform content length):
+
+| content chars | JSON chars | tabular chars | reduction |
+|---|---|---|---|
+| 24 | 2248 | 1651 | 26.56% |
+| 48 | 2488 | 1891 | 24.00% |
+| 96 | 2968 | 2371 | 20.11% |
+| 192 | 3928 | 3331 | 15.20% |
+| 384 | 5848 | 5251 | 10.21% |
+| 768 | 9688 | 9091 | 6.16% |
+
+Tabular only crosses 25% for heavily-truncated (~24-char) content. The opt-in
+param exists precisely for that regime — a wide sweep where the caller has
+budget-truncated memories and wants the field-name overhead gone — while normal
+recall keeps the richer, self-describing JSON default.

--- a/benchmarks/results/tabular-170/result.json
+++ b/benchmarks/results/tabular-170/result.json
@@ -1,0 +1,56 @@
+{
+  "corpus": "longmemeval_s.json haystack turns as recall memory bodies",
+  "n_queries": 100,
+  "max_results": 10,
+  "fields_per_memory": 8,
+  "totals": {
+    "json_chars": 1146694,
+    "tabular_chars": 1086994,
+    "char_reduction_pct": 5.21,
+    "json_tokens_est": 286674,
+    "tabular_tokens_est": 271748,
+    "token_reduction_pct": 5.21
+  },
+  "decision_threshold_pct": 25.0,
+  "default": "json",
+  "per_query_reduction_pct_min": 3.37,
+  "per_query_reduction_pct_max": 12.2,
+  "sensitivity_by_content_length": [
+    {
+      "content_chars": 24,
+      "json_chars": 2248,
+      "tabular_chars": 1651,
+      "reduction_pct": 26.56
+    },
+    {
+      "content_chars": 48,
+      "json_chars": 2488,
+      "tabular_chars": 1891,
+      "reduction_pct": 24.0
+    },
+    {
+      "content_chars": 96,
+      "json_chars": 2968,
+      "tabular_chars": 2371,
+      "reduction_pct": 20.11
+    },
+    {
+      "content_chars": 192,
+      "json_chars": 3928,
+      "tabular_chars": 3331,
+      "reduction_pct": 15.2
+    },
+    {
+      "content_chars": 384,
+      "json_chars": 5848,
+      "tabular_chars": 5251,
+      "reduction_pct": 10.21
+    },
+    {
+      "content_chars": 768,
+      "json_chars": 9688,
+      "tabular_chars": 9091,
+      "reduction_pct": 6.16
+    }
+  ]
+}

--- a/benchmarks/tabular_170/measure.py
+++ b/benchmarks/tabular_170/measure.py
@@ -1,0 +1,233 @@
+"""Measure the tabular-encoding token delta for recall (issue #170).
+
+The issue gates the default: on a fixed recall corpus, if the tabular encoding
+cuts serialized size by >= 25% vs the current JSON encoding, ship tabular as
+the default (with ``format="json"`` as the escape hatch); otherwise keep it an
+opt-in ``format`` param.
+
+Corpus (committed, reproducible): ``benchmarks/longmemeval/longmemeval_s.json``.
+Its haystack turns are natural conversational text — a faithful proxy for
+recall memory bodies (varied length, real prose), which is what the tabular
+saving is measured against. Each simulated query returns ``MAX_RESULTS``
+recall-shaped memory dicts carrying exactly the fields the recall handler
+emits (id, content, score, heat, domain, tags, created_at, source). We build
+the recall response envelope, then measure it two ways through the SAME code
+paths the handler uses:
+
+  (a) JSON  — ``encode_within_budget(..., "json")``: array of objects.
+  (b) tabular — ``encode_within_budget(..., "tabular")``: columns-once rows.
+
+Size is counted with ``response_budget.serialized_length`` (the exact char
+count the MCP host enforces) and tokens with the host's own estimator
+(chars / 4, round) — source: core/response_budget.py module docstring
+(Claude Code 2.1.170 ``Xz(text) = round(len(text) / 4)``).
+
+Output: a JSON result + MANIFEST under ``benchmarks/results/tabular-170/``.
+Run: ``python3 benchmarks/tabular_170/measure.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from mcp_server.core.response_budget import serialized_length
+from mcp_server.core.tabular_encoding import encode_within_budget
+
+REPO = Path(__file__).resolve().parents[2]
+FIXTURE = REPO / "benchmarks" / "longmemeval" / "longmemeval_s.json"
+OUT_DIR = REPO / "benchmarks" / "results" / "tabular-170"
+
+# Fixed corpus knobs. source: chosen to mirror the recall default
+# (max_results=10, mcp_server/handlers/recall.py inputSchema) over a broad,
+# deterministic query sample; N_QUERIES bounded by fixture size.
+MAX_RESULTS = 10
+N_QUERIES = 100
+
+# The host's own token estimator. source: core/response_budget.py docstring
+# (Claude Code 2.1.170 binary: Xz(text) = round(len(text) / 4)).
+CHARS_PER_TOKEN = 4
+
+
+def _est_tokens(chars: int) -> int:
+    return round(chars / CHARS_PER_TOKEN)
+
+
+def _iter_turn_contents(fixture: dict) -> list[str]:
+    """Flatten every haystack turn's text into one ordered content pool."""
+    contents: list[str] = []
+    for question in fixture:
+        for session in question.get("haystack_sessions", []):
+            for turn in session:
+                if isinstance(turn, dict) and turn.get("content"):
+                    contents.append(turn["content"])
+    return contents
+
+
+def _recall_memory(mid: int, content: str) -> dict:
+    """A recall-shaped memory dict — the exact field set the recall handler
+    emits for a hit (mcp_server/handlers/recall.py outputSchema)."""
+    return {
+        "id": f"11111111-0000-0000-0000-{mid:012d}",
+        "content": content,
+        "score": round(0.95 - (mid % 10) * 0.01, 4),
+        "heat": round(0.5 - (mid % 5) * 0.05, 4),
+        "domain": "cortex",
+        "tags": ["decision", "architecture"],
+        "created_at": "2026-07-25T12:00:00Z",
+        "source": "recall",
+    }
+
+
+def _recall_envelope(memories: list[dict]) -> dict:
+    """The recall response envelope around a memories list (schema-aligned
+    keys only — the same shape recall._handler_impl assembles)."""
+    return {
+        "memories": memories,
+        "count": len(memories),
+        "intent": "semantic",
+        "low_signal_dropped": 0,
+        "dispatch_tier": "pg",
+    }
+
+
+def measure() -> dict:
+    fixture = json.loads(FIXTURE.read_text())
+    pool = _iter_turn_contents(fixture)
+    if len(pool) < MAX_RESULTS:
+        raise SystemExit(f"corpus too small: {len(pool)} turns")
+
+    per_query: list[dict] = []
+    total_json = 0
+    total_tab = 0
+    cursor = 0
+    for _ in range(N_QUERIES):
+        window = [pool[(cursor + j) % len(pool)] for j in range(MAX_RESULTS)]
+        cursor += MAX_RESULTS
+        memories = [_recall_memory(i, c) for i, c in enumerate(window)]
+
+        json_resp = encode_within_budget(_recall_envelope(memories), "memories", "json")
+        tab_resp = encode_within_budget(
+            _recall_envelope(memories), "memories", "tabular"
+        )
+        json_chars = serialized_length(json_resp)
+        tab_chars = serialized_length(tab_resp)
+        total_json += json_chars
+        total_tab += tab_chars
+        per_query.append(
+            {
+                "json_chars": json_chars,
+                "tabular_chars": tab_chars,
+                "tabular_is": tab_resp["format"],
+                "reduction_pct": round(100 * (json_chars - tab_chars) / json_chars, 2),
+            }
+        )
+
+    char_reduction = 100 * (total_json - total_tab) / total_json
+    tok_json = _est_tokens(total_json)
+    tok_tab = _est_tokens(total_tab)
+    tok_reduction = 100 * (tok_json - tok_tab) / tok_json
+    return {
+        "corpus": "longmemeval_s.json haystack turns as recall memory bodies",
+        "n_queries": N_QUERIES,
+        "max_results": MAX_RESULTS,
+        "fields_per_memory": len(_recall_memory(0, "x")),
+        "totals": {
+            "json_chars": total_json,
+            "tabular_chars": total_tab,
+            "char_reduction_pct": round(char_reduction, 2),
+            "json_tokens_est": tok_json,
+            "tabular_tokens_est": tok_tab,
+            "token_reduction_pct": round(tok_reduction, 2),
+        },
+        "decision_threshold_pct": 25.0,
+        "default": "tabular" if char_reduction >= 25.0 else "json",
+        "per_query_reduction_pct_min": min(q["reduction_pct"] for q in per_query),
+        "per_query_reduction_pct_max": max(q["reduction_pct"] for q in per_query),
+    }
+
+
+def sensitivity_by_content_length() -> list[dict]:
+    """Tabular reduction as a function of memory content length.
+
+    The tabular saving is fixed field-name overhead per item; its FRACTION of
+    the payload therefore falls as content grows. This sweep makes the
+    crossover explicit — short (budget-truncated) memories save a lot, long
+    prose memories save little — which is exactly why the natural-corpus gate
+    lands where it does. Lengths span the budget-truncation regime up to full
+    prose. source: budget truncation produces short content slices
+    (mcp_server/core/response_budget.py water-filling); prose lengths mirror
+    the fixture's own turn-length distribution (median ~376 chars).
+    """
+    rows: list[dict] = []
+    for length in (24, 48, 96, 192, 384, 768):
+        memories = [_recall_memory(i, "x" * length) for i in range(MAX_RESULTS)]
+        json_chars = serialized_length(
+            encode_within_budget(_recall_envelope(memories), "memories", "json")
+        )
+        tab_chars = serialized_length(
+            encode_within_budget(_recall_envelope(memories), "memories", "tabular")
+        )
+        rows.append(
+            {
+                "content_chars": length,
+                "json_chars": json_chars,
+                "tabular_chars": tab_chars,
+                "reduction_pct": round(100 * (json_chars - tab_chars) / json_chars, 2),
+            }
+        )
+    return rows
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(REPO), "rev-parse", "HEAD"], text=True
+        ).strip()
+    except (subprocess.CalledProcessError, OSError):
+        return "unknown"
+
+
+def main() -> None:
+    result = measure()
+    result["sensitivity_by_content_length"] = sensitivity_by_content_length()
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    (OUT_DIR / "result.json").write_text(json.dumps(result, indent=2) + "\n")
+
+    manifest = {
+        "issue": 170,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "git_commit": _git_commit(),
+        "method": (
+            "encode_within_budget(json) vs encode_within_budget(tabular) over "
+            "recall-shaped memory dicts built from longmemeval haystack turns; "
+            "size via response_budget.serialized_length; tokens via chars/4 "
+            "(Claude Code host estimator)."
+        ),
+        "script": "benchmarks/tabular_170/measure.py",
+        "script_sha256": _sha256(Path(__file__).resolve()),
+        "fixture": "benchmarks/longmemeval/longmemeval_s.json",
+        "fixture_sha256": _sha256(FIXTURE),
+        "result": "result.json",
+    }
+    (OUT_DIR / "MANIFEST.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+    t = result["totals"]
+    print(f"queries={result['n_queries']} max_results={result['max_results']}")
+    print(f"json_chars={t['json_chars']}  tabular_chars={t['tabular_chars']}")
+    print(f"char_reduction={t['char_reduction_pct']}%")
+    print(f"token_reduction={t['token_reduction_pct']}%")
+    print(
+        f"default -> {result['default']} (threshold {result['decision_threshold_pct']}%)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_server/core/tabular_encoding.py
+++ b/mcp_server/core/tabular_encoding.py
@@ -1,0 +1,164 @@
+"""Tabular (columns-once, rows-as-arrays) encoding for homogeneous MCP lists.
+
+A homogeneous result list — every item a dict sharing the same field set —
+repeats every key on every item when serialized as an array of objects. For
+a recall response of N memories that is N copies of ``"id"``, ``"content"``,
+``"score"``, ``"heat"``, … on the wire. The tabular encoding declares the
+column names ONCE and streams each item as an array of cells in column order,
+so the field names are paid for once instead of N times. The saving grows with
+N and with the number of fields; it is exactly the field-name overhead removed.
+
+Reference: cdeust/automatised-pipeline ``src/token_surface.rs`` (issue AP-#56),
+itself an AP-idiomatic reimplementation of the TOON tabular encoding in
+DeusData/codebase-memory-mcp ``src/mcp/compact_out.h`` (columns-once,
+rows-as-arrays). This is the Cortex-Python reimplementation: it stays
+JSON-valued (a client needs no bespoke parser), emits a ``columns`` header plus
+arrays-of-cells, and self-describes with a ``format`` field so the response
+declares its own encoding.
+
+Composition with the response budget (issue #170, contract #1): this transform
+runs AFTER ``response_budget.bound_payload`` has performed selection /
+condensation / water-filling on the object form, and re-checks the SAME budget
+before adopting the tabular shape — it composes with the budget, it does not
+bypass it. Because columns-once is never larger than repeated-keys for lists of
+two or more items, the re-check only ever declines the degenerate single-item
+case (where the object form already fit).
+
+Heterogeneous degradation (issue #170, contract #3): water-filling marks
+condensed items with extra ``truncated`` / ``content_length`` keys, so the list
+handed here is not always uniform. Columns are therefore the UNION of every
+item's keys (first-seen order), and a row carries an explicit ``null`` for any
+column that item lacks. This is lossless for the homogeneous case (no absent
+fields → no nulls) and honest for the mixed case (absent materializes as a
+falsy null, never a fabricated value). No information is lost: every field of
+every item is recoverable by column position (see ``decode_tabular``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_server.core.response_budget import MAX_RESPONSE_CHARS, serialized_length
+
+# The two self-describing encodings a response can declare under ``format``.
+FORMAT_JSON = "json"
+FORMAT_TABULAR = "tabular"
+
+# Chars the self-describing ``format`` field adds to a payload in the worst
+# case (``,"format":"tabular"``). This transform runs AFTER ``bound_payload``
+# has already filled the payload up to the budget, so the field it appends
+# would overshoot the host cap unless that many chars were reserved first.
+# Callers bound against ``reserved_budget(cap)`` so the appended field lands
+# inside the cap. source: exact serialized length of the widest ``format``
+# key/value pair (the ``columns`` header is not reserved here — the tabular
+# branch re-checks the FULL budget and falls back to json when it would not
+# fit, and json is guaranteed to fit by this reservation).
+SELF_DESCRIBE_RESERVE_CHARS = len(',"format":"tabular"')
+
+
+def reserved_budget(budget_chars: int) -> int:
+    """The budget to hand ``bound_payload`` so the later ``format`` field fits.
+
+    precondition: ``budget_chars`` is the host cap the final payload must not
+    exceed. postcondition: returns ``budget_chars`` minus the worst-case
+    ``format``-field cost (never below zero), so a payload bounded to the
+    result still fits the cap once ``encode_within_budget`` appends its
+    self-describing field.
+    """
+    return max(0, budget_chars - SELF_DESCRIBE_RESERVE_CHARS)
+
+
+def parse_format(value: Any) -> str:
+    """Normalize a caller-supplied ``format`` argument.
+
+    precondition: none. postcondition: returns ``FORMAT_TABULAR`` iff
+    ``value`` is exactly the string ``"tabular"``; every other value
+    (including ``None`` and unknown strings) returns ``FORMAT_JSON`` — the
+    unchanged default. An unknown format is not an error: it degrades to the
+    richest encoding rather than rejecting the call.
+    """
+    return FORMAT_TABULAR if value == FORMAT_TABULAR else FORMAT_JSON
+
+
+def derive_columns(items: list[dict]) -> list[str]:
+    """The column header: the union of every item's keys, first-seen order.
+
+    precondition: every element of ``items`` is a dict. postcondition: the
+    result contains each key that appears in at least one item exactly once,
+    ordered by first appearance while scanning items in order. First-seen
+    (not sorted) order keeps the common case — a uniform list — presenting
+    columns in the natural key order the producer emitted.
+    """
+    columns: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        for key in item:
+            if key not in seen:
+                seen.add(key)
+                columns.append(key)
+    return columns
+
+
+def encode_rows(items: list[dict], columns: list[str]) -> list[list[Any]]:
+    """Project each item onto ``columns`` as a cell array.
+
+    precondition: every element of ``items`` is a dict; ``columns`` is the
+    output of ``derive_columns(items)`` (a superset of every item's keys).
+    postcondition: returns one list per item, length ``len(columns)``, where
+    cell ``j`` is ``item[columns[j]]`` if present else ``None``. Item order
+    and cell order are preserved, so an upstream ranking or paging contract
+    is untouched.
+    """
+    return [[item.get(col) for col in columns] for item in items]
+
+
+def decode_tabular(columns: list[str], rows: list[list[Any]]) -> list[dict]:
+    """Inverse of ``encode_rows`` — reconstruct the objects from the table.
+
+    precondition: every row has length ``len(columns)``. postcondition:
+    returns one dict per row mapping ``columns[j] -> row[j]``, so every field
+    of every original item is recovered by column position (the
+    no-information-loss guarantee; absent-in-original fields come back as the
+    explicit ``None`` the encoder wrote). Used by round-trip tests and any
+    client that prefers objects.
+    """
+    return [dict(zip(columns, row)) for row in rows]
+
+
+def encode_within_budget(
+    payload: dict,
+    list_key: str,
+    fmt: str,
+    budget_chars: int = MAX_RESPONSE_CHARS,
+) -> dict:
+    """Self-describe ``payload`` and, when asked, tabularize its list.
+
+    precondition: ``payload`` is a dict already within ``budget_chars`` in its
+    object form (``bound_payload`` ran first); ``fmt`` is a ``parse_format``
+    result. postcondition: ``payload["format"]`` is always set. When ``fmt``
+    is ``FORMAT_TABULAR`` AND ``payload[list_key]`` is a non-empty list of
+    dicts AND the tabular form fits ``budget_chars``, returns a dict whose
+    ``list_key`` holds cell-arrays, with a ``columns`` header and
+    ``format="tabular"``. Otherwise the object form is returned unchanged with
+    ``format="json"``. The budget re-check is what makes this compose with —
+    not bypass — the response budget: a degenerate list whose tabular form
+    would overflow keeps the object form that already fit.
+    """
+    payload["format"] = FORMAT_JSON
+    if fmt != FORMAT_TABULAR:
+        return payload
+    items = payload.get(list_key)
+    if not isinstance(items, list) or not items:
+        return payload
+    if not all(isinstance(item, dict) for item in items):
+        return payload
+    columns = derive_columns(items)
+    candidate = {
+        **payload,
+        list_key: encode_rows(items, columns),
+        "columns": columns,
+        "format": FORMAT_TABULAR,
+    }
+    if serialized_length(candidate) > budget_chars:
+        return payload
+    return candidate

--- a/mcp_server/handlers/recall.py
+++ b/mcp_server/handlers/recall.py
@@ -18,6 +18,11 @@ from mcp_server.core.knowledge_graph import extract_entities
 from mcp_server.core.pg_recall import recall as pg_recall
 from mcp_server.core.query_intent import QueryIntent, classify_query_intent
 from mcp_server.core.response_budget import ListTarget, bound_payload
+from mcp_server.core.tabular_encoding import (
+    encode_within_budget,
+    parse_format,
+    reserved_budget,
+)
 from mcp_server.handlers._tool_meta import NON_IDEMPOTENT_WRITE
 from mcp_server.handlers.injection_receipts import emit_injection_receipt
 from mcp_server.handlers.recall_helpers import (
@@ -47,38 +52,90 @@ schema = {
         "properties": {
             "memories": {
                 "type": "array",
-                "description": "Ranked list of matching memories. Best result is index 0.",
+                "description": (
+                    "Ranked list of matching memories. Best result is index 0. "
+                    'With ``format: "json"`` (default) each element is a '
+                    'memory object; with ``format: "tabular"`` each element '
+                    "is a cell array whose fields are named once in the "
+                    "sibling ``columns`` header (issue #170)."
+                ),
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "id": {"type": "string", "description": "Memory UUID."},
-                        "content": {"type": "string", "description": "Memory body."},
-                        "score": {
-                            "type": "number",
-                            "description": "Final fused + reranked score.",
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "description": "Memory UUID.",
+                                },
+                                "content": {
+                                    "type": "string",
+                                    "description": "Memory body.",
+                                },
+                                "score": {
+                                    "type": "number",
+                                    "description": "Final fused + reranked score.",
+                                },
+                                "heat": {
+                                    "type": "number",
+                                    "description": "Current thermodynamic heat [0,1].",
+                                },
+                                "domain": {"type": "string"},
+                                "tags": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                                "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                },
+                                "source": {"type": "string"},
+                                "truncated": {
+                                    "type": "boolean",
+                                    "description": (
+                                        "Present and true when content was cut "
+                                        "to fit the response budget. Fetch the "
+                                        "full body via the memory_id argument."
+                                    ),
+                                },
+                                "content_length": {
+                                    "type": "integer",
+                                    "description": (
+                                        "Original content size in chars (set "
+                                        "when truncated)."
+                                    ),
+                                },
+                            },
                         },
-                        "heat": {
-                            "type": "number",
-                            "description": "Current thermodynamic heat [0,1].",
-                        },
-                        "domain": {"type": "string"},
-                        "tags": {"type": "array", "items": {"type": "string"}},
-                        "created_at": {"type": "string", "format": "date-time"},
-                        "source": {"type": "string"},
-                        "truncated": {
-                            "type": "boolean",
+                        {
+                            "type": "array",
                             "description": (
-                                "Present and true when content was cut to fit "
-                                "the response budget. Fetch the full body via "
-                                "the memory_id argument."
+                                "Tabular row (format=tabular): cells in the "
+                                "order named by the ``columns`` header."
                             ),
                         },
-                        "content_length": {
-                            "type": "integer",
-                            "description": "Original content size in chars (set when truncated).",
-                        },
-                    },
+                    ],
                 },
+            },
+            "columns": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Present only when ``format`` is ``tabular``: the field "
+                    "names, in order, that each row array in ``memories`` "
+                    "carries. Declared once so field names are not repeated "
+                    "per memory (issue #170)."
+                ),
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "tabular"],
+                "description": (
+                    "The encoding applied to ``memories``: ``json`` (array of "
+                    "objects, default) or ``tabular`` (array of cell arrays + "
+                    "a ``columns`` header). Self-describes the response so a "
+                    "client reads rows correctly without guessing."
+                ),
             },
             "intent": {
                 "type": "string",
@@ -300,6 +357,23 @@ schema = {
                 "default": 0,
                 "minimum": 0,
             },
+            "format": {
+                "type": "string",
+                "enum": ["json", "tabular"],
+                "description": (
+                    "Wire encoding for the ``memories`` list. ``json`` "
+                    "(default) returns an array of memory objects. "
+                    "``tabular`` declares the field names once in a "
+                    "``columns`` header and returns each memory as a cell "
+                    "array in that order, which drops the per-item repetition "
+                    "of field names on homogeneous result sets (issue #170). "
+                    "No information is lost — every field is recoverable by "
+                    "column position, and ids stay present for fetch-by-id. "
+                    "Applied after the response-budget water-filling, so the "
+                    "same budget cap still holds."
+                ),
+                "default": "json",
+            },
         },
     },
 }
@@ -416,17 +490,23 @@ def _track_recall_replay(results: list[dict], store: Any) -> None:
         track_replay_event(mem_id, store)
 
 
-def _fetch_by_id(memory_id: int, content_offset: int) -> dict[str, Any]:
+def _fetch_by_id(
+    memory_id: int, content_offset: int, fmt: str = "json"
+) -> dict[str, Any]:
     """Fetch one memory by id — the retrieval path for truncated results.
 
     ``content_offset`` pages through contents larger than the response
     budget: the slice starts there, ``content_length`` carries the full
     size, and ``bound_payload`` marks the slice ``truncated`` if it
-    still overflows.
+    still overflows. ``fmt`` is honored for a self-describing response, but a
+    single-item list rarely benefits from tabular encoding — the budget
+    re-check in ``encode_within_budget`` keeps whichever form fits.
     """
     stored = _get_store().get_memory(memory_id)
     if stored is None:
-        return {"memories": [], "count": 0, "intent": "general"}
+        return encode_within_budget(
+            {"memories": [], "count": 0, "intent": "general"}, "memories", fmt
+        )
     # Copy before mutating: truncation must never write back into
     # whatever object the store handed us.
     memory = {**stored}
@@ -437,25 +517,29 @@ def _fetch_by_id(memory_id: int, content_offset: int) -> dict[str, Any]:
     memory["content_offset"] = content_offset
     resp = {"memories": [memory], "count": 1, "intent": "general"}
     settings = get_memory_settings()
-    return bound_payload(
-        resp, [ListTarget("memories", weight_key="score")], settings.MAX_RESPONSE_CHARS
+    # Bound against the RESERVED budget so appending the self-describing
+    # ``format`` field below cannot push the payload past the host cap.
+    resp = bound_payload(
+        resp,
+        [ListTarget("memories", weight_key="score")],
+        reserved_budget(settings.MAX_RESPONSE_CHARS),
     )
+    return encode_within_budget(resp, "memories", fmt, settings.MAX_RESPONSE_CHARS)
 
 
 async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
     """Retrieve memories: pg_recall base + production enrichments."""
+    fmt = parse_format(args.get("format") if args else None)
     if args and args.get("memory_id") is not None:
         return _fetch_by_id(
-            int(args["memory_id"]), int(args.get("content_offset") or 0)
+            int(args["memory_id"]), int(args.get("content_offset") or 0), fmt
         )
     if not args or not args.get("query"):
         # Issue #46: even the early-return must satisfy the outputSchema's
         # required keys (`memories`).
-        return {
-            "memories": [],
-            "count": 0,
-            "intent": "semantic",
-        }
+        return encode_within_budget(
+            {"memories": [], "count": 0, "intent": "semantic"}, "memories", fmt
+        )
 
     query = args["query"]
     domain, directory = args.get("domain"), args.get("directory")
@@ -559,8 +643,13 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
     # Bounded I/O: the host rejects tool results over its token cap
     # (core/response_budget.py docstring for the measured derivation).
     # Truncated items keep their id; full content via the memory_id arg.
+    # Bound against the RESERVED budget: the self-describing ``format`` field
+    # (and, in tabular mode, the ``columns`` header) is appended after this,
+    # so its worst-case cost is held out of the cap here (issue #170).
     resp = bound_payload(
-        resp, [ListTarget("memories", weight_key="score")], settings.MAX_RESPONSE_CHARS
+        resp,
+        [ListTarget("memories", weight_key="score")],
+        reserved_budget(settings.MAX_RESPONSE_CHARS),
     )
     resp["count"] = len(resp["memories"])
     # Blame path T1 (decision 4255039): the receipt is emitted AFTER
@@ -578,6 +667,12 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
     )
     if receipt_id is not None:
         resp["receipt_id"] = receipt_id
+    # Tabular encoding (issue #170): compose AFTER bound_payload's
+    # selection/condensation and AFTER the receipt (which needs the memory
+    # objects to record ids), re-checking the SAME budget. On homogeneous
+    # sets this declares field names once instead of per memory; json is the
+    # default escape hatch. Truncated items keep their id in either encoding.
+    resp = encode_within_budget(resp, "memories", fmt, settings.MAX_RESPONSE_CHARS)
     return resp
 
 

--- a/mcp_server/tool_registry_memory.py
+++ b/mcp_server/tool_registry_memory.py
@@ -136,6 +136,7 @@ def _register_recall(mcp: FastMCP) -> None:
             max_results: int = 10,
             min_heat: float = 0.05,
             include_related: bool = False,
+            format: str = "json",
         ) -> dict:
             """Retrieve memories using multi-signal fusion."""
             return await safe_handler(
@@ -147,6 +148,7 @@ def _register_recall(mcp: FastMCP) -> None:
                     "max_results": max_results,
                     "min_heat": min_heat,
                     "include_related": include_related,
+                    "format": format,
                 },
                 tool_name="recall",
             )
@@ -165,6 +167,7 @@ def _register_recall(mcp: FastMCP) -> None:
         min_heat: float = 0.05,
         agent_topic: str | None = None,
         include_related: bool = False,
+        format: str = "json",
     ) -> dict:
         """Retrieve memories using multi-signal fusion."""
         return await safe_handler(
@@ -177,6 +180,7 @@ def _register_recall(mcp: FastMCP) -> None:
                 "min_heat": min_heat,
                 "agent_topic": agent_topic,
                 "include_related": include_related,
+                "format": format,
             },
             tool_name="recall",
         )

--- a/tests_py/core/test_tabular_encoding.py
+++ b/tests_py/core/test_tabular_encoding.py
@@ -1,0 +1,226 @@
+"""Tests for core/tabular_encoding — columns-once, rows-as-arrays (issue #170).
+
+The encoding declares a homogeneous list's field names once and streams each
+item as a cell array. These tests pin the four contract properties: no
+information loss (field-set + value equality under round-trip), honest
+heterogeneous degradation (union columns with explicit nulls), the empty and
+single-item edges, and budget composition (the transform never adopts a shape
+that exceeds the response-budget cap).
+"""
+
+from __future__ import annotations
+
+from mcp_server.core.response_budget import serialized_length
+from mcp_server.core.tabular_encoding import (
+    FORMAT_JSON,
+    FORMAT_TABULAR,
+    SELF_DESCRIBE_RESERVE_CHARS,
+    decode_tabular,
+    derive_columns,
+    encode_rows,
+    encode_within_budget,
+    parse_format,
+    reserved_budget,
+)
+
+
+def _mem(mid: str, content: str, **extra) -> dict:
+    return {"id": mid, "content": content, "score": 0.5, "heat": 0.3, **extra}
+
+
+# ── parse_format ──────────────────────────────────────────────────────
+
+
+def test_parse_format_tabular() -> None:
+    assert parse_format("tabular") == FORMAT_TABULAR
+
+
+def test_parse_format_json_is_default() -> None:
+    assert parse_format("json") == FORMAT_JSON
+
+
+def test_parse_format_unknown_degrades_to_json() -> None:
+    assert parse_format(None) == FORMAT_JSON
+    assert parse_format("csv") == FORMAT_JSON
+    assert parse_format(123) == FORMAT_JSON
+
+
+# ── reserved_budget ───────────────────────────────────────────────────
+
+
+def test_reserved_budget_holds_out_the_format_field() -> None:
+    assert reserved_budget(5_000) == 5_000 - SELF_DESCRIBE_RESERVE_CHARS
+
+
+def test_reserved_budget_never_negative() -> None:
+    assert reserved_budget(0) == 0
+
+
+def test_reserve_covers_json_format_field_cost() -> None:
+    # A payload bounded to reserved_budget(cap) still fits `cap` after the
+    # json ``format`` field is appended — the widest reserve covers it.
+    assert len(',"format":"json"') <= SELF_DESCRIBE_RESERVE_CHARS
+
+
+# ── derive_columns ────────────────────────────────────────────────────
+
+
+def test_derive_columns_homogeneous_first_seen_order() -> None:
+    items = [_mem("1", "a"), _mem("2", "b")]
+    assert derive_columns(items) == ["id", "content", "score", "heat"]
+
+
+def test_derive_columns_union_over_heterogeneous() -> None:
+    # Second item carries the water-fill truncation keys; the union must
+    # include them, in first-seen order (base fields, then the new ones).
+    items = [
+        _mem("1", "short"),
+        _mem("2", "cut", truncated=True, content_length=9000),
+    ]
+    assert derive_columns(items) == [
+        "id",
+        "content",
+        "score",
+        "heat",
+        "truncated",
+        "content_length",
+    ]
+
+
+# ── encode / decode round-trip: no information loss ───────────────────
+
+
+def test_homogeneous_round_trip_preserves_every_field() -> None:
+    items = [_mem("1", "alpha"), _mem("2", "beta")]
+    columns = derive_columns(items)
+    rows = encode_rows(items, columns)
+    assert decode_tabular(columns, rows) == items
+
+
+def test_field_set_equality_union_columns(_none=None) -> None:
+    """No information loss (contract #5): the column set equals the union of
+    all item keys, and every original field's value is recovered by position."""
+    items = [
+        _mem("1", "short"),
+        _mem("2", "cut", truncated=True, content_length=9000),
+    ]
+    columns = derive_columns(items)
+    rows = encode_rows(items, columns)
+
+    union = set().union(*(item.keys() for item in items))
+    assert set(columns) == union
+
+    decoded = decode_tabular(columns, rows)
+    for original, back in zip(items, decoded):
+        # Every field present in the original is recovered with its value.
+        assert all(back[k] == original[k] for k in original)
+
+
+def test_heterogeneous_absent_field_materializes_as_null() -> None:
+    items = [
+        _mem("1", "short"),  # no `truncated`
+        _mem("2", "cut", truncated=True),
+    ]
+    columns = derive_columns(items)
+    rows = encode_rows(items, columns)
+    trunc_idx = columns.index("truncated")
+    # First item lacked `truncated` -> explicit None cell, not a fabricated value.
+    assert rows[0][trunc_idx] is None
+    assert rows[1][trunc_idx] is True
+
+
+def test_ids_remain_present_in_rows() -> None:
+    """ids stay fetchable (contract #5): the id column survives encoding."""
+    items = [_mem("uuid-a", "x"), _mem("uuid-b", "y")]
+    columns = derive_columns(items)
+    rows = encode_rows(items, columns)
+    id_idx = columns.index("id")
+    assert [row[id_idx] for row in rows] == ["uuid-a", "uuid-b"]
+
+
+# ── encode_within_budget: composition + self-description ──────────────
+
+
+def test_json_mode_leaves_objects_and_self_describes() -> None:
+    items = [_mem("1", "a"), _mem("2", "b")]
+    payload = {"memories": list(items), "count": 2}
+    out = encode_within_budget(payload, "memories", FORMAT_JSON)
+    assert out["format"] == FORMAT_JSON
+    assert out["memories"] == items
+    assert "columns" not in out
+
+
+def test_tabular_mode_declares_columns_once_and_streams_rows() -> None:
+    items = [_mem("1", "a"), _mem("2", "b")]
+    payload = {"memories": list(items), "count": 2}
+    out = encode_within_budget(payload, "memories", FORMAT_TABULAR)
+    assert out["format"] == FORMAT_TABULAR
+    assert out["columns"] == ["id", "content", "score", "heat"]
+    assert out["memories"] == [
+        ["1", "a", 0.5, 0.3],
+        ["2", "b", 0.5, 0.3],
+    ]
+
+
+def test_tabular_is_smaller_than_json_on_homogeneous_rows() -> None:
+    """The whole point: not repeating field names shrinks the payload. A
+    regression that inflates the tabular form fails here."""
+    items = [_mem(str(i), f"body number {i} with some prose") for i in range(20)]
+    json_payload = {"memories": list(items), "count": 20}
+    tab_payload = encode_within_budget(
+        {"memories": list(items), "count": 20}, "memories", FORMAT_TABULAR
+    )
+    assert tab_payload["format"] == FORMAT_TABULAR
+    assert serialized_length(tab_payload) < serialized_length(json_payload)
+
+
+def test_empty_list_stays_json() -> None:
+    out = encode_within_budget({"memories": [], "count": 0}, "memories", FORMAT_TABULAR)
+    assert out["format"] == FORMAT_JSON
+    assert out["memories"] == []
+    assert "columns" not in out
+
+
+def test_single_item_does_not_overflow_budget() -> None:
+    """Budget composition (contract #1): a single-item list whose tabular form
+    would be larger keeps whichever form fits; neither exceeds the cap."""
+    payload = {"memories": [_mem("1", "solo")], "count": 1}
+    out = encode_within_budget(payload, "memories", FORMAT_TABULAR)
+    # Never overflow, regardless of which encoding was chosen.
+    assert (
+        serialized_length(out)
+        <= serialized_length({"memories": [_mem("1", "solo")], "count": 1})
+        + len('"columns":[],"format":"tabular"')
+        + 64
+    )
+
+
+def test_non_dict_items_stay_json() -> None:
+    """A list of bare scalars (e.g. wiki_list pages) has no columns to
+    declare; the transform declines and keeps json."""
+    out = encode_within_budget({"pages": ["a/b.md", "c/d.md"]}, "pages", FORMAT_TABULAR)
+    assert out["format"] == FORMAT_JSON
+    assert out["pages"] == ["a/b.md", "c/d.md"]
+
+
+def test_tabular_declined_when_it_would_overflow_tiny_budget() -> None:
+    """Force the budget re-check: a tiny cap the object form fits but the
+    tabular form does not -> keep the object form (compose, not bypass)."""
+    items = [_mem("1", "a")]
+    obj_payload = {"memories": list(items), "count": 1}
+    obj_len = serialized_length(obj_payload)
+    # A budget between the object form and the (larger, single-item) tabular
+    # form: tabular must be declined.
+    tab_len = serialized_length(
+        {
+            "memories": encode_rows(items, derive_columns(items)),
+            "count": 1,
+            "columns": derive_columns(items),
+            "format": FORMAT_TABULAR,
+        }
+    )
+    if tab_len > obj_len:
+        budget = tab_len - 1
+        out = encode_within_budget(obj_payload, "memories", FORMAT_TABULAR, budget)
+        assert out["format"] == FORMAT_JSON
+        assert serialized_length(out) <= budget

--- a/tests_py/handlers/test_recall_tabular_format.py
+++ b/tests_py/handlers/test_recall_tabular_format.py
@@ -1,0 +1,191 @@
+"""Integration tests for the recall handler's tabular format (issue #170).
+
+Drives the real ``recall._handler_impl`` with pg_recall, the store, and the
+session registry faked (the harness mirrors
+``test_recall_receipt_session.py``), proving:
+
+  * ``format="json"`` (default) returns memory objects, self-described.
+  * ``format="tabular"`` returns a ``columns`` header + cell-array rows, with
+    no information loss vs the json form (same field set, same values, ids
+    still present).
+  * The tabular response still respects the response-budget cap — the encoding
+    composes with the budget, it does not bypass it.
+  * A single-content fetch-by-id honors the format param.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from mcp_server.core.response_budget import serialized_length
+from mcp_server.core.tabular_encoding import decode_tabular
+from mcp_server.handlers import recall as recall_mod
+from mcp_server.infrastructure.memory_config import get_memory_settings
+
+
+class _FakeStore:
+    """Minimal store double: answers the enrichment path with no-ops and
+    serves ``get_memory`` for the fetch-by-id path."""
+
+    def __init__(self, by_id: dict | None = None) -> None:
+        self._by_id = by_id or {}
+
+    def get_all_active_rules(self) -> list[dict]:
+        return []
+
+    def get_memory(self, mid: int) -> dict | None:
+        return self._by_id.get(mid)
+
+    def insert_injection_receipt(self, *args, **kwargs) -> int:
+        return 1
+
+    def __getattr__(self, name: str):
+        def _noop(*args, **kwargs):
+            return None
+
+        return _noop
+
+
+def _emb() -> bytes:
+    rng = np.random.default_rng(0)
+    v = rng.standard_normal(384).astype(np.float32)
+    v /= np.linalg.norm(v)
+    return v.tobytes()
+
+
+def _canned_results(n: int) -> list[dict]:
+    return [
+        {
+            "memory_id": i,
+            "id": f"uuid-{i}",
+            "content": f"decision {i}: adopt approach {i} for the subsystem",
+            "score": round(0.9 - i * 0.01, 4),
+            "heat": 0.5,
+            "domain": "cortex",
+            "tags": ["decision"],
+        }
+        for i in range(n)
+    ]
+
+
+def _run(monkeypatch: pytest.MonkeyPatch, args: dict, results: list[dict]) -> dict:
+    store = _FakeStore()
+    monkeypatch.setattr(recall_mod, "_get_store", lambda: store)
+    monkeypatch.setattr(recall_mod, "get_embedding_engine", lambda: _emb())
+    monkeypatch.setattr(
+        recall_mod, "pg_recall", lambda **kw: [dict(r) for r in results]
+    )
+    monkeypatch.setattr(recall_mod, "root_agent_topic", lambda: None)
+    monkeypatch.setattr(recall_mod, "current_window_session", lambda: None)
+    return asyncio.run(recall_mod._handler_impl(args))
+
+
+def test_default_format_returns_objects(monkeypatch: pytest.MonkeyPatch) -> None:
+    out = _run(monkeypatch, {"query": "why pgvector"}, _canned_results(5))
+    assert out["format"] == "json"
+    assert "columns" not in out
+    assert all(isinstance(m, dict) for m in out["memories"])
+
+
+def test_tabular_format_returns_columns_and_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    out = _run(
+        monkeypatch, {"query": "why pgvector", "format": "tabular"}, _canned_results(5)
+    )
+    assert out["format"] == "tabular"
+    assert isinstance(out["columns"], list) and out["columns"]
+    assert all(isinstance(row, list) for row in out["memories"])
+    assert all(len(row) == len(out["columns"]) for row in out["memories"])
+
+
+def test_tabular_has_no_information_loss_vs_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Field-set + value equality (contract #5): decoding the tabular rows
+    reproduces exactly the objects the json form returns."""
+    results = _canned_results(6)
+    json_out = _run(monkeypatch, {"query": "q"}, results)
+    tab_out = _run(monkeypatch, {"query": "q", "format": "tabular"}, results)
+
+    decoded = decode_tabular(tab_out["columns"], tab_out["memories"])
+    json_mems = json_out["memories"]
+    assert len(decoded) == len(json_mems)
+    for obj, back in zip(json_mems, decoded):
+        assert set(back.keys()) >= set(obj.keys())
+        assert all(back[k] == obj[k] for k in obj)
+
+
+def test_tabular_ids_remain_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    tab_out = _run(monkeypatch, {"query": "q", "format": "tabular"}, _canned_results(4))
+    id_idx = tab_out["columns"].index("id")
+    assert [row[id_idx] for row in tab_out["memories"]] == [
+        "uuid-0",
+        "uuid-1",
+        "uuid-2",
+        "uuid-3",
+    ]
+
+
+def test_tabular_respects_budget_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Budget composition (contract #1, #6): the tabular output still fits the
+    same cap the object form is bounded to."""
+    budget = get_memory_settings().MAX_RESPONSE_CHARS
+    tab_out = _run(
+        monkeypatch, {"query": "q", "format": "tabular"}, _canned_results(40)
+    )
+    assert serialized_length(tab_out) <= budget
+
+
+def test_tabular_smaller_than_json_on_recall_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    results = _canned_results(30)
+    json_out = _run(monkeypatch, {"query": "q"}, results)
+    tab_out = _run(monkeypatch, {"query": "q", "format": "tabular"}, results)
+    assert serialized_length(tab_out) < serialized_length(json_out)
+
+
+def test_tabular_fits_tight_budget_with_self_describe_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the self-describe overshoot: at a budget the object form
+    fills to the cap, appending ``format``/``columns`` must NOT push the
+    tabular response past the cap (issue #170 budget composition). The reserve
+    holds room for the field before bound_payload runs."""
+
+    class _TightSettings:
+        def __init__(self, base) -> None:
+            self._base = base
+
+        def __getattr__(self, name):
+            if name == "MAX_RESPONSE_CHARS":
+                return 5_000
+            return getattr(self._base, name)
+
+    base = get_memory_settings()
+    tight = _TightSettings(base)
+    monkeypatch.setattr(recall_mod, "get_memory_settings", lambda: tight)
+    fat = [
+        {"memory_id": i, "id": f"uuid-{i}", "content": "x" * 20_000, "score": 0.9}
+        for i in range(5)
+    ]
+    out = _run(monkeypatch, {"query": "q", "format": "tabular"}, fat)
+    assert serialized_length(out) <= 5_000
+
+
+def test_fetch_by_id_honors_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _FakeStore(
+        by_id={7: {"id": "uuid-7", "content": "full body", "score": 0.9}}
+    )
+    monkeypatch.setattr(recall_mod, "_get_store", lambda: store)
+    out = asyncio.run(
+        recall_mod._handler_impl({"query": "x", "memory_id": 7, "format": "tabular"})
+    )
+    # Self-described either way; the single-item budget re-check may keep json,
+    # but the format field must always be present and valid.
+    assert out["format"] in ("json", "tabular")
+    assert out["count"] == 1


### PR DESCRIPTION
Closes #170

## Summary
Adds a columns-once / rows-as-arrays `format: "tabular"` encoding to the recall
response, built INSIDE the existing `response_budget` machinery — it runs after
water-filling selection/condensation and re-checks the same host cap, it does
not bypass the budget. AP-idiomatic reimplementation of
`automatised-pipeline/src/token_surface.rs` (columns header + arrays-of-cells,
JSON-valued, self-describing `format` field), done Cortex-idiomatically in
Python as a pure `core/` module.

## Surfaces chosen (contract #2 — enumerated)
| Surface | Decision | Reason |
|---|---|---|
| **recall** (+ its `_fetch_by_id`) | **included** | Bounded homogeneous list of memory dicts; already on the `bound_payload` path — the one place tabular can compose WITH the budget. |
| recall_hierarchical | excluded | Its `results` list never goes through `bound_payload`; adding tabular there would be a budget-less transform, the opposite of contract #1. |
| wiki_list | excluded | `pages` is a list of bare path **strings** — no per-item fields to declare once, zero tabular benefit. |
| memory_stats | excluded | Scalar counts, not a homogeneous row list. |
| unified_search | excluded | Heterogeneous by construction (memories + wiki + code-graph rows have different shapes). |

## Measurement (contract #4 — the gate)
Fixed corpus: `benchmarks/longmemeval/longmemeval_s.json` haystack turns as
recall memory bodies, 100 queries x 10 memories, recall's exact field set.
Size = `response_budget.serialized_length` (host char count); tokens = chars/4
(host estimator). Committed under `benchmarks/results/tabular-170/` with
MANIFEST (sha256 of script + fixture, date, method). Reproduce:
`PYTHONPATH=. python3 benchmarks/tabular_170/measure.py`.

| Encoding | chars | tokens (est) |
|---|---|---|
| JSON | 1,146,694 | 286,674 |
| tabular | 1,086,994 | 271,749 |
| **reduction** | **5.21%** | **5.21%** |

Sensitivity (why it is small): tabular saves fixed field-name overhead; its
FRACTION falls as content grows. It only crosses 25% at ~24-char
(heavily-truncated) content; at the fixture's ~376-char median it is ~10%.

| content chars | reduction |
|---|---|
| 24 | 26.56% |
| 48 | 24.00% |
| 96 | 20.11% |
| 192 | 15.20% |
| 384 | 10.21% |
| 768 | 6.16% |

## Default decision
**5.21% < 25% → opt-in.** `format: "tabular"` is an opt-in param; the default
stays `format: "json"` (which is also the escape hatch the issue asks for).
Stated plainly: on realistic long-content recall memories the field-name
dedup is a small win, unlike AP's 48% on short symbol rows — the opt-in exists
for the budget-truncated regime where it does pay off.

## No information loss (contract #5)
Columns = union of all item keys; every field recoverable by column position;
absent-in-original fields materialize as explicit `null` (honest degradation
for mixed truncated/full water-filled output, contract #3). ids stay present
in rows. Field-set + value equality asserted in tests.

## Budget composition fix
The wiring tests caught a real bug: appending the self-describing `format`
field AFTER `bound_payload` (which fills to the cap) could overshoot the host
cap by ~17 chars. `reserved_budget()` now holds out the worst-case field cost
before bounding, so both encodings stay within the cap.

## Completion Ledger
- [x] Read `core/response_budget.py` first; tabular composes WITH the budget (encode after selection/condensation, re-check same cap)
- [x] `format: "tabular"` param on recall; default decided by measurement (opt-in)
- [x] Surfaces enumerated (table above)
- [x] Heterogeneous degradation: union columns with explicit nulls, decided from real recall output shapes, documented
- [x] Measurement committed under `benchmarks/results/tabular-170/` with MANIFEST (sha/date/method); ≥25% rule applied → opt-in
- [x] No information loss: ids fetchable, all fields present both encodings; field-set equality asserted in tests
- [x] Tests: encoding units (homogeneous / heterogeneous-degrade / empty / single), integration through real recall handler both formats, budget-composition (tabular respects cap)
- [x] Gates: `ruff check` + `ruff format --check .` (tree-wide) clean; handlers suite 1114 passed / 0 failed; new tabular + budget-wiring tests green. Remaining suite reds are pre-existing PG-absent `UndefinedTable` env failures (verified identical on clean main), not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)