### PR TITLE
refactor(core): split reranker.py under the 300-line cap (#199)

### DIFF
--- a/docs/module-inventory.md
+++ b/docs/module-inventory.md
@@ -152,7 +152,9 @@ Treat gaps as "undocumented," not "does not exist."
 - `retrieval_signals.py` — Retrieval signal definitions and computation
 - `query_router.py` — Query routing to appropriate retrieval tier
 - `pg_recall.py` — PostgreSQL recall orchestration
-- `reranker.py` — FlashRank ONNX cross-encoder reranking (client-side post-PG)
+- `reranker.py` — FlashRank ONNX cross-encoder reranking: lifecycle singleton + rerank entrypoints (client-side post-PG)
+- `reranker_model.py` — FlashRank model identity, durable cache_dir, offline-fetch gate, `RerankerStatus`, weights sha256
+- `reranker_scoring.py` — Pure score-blending math: confidence gate, adaptive alpha, WRRF/CE blend
 - `scoring.py` — BM25, n-gram, keyword scoring (reference; PG does this server-side)
 - `temporal.py` — Date parsing, distance decay, recency boost (reference; PG does this server-side)
 - `spreading_activation.py` — Collins & Loftus 1975 semantic priming over entity graph

--- a/mcp_server/core/reranker.py
+++ b/mcp_server/core/reranker.py
@@ -3,162 +3,71 @@
 FlashRank (ms-marco-MiniLM-L-12-v2) provides fast cross-encoder reranking.
 Validated through LongMemEval and LoCoMo where it improves MRR by 5-15%.
 
-CE reranking with alpha blending of first-stage and CE scores is standard
-IR practice — linear interpolation of retrieval and CE scores is the common
-approach in multi-stage retrieval (Nogueira & Cho, 2019).
+This module is the FlashRank lifecycle + reranking entrypoint. It owns the
+process-global singleton (``_flashrank_instance`` / ``_flashrank_failed`` /
+``_flashrank_load_error``) — a lazy-loaded singleton, no persistent I/O,
+same shape as write_post_store.py's ``_global_buffer``. Two cohesive
+companions carry the rest, and are re-exported here so the public import
+surface (``mcp_server.core.reranker.<name>``) is unchanged:
 
-Adaptive alpha (EXPERIMENTAL — disabled by default):
-    Attempted per-query alpha based on CE score spread (QPP, Shtok et al.,
-    TOIS 2012). Hypothesis: high CE spread → CE is confident → boost alpha.
-    Results: BEAM -0.002, LME +0.003, LoCoMo -3.8pp MRR / -5.1pp R@10.
-    The mechanism cannot distinguish "one great match" from "one outlier".
-    Kept as opt-in (adaptive=True) for future experimentation.
-    See benchmarks/beam/ablation_results.json for full data.
-
-Sufficient Context gate (Joren et al., ICLR 2025):
-    The paper uses an LLM autorater (Gemini 1.5 Pro CoT) to classify whether
-    retrieved context is sufficient — not applicable at <200ms retrieval latency.
-    This implementation uses a binary threshold gate: if the max CE score
-    falls below gate_threshold, all scores are suppressed by a fixed multiplier.
-
-    Platt sigmoid with BENCHMARK-DERIVED A,B — REJECTED (2026-04-03):
-    Attempted replacing the binary gate with Platt-calibrated sigmoid
-    using hand-picked A, B tuned to max_CE on benchmark data. All benchmarks
-    regressed. See reranker_calibration.py for the follow-up: Platt params
-    FIT from user rate_memory feedback (different input distribution) are
-    applied opt-in via apply_platt=True, default False until benchmark
-    re-validation lands.
-      A=10, B=-1.5 (inflection 0.15): BEAM 0.479 (-0.148), LoCoMo R@10 92.6% (-5.1pp)
-      A=30, B=-1.5 (inflection 0.05): BEAM 0.442 (-0.185)
-
-    ENGINEERING DEFAULTS (not paper-prescribed):
-    - alpha=0.70: Base blend weight for CE vs first-stage scores. Empirically
-      determined via BEAM ablation (see benchmarks/beam/ablation_results.json):
-      0.30→0.511, 0.50→0.529, 0.55→0.535, 0.70→0.542.
-    - gate_threshold=0.15: Min CE score to consider retrieval sufficient.
-    - suppression=0.1: Score multiplier when gated.
-
-Pure business logic -- lazy-loaded singleton, no persistent I/O.
-
-Model cache directory (fix 2026-07-11, incident: silent reranker skip):
-    FlashRank 0.2.10's own default cache_dir is ``/tmp`` (see the
-    installed package's ``flashrank/Config.py``: ``default_cache_dir =
-    "/tmp"``). macOS periodically purges /tmp; the first process restart
-    after a purge hit ``NoSuchFile`` inside ``Ranker.__init__`` -> the
-    bare ``except Exception`` below swallowed it with no log line ->
-    every subsequent ``rerank_results`` call for the rest of that
-    process's life silently returned first-stage-only scores. This ran
-    unnoticed through 6 LongMemEval benchmark executions; measured
-    impact MRR 0.9163 -> 0.8636 (R@10 nearly unaffected — the metric a
-    quick eyeball check would have caught was the one metric this bug
-    barely touched). Fix: pass an EXPLICIT, DURABLE ``cache_dir``
-    (``~/.cache/flashrank``, honoring ``$XDG_CACHE_HOME`` — see
-    ``mcp_server.shared.platform.cache_dir``) instead of the library
-    default, and log (not swallow) any load failure. See
-    ``reranker_status()`` for the externally-consumable load state this
-    fix also introduces.
-
-    FlashRank's own download behavior (verified by reading the installed
-    0.2.10 package, not assumed): ``Ranker._prepare_model_dir`` checks
-    ``if not self.model_dir.exists()`` and, when absent, downloads +
-    unzips the model from Hugging Face
-    (``https://huggingface.co/prithivida/flashrank/resolve/main/{model}.zip``)
-    into ``cache_dir``. This means a durable ``cache_dir`` is
-    self-provisioning: first run in a fresh cache downloads once (~34MB
-    for ms-marco-MiniLM-L-12-v2), every subsequent run in the same
-    process or a new one reuses the on-disk copy. No custom download
-    logic is needed in Cortex; the failure mode this module now logs is
-    exactly the cases where that self-provisioning itself fails (no
-    network, no write permission, corrupted archive, etc.).
+    - ``reranker_model``  — model identity, durable cache_dir, offline
+      gate, ``RerankerStatus``, and the on-disk weights sha256. See that
+      module's docstring for the 2026-07-11 silent-skip incident (the
+      ``/tmp`` cache_dir root cause) and the 2026-07-27 timeout-less
+      download hang.
+    - ``reranker_scoring`` — the pure score-blending math (confidence
+      gate, adaptive alpha, WRRF/CE blend). See that module's docstring
+      for the sourced engineering defaults, the rejected Platt sigmoid
+      parameters with their benchmark numbers, and the adaptive-alpha
+      ablation results.
 """
 
 from __future__ import annotations
 
-import hashlib
 import logging
-import os
-from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
-from mcp_server.core import platt_calibration, reranker_calibration
+from mcp_server.core.reranker_model import (
+    _MODEL_FILE,
+    _MODEL_NAME,
+    _OFFLINE_ENV,
+    RerankerStatus,
+    _model_path,
+    _offline_requested,
+    model_sha256,
+    reranker_cache_dir,
+)
+from mcp_server.core.reranker_scoring import (
+    _blend_scores,
+    _compute_adaptive_alpha,
+    _compute_retrieval_confidence,
+)
 from mcp_server.observability import silent_failure
-from mcp_server.shared.platform import cache_dir as _base_cache_dir
 
 logger = logging.getLogger(__name__)
 
-# source: flashrank==0.2.10 installed package, flashrank/Config.py
-# model_file_map["ms-marco-MiniLM-L-12-v2"] — verified by reading the
-# installed site-packages file directly (see module docstring).
-_MODEL_NAME = "ms-marco-MiniLM-L-12-v2"
-_MODEL_FILE = "flashrank-MiniLM-L-12-v2_Q.onnx"
-
-# FlashRank downloads its model with a bare ``requests.get(..., stream=True)``
-# carrying NO timeout (verified by reading the installed 0.2.10
-# ``Ranker._download_model_files``), so a stalled TCP connect blocks the
-# calling thread forever rather than raising -- the ``except Exception``
-# in ``_ensure_reranker`` cannot engage against a hang. That is not
-# hypothetical: CI run 30263190266 (main, Python 3.13, 2026-07-27) hung in
-# ``sock.connect`` inside a recall test until pytest-timeout killed the whole
-# suite at 300s. ``HF_HUB_OFFLINE``/``TRANSFORMERS_OFFLINE`` do not reach
-# FlashRank because it bypasses the ``huggingface_hub`` client entirely, so
-# forbidding the fetch needs its own switch.
-_OFFLINE_ENV = "CORTEX_RERANKER_OFFLINE"
+__all__ = [
+    "RerankerStatus",
+    "_MODEL_FILE",
+    "_MODEL_NAME",
+    "_OFFLINE_ENV",
+    "_blend_scores",
+    "_compute_adaptive_alpha",
+    "_compute_retrieval_confidence",
+    "_ensure_reranker",
+    "_model_path",
+    "_offline_requested",
+    "ensure_reranker_loaded",
+    "get_raw_ce_score",
+    "model_sha256",
+    "rerank_results",
+    "reranker_cache_dir",
+    "reranker_status",
+]
 
 _flashrank_instance: Any = None
 _flashrank_failed: bool = False
 _flashrank_load_error: str | None = None
-
-
-def _offline_requested() -> bool:
-    """True when the caller has forbidden a network fetch of the model.
-
-    Precondition: none.
-    Postcondition: True iff ``$CORTEX_RERANKER_OFFLINE`` is set to
-        anything other than the empty string, "0", "false", or "no"
-        (case- and whitespace-insensitive). Unset means False, so
-        production keeps FlashRank's self-provisioning first-run
-        download that PRIVACY.md documents; only callers that opt in
-        (CI test steps, air-gapped installs) get the strict behavior.
-    """
-    return os.environ.get(_OFFLINE_ENV, "").strip().lower() not in (
-        "",
-        "0",
-        "false",
-        "no",
-    )
-
-
-@dataclass(frozen=True)
-class RerankerStatus:
-    """Snapshot of the FlashRank reranker singleton's load state.
-
-    state is one of "loaded" | "failed" | "not_attempted". model_path is
-    the ONNX file ``_ensure_reranker`` reads from (or would read from),
-    computed without touching disk — callers that need to confirm the
-    file is actually present (e.g. to sha256 it for a bench manifest)
-    must stat/hash ``model_path`` themselves.
-    """
-
-    state: str
-    model_path: str
-    error: str | None = None
-
-
-def reranker_cache_dir() -> Path:
-    """Durable on-disk cache directory for the FlashRank ONNX model.
-
-    See module docstring for why FlashRank's own ``/tmp`` default is
-    unsafe. Honors ``$XDG_CACHE_HOME`` (via
-    ``mcp_server.shared.platform.cache_dir``); falls back to
-    ``~/.cache/flashrank`` — the location already adopted de facto (a
-    manually-placed copy of the model existed there before this fix).
-    """
-    return _base_cache_dir() / "flashrank"
-
-
-def _model_path() -> Path:
-    return reranker_cache_dir() / _MODEL_NAME / _MODEL_FILE
 
 
 def _ensure_reranker() -> Any:
@@ -219,8 +128,8 @@ def ensure_reranker_loaded() -> RerankerStatus:
     Public entrypoint for preflight checks — e.g. a benchmark harness
     that must fail fast rather than silently score first-stage-only
     results as if they were production quality (the 2026-07-10 incident
-    this module's docstring describes). Idempotent: only the first call
-    in a process pays the load (or failure) cost.
+    reranker_model.py's docstring describes). Idempotent: only the first
+    call in a process pays the load (or failure) cost.
     """
     _ensure_reranker()
     return reranker_status()
