### PR TITLE
chore(marketplace): bump zetetic-team-subagents pin to 2.36.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -89,7 +89,7 @@
         "repo": "cdeust/zetetic-team-subagents"
       },
       "description": "Zetetic agent team for Cortex — 97 genius reasoning patterns from history's greatest minds + 23 team specialists (architect, engineer, code-reviewer, refactorer, …), 78 skills, 26 commands, 42 tools, 20 hooks, under one epistemic standard none of them can bypass. Composes with Cortex memory: every agent recalls/remembers through the Cortex MCP and routes via /genius, /agent, /zetetic, /quality, /research commands.",
-      "version": "2.35.0",
+      "version": "2.36.0",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"


### PR DESCRIPTION
## What

One line: the `zetetic-team-subagents` marketplace pin moves `2.35.0` -> `2.36.0`.

## Why it is not cosmetic

zetetic v2.36.0 fixes a failure this repo caused. Cortex 4.15.0 renamed the
plugin `cortex` -> `hypermnesia-mcp`. The host derives a tool's name as
`mcp__plugin_<plugin-name>_<mcp-server-key>__<tool>`, so the rename changed
every Cortex tool name the zetetic fleet declares. 122 zetetic files still
named `mcp__plugin_cortex_cortex__*`; an unresolvable MCP tool name in an
agent's `tools:` list is **dropped silently** by the host, so all 119 agents
lost `recall`/`remember` with no error anywhere. v2.36.0 renames them and adds
a hard gate (`agent-definition-auditor.sh` check `FP`) so it cannot regress.

Installs subscribe through this manifest. Until this pin moves, the fix ships
to zero installs -- the same failure mode as #179.

## Evidence the target exists

- Release workflow on tag `v2.36.0`: **success**.
- Release `v2.36.0` published (not draft) at 2026-07-27T22:10:33Z with 6
  assets: `zetetic-team-subagents.tar.gz`, `EXECUTABLE-MANIFEST.sha256`,
  `zetetic-team-subagents.cdx.json` and their `.sha256` sidecars.
- `gh release list --repo cdeust/zetetic-team-subagents` shows v2.36.0 as
  Latest.

## Completion Ledger

Diff = one JSON string value. It introduces **no branch, no early return, no
error arm, no fallback and no degraded mode**, so the path-enumeration duty
(§13.2) yields an empty path set. Checklist:

| Item | State | Evidence |
|---|---|---|
| A1 happy path | done | `python3 scripts/check_marketplace_pins.py` -> `All marketplace pins current.`, rc 0 |
| A2 edge cases | N/A | no input is parsed by this change; the value is a literal consumed by the plugin host |
| A3 failure paths | N/A | zero code paths introduced (see above) |
| A4 boundary validation | N/A | no new trust boundary; the manifest is repo-controlled |
| A5 invariants | done | invariant "every pin names a published release" holds: verified v2.36.0 exists and is not a draft |
| A6 idempotency | done | re-running the pin check is read-only and repeatable |
| B1-B3 concurrency | N/A | no concurrency touched |
| C1-C3 resources/perf | N/A | one static string; no loop, query or allocation |
| D1-D3 security | done | no secret, no query construction, no privilege change. Pin points at a **signed and attested** bundle |
| E1 API/schema | done | additive-free: the schema is unchanged, only a value moves |
| E2 downstream consumers | done | consumer is the Claude Code plugin host + `scripts/check_marketplace_pins.py`; both verified above |
| E3 persisted data | N/A | no persisted format changes |
| E4 cross-platform | N/A | JSON literal |
| F1-F2 observability | done | the CI marketplace-pins workflow is the signal; it gates this manifest on PR/push and weekly cron |
| G1 path->test ledger | done | empty path set, mapped to the pin check |
| G2 regression test | done | `check_marketplace_pins.py` fails on the pre-fix value -- that is exactly the PIN_LAG it reports |
| G3 determinism | done | pin check is deterministic and order-independent |
| G4 negative assertions | done | `git diff --stat` = `1 file changed, 1 insertion(+), 1 deletion(-)`; nothing else touched |
| G5 gates | done | pin check rc 0; no `.py` changed so ruff has nothing in scope |
| H1 standards | done | no code; JSON formatting preserved |
| H2 readability | done | one value |
| H3 conventions | done | matches the shape of the 2.35.0 bump (#207) |
| H4 CHANGELOG | N/A | no observable behavior change in **this** repo; the behavior change is documented in zetetic's own `## [2.36.0]` section, which the release publishes verbatim |
| H5 commit hygiene | done | single conventional commit, one file |
| H6 CI green | pending | to be confirmed on this PR before merge |
| **H7 boy-scout (§14)** | done | see below |

### H7 -- boy-scout on touched material

- **Inventory counts in the touched description re-measured** against the
  v2.36.0 tree rather than trusted: 97 genius patterns (98 `.md` including
  `INDEX.md`), 23 team specialists, 78 skills, 26 commands, 42 top-level
  tools, 20 hooks. All still correct. The only `tools/` delta between v2.35.0
  and v2.36.0 is one new test script under `tools/tests/`, which does not move
  the top-level count -- so no correction was needed and none was invented.
- **Every other pin audited for staleness**, not just the one being changed:
  `cortex-viz` 2.7.1 is the latest published release; `hypermnesia-mcp` 4.16.0
  matches `metadata.version`; the `cortex` 4.15.0 entry is the intentional
  deprecated shim. No un-filed stale pin remains.

No deferral, no filed issue -- nothing was left untreated.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
