### PR TITLE
build: pin container base images by digest, add Dependabot to refresh them

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,14 @@
 # (normally invoked by the Dev Containers CLI / VS Code "Reopen in
 # Container", never by hand.)
 
-FROM python:3.13-slim
+# Base image pinned by digest so a rebuild cannot silently pick up a
+# different python:3.13-slim. Digest resolved from the multi-arch manifest
+# list, so it stays correct on both amd64 and arm64.
+#   source: registry-1.docker.io/v2/library/python/manifests/3.13-slim,
+#           docker-content-digest header, fetched 2026-07-27.
+# Refresh: Dependabot's `docker` ecosystem (.github/dependabot.yml) opens a
+# PR when the tag moves; do not hand-edit without re-fetching the header.
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
 
 LABEL org.opencontainers.image.source="https://github.com/cdeust/Cortex"
 LABEL org.opencontainers.image.description="Cortex development container (issue #118)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+# Dependabot config.
+#
+# This file exists because this repo pins by hash: every `uses:` in
+# .github/workflows is a 40-char commit SHA, and every `FROM` in the three
+# Dockerfiles is a digest. A hash pin that nothing refreshes is strictly worse
+# than a tag — it freezes the dependency at the day it was pinned and stops
+# receiving upstream security fixes. Dependabot is the half of "pinned
+# dependencies" that makes the pins safe rather than merely reproducible.
+#
+# Scope note: `open-pull-requests-limit` is deliberately low. The point is a
+# steady trickle that gets reviewed, not a queue nobody reads.
+version: 2
+updates:
+  # Keeps the SHA pins in .github/workflows fresh. Dependabot rewrites the SHA
+  # and updates the trailing `# vX.Y.Z` comment in the same edit.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+
+  # One entry per Dockerfile: Dependabot's docker ecosystem scans a directory,
+  # not a file tree, so a single "/" entry would miss docker/ and .devcontainer/.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "build"
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "build"
+
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "build"
+
+  # Python dependencies are declared in pyproject.toml and locked in uv.lock.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,14 @@
 #
 # Source: docs/program/phase-5-pool-admission-design.md §7.
 
-FROM python:3.13-slim AS builder
+# Base image pinned by digest so a rebuild cannot silently pick up a
+# different python:3.13-slim. Digest resolved from the multi-arch manifest
+# list, so it stays correct on both amd64 and arm64.
+#   source: registry-1.docker.io/v2/library/python/manifests/3.13-slim,
+#           docker-content-digest header, fetched 2026-07-27.
+# Refresh: Dependabot's `docker` ecosystem (.github/dependabot.yml) opens a
+# PR when the tag moves; do not hand-edit without re-fetching the header.
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS builder
 
 WORKDIR /build
 
@@ -49,7 +56,7 @@ RUN pip install --no-cache-dir --upgrade pip build && \
 
 # ── Runtime stage ────────────────────────────────────────────────────────
 
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
 
 LABEL org.opencontainers.image.source="https://github.com/cdeust/Cortex"
 LABEL org.opencontainers.image.description="Cortex — neuroscience-backed memory system for Claude Code (MCP)"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,14 @@
 
 # ── Builder ───────────────────────────────────────────────────────────────
 
-FROM python:3.12-slim-bookworm AS builder
+# Base image pinned by digest so a rebuild cannot silently pick up a
+# different python:3.12-slim-bookworm. Digest resolved from the multi-arch manifest
+# list, so it stays correct on both amd64 and arm64.
+#   source: registry-1.docker.io/v2/library/python/manifests/3.12-slim-bookworm,
+#           docker-content-digest header, fetched 2026-07-27.
+# Refresh: Dependabot's `docker` ecosystem (.github/dependabot.yml) opens a
+# PR when the tag moves; do not hand-edit without re-fetching the header.
+FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b AS builder
 
 # Node.js 22 LTS
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -44,7 +51,7 @@ RUN python3 -c "from sentence_transformers import SentenceTransformer; \
 
 # ── Runtime ───────────────────────────────────────────────────────────────
 
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b
 
 # System: PostgreSQL 17 + pgvector + git + ripgrep
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
OpenSSF Scorecard's `Pinned-Dependencies` check scores **3/10**. All 48 `uses:` in `.github/workflows` were already 40-char SHAs; the losses are the five `FROM` lines across the three Dockerfiles, which named floating tags.

