### PR TITLE
chore(marketplace): bump zetetic-team-subagents pin to 2.35.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,8 +88,8 @@
         "source": "github",
         "repo": "cdeust/zetetic-team-subagents"
       },
-      "description": "Zetetic agent team for Cortex — 97 genius reasoning patterns from history's greatest minds + 19 team specialists (architect, engineer, code-reviewer, refactorer, …), 63 skills, 24 commands, 18 tools, 17 hooks, under one epistemic standard none of them can bypass. Composes with Cortex memory: every agent recalls/remembers through the Cortex MCP and routes via /genius, /agent, /zetetic, /quality, /research commands.",
-      "version": "2.34.0",
+      "description": "Zetetic agent team for Cortex — 97 genius reasoning patterns from history's greatest minds + 23 team specialists (architect, engineer, code-reviewer, refactorer, …), 78 skills, 26 commands, 42 tools, 20 hooks, under one epistemic standard none of them can bypass. Composes with Cortex memory: every agent recalls/remembers through the Cortex MCP and routes via /genius, /agent, /zetetic, /quality, /research commands.",
+      "version": "2.35.0",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"


### PR DESCRIPTION
Closes the `PIN_LAG` that zetetic's own currency check exists to name (counterpart to cdeust/zetetic-team-subagents#52, and the publishing-side gate tracked as #179).

This manifest is the only thing standing between a published zetetic release and its installs: the plugin is served from `cdeust/zetetic-team-subagents` but **pinned here**, so eleven merged commits reached zero installs until now. No user action could have fixed that.

## Change

`.claude-plugin/marketplace.json`, `zetetic-team-subagents` entry: `2.34.0` to `2.35.0`, plus a Boy-scout (§14) correction of the entry's stale inventory counts.

## Completion Ledger

| Item | Evidence |
|---|---|
| The pin points at a release that exists | `gh release view v2.35.0`: `draft=false`, 6 assets (signed bundle, checksums, EXECUTABLE-MANIFEST, CycloneDX SBOM) |
| That release is attested and gate-passed | Release workflow run `30295753272`, conclusion **success**, 4m12s |
| Upstream repo self-consistent at 2.35.0 | zetetic `plugin.json` and its own `marketplace.json` both read 2.35.0 on `main` @ `220c866` |
| Manifest stays valid JSON | `python3 -c "json.load(...)"` passes |
| Counts measured, not guessed | Against the v2.35.0 tree: 97 genius, 23 team agents, 78 skills, 26 commands, 42 tools, 20 hooks |
| Counts now agree with the plugin's own manifest | Both manifests state the same six figures |
| Isolated from unrelated work | Authored in a worktree off `origin/main`; the dirty `chore/pyright-standard-197` tree was not touched |
| End-state verification | Deferred by construction: `plugin-version-check.sh` reads `latest` from the GitHub release and `pinned` from this file, so it can only confirm 2.35.0/2.35.0 after this merges. `installed` stays 2.34.0 until the user updates the plugin, which is `INSTALL_LAG` and user-fixable by design |

## Before

```json
{"installed":"2.34.0","pinned":"2.34.0","latest":"2.34.0","status":0}
```

The check read "current" while eleven commits sat unreleased, which is exactly the two-value blind spot it was built to replace: it can only see a pin lag once the release exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gFqzbbNDwPtFzaoGDti7R