@@ -244,146 +153,6 @@ def reranker_status() -> RerankerStatus:
             state="failed", model_path=model_path, error=_flashrank_load_error
         )
     return RerankerStatus(state="not_attempted", model_path=model_path)
-
-
-def model_sha256() -> str | None:
-    """Sha256 of the on-disk ONNX weights file, or None if it is absent.
-
-    Used by bench manifests to fingerprint the exact reranker weights a
-    run used (mirrors the existing ``embedding_model_revision`` manifest
-    field — see benchmarks/reproduce.sh's ``write_manifest``). Reads the
-    file in fixed-size chunks to bound memory use regardless of file size.
-    """
-    path = _model_path()
-    if not path.is_file():
-        return None
-    digest = hashlib.sha256()
-    with path.open("rb") as fh:
-        for chunk in iter(lambda: fh.read(1 << 20), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _compute_retrieval_confidence(
-    ce_scores: list[float],
-    gate_threshold: float = 0.15,
-    suppression: float = 0.1,
-) -> float:
-    """Compute confidence that retrieval found relevant results.
-
-    Binary threshold gate: if max CE score >= threshold, results are
-    considered sufficient (confidence=1.0). Otherwise, all scores are
-    suppressed by a fixed multiplier.
-
-    Platt sigmoid was attempted (2026-04-03) and rejected — see module
-    docstring for ablation data showing regression on all benchmarks.
-
-    Args:
-        ce_scores: Raw cross-encoder scores from FlashRank.
-        gate_threshold: Below this max CE, results are likely irrelevant.
-            Hand-tuned (0.15 default).
-        suppression: Score multiplier when gated. Hand-tuned (0.1 default).
-
-    Returns:
-        float — 1.0 (sufficient context) or suppression (insufficient).
-    """
-    if not ce_scores:
-        return suppression
-    max_ce = max(ce_scores)
-    if max_ce >= gate_threshold:
-        return 1.0
-    return suppression
-
-
-def _compute_adaptive_alpha(
-    ce_scores: list[float],
-    base_alpha: float,
-) -> float:
-    """Compute per-query alpha from CE score distribution.
-
-    Based on post-retrieval QPP (Shtok et al., TOIS 2012): the standard
-    deviation / spread of retrieval scores predicts whether the retrieval
-    system can discriminate relevant from non-relevant documents.
-
-    When CE scores have high spread → CE found clear relevance signal →
-    trust CE more (higher alpha). When spread is low → ambiguous result
-    → use base alpha (already optimized via ablation).
-
-    IMPORTANT: alpha never drops BELOW base_alpha. Ablation on BEAM shows
-    lower alpha hurts (0.30→0.511, 0.50→0.529, 0.70→0.542). And higher
-    fixed alpha also hurts (0.80→0.476, 0.90→0.469, 1.00→0.465). The
-    adaptive mechanism ONLY boosts alpha when CE has high confidence,
-    staying at base_alpha otherwise.
-
-    The boost is conservative: base_alpha + small_delta when CE is confident.
-    This prevents the regression seen when alpha_min < base_alpha (which
-    degraded LME by -3.9pp MRR).
-
-    Args:
-        ce_scores: Raw cross-encoder scores from FlashRank.
-        base_alpha: Optimized base alpha (0.70 from BEAM ablation).
-
-    Returns:
-        Adaptive alpha in [base_alpha, base_alpha + 0.15].
-    """
-    if len(ce_scores) < 2:
-        return base_alpha
-
-    spread = max(ce_scores) - min(ce_scores)
-    # Only boost alpha when CE shows high discriminative power.
-    # FlashRank scores are typically in [-1, 1], spread ∈ [0, 2].
-    # High spread (>0.5) → CE found clear winner → small alpha boost.
-    # Low spread → ambiguous → keep base alpha (don't reduce!).
-    max_boost = 0.15  # Conservative: max alpha = base + 0.15 = 0.85
-    if spread < 0.3:
-        return base_alpha
-    # Linear boost above spread=0.3, capped at max_boost
-    normalized = min((spread - 0.3) / 0.7, 1.0)
-    return min(base_alpha + max_boost * normalized, 1.0)
-
-
-def _blend_scores(
-    candidates: list[tuple[int, float]],
-    ce_scores: dict[int, float],
-    alpha: float,
-    adaptive: bool = True,
-    apply_platt: bool = False,
-) -> list[tuple[int, float]]:
-    """Blend WRRF scores with cross-encoder scores, scaled by confidence.
-
-    Retrieval confidence from raw CE scores gates the final blended score.
-    When no result strongly matches (low CE), confidence pulls scores down,
-    enabling natural abstention for unanswerable queries.
-
-    When adaptive=True, alpha is adjusted per-query based on CE score
-    spread (Shtok et al., TOIS 2012 QPP principle).
-
-    When apply_platt=True AND fitted Platt parameters are available from
-    user rate_memory feedback, the CE scores used in the blend are
-    replaced by their calibrated probabilities P(useful | raw_score)
-    via ``platt_calibration.calibrate_score`` (Platt 1999). When no
-    parameters exist (cold start) or apply_platt=False, raw CE scores
-    are used unchanged — identical to the pre-AF-2 behaviour.
-    """
-    raw_ce_list = [ce_scores.get(i, 0.0) for i in range(len(candidates))]
-    confidence = _compute_retrieval_confidence(raw_ce_list)
-
-    # Per-query adaptive alpha based on CE score distribution
-    effective_alpha = _compute_adaptive_alpha(raw_ce_list, alpha) if adaptive else alpha
-
-    # Optional Platt calibration of the CE dimension of the blend. If the
-    # calibrator has no fitted params (cold start), calibrate_score is the
-    # identity — the blend matches the pre-AF-2 behaviour exactly.
-    platt_params = reranker_calibration.get_params() if apply_platt else None
-
-    reranked = []
-    for i, (mem_id, wrrf_score) in enumerate(candidates):
-        ce = ce_scores.get(i, 0.0)
-        ce_for_blend = platt_calibration.calibrate_score(ce, platt_params)
-        blended = (1 - effective_alpha) * wrrf_score + effective_alpha * ce_for_blend
-        reranked.append((mem_id, blended * confidence))
-    reranked.sort(key=lambda x: x[1], reverse=True)
-    return reranked
 
 
 def rerank_results(
@@ -410,7 +179,7 @@ def rerank_results(
             reranker_calibration (>=50 rate_memory pairs collected),
             calibrate CE scores to P(useful|raw_ce) before blending.
             Default False until benchmark re-validation lands — see
-            AF-2 ablation note in the module docstring.
+            AF-2 ablation note in reranker_scoring.py's docstring.
     """
     ranker = _ensure_reranker()
     if ranker is None or not candidates:
@@ -429,8 +198,8 @@ def rerank_results(
         )
     except Exception as exc:
         # Distinct failure point from _ensure_reranker's load failure (see
-        # module docstring, bb1c581f): the model loaded fine but THIS
-        # inference call raised (malformed passage, ONNX runtime error,
+        # reranker_model.py docstring, bb1c581f): the model loaded fine but
+        # THIS inference call raised (malformed passage, ONNX runtime error,
         # OOM, ...). Same silent-skip shape, different trigger — must be
         # equally observable.
         silent_failure.note("reranker.rerank_call", exc)

--- a/mcp_server/core/reranker_model.py
+++ b/mcp_server/core/reranker_model.py
@@ -1,0 +1,135 @@
+"""FlashRank model identity, cache location, and the offline-fetch gate.
+
+Pure, stateless helpers describing WHERE the cross-encoder weights live
+and WHETHER a network fetch of them is permitted. No process-global
+singleton state lives here (that is the concern of ``reranker.py``); these
+functions can be called any number of times without side effects beyond
+reading the environment and the filesystem.
+
+Model cache directory (fix 2026-07-11, incident: silent reranker skip):
+    FlashRank 0.2.10's own default cache_dir is ``/tmp`` (see the
+    installed package's ``flashrank/Config.py``: ``default_cache_dir =
+    "/tmp"``). macOS periodically purges /tmp; the first process restart
+    after a purge hit ``NoSuchFile`` inside ``Ranker.__init__`` -> the
+    bare ``except Exception`` in ``reranker._ensure_reranker`` swallowed
+    it with no log line -> every subsequent ``rerank_results`` call for
+    the rest of that process's life silently returned first-stage-only
+    scores. This ran unnoticed through 6 LongMemEval benchmark
+    executions; measured impact MRR 0.9163 -> 0.8636 (R@10 nearly
+    unaffected — the metric a quick eyeball check would have caught was
+    the one metric this bug barely touched). Fix: pass an EXPLICIT,
+    DURABLE ``cache_dir`` (``~/.cache/flashrank``, honoring
+    ``$XDG_CACHE_HOME`` — see ``mcp_server.shared.platform.cache_dir``)
+    instead of the library default, and log (not swallow) any load
+    failure. See ``reranker.reranker_status()`` for the
+    externally-consumable load state that fix also introduced.
+
+    FlashRank's own download behavior (verified by reading the installed
+    0.2.10 package, not assumed): ``Ranker._prepare_model_dir`` checks
+    ``if not self.model_dir.exists()`` and, when absent, downloads +
+    unzips the model from Hugging Face
+    (``https://huggingface.co/prithivida/flashrank/resolve/main/{model}.zip``)
+    into ``cache_dir``. This means a durable ``cache_dir`` is
+    self-provisioning: first run in a fresh cache downloads once (~34MB
+    for ms-marco-MiniLM-L-12-v2), every subsequent run in the same
+    process or a new one reuses the on-disk copy. No custom download
+    logic is needed in Cortex; the failure mode this module now logs is
+    exactly the cases where that self-provisioning itself fails (no
+    network, no write permission, corrupted archive, etc.).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from mcp_server.shared.platform import cache_dir as _base_cache_dir
+
+# source: flashrank==0.2.10 installed package, flashrank/Config.py
+# model_file_map["ms-marco-MiniLM-L-12-v2"] — verified by reading the
+# installed site-packages file directly (see module docstring).
+_MODEL_NAME = "ms-marco-MiniLM-L-12-v2"
+_MODEL_FILE = "flashrank-MiniLM-L-12-v2_Q.onnx"
+
+# FlashRank downloads its model with a bare ``requests.get(..., stream=True)``
+# carrying NO timeout (verified by reading the installed 0.2.10
+# ``Ranker._download_model_files``), so a stalled TCP connect blocks the
+# calling thread forever rather than raising -- the ``except Exception``
+# in ``reranker._ensure_reranker`` cannot engage against a hang. That is not
+# hypothetical: CI run 30263190266 (main, Python 3.13, 2026-07-27) hung in
+# ``sock.connect`` inside a recall test until pytest-timeout killed the whole
+# suite at 300s. ``HF_HUB_OFFLINE``/``TRANSFORMERS_OFFLINE`` do not reach
+# FlashRank because it bypasses the ``huggingface_hub`` client entirely, so
+# forbidding the fetch needs its own switch.
+_OFFLINE_ENV = "CORTEX_RERANKER_OFFLINE"
+
+
+def _offline_requested() -> bool:
+    """True when the caller has forbidden a network fetch of the model.
+
+    Precondition: none.
+    Postcondition: True iff ``$CORTEX_RERANKER_OFFLINE`` is set to
+        anything other than the empty string, "0", "false", or "no"
+        (case- and whitespace-insensitive). Unset means False, so
+        production keeps FlashRank's self-provisioning first-run
+        download that PRIVACY.md documents; only callers that opt in
+        (CI test steps, air-gapped installs) get the strict behavior.
+    """
+    return os.environ.get(_OFFLINE_ENV, "").strip().lower() not in (
+        "",
+        "0",
+        "false",
+        "no",
+    )
+
+
+@dataclass(frozen=True)
+class RerankerStatus:
+    """Snapshot of the FlashRank reranker singleton's load state.
+
+    state is one of "loaded" | "failed" | "not_attempted". model_path is
+    the ONNX file ``reranker._ensure_reranker`` reads from (or would read
+    from), computed without touching disk — callers that need to confirm
+    the file is actually present (e.g. to sha256 it for a bench manifest)
+    must stat/hash ``model_path`` themselves.
+    """
+
+    state: str
+    model_path: str
+    error: str | None = None
+
+
+def reranker_cache_dir() -> Path:
+    """Durable on-disk cache directory for the FlashRank ONNX model.
+
+    See module docstring for why FlashRank's own ``/tmp`` default is
+    unsafe. Honors ``$XDG_CACHE_HOME`` (via
+    ``mcp_server.shared.platform.cache_dir``); falls back to
+    ``~/.cache/flashrank`` — the location already adopted de facto (a
+    manually-placed copy of the model existed there before this fix).
+    """
+    return _base_cache_dir() / "flashrank"
+
+
+def _model_path() -> Path:
+    return reranker_cache_dir() / _MODEL_NAME / _MODEL_FILE
+
+
+def model_sha256() -> str | None:
+    """Sha256 of the on-disk ONNX weights file, or None if it is absent.
+
+    Used by bench manifests to fingerprint the exact reranker weights a
+    run used (mirrors the existing ``embedding_model_revision`` manifest
+    field — see benchmarks/reproduce.sh's ``write_manifest``). Reads the
+    file in fixed-size chunks to bound memory use regardless of file size.
+    """
+    path = _model_path()
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/mcp_server/core/reranker_scoring.py
+++ b/mcp_server/core/reranker_scoring.py
@@ -1,0 +1,168 @@
+"""Score blending math for cross-encoder reranking.
+
+Pure ranking arithmetic: it consumes first-stage WRRF scores and raw
+cross-encoder scores and produces the blended, confidence-gated ranking.
+No I/O, no model loading, no process-global state — the FlashRank
+lifecycle lives in ``reranker.py``; this module never touches it.
+
+CE reranking with alpha blending of first-stage and CE scores is standard
+IR practice — linear interpolation of retrieval and CE scores is the common
+approach in multi-stage retrieval (Nogueira & Cho, 2019).
+
+Adaptive alpha (EXPERIMENTAL — disabled by default):
+    Attempted per-query alpha based on CE score spread (QPP, Shtok et al.,
+    TOIS 2012). Hypothesis: high CE spread → CE is confident → boost alpha.
+    Results: BEAM -0.002, LME +0.003, LoCoMo -3.8pp MRR / -5.1pp R@10.
+    The mechanism cannot distinguish "one great match" from "one outlier".
+    Kept as opt-in (adaptive=True) for future experimentation.
+    See benchmarks/beam/ablation_results.json for full data.
+
+Sufficient Context gate (Joren et al., ICLR 2025):
+    The paper uses an LLM autorater (Gemini 1.5 Pro CoT) to classify whether
+    retrieved context is sufficient — not applicable at <200ms retrieval latency.
+    This implementation uses a binary threshold gate: if the max CE score
+    falls below gate_threshold, all scores are suppressed by a fixed multiplier.
+
+    Platt sigmoid with BENCHMARK-DERIVED A,B — REJECTED (2026-04-03):
+    Attempted replacing the binary gate with Platt-calibrated sigmoid
+    using hand-picked A, B tuned to max_CE on benchmark data. All benchmarks
+    regressed. See reranker_calibration.py for the follow-up: Platt params
+    FIT from user rate_memory feedback (different input distribution) are
+    applied opt-in via apply_platt=True, default False until benchmark
+    re-validation lands.
+      A=10, B=-1.5 (inflection 0.15): BEAM 0.479 (-0.148), LoCoMo R@10 92.6% (-5.1pp)
+      A=30, B=-1.5 (inflection 0.05): BEAM 0.442 (-0.185)
+
+    ENGINEERING DEFAULTS (not paper-prescribed):
+    - alpha=0.70: Base blend weight for CE vs first-stage scores. Empirically
+      determined via BEAM ablation (see benchmarks/beam/ablation_results.json):
+      0.30→0.511, 0.50→0.529, 0.55→0.535, 0.70→0.542.
+    - gate_threshold=0.15: Min CE score to consider retrieval sufficient.
+    - suppression=0.1: Score multiplier when gated.
+"""
+
+from __future__ import annotations
+
+from mcp_server.core import platt_calibration, reranker_calibration
+
+
+def _compute_retrieval_confidence(
+    ce_scores: list[float],
+    gate_threshold: float = 0.15,
+    suppression: float = 0.1,
+) -> float:
+    """Compute confidence that retrieval found relevant results.
+
+    Binary threshold gate: if max CE score >= threshold, results are
+    considered sufficient (confidence=1.0). Otherwise, all scores are
+    suppressed by a fixed multiplier.
+
+    Platt sigmoid was attempted (2026-04-03) and rejected — see module
+    docstring for ablation data showing regression on all benchmarks.
+
+    Args:
+        ce_scores: Raw cross-encoder scores from FlashRank.
+        gate_threshold: Below this max CE, results are likely irrelevant.
+            Hand-tuned (0.15 default).
+        suppression: Score multiplier when gated. Hand-tuned (0.1 default).
+
+    Returns:
+        float — 1.0 (sufficient context) or suppression (insufficient).
+    """
+    if not ce_scores:
+        return suppression
+    max_ce = max(ce_scores)
+    if max_ce >= gate_threshold:
+        return 1.0
+    return suppression
+
+
+def _compute_adaptive_alpha(
+    ce_scores: list[float],
+    base_alpha: float,
+) -> float:
+    """Compute per-query alpha from CE score distribution.
+
+    Based on post-retrieval QPP (Shtok et al., TOIS 2012): the standard
+    deviation / spread of retrieval scores predicts whether the retrieval
+    system can discriminate relevant from non-relevant documents.
+
+    When CE scores have high spread → CE found clear relevance signal →
+    trust CE more (higher alpha). When spread is low → ambiguous result
+    → use base alpha (already optimized via ablation).
+
+    IMPORTANT: alpha never drops BELOW base_alpha. Ablation on BEAM shows
+    lower alpha hurts (0.30→0.511, 0.50→0.529, 0.70→0.542). And higher
+    fixed alpha also hurts (0.80→0.476, 0.90→0.469, 1.00→0.465). The
+    adaptive mechanism ONLY boosts alpha when CE has high confidence,
+    staying at base_alpha otherwise.
+
+    The boost is conservative: base_alpha + small_delta when CE is confident.
+    This prevents the regression seen when alpha_min < base_alpha (which
+    degraded LME by -3.9pp MRR).
+
+    Args:
+        ce_scores: Raw cross-encoder scores from FlashRank.
+        base_alpha: Optimized base alpha (0.70 from BEAM ablation).
+
+    Returns:
+        Adaptive alpha in [base_alpha, base_alpha + 0.15].
+    """
+    if len(ce_scores) < 2:
+        return base_alpha
+
+    spread = max(ce_scores) - min(ce_scores)
+    # Only boost alpha when CE shows high discriminative power.
+    # FlashRank scores are typically in [-1, 1], spread ∈ [0, 2].
+    # High spread (>0.5) → CE found clear winner → small alpha boost.
+    # Low spread → ambiguous → keep base alpha (don't reduce!).
+    max_boost = 0.15  # Conservative: max alpha = base + 0.15 = 0.85
+    if spread < 0.3:
+        return base_alpha
+    # Linear boost above spread=0.3, capped at max_boost
+    normalized = min((spread - 0.3) / 0.7, 1.0)
+    return min(base_alpha + max_boost * normalized, 1.0)
+
+
+def _blend_scores(
+    candidates: list[tuple[int, float]],
+    ce_scores: dict[int, float],
+    alpha: float,
+    adaptive: bool = True,
+    apply_platt: bool = False,
+) -> list[tuple[int, float]]:
+    """Blend WRRF scores with cross-encoder scores, scaled by confidence.
+
+    Retrieval confidence from raw CE scores gates the final blended score.
+    When no result strongly matches (low CE), confidence pulls scores down,
+    enabling natural abstention for unanswerable queries.
+
+    When adaptive=True, alpha is adjusted per-query based on CE score
+    spread (Shtok et al., TOIS 2012 QPP principle).
+
+    When apply_platt=True AND fitted Platt parameters are available from
+    user rate_memory feedback, the CE scores used in the blend are
+    replaced by their calibrated probabilities P(useful | raw_score)
+    via ``platt_calibration.calibrate_score`` (Platt 1999). When no
+    parameters exist (cold start) or apply_platt=False, raw CE scores
+    are used unchanged — identical to the pre-AF-2 behaviour.
+    """
+    raw_ce_list = [ce_scores.get(i, 0.0) for i in range(len(candidates))]
+    confidence = _compute_retrieval_confidence(raw_ce_list)
+
+    # Per-query adaptive alpha based on CE score distribution
+    effective_alpha = _compute_adaptive_alpha(raw_ce_list, alpha) if adaptive else alpha
+
+    # Optional Platt calibration of the CE dimension of the blend. If the
+    # calibrator has no fitted params (cold start), calibrate_score is the
+    # identity — the blend matches the pre-AF-2 behaviour exactly.
+    platt_params = reranker_calibration.get_params() if apply_platt else None
+
+    reranked = []
+    for i, (mem_id, wrrf_score) in enumerate(candidates):
+        ce = ce_scores.get(i, 0.0)
+        ce_for_blend = platt_calibration.calibrate_score(ce, platt_params)
+        blended = (1 - effective_alpha) * wrrf_score + effective_alpha * ce_for_blend
+        reranked.append((mem_id, blended * confidence))
+    reranked.sort(key=lambda x: x[1], reverse=True)
+    return reranked


### PR DESCRIPTION
Closes #199

## What

Behavior-preserving split of `mcp_server/core/reranker.py` (**469 lines**, 56% over the repo's 300-line cap) into three cohesive `core/` modules along the seam issue #199 defines — scoring depends on lifecycle, never the reverse. Public import surface (`mcp_server.core.reranker.<name>`) is unchanged via re-exports, so no caller churns.

## Extractions (Fowler catalog)

| File | Lines | Fowler entry | Contents |
|---|---|---|---|
| `reranker_model.py` (new) | 135 | Extract Class + Move Function | model identity constants, durable `cache_dir`, offline-fetch gate `_offline_requested`, `RerankerStatus`, `_model_path`, `model_sha256` — pure, no singleton state |
| `reranker_scoring.py` (new) | 168 | Extract Function | `_compute_retrieval_confidence`, `_compute_adaptive_alpha`, `_blend_scores` — pure ranking math, no I/O |
| `reranker.py` (was 469) | 238 | (facade) | process-global FlashRank singleton + public entrypoints (`_ensure_reranker`, `ensure_reranker_loaded`, `reranker_status`, `rerank_results`, `get_raw_ce_score`); re-exports both companions |

The singleton state (`_flashrank_instance/_failed/_load_error`) and `_ensure_reranker` **stay** in `reranker.py`: the suite mutates `reranker_mod._flashrank_instance` and calls `reranker_mod._ensure_reranker()` directly, so those must read/write one module's globals. Moving them would silently break the singleton-reset fixture (test pollution) — the split respects that constraint rather than editing tests. Every sourced comment and incident record survives, attached to the code it now explains (2026-07-10 silent-skip, `/tmp` cache_dir root cause, rejected Platt params + benchmark numbers, adaptive-alpha ablation, 2026-07-27 timeout-less download).

## Proof it is a refactor, not a rewrite

Full suite, identical before and after — **0 test files edited**:

| | passed | failed | skipped | errors |
|---|---|---|---|---|
| before (origin/main) | 5361 | 21 | 95 | 18 |
| after | 5361 | 21 | 95 | 18 |

The 21 failures + 18 collection errors are pre-existing `psycopg`-less SQLite-env failures (the DB-backed pg/handler/doctor tests), reproduced identically on the pre-refactor baseline; **none are reranker-related**. Reranker-touching tests (`test_reranker.py`, `test_flashrank_platt.py`, `test_beam_standard_rag.py`) — 50 passed.

## Gates

- `ruff check .` → **All checks passed!** (CI-pinned 0.15.20, tree-wide)
- `ruff format --check .` → **1021 files already formatted**
- `pyright` on the 3 touched files → **0 errors, 0 warnings**
- §12: pure Move/Extract, no logic change → no new mutation run (behavior-preserving; the unchanged suite is the proof).
- §14 Boy-Scout: `docs/module-inventory.md` updated to list the two new companions. The 21 env-bound failures are outside this change's blast radius and predate it (identical on the captured baseline); they need a live Postgres, not a code fix, so nothing untreated in touched material remains.

## Completion Ledger

| Item | Evidence |
|---|---|
| No file > 300 lines | `wc -l`: 238 / 135 / 168 |
| Behavior-preserving, suite unchanged | 5361/21/95/18 before == after; 0 test edits |
| Every sourced comment / incident record preserved | docstrings apportioned across the 3 files (see diff) |
| Public import sites keep working | re-exports + `__all__` in `reranker.py`; callers grepped (`pg_recall`, `retrieval_dispatch`, `benchmarks/`, `embedding_model_lifecycle`) unchanged |
| No behavior change (no new env vars / defaults / log lines) | code moved verbatim; ruff+pyright clean; reranker tests green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)