### PR TITLE
feat(mcp): tool profiles + prompts + per-profile instructions (#176, #177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **MCP prompts capability** (#176): `prompts/list` + `prompts/get` publish three guided workflows composed from Cortex's real tool surface — `session_recall` (query_methodology → recall → unified_search → recall_hierarchical → memory_stats), `promote_memories` (episodic→semantic CLS: consolidate → memory_stats → curate_distill → remember), and `curate_wiki` (unified_search → curate_wiki → wiki_write → wiki_verify). Prompt step summaries are pulled from the same handler-schema map (`merged_schemas()`) that `tools/list` is built from, so a prompt's description of a tool cannot drift from the tool's own schema (the #98 drift class). `mcp_server/mcp_prompts.py`.
+- **MCP tool profiles** (#177): a `full`/`lean` profile (`mcp_server/tool_profiles.py`) selected by `--profile` or `CORTEX_MCP_PROFILE`, enforced by `ToolProfileMiddleware`. `lean` advertises the 10-tool recall/onboarding surface (derived from `docs/mcp-tools.md` tiers + the common-session workflow); `full` keeps every tool. Per-profile `initialize.instructions`. Measured: `lean` cuts the per-session `initialize`+`tools/list` cost from ~29.9k to ~7.6k estimated tokens (74.6%), benchmark `benchmarks/mcp_profile_tokens.py`.
+
+### Security
+- Destructive tools (`forget`, `wiki_purge`, `wiki_migrate`) are **gated, not merely hidden** under `lean` (#177 criterion 5): excluded tools are absent from `tools/list` AND rejected on call by `ToolProfileMiddleware.on_call_tool`. Hiding a tool from the list while still executing it on call would be a hole, not a token optimisation. Asserted by `tests_py/test_tool_profiles.py::TestSurface::test_lean_hides_and_rejects_destructive_calls`.
+
+### Changed
+- **The default MCP tool profile is `full`** (behaviour preserved; H4 note). This diverges from #177 criterion 2's "default to the common-session profile": shrinking the default advertised surface is a breaking change (a client that called a now-hidden tool would break), so — mirroring `automatised-pipeline`'s `ToolProfile` reasoning and this wave's explicit decision — `full` stays the default and `lean` is opt-in. Existing sessions are unchanged; the middleware is a pass-through under `full`.
+
 ## [4.16.0] - 2026-07-25
 
 ### Added

--- a/benchmarks/mcp_profile_tokens.py
+++ b/benchmarks/mcp_profile_tokens.py
@@ -1,0 +1,86 @@
+"""Measure the per-session token cost of the initialize + tools/list exchange,
+per tool profile (issue #177 criterion 6).
+
+This is the fixed cost a client pays before the user types anything: the
+`initialize.instructions` string plus every advertised tool's schema in
+`tools/list`. The profile filter reduces the tool set; this benchmark quantifies
+the reduction so the claim "reduces bytes per session" is measured, not asserted.
+
+Token estimate: characters / 4. source: OpenAI tokenizer rule of thumb for
+English text (~4 chars/token), https://platform.openai.com/tokenizer — used
+only as an order-of-magnitude estimate; the exact serialized byte count (also
+reported) is unambiguous and tokenizer-independent.
+
+Run: `python -m benchmarks.mcp_profile_tokens` (from repo root, in the venv).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from fastmcp import Client, FastMCP
+
+from mcp_server import mcp_prompts, tool_profiles
+from mcp_server.__main__ import merged_schemas, register_all
+from mcp_server.tool_profile_middleware import ToolProfileMiddleware
+from mcp_server.tool_profiles import ToolProfile
+
+_CHARS_PER_TOKEN = 4  # source: OpenAI tokenizer rule of thumb (see module docstring)
+
+
+def _build(profile: ToolProfile) -> FastMCP:
+    server = FastMCP(
+        name="bench", version="0", instructions=tool_profiles.instructions(profile)
+    )
+    register_all(server, codebase=False, prd=False)
+    mcp_prompts.register_prompts(server, merged_schemas())
+    server.add_middleware(ToolProfileMiddleware(profile))
+    return server
+
+
+async def _list_tools_payload(server: FastMCP) -> tuple[int, str]:
+    async with Client(server) as client:
+        tools = await client.list_tools()
+        return len(tools), json.dumps([t.model_dump(mode="json") for t in tools])
+
+
+def _measure(profile: ToolProfile) -> dict[str, int]:
+    # Build the server on the main thread first: register_all internally calls
+    # asyncio.run (apply_param_docs), which cannot run inside a live loop.
+    server = _build(profile)
+    tool_count, tools_payload = asyncio.run(_list_tools_payload(server))
+    instructions = tool_profiles.instructions(profile)
+    chars = len(tools_payload) + len(instructions)
+    return {
+        "tools": tool_count,
+        "instructions_chars": len(instructions),
+        "tools_list_chars": len(tools_payload),
+        "total_chars": chars,
+        "est_tokens": chars // _CHARS_PER_TOKEN,
+    }
+
+
+def main() -> None:
+    rows = {p.value: _measure(p) for p in (ToolProfile.FULL, ToolProfile.LEAN)}
+    full, lean = rows["full"], rows["lean"]
+    print("initialize + tools/list per-session cost by profile")
+    print("-" * 60)
+    for name, r in rows.items():
+        print(
+            f"{name:5} tools={r['tools']:2d} "
+            f"instructions={r['instructions_chars']:5d}c "
+            f"tools/list={r['tools_list_chars']:6d}c "
+            f"total={r['total_chars']:6d}c ~{r['est_tokens']:5d} tok"
+        )
+    saved = full["total_chars"] - lean["total_chars"]
+    pct = 100 * saved / full["total_chars"] if full["total_chars"] else 0
+    print("-" * 60)
+    print(
+        f"lean saves {saved} chars (~{saved // _CHARS_PER_TOKEN} tokens), "
+        f"{pct:.1f}% of the full initialize+tools/list cost"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -41,6 +41,8 @@ except Exception:
 from fastmcp import FastMCP
 
 from mcp_server import (
+    mcp_prompts,
+    tool_profiles,
     tool_registry_advanced,
     tool_registry_core,
     tool_registry_ingest,
@@ -50,6 +52,7 @@ from mcp_server import (
     tool_registry_wiki,
 )
 from mcp_server.core import telemetry
+from mcp_server.tool_profile_middleware import ToolProfileMiddleware
 from mcp_server.core.wiki_axis_registry import configure_default_wiki_root
 from mcp_server.core.wiki_classifier import configure_user_rules_provider
 from mcp_server.handlers._tool_meta import apply_param_docs
@@ -80,20 +83,46 @@ configure_user_rules_provider(lambda: load_registry(WIKI_ROOT).rules)
 # for every existing deployment.
 telemetry.set_exporter(build_otel_exporter())
 
+# ── Active tool profile (issue #177) ───────────────────────────────────────
+#
+# Resolved once at startup from --profile / CORTEX_MCP_PROFILE, defaulting to
+# FULL. The default stays FULL because shrinking the advertised surface is a
+# breaking change (a client that called a now-hidden tool breaks) — this
+# diverges from #177 criterion 2 and is recorded in CHANGELOG.md, mirroring
+# automatised-pipeline's ToolProfile reasoning.
+ACTIVE_PROFILE = tool_profiles.resolve()
+
 # ── Server Instance ────────────────────────────────────────────────────────
 
 mcp = FastMCP(
     name="methodology-agent",
     version="1.0.0",
-    instructions=(
-        "Cortex cognitive profiling system for Claude Code. "
-        "Extracts reasoning signatures from session history and pre-loads them at session start. "
-        "Call query_methodology at the beginning of every session. "
-        "Use remember/recall for persistent thermodynamic memory across sessions."
-    ),
+    # Per-profile instructions: the server describes itself in the shape it was
+    # started in (issue #177 criterion 3). FULL keeps the historical onboarding
+    # line ("Call query_methodology…").
+    instructions=tool_profiles.instructions(ACTIVE_PROFILE),
 )
 
 # ── Tool Registration ──────────────────────────────────────────────────────
+
+
+def merged_schemas() -> dict[str, dict]:
+    """The tool-name → handler-schema map, merged across every registry.
+
+    Single source of truth for both ``apply_param_docs`` (client-visible
+    parameter docs) and ``mcp_prompts`` (prompt step summaries), so a prompt's
+    description of a tool cannot drift from the tool's own schema (#176
+    criterion 3, the #98 drift class).
+    """
+    return {
+        **tool_registry_core.SCHEMAS,
+        **tool_registry_memory.SCHEMAS,
+        **tool_registry_manage.SCHEMAS,
+        **tool_registry_nav.SCHEMAS,
+        **tool_registry_advanced.SCHEMAS,
+        **tool_registry_wiki.SCHEMAS,
+        **tool_registry_ingest.SCHEMAS,
+    }
 
 
 def register_all(mcp: FastMCP, *, codebase: bool, prd: bool) -> None:
@@ -119,18 +148,7 @@ def register_all(mcp: FastMCP, *, codebase: bool, prd: bool) -> None:
     # FastMCP derives input schemas from function signatures; project the
     # hand-written inputSchema parameter descriptions onto them so clients
     # (and registry graders) see documented parameters.
-    apply_param_docs(
-        mcp,
-        {
-            **tool_registry_core.SCHEMAS,
-            **tool_registry_memory.SCHEMAS,
-            **tool_registry_manage.SCHEMAS,
-            **tool_registry_nav.SCHEMAS,
-            **tool_registry_advanced.SCHEMAS,
-            **tool_registry_wiki.SCHEMAS,
-            **tool_registry_ingest.SCHEMAS,
-        },
-    )
+    apply_param_docs(mcp, merged_schemas())
 
 
 register_all(
@@ -138,6 +156,25 @@ register_all(
     codebase=codebase_upstream_available(),
     prd=prd_upstream_available(),
 )
+
+# ── Prompts + profile enforcement (issues #176, #177) ───────────────────────
+#
+# Prompts render their step summaries from the same schema map as tools/list
+# (no drift). ToolProfileMiddleware filters the advertised tool/prompt surface
+# to ACTIVE_PROFILE and REJECTS calls to tools the profile excludes — hiding a
+# destructive tool while still executing it on call would be a security hole,
+# not a token optimisation (#177 criterion 5). Under the default FULL profile
+# the middleware is a pass-through, so existing behaviour is unchanged.
+mcp_prompts.register_prompts(mcp, merged_schemas())
+mcp.add_middleware(ToolProfileMiddleware(ACTIVE_PROFILE))
+
+# resources/list interop shim (#176 criterion 4): FastMCP 3.2.4 already answers
+# resources/list and resources/templates/list with empty arrays and declares
+# the capability, so the -32601 failure some clients surface on connect
+# (CBM upstream #958) does not occur here — the framework provides the shim.
+# Verified 2026-07-25 by an in-memory Client round-trip:
+#   list_resources() -> []   list_resource_templates() -> []
+# No code is needed; recorded here per §8 rather than left implicit.
 
 # ── Lifecycle ──────────────────────────────────────────────────────────────
 

--- a/mcp_server/mcp_prompts.py
+++ b/mcp_server/mcp_prompts.py
@@ -1,0 +1,254 @@
+"""MCP prompts for Cortex — ``prompts/list`` + ``prompts/get`` (issue #176).
+
+Cortex registers ~51 tools but exposes no prompts, so every multi-tool
+workflow it supports is discoverable only by reading docs or guessing — and
+those are exactly the compositions where a caller gets the order wrong
+(promotion episodic→semantic, wiki curation, session recall/onboarding). This
+module publishes those compositions as protocol the client can enumerate.
+
+Source of truth (issue #176 criterion 3, the #98 drift class): a prompt step
+names a tool and pulls that tool's one-line summary from the SAME handler
+schema map (``SCHEMAS``) that ``tools/list`` is built from — never a second,
+hand-maintained copy that can drift. ``test_mcp_prompts`` asserts every step
+tool exists in that map.
+
+Profile awareness (issue #177): ``is_available`` decides whether a prompt is
+offered under a profile — a prompt is offered iff the profile registers every
+tool its workflow drives. So ``session_recall`` (all-lean tools) is offered in
+both profiles, while ``promote_memories`` and ``curate_wiki`` (which drive the
+full curation/consolidation surface) are hidden AND gated under ``lean`` by
+``ToolProfileMiddleware``.
+
+Per-argument ``title``: the installed MCP SDK models a prompt argument as
+``name``/``description``/``required`` only (``mcp.types.PromptArgument`` has no
+``title`` field in this protocol version), so the human title is folded into
+each argument's description rather than emitted as a separate field. The
+prompt-level ``title`` IS emitted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from mcp_server.tool_profiles import ToolProfile, allows
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from fastmcp import FastMCP
+
+
+@dataclass(frozen=True)
+class _Step:
+    tool: str
+    guidance: str
+
+
+@dataclass(frozen=True)
+class _Spec:
+    name: str
+    title: str
+    description: str
+    steps: tuple[_Step, ...]
+    closing: str
+
+
+# ── Prompt catalog ──────────────────────────────────────────────────────────
+# Each step's tool must exist in the merged handler SCHEMAS (asserted by test).
+
+SESSION_RECALL = _Spec(
+    name="session_recall",
+    title="Session recall / onboarding",
+    description="Onboard onto a project and recall what Cortex already knows about it.",
+    steps=(
+        _Step(
+            "query_methodology",
+            "Load the cognitive profile + hot memories for this project first.",
+        ),
+        _Step(
+            "recall",
+            "Pull memories relevant to your focus via the 6-signal WRRF fusion.",
+        ),
+        _Step(
+            "unified_search",
+            "Widen to memories + wiki + code in one pass when recall is thin.",
+        ),
+        _Step(
+            "recall_hierarchical",
+            "Zoom out to fractal L0/L1/L2 clusters for the shape, not just hits.",
+        ),
+        _Step(
+            "memory_stats",
+            "Sanity-check store health and coverage before trusting a sparse result.",
+        ),
+    ),
+    closing=(
+        "Absence from recall is not proof of absence — memory decays; widen with "
+        "unified_search or lower thresholds before concluding nothing is stored."
+    ),
+)
+
+PROMOTE_MEMORIES = _Spec(
+    name="promote_memories",
+    title="Promote episodic memories to semantic",
+    description="Consolidate episodic memories into durable semantic knowledge (CLS).",
+    steps=(
+        _Step(
+            "consolidate",
+            "Run the maintenance cycle — this drives CLS episodic→semantic abstraction.",
+        ),
+        _Step(
+            "memory_stats",
+            "Read what consolidation moved: stage counts, semantic vs episodic.",
+        ),
+        _Step(
+            "curate_distill",
+            "Pull understanding-level dossiers (error→success, co-access, entity family) to author lessons from.",
+        ),
+        _Step(
+            "remember",
+            "Write each distilled insight back as a `lesson` memory so it survives as semantic knowledge.",
+        ),
+    ),
+    closing=(
+        "curate_distill returns source material for lesson authoring, not memories — "
+        "do not treat its dossiers as stored. Cite concrete entities in each lesson so "
+        "synaptic tagging can link it to related traces."
+    ),
+)
+
+CURATE_WIKI = _Spec(
+    name="curate_wiki",
+    title="Wiki curation kickoff",
+    description="Turn a topic's memory + code evidence into a verified first-class wiki page.",
+    steps=(
+        _Step(
+            "unified_search",
+            "Gather the memory + code evidence for the topic before writing.",
+        ),
+        _Step(
+            "curate_wiki",
+            "Auto-curate candidate pages from the relevant memory clusters.",
+        ),
+        _Step(
+            "wiki_write",
+            "Author or refine the first-class page (ADR/spec/note) from the curated material.",
+        ),
+        _Step("wiki_verify", "Verify the page's integrity and links before finishing."),
+    ),
+    closing=(
+        "Curate from evidence, not intuition — every claim on the page should trace to a "
+        "memory or code reference you gathered. Verify links so the page stays navigable."
+    ),
+)
+
+_SPECS: tuple[_Spec, ...] = (SESSION_RECALL, PROMOTE_MEMORIES, CURATE_WIKI)
+_SPEC_BY_NAME: dict[str, _Spec] = {s.name: s for s in _SPECS}
+
+PROMPT_NAMES: tuple[str, ...] = tuple(s.name for s in _SPECS)
+
+
+def required_tools(prompt_name: str) -> tuple[str, ...]:
+    """The tools a prompt's workflow drives, or ``()`` if no such prompt."""
+    spec = _SPEC_BY_NAME.get(prompt_name)
+    return tuple(step.tool for step in spec.steps) if spec else ()
+
+
+def is_available(prompt_name: str, profile: ToolProfile) -> bool:
+    """Whether ``prompt_name`` is offered under ``profile``.
+
+    A prompt is offered iff it exists and the profile registers every tool its
+    workflow drives (mirrors ``ToolProfile.allows`` for tools).
+    """
+    tools = required_tools(prompt_name)
+    return bool(tools) and all(allows(profile, tool) for tool in tools)
+
+
+def tool_summary(schemas: dict[str, dict], tool: str) -> str:
+    """First sentence of ``tool``'s description from the handler schema map.
+
+    Source of truth is ``schemas`` (the same map ``tools/list`` is built from).
+    Returns a backticked fallback if the tool or its description is absent.
+    """
+    description = schemas.get(tool, {}).get("description")
+    if not description:
+        return f"`{tool}`"
+    head, _, _ = description.partition(". ")
+    return head + "." if head else description
+
+
+def _render_body(schemas: dict[str, dict], spec: _Spec, intro: str) -> str:
+    lines = [
+        intro,
+        "",
+        "Cortex's tools compose in a specific order; call them out of order and you "
+        "get an empty or misleading result, not an error. Work them in this order:",
+        "",
+    ]
+    for i, step in enumerate(spec.steps, start=1):
+        lines.append(
+            f"{i}. `{step.tool}` — {tool_summary(schemas, step.tool)} {step.guidance}"
+        )
+    lines += ["", spec.closing]
+    return "\n".join(lines)
+
+
+def register_prompts(mcp: FastMCP, schemas: dict[str, dict]) -> None:
+    """Register every prompt on ``mcp``, rendering bodies from ``schemas``.
+
+    Prompts are registered unconditionally; ``ToolProfileMiddleware`` hides and
+    gates the ones a ``lean`` session cannot run (``is_available``).
+    """
+    _register_session_recall(mcp, schemas)
+    _register_promote_memories(mcp, schemas)
+    _register_curate_wiki(mcp, schemas)
+
+
+def _register_session_recall(mcp: FastMCP, schemas: dict[str, dict]) -> None:
+    @mcp.prompt(
+        name=SESSION_RECALL.name,
+        title=SESSION_RECALL.title,
+        description=SESSION_RECALL.description,
+    )
+    def session_recall(project: str, focus: str = "") -> str:
+        """Guide a recall/onboarding session.
+
+        Args:
+            project: Project — absolute path or project id to onboard onto.
+            focus: Optional focus — a topic or question to steer recall.
+        """
+        intro = f'Onboard onto project "{project}" and recall what Cortex already knows'
+        intro += f" about: {focus}." if focus else "."
+        return _render_body(schemas, SESSION_RECALL, intro)
+
+
+def _register_promote_memories(mcp: FastMCP, schemas: dict[str, dict]) -> None:
+    @mcp.prompt(
+        name=PROMOTE_MEMORIES.name,
+        title=PROMOTE_MEMORIES.title,
+        description=PROMOTE_MEMORIES.description,
+    )
+    def promote_memories(scope: str = "") -> str:
+        """Guide episodic→semantic promotion.
+
+        Args:
+            scope: Optional scope — a domain or project to bound the promotion.
+        """
+        intro = "Promote episodic memories into consolidated semantic knowledge"
+        intro += f' for scope "{scope}".' if scope else "."
+        return _render_body(schemas, PROMOTE_MEMORIES, intro)
+
+
+def _register_curate_wiki(mcp: FastMCP, schemas: dict[str, dict]) -> None:
+    @mcp.prompt(
+        name=CURATE_WIKI.name,
+        title=CURATE_WIKI.title,
+        description=CURATE_WIKI.description,
+    )
+    def curate_wiki(topic: str) -> str:
+        """Guide a wiki curation kickoff.
+
+        Args:
+            topic: Topic — the subject the wiki page should cover.
+        """
+        intro = f'Kick off wiki curation for "{topic}".'
+        return _render_body(schemas, CURATE_WIKI, intro)

--- a/mcp_server/tool_profile_middleware.py
+++ b/mcp_server/tool_profile_middleware.py
@@ -1,0 +1,108 @@
+"""FastMCP middleware enforcing the active tool profile (issue #177).
+
+One place decides what a session sees and what it may run:
+
+- ``on_list_tools`` — filters the advertised tool set to the profile's
+  allowed tools (hides the rest).
+- ``on_call_tool`` — REJECTS a call to a tool the profile excludes. Hiding a
+  tool from ``tools/list`` while still executing it on call is a security
+  hole, not a token optimisation (#177 criterion 5): destructive tools
+  (``forget``, ``wiki_purge``, ``wiki_migrate``, delete-class) must be gated,
+  not merely hidden. Filtering the list AND gating the call closes both.
+- ``on_list_prompts`` / ``on_get_prompt`` — the same rule for prompts: a
+  prompt is offered only when the profile registers every tool its workflow
+  drives (see ``mcp_prompts.required_tools``).
+
+Under the default ``full`` profile every hook is a pass-through, so existing
+behaviour is unchanged — the middleware only bites under ``lean``.
+
+Why middleware and not conditional registration: registration stays in the
+seven ``tool_registry_*`` modules untouched, and profile membership lives in
+exactly one place (``tool_profiles`` + ``mcp_prompts``). Adding a tool never
+requires editing profile code (§1.2 / #177 non-goal).
+
+FastMCP owns the ``tools/list`` response envelope: ``on_list_tools`` returns a
+``Sequence[Tool]`` and cannot set ``nextCursor``. Empirically (FastMCP 3.2.4)
+the framework returns the full allowed set in a single page with no cursor —
+which is exactly #177 criterion 4's mandated absent-cursor behaviour ("returns
+the full allowed set — the one that cannot break existing clients"). We do not
+fork FastMCP's protocol layer to synthesise a cursor; the per-session token
+win comes from the profile filter reducing that set, and is measured in
+``benchmarks/mcp_profile_tokens.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+from fastmcp.exceptions import NotFoundError, PromptError
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+from mcp_server import mcp_prompts, tool_profiles
+from mcp_server.tool_profiles import ToolProfile
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import mcp.types as mt
+    from fastmcp.prompts.prompt import Prompt
+    from fastmcp.tools.tool import Tool, ToolResult
+
+
+class ToolProfileMiddleware(Middleware):
+    """Enforces ``profile`` over the tool and prompt surfaces."""
+
+    def __init__(self, profile: ToolProfile) -> None:
+        self.profile = profile
+
+    # ── Tools ───────────────────────────────────────────────────────────
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next,
+    ) -> Sequence[Tool]:
+        tools = await call_next(context)
+        if self.profile is ToolProfile.FULL:
+            return tools
+        return [t for t in tools if tool_profiles.allows(self.profile, t.name)]
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next,
+    ) -> ToolResult:
+        name = context.message.name
+        if not tool_profiles.allows(self.profile, name):
+            # Excluded tools look exactly like unregistered ones — the profile
+            # IS the registry. This is the security gate: a destructive tool
+            # excluded from the profile is rejected here even though it is a
+            # registered handler.
+            raise NotFoundError(
+                f"Unknown tool: {name} (not registered under the "
+                f"'{self.profile.value}' profile; restart with --profile full "
+                f"to expose every tool)"
+            )
+        return await call_next(context)
+
+    # ── Prompts ─────────────────────────────────────────────────────────
+    async def on_list_prompts(
+        self,
+        context: MiddlewareContext[mt.ListPromptsRequest],
+        call_next,
+    ) -> Sequence[Prompt]:
+        prompts = await call_next(context)
+        if self.profile is ToolProfile.FULL:
+            return prompts
+        return [p for p in prompts if mcp_prompts.is_available(p.name, self.profile)]
+
+    async def on_get_prompt(
+        self,
+        context: MiddlewareContext[mt.GetPromptRequestParams],
+        call_next,
+    ):
+        name = context.message.name
+        if not mcp_prompts.is_available(name, self.profile):
+            raise PromptError(
+                f"Unknown prompt: {name} (not available under the "
+                f"'{self.profile.value}' profile; restart with --profile full "
+                f"to expose every prompt)"
+            )
+        return await call_next(context)

--- a/mcp_server/tool_profiles.py
+++ b/mcp_server/tool_profiles.py
@@ -1,0 +1,191 @@
+"""MCP tool profiles — which of Cortex's ~51 tools a session registers.
+
+Cortex registers its whole tool surface to every client on every session
+(issue #177): the largest fixed token cost in the ecosystem, paid before the
+user types anything. A profile narrows that surface for sessions that only
+need the common recall/onboarding loop, without removing any tool from the
+`full` surface.
+
+Two profiles:
+
+- ``full`` — every registered tool. **The default.** Shrinking the default
+  surface is a breaking change (a client that called a now-hidden tool would
+  break), so — mirroring ``automatised-pipeline``'s ``ToolProfile`` reasoning
+  and this wave's explicit decision — ``full`` stays the default. This
+  diverges from #177 criterion 2's "default to the common-session profile";
+  the divergence and its rationale are recorded in the CHANGELOG and PR.
+- ``lean`` — the recall/onboarding surface an outside agent needs.
+
+Selection precedence: ``--profile`` CLI flag > ``CORTEX_MCP_PROFILE`` env var
+> ``full`` (matches the ``CORTEX_*`` runtime-toggle convention, e.g.
+``CORTEX_RUNTIME``).
+
+LEAN membership derivation (issue #177 criterion 1)
+---------------------------------------------------
+The set is derived from the documented tool tiers (``docs/mcp-tools.md``) and
+the common-session workflow the issue itself characterises: a session doing
+recall/onboarding "never calls ``wiki_migrate``, ``wiki_purge``,
+``rebuild_profiles``, ``import_sessions``, ``backfill_memories`` or
+``forget``". The runtime instrument that refines this per-deployment is
+``get_telemetry`` (per-tool call counts in ``~/.claude/methodology/
+telemetry.jsonl``); no committed telemetry corpus ships in-repo, so member-
+ship is taxonomy-derived here and is intended to be tightened against a
+deployment's own ``get_telemetry`` output rather than guessed wider.
+
+The lean set is exactly the tools the recall/onboarding loop touches:
+  - onboarding entry: ``query_methodology`` (CLAUDE.md: "Call
+    query_methodology at the beginning of every session");
+  - store / retrieve: ``remember``, ``recall``, ``unified_search``,
+    ``recall_hierarchical``;
+  - maintenance the loop runs itself: ``consolidate``;
+  - health / diagnostics: ``memory_stats``, ``check_setup``;
+  - wiki read side ("wiki basics"): ``wiki_read``, ``wiki_list``.
+Every lean tool is read-only or idempotent-write; no destructive tool
+(``forget``, ``wiki_purge``, ``wiki_migrate``, delete-class) is a member, so
+the destructive surface is excluded — and, per criterion 5, gated on call.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from enum import Enum
+
+
+class ToolProfile(str, Enum):
+    """Which tool surface the server exposes for a session."""
+
+    FULL = "full"
+    LEAN = "lean"
+
+
+# CLI flag / env var selecting the profile.
+PROFILE_FLAG = "--profile"
+PROFILE_ENV_VAR = "CORTEX_MCP_PROFILE"
+
+# The recall/onboarding surface. See module docstring for the derivation.
+# source: docs/mcp-tools.md tiers + issue #177 common-session characterisation.
+LEAN_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "query_methodology",
+        "remember",
+        "recall",
+        "unified_search",
+        "recall_hierarchical",
+        "consolidate",
+        "memory_stats",
+        "check_setup",
+        "wiki_read",
+        "wiki_list",
+    }
+)
+
+
+def parse(value: str) -> ToolProfile:
+    """Parse a profile name. Accepts exactly ``full`` and ``lean``.
+
+    Precondition: ``value`` is any string.
+    Postcondition: returns the matching ``ToolProfile`` or raises
+    ``ValueError`` naming the accepted values.
+    """
+    try:
+        return ToolProfile(value)
+    except ValueError:
+        raise ValueError(
+            f"invalid profile {value!r}: expected 'full' or 'lean'"
+        ) from None
+
+
+def resolve(
+    argv: list[str] | None = None, env: dict[str, str] | None = None
+) -> ToolProfile:
+    """Resolve the active profile from CLI args and the environment.
+
+    Precondition: ``argv`` is the process args (program name already stripped
+    is fine; the flag is searched positionally); ``env`` is a mapping.
+    Postcondition: returns the flag's profile if ``--profile`` is present,
+    else the env var's profile if set, else ``ToolProfile.FULL``. Raises
+    ``ValueError`` for an unknown name in either source.
+    """
+    argv = list(argv if argv is not None else sys.argv[1:])
+    env = env if env is not None else dict(os.environ)
+
+    flag_value = _flag_value(argv)
+    if flag_value is not None:
+        return parse(flag_value)
+
+    env_value = env.get(PROFILE_ENV_VAR)
+    if env_value:
+        return parse(env_value)
+
+    return ToolProfile.FULL
+
+
+def _flag_value(argv: list[str]) -> str | None:
+    """Value of ``--profile`` / ``--profile=<v>`` in ``argv``; last wins.
+
+    A trailing ``--profile`` with no value raises ``ValueError``.
+    """
+    found: str | None = None
+    it = iter(range(len(argv)))
+    for i in it:
+        arg = argv[i]
+        if arg == PROFILE_FLAG:
+            if i + 1 >= len(argv):
+                raise ValueError(f"{PROFILE_FLAG} requires a value: 'full' or 'lean'")
+            found = argv[i + 1]
+            next(it, None)  # consume the value
+        elif arg.startswith(PROFILE_FLAG + "="):
+            found = arg[len(PROFILE_FLAG) + 1 :]
+    return found
+
+
+def allows(profile: ToolProfile, tool_name: str) -> bool:
+    """Whether ``tool_name`` is registered under ``profile``.
+
+    ``full`` allows everything; ``lean`` allows exactly ``LEAN_TOOL_NAMES``.
+    """
+    if profile is ToolProfile.FULL:
+        return True
+    return tool_name in LEAN_TOOL_NAMES
+
+
+# ── Per-profile initialize instructions (issue #177 criterion 3) ────────────
+#
+# The server describes itself in the shape it was started in. The FULL text
+# preserves the historical onboarding line ("Call query_methodology…") so
+# existing clients and the `test_mcp_server_has_instructions` contract are
+# unchanged.
+
+FULL_INSTRUCTIONS = (
+    "Cortex cognitive profiling and persistent-memory system for Claude Code "
+    "('full' profile — every tool; the default). "
+    "Extracts reasoning signatures from session history and pre-loads them at "
+    "session start. Call query_methodology at the beginning of every session. "
+    "Use remember/recall for persistent thermodynamic memory across sessions; "
+    "unified_search for retrieval across memories, wiki, and code; consolidate "
+    "for maintenance (decay, compression, episodic→semantic CLS); the wiki_* "
+    "tools for first-class pages; and the navigation tools "
+    "(recall_hierarchical/drill_down/get_causal_chain) to traverse memory. "
+    "Guided multi-tool workflows are published via prompts/list. Restart with "
+    "--profile lean (or CORTEX_MCP_PROFILE=lean) for the recall/onboarding "
+    "subset only."
+)
+
+LEAN_INSTRUCTIONS = (
+    "Cortex persistent-memory system for Claude Code ('lean' profile — the "
+    "recall/onboarding surface). Call query_methodology at the beginning of "
+    "every session to load the cognitive profile, then remember/recall and "
+    "unified_search for persistent memory across sessions, recall_hierarchical "
+    "for fractal recall, consolidate for maintenance, memory_stats/check_setup "
+    "for health, and wiki_read/wiki_list to read the wiki. The full "
+    "profiling, curation, ingestion, and destructive-maintenance surface "
+    "(including forget and the wiki_purge/wiki_migrate class) is hidden AND "
+    "rejected on call in this profile; restart with --profile full to expose "
+    "every tool. The session_recall prompt (prompts/list) guides the loop."
+)
+
+
+def instructions(profile: ToolProfile) -> str:
+    """The ``initialize.instructions`` string for ``profile``."""
+    return LEAN_INSTRUCTIONS if profile is ToolProfile.LEAN else FULL_INSTRUCTIONS

--- a/tests_py/test_mcp_prompts.py
+++ b/tests_py/test_mcp_prompts.py
@@ -1,0 +1,151 @@
+"""Tests for MCP prompts (prompts/list + prompts/get), issue #176."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server import mcp_prompts, tool_profiles
+from mcp_server.__main__ import merged_schemas, register_all
+from mcp_server.tool_profile_middleware import ToolProfileMiddleware
+from mcp_server.tool_profiles import ToolProfile
+
+
+def _build(profile: ToolProfile) -> FastMCP:
+    server = FastMCP(
+        name="t", version="0", instructions=tool_profiles.instructions(profile)
+    )
+    register_all(server, codebase=False, prd=False)
+    mcp_prompts.register_prompts(server, merged_schemas())
+    server.add_middleware(ToolProfileMiddleware(profile))
+    return server
+
+
+def _run(server: FastMCP, coro_fn):
+    async def go():
+        async with Client(server) as client:
+            return await coro_fn(client)
+
+    return asyncio.run(go())
+
+
+# ── source of truth (criterion 3) ───────────────────────────────────────────
+
+
+def test_every_prompt_step_names_a_real_tool():
+    """A prompt step must name a tool present in the merged schema map — the
+    same source of truth as tools/list. Drift here is the #98 defect class."""
+    schemas = merged_schemas()
+    for name in mcp_prompts.PROMPT_NAMES:
+        for tool in mcp_prompts.required_tools(name):
+            assert tool in schemas, f"prompt {name} references unknown tool {tool}"
+
+
+def test_tool_summary_comes_from_schema_description():
+    schemas = merged_schemas()
+    summary = mcp_prompts.tool_summary(schemas, "recall")
+    assert summary
+    assert schemas["recall"]["description"].startswith(summary.rstrip("."))
+
+
+# ── prompts/list per profile (criteria 1, 2) ────────────────────────────────
+
+
+def test_full_lists_all_three_prompts():
+    server = _build(ToolProfile.FULL)
+    names = {p.name for p in _run(server, lambda c: c.list_prompts())}
+    assert names == {"session_recall", "promote_memories", "curate_wiki"}
+
+
+def test_lean_lists_only_session_recall():
+    # promote_memories and curate_wiki drive full-only tools, so lean hides them.
+    server = _build(ToolProfile.LEAN)
+    names = {p.name for p in _run(server, lambda c: c.list_prompts())}
+    assert names == {"session_recall"}
+
+
+def test_every_argument_has_name_description_required():
+    server = _build(ToolProfile.FULL)
+    prompts = _run(server, lambda c: c.list_prompts())
+    for prompt in prompts:
+        for arg in prompt.arguments:
+            assert arg.name
+            assert arg.description  # human title folded into the description
+            assert isinstance(arg.required, bool)
+
+
+# ── prompts/get render (criterion 1) ────────────────────────────────────────
+
+
+def test_get_session_recall_embeds_args_and_canonical_summary():
+    server = _build(ToolProfile.FULL)
+    schemas = merged_schemas()
+
+    async def call(c):
+        return await c.get_prompt(
+            "session_recall", {"project": "/repo", "focus": "auth"}
+        )
+
+    result = _run(server, call)
+    text = result.messages[0].content.text
+    assert "/repo" in text
+    assert "auth" in text
+    assert "`query_methodology`" in text
+    assert mcp_prompts.tool_summary(schemas, "query_methodology") in text
+
+
+def test_get_promote_memories_available_under_full():
+    server = _build(ToolProfile.FULL)
+
+    async def call(c):
+        return await c.get_prompt("promote_memories", {})
+
+    result = _run(server, call)
+    assert "`consolidate`" in result.messages[0].content.text
+
+
+# ── failure arms (criterion 6 / §13 A3) ─────────────────────────────────────
+
+
+def test_unknown_prompt_name_errors():
+    server = _build(ToolProfile.FULL)
+
+    async def call(c):
+        return await c.get_prompt("no_such_prompt", {})
+
+    with pytest.raises(Exception):
+        _run(server, call)
+
+
+def test_missing_required_argument_errors():
+    server = _build(ToolProfile.FULL)
+
+    async def call(c):
+        return await c.get_prompt("session_recall", {})  # 'project' required
+
+    with pytest.raises(Exception):
+        _run(server, call)
+
+
+def test_full_only_prompt_rejected_under_lean():
+    server = _build(ToolProfile.LEAN)
+
+    async def call(c):
+        return await c.get_prompt("promote_memories", {})
+
+    with pytest.raises(Exception) as exc:
+        _run(server, call)
+    assert (
+        "profile" in str(exc.value).lower()
+        or "unknown prompt" in str(exc.value).lower()
+    )
+
+
+def test_is_available_matches_profile_membership():
+    assert mcp_prompts.is_available("session_recall", ToolProfile.LEAN)
+    assert mcp_prompts.is_available("session_recall", ToolProfile.FULL)
+    assert not mcp_prompts.is_available("promote_memories", ToolProfile.LEAN)
+    assert mcp_prompts.is_available("promote_memories", ToolProfile.FULL)
+    assert not mcp_prompts.is_available("no_such_prompt", ToolProfile.FULL)

--- a/tests_py/test_tool_profiles.py
+++ b/tests_py/test_tool_profiles.py
@@ -1,0 +1,130 @@
+"""Tests for MCP tool profiles + the profile-enforcement middleware (#177)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server import mcp_prompts, tool_profiles
+from mcp_server.__main__ import merged_schemas, register_all
+from mcp_server.tool_profile_middleware import ToolProfileMiddleware
+from mcp_server.tool_profiles import ToolProfile
+
+# Destructive tools that MUST be excluded from lean and rejected on call
+# (issue #177 criterion 5). source: annotations.destructiveHint in the
+# handler schemas + docs/mcp-tools.md.
+_DESTRUCTIVE = {"forget", "wiki_purge", "wiki_migrate"}
+
+
+def _build(profile: ToolProfile) -> FastMCP:
+    server = FastMCP(
+        name="t", version="0", instructions=tool_profiles.instructions(profile)
+    )
+    register_all(server, codebase=False, prd=False)
+    mcp_prompts.register_prompts(server, merged_schemas())
+    server.add_middleware(ToolProfileMiddleware(profile))
+    return server
+
+
+def _run(server: FastMCP, coro_fn):
+    async def go():
+        async with Client(server) as client:
+            return await coro_fn(client)
+
+    return asyncio.run(go())
+
+
+# ── resolve / parse (criterion 7: unknown profile name) ─────────────────────
+
+
+class TestResolve:
+    def test_default_is_full(self):
+        assert tool_profiles.resolve(argv=[], env={}) is ToolProfile.FULL
+
+    def test_env_selects_lean(self):
+        assert (
+            tool_profiles.resolve(argv=[], env={"CORTEX_MCP_PROFILE": "lean"})
+            is ToolProfile.LEAN
+        )
+
+    def test_flag_wins_over_env(self):
+        got = tool_profiles.resolve(
+            argv=["--profile", "full"], env={"CORTEX_MCP_PROFILE": "lean"}
+        )
+        assert got is ToolProfile.FULL
+
+    def test_equals_spelling(self):
+        assert (
+            tool_profiles.resolve(argv=["--profile=lean"], env={}) is ToolProfile.LEAN
+        )
+
+    def test_unknown_profile_name_raises(self):
+        with pytest.raises(ValueError):
+            tool_profiles.resolve(argv=[], env={"CORTEX_MCP_PROFILE": "bogus"})
+
+    def test_flag_without_value_raises(self):
+        with pytest.raises(ValueError):
+            tool_profiles.resolve(argv=["--profile"], env={})
+
+
+# ── allows (criterion 7: tool allowed / excluded) ───────────────────────────
+
+
+class TestAllows:
+    def test_full_allows_everything(self):
+        assert tool_profiles.allows(ToolProfile.FULL, "forget")
+        assert tool_profiles.allows(ToolProfile.FULL, "anything_at_all")
+
+    def test_lean_allows_only_the_set(self):
+        assert tool_profiles.allows(ToolProfile.LEAN, "recall")
+        assert not tool_profiles.allows(ToolProfile.LEAN, "forget")
+
+    def test_lean_excludes_every_destructive_tool(self):
+        for name in _DESTRUCTIVE:
+            assert not tool_profiles.allows(ToolProfile.LEAN, name), name
+
+    def test_instructions_differ_by_profile(self):
+        full = tool_profiles.instructions(ToolProfile.FULL)
+        lean = tool_profiles.instructions(ToolProfile.LEAN)
+        assert full != lean
+        assert "query_methodology" in full and "query_methodology" in lean
+        assert "full" in full.lower() and "lean" in lean.lower()
+
+
+# ── list filtering + call gating (criteria 4, 5, 7) ─────────────────────────
+
+
+class TestSurface:
+    def test_full_lists_all_51_tools(self):
+        server = _build(ToolProfile.FULL)
+        names = _run(server, lambda c: c.list_tools())
+        assert len({t.name for t in names}) == 51
+
+    def test_lean_lists_exactly_the_lean_set(self):
+        server = _build(ToolProfile.LEAN)
+        names = {t.name for t in _run(server, lambda c: c.list_tools())}
+        assert names == set(tool_profiles.LEAN_TOOL_NAMES)
+
+    def test_lean_hides_and_rejects_destructive_calls(self):
+        # criterion 5: gated, not merely hidden.
+        server = _build(ToolProfile.LEAN)
+        names = {t.name for t in _run(server, lambda c: c.list_tools())}
+        for tool in _DESTRUCTIVE:
+            assert tool not in names, f"{tool} should be hidden under lean"
+
+            async def call(c, _tool=tool):
+                return await c.call_tool(_tool, {})
+
+            with pytest.raises(Exception) as exc:
+                _run(server, call)
+            assert (
+                "profile" in str(exc.value).lower()
+                or "unknown tool" in str(exc.value).lower()
+            )
+
+    def test_full_does_not_reject_or_hide(self):
+        server = _build(ToolProfile.FULL)
+        names = {t.name for t in _run(server, lambda c: c.list_tools())}
+        assert _DESTRUCTIVE <= names


### PR DESCRIPTION
Closes #176
Closes #177

CBM-parity pass for Cortex's MCP protocol surface, done as one change because the two issues share the profile plumbing.

## #176 — Prompts capability + resources interop

**Prompts.** `prompts/list` + `prompts/get` publish three workflows composed from Cortex's real handler surface (enumerated, not invented):

| Prompt | Workflow (real tools) | Profiles |
|---|---|---|
| `session_recall(project, focus?)` | session recall/onboarding: `query_methodology → recall → unified_search → recall_hierarchical → memory_stats` | full + lean |
| `promote_memories(scope?)` | episodic→semantic (CLS): `consolidate → memory_stats → curate_distill → remember` | full only |
| `curate_wiki(topic)` | wiki curation kickoff: `unified_search → curate_wiki → wiki_write → wiki_verify` | full only |

**Source of truth (criterion 3, the #98 drift class).** Each step names a tool and pulls that tool's one-line summary from `merged_schemas()` — the same map `tools/list` is built from (fed to `apply_param_docs`). No hand-copied second description. `test_every_prompt_step_names_a_real_tool` fails loudly if a step ever names a tool the schema map does not carry.

**Per-argument `title` — finding.** The installed MCP SDK (`mcp.types.PromptArgument`) and FastMCP both model a prompt argument as `name`/`description`/`required` only; there is no per-argument `title` field in this protocol version. The human title is folded into each argument's description; the prompt-level `title` IS emitted. Stated rather than faked.

**Resources shim (criterion 4) — finding.** FastMCP 3.2.4 already answers `resources/list` and `resources/templates/list` with empty arrays and declares the capability, so the `-32601`-on-connect failure some clients surface (CBM #958) does not occur here — the framework provides the shim. Verified by an in-memory `Client` round-trip; recorded at the use site in `__main__.py` per §8. No code needed.

## #177 — Tool profiles + per-profile instructions + tools/list finding

**Profiles.** `full` (every tool) and `lean` (the 10-tool recall/onboarding surface), selected by `--profile` / `CORTEX_MCP_PROFILE` (matches the `CORTEX_*` runtime-toggle convention), enforced by one `ToolProfileMiddleware`.

**LEAN membership derivation (criterion 1).** Derived from the documented tiers (`docs/mcp-tools.md`) and the common-session workflow the issue itself characterises (a recall/onboarding session "never calls wiki_migrate, wiki_purge, rebuild_profiles, import_sessions, backfill_memories or forget"). The runtime instrument to refine it per-deployment is `get_telemetry` (per-tool call counts); no telemetry corpus ships in-repo, so membership is taxonomy-derived and intended to be tightened against a deployment's own `get_telemetry`, not guessed wider. The set: `query_methodology, remember, recall, unified_search, recall_hierarchical, consolidate, memory_stats, check_setup, wiki_read, wiki_list`. Every member is read-only or idempotent-write.

**Default stays `full` (criterion 2 — documented divergence, H4).** #177 asks the default to be the common-session profile. This wave's explicit decision — mirroring `automatised-pipeline`'s `ToolProfile` — is that shrinking the default advertised surface is breaking (a client that called a now-hidden tool breaks), so `full` stays the default and `lean` is opt-in. Recorded in CHANGELOG under Changed. Under `full` the middleware is a pass-through: zero behaviour change, and `test_standalone_baseline_is_51_tools` is untouched.

**Destructive tools GATED, not merely hidden (criterion 5).** `forget`, `wiki_purge`, `wiki_migrate` (exactly the `destructiveHint` set) are excluded from `lean` — absent from `tools/list` AND rejected on call by `on_call_tool`. Hiding while still executing on call would be a hole. Asserted by `test_lean_hides_and_rejects_destructive_calls`.

**Per-profile instructions (criterion 3).** `initialize.instructions` varies by profile; `full` keeps the historical "Call query_methodology…" onboarding line.

**Measurement (criterion 6).** Benchmark `benchmarks/mcp_profile_tokens.py` (committed), measuring the `initialize`+`tools/list` per-session cost:

```
full  tools=51 instructions= 760c tools/list=118933c total=119693c ~29923 tok
lean  tools=10 instructions= 702c tools/list= 29683c total= 30385c ~ 7596 tok
lean saves 89308 chars (~22327 tokens), 74.6% of the full cost
```
(token estimate = chars/4, OpenAI rule of thumb; byte counts are exact.)

**tools/list pagination (criterion 4) — finding, not rebuilt.** FastMCP owns the `tools/list` envelope: `on_list_tools` returns `Sequence[Tool]` and cannot set `nextCursor`. Empirically FastMCP 3.2.4 returns the full allowed set in one page with no cursor — which is exactly criterion 4's mandated absent-cursor behaviour ("returns the full allowed set — the one that cannot break existing clients"). We do not fork FastMCP's protocol layer to synthesise a cursor; the per-session token win comes from the profile filter reducing the set (measured above). Per the wave's "verify, don't rebuild what the framework handles" guidance.

## Verified against a real client

In-memory FastMCP `Client` round-trip, both profiles:

```
########## FULL profile ##########
tools/list -> 51 tools
prompts/list -> ['session_recall', 'promote_memories', 'curate_wiki']
resources/list -> []          resources/templates/list -> []
prompts/get session_recall  -> OK (2093c)
prompts/get promote_memories -> OK (1880c)
prompts/get curate_wiki      -> OK (1260c)

########## LEAN profile (--profile lean) ##########
tools/list -> 10 tools
prompts/list -> ['session_recall']
resources/list -> []          resources/templates/list -> []
prompts/get session_recall   -> OK (2093c)
prompts/get promote_memories -> McpError: Unknown prompt (not available under 'lean')
prompts/get curate_wiki      -> McpError: Unknown prompt (not available under 'lean')
call forget      -> rejected (ToolError)
call wiki_purge  -> rejected (ToolError)
```

## Completion Ledger

| Item | Asserting test |
|---|---|
| session_recall served + renders args + canonical summary | `test_get_session_recall_embeds_args_and_canonical_summary` |
| promote_memories served (full) | `test_get_promote_memories_available_under_full` |
| curate_wiki served (full) | `test_full_lists_all_three_prompts` |
| prompts list per profile | `test_full_lists_all_three_prompts`, `test_lean_lists_only_session_recall` |
| every arg has name/description/required | `test_every_argument_has_name_description_required` |
| source of truth = tool schemas | `test_every_prompt_step_names_a_real_tool`, `test_tool_summary_comes_from_schema_description` |
| err arm: unknown prompt | `test_unknown_prompt_name_errors` |
| err arm: missing required arg | `test_missing_required_argument_errors` |
| err arm: full-only prompt under lean | `test_full_only_prompt_rejected_under_lean` |
| profile resolve precedence | `TestResolve::*` |
| unknown profile name | `test_unknown_profile_name_raises` |
| tool allowed / excluded | `TestAllows::*` |
| lean lists exactly the lean set | `test_lean_lists_exactly_the_lean_set` |
| destructive gated (hidden + rejected on call) | `test_lean_hides_and_rejects_destructive_calls` |
| full unchanged (51 tools, no gating) | `test_full_lists_all_51_tools`, `test_full_does_not_reject_or_hide` |
| per-profile instructions | `test_instructions_differ_by_profile` |
| token measurement | `benchmarks/mcp_profile_tokens.py` |

## Gates
`ruff check .` and `ruff format --check .` tree-wide: clean. `pytest` full suite: new tests green; PG-absent failures are identical to `main` (CI's concern). Files within craftsmanship limits (≤300 lines, ≤40-line methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