## What changed

All five base images pinned by **multi-arch manifest-list** digest, so amd64 and arm64 both resolve:

| File | Image |
|---|---|
| `Dockerfile:31` (builder), `:59` (runtime) | `python:3.13-slim@sha256:6771159c…` |
| `.devcontainer/Dockerfile:24` | `python:3.13-slim@sha256:6771159c…` |
| `docker/Dockerfile:28` (builder), `:54` (runtime) | `python:3.12-slim-bookworm@sha256:d50fb761…` |

Each digest carries a provenance comment naming the registry endpoint, the header it came from, and the date (§8).

## Why Dependabot is in the same PR

A hash pin that nothing refreshes is **worse** than a tag: it freezes the base image on the day it was pinned and stops taking upstream security fixes. This repo had no updater at all — no `dependabot.yml`, no `renovate.json`, and no updater-authored PR anywhere in its history — which means the 48 already-SHA-pinned actions were quietly accumulating that same debt. Pinning without wiring an updater would have made this change a net security regression, so `.github/dependabot.yml` ships with it.

One `docker` entry per Dockerfile: the ecosystem scans a **directory**, not a tree, so a single `/` entry would silently miss `docker/` and `.devcontainer/`.

## Evidence

Digests were not copied from a registry UI. Both were resolved from the manifest-list `docker-content-digest` header, then **pulled and executed** to confirm the digest is the image the tag claims:

```
pulled OK: python:3.13-slim          -> Python 3.13.14 (main, Jul 14 2026) [GCC 14.2.0]
pulled OK: python:3.12-slim-bookworm -> Python 3.12.13 (main, Jul 14 2026) [GCC 12.2.0]
```

The `python:3.13-slim` digest independently matches the one Scorecard itself suggests in its warning text.

`docker buildx` is not available in this environment, so no static Dockerfile validation was run. The root `Dockerfile` is covered by the blocking **Docker Smoke** job in `ci.yml`. `docker/Dockerfile` and `.devcontainer/Dockerfile` are built by **no CI job at all** — noted in #203, since a regression in either is currently invisible.

## Deferred, with an issue (§14.3)

The remaining `Pinned-Dependencies` warnings are package-manager invocations — `pipCommand` ×7, `npmCommand` ×1, `downloadThenRun` ×1. Hash-pinning them means a fully hashed constraints file generated from `uv.lock`, across a second torch CPU-wheel index, plus a decision on the NodeSource `setup_22.x | bash` step. Filed as **#203** with acceptance criteria.

## Completion Ledger

| Item | Evidence |
|---|---|
| Five `FROM` lines pinned | `grep '^FROM python' Dockerfile docker/Dockerfile .devcontainer/Dockerfile` shows 5/5 with `@sha256:` |
| Digests are valid and correct | pulled + `python3 -VV` output above; registry returns HTTP 200 for both |
| Multi-arch preserved | digests taken from the manifest **list**, not a platform-specific manifest |
| Dependabot config is valid | parses under `yaml.safe_load`; 5 entries — github-actions, docker ×3, pip |
| Every Dockerfile directory covered | `/`, `/docker`, `/.devcontainer` each have an entry |
| Constants sourced (§8) | provenance comment above each pinned `FROM` |
| A1 happy path | root image build is exercised by CI's Docker Smoke job on this PR |
| A2 edge case: stale pin | addressed by the Dependabot entries, which is why they are in this PR |
| E1 compatibility | no interface change; tags unchanged, only qualified by digest |
| H4 CHANGELOG | N/A — no consumer-observable behavior change; the image content is byte-identical to what the tags resolved to at pin time |
| H6 CI green | pending on this PR |
| H7 boy-scout (§14) | the missing dependency updater was found en route and fixed here rather than filed |
