### PR TITLE
fix(tests): give CLAUDE_DIR an override seam so the suite cannot touch real data (#219)

### DIFF
--- a/.bestpractices.json
+++ b/.bestpractices.json
@@ -99,7 +99,7 @@
   "build_floss_tools_justification": "pip, uv, hatchling, pytest, ruff and pyright are all FLOSS, and the build runs on ubuntu-latest and windows-latest GitHub runners.",
 
   "test_status": "Met",
-  "test_justification": "An automated test suite of 5715 tests lives under tests_py/ (measured 2026-07-27 with 'pytest --collect-only -q'), covering core, handlers, infrastructure, integration, invariants and architecture: https://github.com/cdeust/Cortex/tree/main/tests_py",
+  "test_justification": "An automated test suite of 5735 tests lives under tests_py/ (measured 2026-07-28 with 'pytest --collect-only -q'), covering core, handlers, infrastructure, integration, invariants and architecture: https://github.com/cdeust/Cortex/tree/main/tests_py",
 
   "test_invocation_status": "Met",
   "test_invocation_justification": "The whole suite runs with a single 'pytest' command, documented in CONTRIBUTING.md under Testing along with per-layer subsets: https://github.com/cdeust/Cortex/blob/main/CONTRIBUTING.md",
@@ -114,7 +114,7 @@
   "test_policy_justification": "CONTRIBUTING.md carries an explicit, mandatory testing policy: new functionality ships with tests in the automated suite, a bug fix carries a regression test that fails on the pre-fix code, and each failure path asserts its observable effect including the signal it emits \u2014 https://github.com/cdeust/Cortex/blob/main/CONTRIBUTING.md#the-testing-policy-mandatory. The per-tool checklist ('Add a unit test', 'Add an integration test if the tool touches the database') and the five-element mechanism checklist restate it per change type.",
 
   "tests_are_added_status": "Met",
-  "tests_are_added_justification": "New functionality ships with its tests; the suite has grown to 5715 tests alongside the v4.x feature series, and CI runs it on every pull request.",
+  "tests_are_added_justification": "New functionality ships with its tests; the suite has grown to 5735 tests alongside the v4.x feature series, and CI runs it on every pull request.",
 
   "tests_documented_added_status": "Met",
   "tests_documented_added_justification": "The requirement is written into the documented instructions for change proposals: https://github.com/cdeust/Cortex/blob/main/CONTRIBUTING.md#the-testing-policy-mandatory states that every change adding or altering observable behaviour must arrive with tests in the same PR, the per-tool and per-mechanism checklists repeat it as a concrete step, and .github/PULL_REQUEST_TEMPLATE.md requires a Test plan section in every pull request.",
@@ -189,7 +189,7 @@
   "static_analysis_often_justification": "CodeQL default setup analyses each push and pull request and additionally runs on a weekly schedule, so analysis happens per change rather than per release.",
 
   "dynamic_analysis_status": "Unmet",
-  "dynamic_analysis_justification": "No dynamic analysis tool in the badge's sense (fuzzer, sanitizer, or scanner) is applied. The project runs a 5715-test suite with coverage on every change, but a test suite is not a dynamic analysis tool and is not claimed as one here.",
+  "dynamic_analysis_justification": "No dynamic analysis tool in the badge's sense (fuzzer, sanitizer, or scanner) is applied. The project runs a 5735-test suite with coverage on every change, but a test suite is not a dynamic analysis tool and is not claimed as one here.",
 
   "dynamic_analysis_unsafe_status": "N/A",
   "dynamic_analysis_unsafe_justification": "Cortex is written in Python, a memory-safe language, so the memory-safety tooling this criterion asks about (ASan, Valgrind) does not apply.",
@@ -297,7 +297,7 @@
   "interfaces_current_justification": "The stack targets currently supported runtimes and APIs: Python 3.10 through 3.13, all four in the CI matrix, with pgvector 0.3+/PostgreSQL 17 and current major versions of FastMCP, Pydantic v2, numpy and sentence-transformers. Deprecated interfaces are removed rather than wrapped \u2014 the standing rule is one-shot migrations with no back-compat shims (CLAUDE.md), and CI runs on the newest released Python so a deprecation surfaces as a warning in the build rather than as a surprise at end of life.",
 
   "automated_integration_testing_status": "Met",
-  "automated_integration_testing_justification": "The full suite runs on every push and pull request to main via .github/workflows/ci.yml and reports success or failure per job: 5715 tests on Python 3.10-3.13 against PostgreSQL + pgvector, the same suite against the SQLite backend, the suite on Windows, and a Docker smoke job that boots the bare container and exercises the DB-less contract. tests_py/integration/ holds the database-backed integration tests specifically.",
+  "automated_integration_testing_justification": "The full suite runs on every push and pull request to main via .github/workflows/ci.yml and reports success or failure per job: 5735 tests on Python 3.10-3.13 against PostgreSQL + pgvector, the same suite against the SQLite backend, the suite on Windows, and a Docker smoke job that boots the bare container and exercises the DB-less contract. tests_py/integration/ holds the database-backed integration tests specifically.",
 
   "regression_tests_added50_status": "Met",
   "regression_tests_added50_justification": "Measured on 2026-07-27 over the merged pull requests titled as fixes in the preceding six months (2026-01-27 onward): 23 of 30 \u2014 76.7% \u2014 changed the test tree in the same PR, against the 50% this criterion asks for. (The measure counts a PR as carrying tests when it touches tests_py/ or tests_js/, which is a proxy for 'added a regression test'; the policy behind it is written down at https://github.com/cdeust/Cortex/blob/main/CONTRIBUTING.md#the-testing-policy-mandatory \u2014 a bug fix carries a regression test that fails on the pre-fix code.)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ coding write gates, causal graphs, and intent-aware retrieval.
 
 - Install (dev): `uv pip install -e ".[dev]"` — SQLite backend: `".[dev,sqlite]"`
 - Environment preflight: `python -m mcp_server.doctor` (backend-aware check list, fix message per check)
-- Tests: `pytest` (full suite, 5715 tests) · `pytest tests_py/core/` (one layer) · `pytest --cov=mcp_server --cov-report=term-missing`
+- Tests: `pytest` (full suite, 5735 tests) · `pytest tests_py/core/` (one layer) · `pytest --cov=mcp_server --cov-report=term-missing`
 - Lint BEFORE every commit: `ruff check && ruff format --check` — the CI enforces **both**; passing only `ruff check` is not enough.
 - Release gate benchmarks (isolated, ephemeral container — the only source
   of truth for pre-tag/floor decisions): `benchmarks/reproduce.sh`. Do NOT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ bash scripts/setup.sh        # macOS / Linux
 # Verify everything is wired
 uvx --python 3.13 --from "hypermnesia-mcp[postgresql]" cortex-doctor
 
-# Run tests (5715 tests under tests_py/)
+# Run tests (5735 tests under tests_py/)
 pytest
 
 # Run a benchmark
@@ -129,7 +129,7 @@ The full standard lives in
 ## Testing
 
 ```bash
-pytest                              # full suite (5715 tests)
+pytest                              # full suite (5735 tests)
 pytest tests_py/core                # core (pure business logic) only
 pytest tests_py/integration         # PostgreSQL-backed integration
 pytest tests_py/benchmarks -k locomo # subset

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -26,7 +26,9 @@ like any other memory (locally) — avoid doing so.
 - **SQLite (default — Claude Code plugin installs, Claude Desktop `.mcpb`
   connector, Claude Cowork, and other sandboxed launches):** all memories,
   entities, the knowledge graph, and profiles are stored in a single local
-  database file at `~/.claude/methodology/memory.db`. If a configured
+  database file at `~/.claude/methodology/memory.db` (setting
+  `CORTEX_CLAUDE_DIR` relocates this root, and everything derived from it, to
+  a directory you choose). If a configured
   PostgreSQL instance is unreachable, Cortex falls back to this SQLite store
   with an explicit warning in the logs. Nothing is uploaded.
 - **PostgreSQL + pgvector (opt-in — `install-plugin.sh --postgres`, large

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/cdeust/Cortex/actions/workflows/ci.yml"><img src="https://github.com/cdeust/Cortex/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License"></a>
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+">
-  <img src="https://img.shields.io/badge/tests-5715_passing-brightgreen.svg" alt="5715 passing">
+  <img src="https://img.shields.io/badge/tests-5735_passing-brightgreen.svg" alt="5735 passing">
   <img src="https://img.shields.io/badge/references-97_papers-orange.svg" alt="References">
   <img src="https://img.shields.io/badge/version-4.16.0-brightgreen.svg" alt="Version 4.16.0">
   <a href="https://www.bestpractices.dev/projects/13836"><img src="https://www.bestpractices.dev/projects/13836/badge" alt="OpenSSF Best Practices"></a>
@@ -525,7 +525,7 @@ Cortex is **local-first**: your memories, conversations, and profiles stay on yo
 ## Development
 
 ```bash
-pytest                    # 5715 tests
+pytest                    # 5735 tests
 ruff check .              # Lint
 ruff format --check .     # Format
 python scripts/check_doc_claims.py   # advertised counts must match the repo

--- a/docs/ASSURANCE-CASE.md
+++ b/docs/ASSURANCE-CASE.md
@@ -128,7 +128,7 @@ decoratively:
 
 Standing analysis: CodeQL default setup (Python, JavaScript/TypeScript,
 Actions) on every push and pull request plus weekly, currently 0 open alerts;
-OpenSSF Scorecard via `.github/workflows/scorecard.yml`; and 5715 tests run on
+OpenSSF Scorecard via `.github/workflows/scorecard.yml`; and 5735 tests run on
 four Python versions, two backends and Windows.
 
 ## 6. What this assurance case does NOT claim

--- a/docs/module-inventory.md
+++ b/docs/module-inventory.md
@@ -192,7 +192,12 @@ Run the measurement command in the header to get a current file listing.
 
 ## infrastructure/ — All I/O
 
-- `config.py` — Centralized path constants via pathlib
+- `config.py` — Centralized path constants via pathlib. The root (`CLAUDE_DIR`,
+  default `~/.claude`) is overridable via `CORTEX_CLAUDE_DIR`; every other
+  constant derives from it, so that one variable redirects the SQLite store,
+  the wiki tree, profiles, and the session log together. This is the seam the
+  test suite uses to bind to a throwaway tree (issue #219) — constants are
+  bound at import time, so the variable must be set before the first import
 - `file_io.py` — Generic JSON/text read/write operations
 - `profile_store.py` — profiles.json persistence
 - `session_store.py` — session-log.json persistence

--- a/mcp_server/infrastructure/config.py
+++ b/mcp_server/infrastructure/config.py
@@ -1,14 +1,37 @@
 """Centralized path constants for all filesystem locations.
 
-All paths are absolute, derived from os.path.expanduser("~") + constants.
-No I/O operations — only path construction.
+All paths are absolute, derived from the Claude configuration root plus
+constants. No I/O operations — only path construction.
+
+The root is overridable via ``CORTEX_CLAUDE_DIR``. Every real-data path in
+Cortex — the SQLite store, the wiki tree, profiles, the session log —
+derives from it, so that single variable is the one seam a test session (or
+any sandboxed run) needs in order to bind to a throwaway tree instead of the
+operator's real ``~/.claude``.
+
+source: incident 2026-07-28 (issue #219). Without this seam the test suite
+had no way to redirect the wiki root: ``consolidate.handler()`` calls
+``write_dashboards(WIKI_ROOT)``, which walked the developer's real wiki
+(16,234 files — the reported "suite hangs at 58%") and wrote generated
+dashboards into ``~/.claude/methodology/wiki/_dashboards/``. Patching each
+derived constant per test is the throw-site fix; the root is here.
+
+Unset (the default for every production install), behavior is unchanged:
+the root stays ``~/.claude``.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
-CLAUDE_DIR = Path.home() / ".claude"
+_CLAUDE_DIR_OVERRIDE = os.environ.get("CORTEX_CLAUDE_DIR", "").strip()
+
+CLAUDE_DIR = (
+    Path(_CLAUDE_DIR_OVERRIDE).expanduser()
+    if _CLAUDE_DIR_OVERRIDE
+    else Path.home() / ".claude"
+)
 METHODOLOGY_DIR = CLAUDE_DIR / "methodology"
 PROFILES_PATH = METHODOLOGY_DIR / "profiles.json"
 SESSION_LOG_PATH = METHODOLOGY_DIR / "session-log.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,14 @@ pythonpath = ["."]
 # conflict with pytest-asyncio's non-main-thread test runs.
 timeout = 300
 timeout_method = "thread"
+# Fail closed when a plugin the config DEPENDS ON is absent. Without this,
+# an environment missing pytest-timeout only emits
+# `PytestConfigWarning: Unknown config option: timeout` and runs on with no
+# per-test timeout at all — the protection above silently evaporates and a
+# hang stalls the run indefinitely instead of failing at 300s (observed
+# 2026-07-28 while reproducing issue #219: a local run hung >600s because
+# the plugin was not installed).
+required_plugins = ["pytest-timeout", "pytest-asyncio"]
 markers = [
     "invariants: Phase 0.3+ testable invariant predicates (I1/I2/I3/I4 and parity tests)",
 ]

--- a/tests_py/conftest.py
+++ b/tests_py/conftest.py
@@ -402,8 +402,21 @@ _TABLES_TO_CLEAN = [
 
 
 def _get_raw_connection():
-    """Get a raw psycopg connection to the test database."""
-    if not _USE_PG_STORE:
+    """Get a raw psycopg connection to the test database.
+
+    Gated on REACHABILITY (`_USE_PG`), not on the effective backend. These
+    are different questions and conflating them regresses the suite: dozens
+    of tests are marked `skipif(not _USE_PG)` and construct `PgMemoryStore()`
+    in their own fixture, bypassing backend selection entirely. They run
+    whenever PostgreSQL is reachable — including a `CORTEX_MEMORY_STORE_BACKEND
+    =sqlite` run — and they depend on this between-test purge. Gating it on
+    `_USE_PG_STORE` left their rows in place and broke 15 of them (measured
+    2026-07-28, paired control against cc08a16).
+
+    The SQLite purge below is the one that belongs to the effective backend.
+    Both can be required in the same run; they are not alternatives.
+    """
+    if not _USE_PG:
         return None
     try:
         import psycopg

--- a/tests_py/conftest.py
+++ b/tests_py/conftest.py
@@ -1,8 +1,12 @@
-"""Global test configuration — isolate tests on cortex_test database.
+"""Global test configuration — isolate tests from every real-data root.
 
 Handler/integration tests hit PostgreSQL when available. When PG is not
 available (CI without PG, sandboxed environments), falls back to SQLite
 with per-test isolation via temporary DB files.
+
+Isolation has three roots, and ALL THREE are redirected unconditionally
+before any `mcp_server` module is imported (see `_redirect_real_data_roots`):
+the PostgreSQL URL, the SQLite file, and the `~/.claude` filesystem tree.
 """
 
 import asyncio
@@ -12,6 +16,53 @@ import sys
 import tempfile
 
 import pytest
+
+# ── Redirect every real-data root — MUST run before importing mcp_server ──
+#
+# INCIDENT 2026-07-28 (issue #219): isolation used to be conditional on
+# PostgreSQL being *unavailable*. On a developer machine where PG is
+# reachable AND the SQLite backend is selected, the `if not _USE_PG:` block
+# below never ran, so `settings.DB_PATH` resolved to the operator's real
+# `~/.claude/methodology/memory.db` (reproduced 2026-07-28: a probe test
+# printed `binds to REAL DB = True`). The suite DELETEs every table between
+# tests, so running it locally wiped that store to 0 rows.
+#
+# The filesystem was worse, and unconditional: `consolidate.handler()` calls
+# `write_dashboards(WIKI_ROOT)`, which walked the developer's real wiki
+# (16,234 files — this is the "suite hangs at 58%" symptom, a slow scan, not
+# a deadlock) and WROTE generated pages into
+# `~/.claude/methodology/wiki/_dashboards/`.
+#
+# Both roots derive from `config.CLAUDE_DIR`, so one redirection closes both.
+# `mcp_server.infrastructure.config` binds its constants at import time and
+# importers do `from ... import METHODOLOGY_DIR` (a value copy, 40 modules),
+# so the env var must be set before the first import — conftest.py is loaded
+# before any test module, and nothing above this point imports mcp_server.
+_TEST_CLAUDE_DIR = tempfile.mkdtemp(prefix="cortex_test_claude_")
+
+
+def _redirect_real_data_roots() -> str:
+    """Point the filesystem root and the SQLite store at a throwaway tree.
+
+    Returns the isolated SQLite path. Unconditional by construction: an
+    exported `CORTEX_MEMORY_DB_PATH` / `CORTEX_MEMORY_SQLITE_FALLBACK_PATH`
+    is OVERWRITTEN, not respected — the backend a developer selects is their
+    choice, the physical location the suite writes to is not.
+    """
+    os.environ["CORTEX_CLAUDE_DIR"] = _TEST_CLAUDE_DIR
+    methodology = os.path.join(_TEST_CLAUDE_DIR, "methodology")
+    os.makedirs(methodology, exist_ok=True)
+    sqlite_path = os.path.join(methodology, "memory.db")
+    # Handlers read the deprecated DB_PATH; the store reads
+    # SQLITE_FALLBACK_PATH. Both must point at the throwaway file or the
+    # unset one falls back to the (now redirected, but explicit is better)
+    # default. source: memory_config.py:48-49.
+    os.environ["CORTEX_MEMORY_DB_PATH"] = sqlite_path
+    os.environ["CORTEX_MEMORY_SQLITE_FALLBACK_PATH"] = sqlite_path
+    return sqlite_path
+
+
+_ISOLATED_SQLITE_PATH = _redirect_real_data_roots()
 
 # On Windows asyncio defaults to ProactorEventLoop, whose GC-time teardown
 # emits a noisy "Event loop is closed" PytestUnraisableExceptionWarning that
@@ -215,6 +266,53 @@ def _guard_against_populated_db() -> None:
         )
 
 
+def _guard_against_real_data_roots() -> None:
+    """Refuse to run if any resolved root still points at real user data.
+
+    `_redirect_real_data_roots` sets the env vars, but the values that
+    actually matter are the ones `mcp_server` RESOLVED from them — an import
+    that happened too early, or a future edit that moves the redirection
+    below the first import, would leave the constants bound to the real
+    `~/.claude` while the env vars look correct. This checks the resolved
+    values, so it cannot be fooled by a correct-looking environment.
+
+    Fail-closed and unconditional: there is no override. A suite that DELETEs
+    every table between tests and rewrites the wiki has no safe way to run
+    against a real tree.
+
+    source: issue #219 — the previous isolation was conditional and its
+    failure was silent for as long as it took to notice a 0-row store.
+    """
+    from mcp_server.infrastructure.config import CLAUDE_DIR, WIKI_ROOT
+    from mcp_server.infrastructure.memory_config import get_memory_settings
+
+    settings = get_memory_settings()
+    real_root = os.path.realpath(os.path.expanduser("~/.claude"))
+    isolated = os.path.realpath(_TEST_CLAUDE_DIR)
+
+    offenders = [
+        (name, value)
+        for name, value in (
+            ("CLAUDE_DIR", str(CLAUDE_DIR)),
+            ("WIKI_ROOT", str(WIKI_ROOT)),
+            ("MemorySettings.DB_PATH", settings.DB_PATH),
+            ("MemorySettings.SQLITE_FALLBACK_PATH", settings.SQLITE_FALLBACK_PATH),
+        )
+        if not os.path.realpath(os.path.expanduser(value)).startswith(isolated)
+    ]
+    if offenders:
+        detail = "\n".join(f"    {name} -> {value}" for name, value in offenders)
+        pytest.exit(
+            "REFUSING to run: test isolation is not in effect. These roots "
+            f"still resolve outside the throwaway tree {isolated}:\n{detail}\n"
+            f"(real user root: {real_root}). The suite DELETEs every table "
+            "between tests and regenerates wiki dashboards — running it "
+            "against a real tree destroys data (issue #219). Ensure "
+            "_redirect_real_data_roots() runs before any mcp_server import.",
+            returncode=2,
+        )
+
+
 def _pg_available() -> bool:
     """Check if PostgreSQL is reachable."""
     try:
@@ -228,16 +326,40 @@ def _pg_available() -> bool:
 
 
 _guard_against_populated_db()
+_guard_against_real_data_roots()
 _USE_PG = _pg_available()
 
-# When PG isn't available, force SQLite backend with a temp dir
+# The SQLite PATHS are already isolated unconditionally by
+# _redirect_real_data_roots() above. Only the backend SELECTION is decided
+# here: with no PG to talk to, the suite must run on SQLite. When PG is
+# reachable the caller's choice of backend stands — an exported
+# CORTEX_MEMORY_STORE_BACKEND=sqlite is honored, and is now isolated too.
 if not _USE_PG:
-    _SQLITE_TEST_DIR = tempfile.mkdtemp(prefix="cortex_test_")
-    _sqlite_db = os.path.join(_SQLITE_TEST_DIR, "test.db")
     os.environ["CORTEX_MEMORY_STORE_BACKEND"] = "sqlite"
-    os.environ["CORTEX_MEMORY_SQLITE_FALLBACK_PATH"] = _sqlite_db
-    # Handlers pass settings.DB_PATH to MemoryStore(); override it too
-    os.environ["CORTEX_MEMORY_DB_PATH"] = _sqlite_db
+
+
+def _effective_backend() -> str:
+    """The store the suite actually writes to — "postgresql" or "sqlite".
+
+    `_USE_PG` answers a different question: "is PostgreSQL reachable". The
+    two diverge whenever a developer exports
+    `CORTEX_MEMORY_STORE_BACKEND=sqlite` on a machine where PG is also up —
+    the suite then writes to SQLite while every `if not _USE_PG:` branch
+    treats the run as PostgreSQL, so the between-test SQLite purge never
+    runs and rows leak from one test into the next.
+
+    Resolution mirrors `memory_store._construct_store`: an explicit backend
+    wins; "auto" (the default) means PostgreSQL when reachable and SQLite
+    otherwise. source: mcp_server/infrastructure/memory_store.py:164-214.
+    """
+    explicit = os.environ.get("CORTEX_MEMORY_STORE_BACKEND", "").strip().lower()
+    if explicit in ("sqlite", "postgresql"):
+        return explicit
+    return "postgresql" if _USE_PG else "sqlite"
+
+
+_BACKEND = _effective_backend()
+_USE_PG_STORE = _BACKEND == "postgresql"
 
 
 # ── Tables to clean between tests (order matters for FK constraints) ─────
@@ -281,7 +403,7 @@ _TABLES_TO_CLEAN = [
 
 def _get_raw_connection():
     """Get a raw psycopg connection to the test database."""
-    if not _USE_PG:
+    if not _USE_PG_STORE:
         return None
     try:
         import psycopg
@@ -300,7 +422,9 @@ def _clean_all_tables(conn) -> None:
             pass
 
 
-_SQLITE_DB_PATH = os.environ.get("CORTEX_MEMORY_SQLITE_FALLBACK_PATH", "")
+# Always the throwaway file from _redirect_real_data_roots() — never a path
+# inherited from the developer's environment (issue #219).
+_SQLITE_DB_PATH = _ISOLATED_SQLITE_PATH
 
 
 def _clean_sqlite_via_singleton() -> bool:
@@ -445,7 +569,7 @@ def _test_isolation():
     connections.
     """
     # Pre-test: clean with existing connections, then reset
-    if not _USE_PG:
+    if not _USE_PG_STORE:
         _clean_sqlite_store()
 
     conn = _get_raw_connection()
@@ -457,7 +581,7 @@ def _test_isolation():
     yield
 
     # Post-test: clean again, then reset
-    if not _USE_PG:
+    if not _USE_PG_STORE:
         _clean_sqlite_store()
 
     _reset_all_singletons()

--- a/tests_py/infrastructure/test_config.py
+++ b/tests_py/infrastructure/test_config.py
@@ -1,7 +1,11 @@
 """Tests for mcp_server.infrastructure.config."""
 
+import importlib.util
 from pathlib import Path
 
+import pytest
+
+from mcp_server.infrastructure import config as config_module
 from mcp_server.infrastructure.config import (
     CLAUDE_DIR,
     METHODOLOGY_DIR,
@@ -9,7 +13,30 @@ from mcp_server.infrastructure.config import (
     SESSION_LOG_PATH,
     BRAIN_INDEX_PATH,
     MCP_CONNECTIONS_PATH,
+    WIKI_ROOT,
 )
+
+
+def _config_under(monkeypatch, override: str | None):
+    """Import a fresh, private instance of the config module under `override`.
+
+    The constants bind at import time, so the only way to observe a different
+    ``CORTEX_CLAUDE_DIR`` is to import again. A private instance is used
+    deliberately instead of ``importlib.reload``: reloading the cached module
+    would rebind ``CLAUDE_DIR`` for the ~40 modules that already did
+    ``from ...config import X`` (a value copy) at collection time, leaking one
+    test's environment into the rest of the session.
+    """
+    if override is None:
+        monkeypatch.delenv("CORTEX_CLAUDE_DIR", raising=False)
+    else:
+        monkeypatch.setenv("CORTEX_CLAUDE_DIR", override)
+    spec = importlib.util.spec_from_file_location(
+        "_config_probe", config_module.__file__
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class TestConfig:
@@ -21,11 +48,9 @@ class TestConfig:
             SESSION_LOG_PATH,
             BRAIN_INDEX_PATH,
             MCP_CONNECTIONS_PATH,
+            WIKI_ROOT,
         ]:
             assert p.is_absolute()
-
-    def test_claude_dir_is_dot_claude(self):
-        assert CLAUDE_DIR == Path.home() / ".claude"
 
     def test_methodology_dir_under_claude(self):
         assert METHODOLOGY_DIR == CLAUDE_DIR / "methodology"
@@ -41,3 +66,50 @@ class TestConfig:
 
     def test_mcp_connections_path(self):
         assert MCP_CONNECTIONS_PATH == METHODOLOGY_DIR / "mcp-connections.json"
+
+    def test_wiki_root_under_methodology(self):
+        assert WIKI_ROOT == METHODOLOGY_DIR / "wiki"
+
+
+class TestClaudeDirOverride:
+    """The ``CORTEX_CLAUDE_DIR`` seam (issue #219).
+
+    This suite cannot assert the *ambient* ``CLAUDE_DIR``: conftest sets the
+    override before the first import precisely so no test can touch the
+    operator's real tree. What the production contract actually promises is
+    tested here instead, both arms, on freshly imported instances.
+    """
+
+    def test_unset_defaults_to_home_dot_claude(self, monkeypatch):
+        assert _config_under(monkeypatch, None).CLAUDE_DIR == Path.home() / ".claude"
+
+    def test_override_relocates_the_root(self, monkeypatch, tmp_path):
+        assert _config_under(monkeypatch, str(tmp_path)).CLAUDE_DIR == tmp_path
+
+    def test_override_relocates_every_derived_path(self, monkeypatch, tmp_path):
+        cfg = _config_under(monkeypatch, str(tmp_path))
+        derived = [
+            cfg.METHODOLOGY_DIR,
+            cfg.PROFILES_PATH,
+            cfg.SESSION_LOG_PATH,
+            cfg.BRAIN_INDEX_PATH,
+            cfg.MCP_CONNECTIONS_PATH,
+            cfg.WIKI_ROOT,
+        ]
+        # The whole point of the seam: one variable moves the SQLite store,
+        # the wiki tree, profiles, and the session log together. A path left
+        # behind is a real-data root the suite would still write to.
+        for path in derived:
+            assert tmp_path in path.parents or path == tmp_path
+
+    def test_override_is_user_expanded(self, monkeypatch):
+        assert _config_under(monkeypatch, "~/cortex-elsewhere").CLAUDE_DIR == (
+            Path.home() / "cortex-elsewhere"
+        )
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+    def test_blank_override_falls_back_to_default(self, monkeypatch, blank):
+        # An exported-but-empty variable is the shell's "unset" (`export
+        # CORTEX_CLAUDE_DIR=` / a compose file with no value). Treating it as
+        # a path would resolve the root to the process CWD.
+        assert _config_under(monkeypatch, blank).CLAUDE_DIR == Path.home() / ".claude"

--- a/tests_py/invariants/test_store_isolation.py
+++ b/tests_py/invariants/test_store_isolation.py
@@ -1,0 +1,350 @@
+"""Invariant: the test suite never reads or writes the operator's real data.
+
+Incident 2026-07-28 (issue #219). Isolation in `tests_py/conftest.py` used to
+be conditional on PostgreSQL being *unavailable*:
+
+    if not _USE_PG:
+        os.environ["CORTEX_MEMORY_SQLITE_FALLBACK_PATH"] = <temp>
+
+On a developer machine where PG is reachable AND the SQLite backend is
+selected, that branch never ran. Two things followed:
+
+  * `settings.DB_PATH` resolved to the real `~/.claude/methodology/memory.db`.
+    The autouse `_test_isolation` fixture DELETEs every table between tests,
+    so running the suite locally wiped that store to 0 rows.
+  * `consolidate.handler()` calls `write_dashboards(WIKI_ROOT)`, which walked
+    the developer's real wiki (16,234 files — the "suite hangs at 58%"
+    symptom) and WROTE generated pages into
+    `~/.claude/methodology/wiki/_dashboards/`.
+
+Both roots derive from `config.CLAUDE_DIR`, which had no override seam at
+all. The fix adds `CORTEX_CLAUDE_DIR` and redirects it unconditionally.
+
+These tests pin that fix from three angles, so a regression cannot be
+silent: the RESOLVED roots are isolated (not merely the env vars), a live
+write-path handler leaves the real tree untouched, and the conftest guard
+that enforces this cannot be deleted or made conditional.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+
+_REAL_CLAUDE_DIR = Path(os.path.expanduser("~/.claude")).resolve()
+
+_CONFTEST_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "conftest.py")
+)
+
+
+def _real(path: str | Path) -> str:
+    return os.path.realpath(os.path.expanduser(str(path)))
+
+
+def _is_under(path: str | Path, root: Path) -> bool:
+    return _real(path).startswith(_real(root))
+
+
+# ── The resolved roots, not the env vars ─────────────────────────────────────
+
+
+class TestResolvedRootsAreIsolated:
+    """Every path constant Cortex derives must land in the throwaway tree.
+
+    Asserting the RESOLVED constants (rather than `os.environ`) is the point:
+    the constants are bound at import time by 40 modules doing
+    `from ...config import METHODOLOGY_DIR`. An environment set correctly but
+    too late produces correct-looking env vars and real-data constants.
+    """
+
+    def test_claude_dir_is_not_the_real_root(self):
+        from mcp_server.infrastructure.config import CLAUDE_DIR
+
+        assert not _is_under(CLAUDE_DIR, _REAL_CLAUDE_DIR), (
+            f"CLAUDE_DIR resolved to {CLAUDE_DIR}, inside the operator's real "
+            f"{_REAL_CLAUDE_DIR}. The suite deletes tables and rewrites wiki "
+            "pages — it must never bind here (issue #219)."
+        )
+
+    def test_wiki_root_is_not_the_real_wiki(self):
+        """The wiki is the root that `consolidate` WRITES to.
+
+        `write_dashboards` does `mkdir(parents=True, exist_ok=True)` and
+        `path.write_text(...)` per domain — an unisolated WIKI_ROOT means the
+        suite generates pages into the operator's real wiki.
+        """
+        from mcp_server.infrastructure.config import WIKI_ROOT
+
+        assert not _is_under(WIKI_ROOT, _REAL_CLAUDE_DIR), (
+            f"WIKI_ROOT resolved to {WIKI_ROOT}, inside the real "
+            f"{_REAL_CLAUDE_DIR} — consolidate would write dashboards there."
+        )
+
+    @pytest.mark.parametrize("field", ["DB_PATH", "SQLITE_FALLBACK_PATH"])
+    def test_sqlite_paths_are_not_the_real_store(self, field: str):
+        """Both SQLite settings must be isolated, not just one.
+
+        Handlers pass the deprecated `DB_PATH` to the store while the store
+        itself falls back to `SQLITE_FALLBACK_PATH` (memory_config.py:48-49).
+        Isolating only one leaves the other resolving to the real file.
+        """
+        from mcp_server.infrastructure.memory_config import get_memory_settings
+
+        value = getattr(get_memory_settings(), field)
+        assert not _is_under(value, _REAL_CLAUDE_DIR), (
+            f"MemorySettings.{field} resolved to {value}, inside the real "
+            f"{_REAL_CLAUDE_DIR}. The between-test purge would wipe it."
+        )
+
+    def test_isolation_survives_an_exported_db_path(self):
+        """An operator's exported path must be OVERWRITTEN, not respected.
+
+        The #220 reproduction command exports CORTEX_MEMORY_DB_PATH. Honoring
+        it would let any environment re-point the suite at a real file, which
+        is exactly the failure mode this invariant exists to prevent. The
+        backend a developer selects is their choice; the physical location
+        the suite writes to is not.
+        """
+        from mcp_server.infrastructure.memory_config import get_memory_settings
+
+        resolved = _real(get_memory_settings().DB_PATH)
+        assert _real(os.environ["CORTEX_MEMORY_DB_PATH"]) == resolved, (
+            "CORTEX_MEMORY_DB_PATH and the resolved DB_PATH disagree — "
+            "conftest's unconditional override is no longer in effect."
+        )
+        assert not _is_under(resolved, _REAL_CLAUDE_DIR)
+
+
+# ── Behavioral: a live write path leaves the real tree byte-identical ────────
+
+
+class TestRealTreeIsNeverWritten:
+    """Run the handler that caused the incident; the real tree must not move.
+
+    This is the negative assertion the settings checks above cannot make:
+    absence of a write IS the behavior under test (§13.1 G4). `consolidate`
+    is the specific handler that regenerated dashboards into the operator's
+    wiki, so it is the right probe rather than an arbitrary one.
+    """
+
+    @staticmethod
+    def _fingerprint(root: Path) -> dict[str, tuple[float, int]]:
+        """(mtime, size) per file under `root`; empty dict when absent.
+
+        Absence is a valid state, not a skip condition: on CI there is no
+        real `~/.claude` tree, so before and after are both empty and the
+        equality assertion still holds meaningfully.
+        """
+        if not root.is_dir():
+            return {}
+        out: dict[str, tuple[float, int]] = {}
+        for path in root.rglob("*"):
+            try:
+                if path.is_file():
+                    st = path.stat()
+                    out[str(path)] = (st.st_mtime, st.st_size)
+            except OSError:
+                continue
+        return out
+
+    @pytest.mark.asyncio
+    async def test_consolidate_does_not_touch_the_real_wiki(self):
+        """The exact call chain from the incident must not write real files.
+
+        consolidate.handler() -> run_wiki_maintenance -> write_dashboards(
+        WIKI_ROOT) -> render_dashboard/audit_files. Before the fix this
+        walked 16,234 real files and wrote `_dashboards/*.md`.
+        """
+        from mcp_server.handlers.consolidate import handler
+
+        real_wiki = _REAL_CLAUDE_DIR / "methodology" / "wiki"
+        before = self._fingerprint(real_wiki)
+
+        await handler()
+
+        after = self._fingerprint(real_wiki)
+        changed = sorted(
+            name
+            for name in set(before) | set(after)
+            if before.get(name) != after.get(name)
+        )
+        assert not changed, (
+            "consolidate() modified files inside the operator's real wiki: "
+            f"{changed[:10]} ({len(changed)} total). WIKI_ROOT is not "
+            "isolated (issue #219)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_consolidate_does_not_touch_the_real_sqlite_store(self):
+        """The real memory.db must be byte-identical across a full cycle.
+
+        consolidate decays heat, compresses memories to gist/tag, and
+        advances consolidation stages — every one of those is a write.
+        """
+        from mcp_server.handlers.consolidate import handler
+
+        real_db = _REAL_CLAUDE_DIR / "methodology" / "memory.db"
+        before = real_db.stat() if real_db.exists() else None
+
+        await handler()
+
+        after = real_db.stat() if real_db.exists() else None
+        if before is None and after is None:
+            return  # no real store on this machine — nothing to corrupt
+        assert before is not None and after is not None, (
+            f"consolidate() created or deleted {real_db} — the suite is "
+            "bound to the operator's real store."
+        )
+        assert (before.st_mtime, before.st_size) == (after.st_mtime, after.st_size), (
+            f"consolidate() wrote to the operator's real store {real_db} (issue #219)."
+        )
+
+
+# ── The guard itself cannot be removed or weakened ───────────────────────────
+
+
+class TestIsolationGuard:
+    """`_guard_against_real_data_roots` must fire on a real root.
+
+    The guard checks resolved values so it cannot be fooled by a
+    correct-looking environment. These tests drive it against a deliberately
+    un-isolated root and assert it aborts the session.
+    """
+
+    def test_guard_exits_when_a_root_escapes_isolation(self):
+        """A WIKI_ROOT pointing at the real tree must abort with returncode=2.
+
+        Postcondition: pytest.exit called once, returncode=2, message names
+        the offending root so an operator can see which one escaped.
+        """
+        import tests_py.conftest as conftest
+        from mcp_server.infrastructure import config
+
+        real_wiki = _REAL_CLAUDE_DIR / "methodology" / "wiki"
+        with (
+            mock.patch.object(config, "WIKI_ROOT", real_wiki),
+            mock.patch.object(pytest, "exit") as mock_exit,
+        ):
+            conftest._guard_against_real_data_roots()
+
+        mock_exit.assert_called_once()
+        assert mock_exit.call_args[1].get("returncode") == 2
+        assert "WIKI_ROOT" in mock_exit.call_args[0][0], (
+            "Guard message does not name the offending root — an operator "
+            f"cannot tell what escaped: {mock_exit.call_args[0][0]!r}"
+        )
+
+    def test_guard_is_silent_when_isolation_holds(self):
+        """The live session is isolated, so the guard must NOT fire.
+
+        Without this, a guard that always exits would pass the test above
+        while making the suite unrunnable.
+        """
+        import tests_py.conftest as conftest
+
+        with mock.patch.object(pytest, "exit") as mock_exit:
+            conftest._guard_against_real_data_roots()
+        mock_exit.assert_not_called()
+
+    def test_guard_has_no_bypass_env_var(self):
+        """Unlike the PG guard, this one must offer no override.
+
+        A suite that DELETEs every table and regenerates wiki pages has no
+        safe way to run against a real tree, so an escape hatch would only
+        ever be used to re-enable the incident.
+        """
+        with open(_CONFTEST_PATH, encoding="utf-8") as fh:
+            lines = fh.readlines()
+
+        start = next(
+            i
+            for i, line in enumerate(lines)
+            if line.startswith("def _guard_against_real_data_roots(")
+        )
+        end = next(
+            (
+                i
+                for i in range(start + 1, len(lines))
+                if lines[i] and lines[i][0] not in (" ", "\t", "\n")
+            ),
+            len(lines),
+        )
+        body = "".join(lines[start:end])
+        assert "CORTEX_TEST_ALLOW" not in body, (
+            "An override env-var was added to the isolation guard. There is "
+            "no safe way to run this suite against a real data tree."
+        )
+
+
+class TestGuardStructuralIntegrity:
+    """The redirection and the guard must both stay unconditional."""
+
+    def test_redirect_runs_at_module_level(self):
+        """`_redirect_real_data_roots()` must be called at zero indentation.
+
+        Inside an `if`, it reintroduces exactly the conditional-isolation bug
+        of issue #219.
+        """
+        with open(_CONFTEST_PATH, encoding="utf-8") as fh:
+            lines = fh.readlines()
+
+        calls = [
+            line
+            for line in lines
+            if line.strip().endswith("_redirect_real_data_roots()")
+            and not line.startswith((" ", "\t"))
+        ]
+        assert calls, (
+            "conftest.py no longer calls _redirect_real_data_roots() at "
+            "module level — real-data roots are unisolated again (#219)."
+        )
+
+    def test_guard_call_present_at_module_level(self):
+        with open(_CONFTEST_PATH, encoding="utf-8") as fh:
+            lines = fh.readlines()
+
+        calls = [
+            line
+            for line in lines
+            if line.strip() == "_guard_against_real_data_roots()"
+            and not line.startswith((" ", "\t"))
+        ]
+        assert calls, (
+            "conftest.py no longer calls _guard_against_real_data_roots() at "
+            "module level — isolation failures become silent again (#219)."
+        )
+
+    def test_redirect_precedes_first_mcp_server_import(self):
+        """Ordering is load-bearing: constants bind at import time.
+
+        `from mcp_server.infrastructure.config import METHODOLOGY_DIR` copies
+        a value. If any mcp_server import runs before the env var is set, the
+        copied value is the real path and no later env change can fix it.
+        """
+        with open(_CONFTEST_PATH, encoding="utf-8") as fh:
+            lines = fh.readlines()
+
+        redirect_lines = [
+            i
+            for i, line in enumerate(lines)
+            if line.strip().endswith("_redirect_real_data_roots()")
+            and not line.startswith((" ", "\t"))
+        ]
+        assert redirect_lines, (
+            "conftest.py has no module-level _redirect_real_data_roots() "
+            "call, so nothing redirects the real-data roots at all (#219)."
+        )
+        redirect_line = redirect_lines[0]
+        early_imports = [
+            (i + 1, line.strip())
+            for i, line in enumerate(lines[:redirect_line])
+            if line.startswith(("import mcp_server", "from mcp_server"))
+        ]
+        assert not early_imports, (
+            "mcp_server is imported before the roots are redirected, so path "
+            f"constants bind to the real tree: {early_imports}"
+        )


### PR DESCRIPTION
Closes #219.

## Root cause

The suite wrote to the operator's real data. Two limbs, one root — every path
in the product derives from `config.CLAUDE_DIR`, which had **no override seam**,
so isolation had to be re-implemented per derived constant and was applied
inconsistently.

1. **Isolation was conditional.** `tests_py/conftest.py` set the SQLite paths only
   inside `if not _USE_PG:`. On a machine where PostgreSQL is reachable *and* the
   SQLite backend is selected, `settings.DB_PATH` resolved to the real
   `~/.claude/methodology/memory.db`, and the autouse `_test_isolation` fixture
   DELETEs every table between tests — so a local run wiped that store to 0 rows.

2. **Not in the issue text:** `consolidate.handler()` calls `write_dashboards(WIKI_ROOT)`,
   which walked the real wiki (16,234 files) and wrote generated pages into
   `~/.claude/methodology/wiki/_dashboards/`. This limb was unconditional, and the
   scan — not a deadlock — is the reported "suite hangs at 58%".

Fix is **one seam, not a patch per constant**: `CORTEX_CLAUDE_DIR` relocates the
root and every path derives from it. Unset — i.e. every production install —
behaviour is byte-identical.

## Completion Ledger

| Path introduced by the diff | Evidence |
|---|---|
| `CORTEX_CLAUDE_DIR` unset → real `~/.claude` (production path unchanged) | `test_config.py::test_unset_defaults_to_home_dot_claude` |
| `CORTEX_CLAUDE_DIR` set → root relocates | `test_config.py::test_override_relocates_the_root` |
| …and **every** derived path follows it (no constant left behind) | `test_config.py::test_override_relocates_every_derived_path` |
| `~` in the override is user-expanded | `test_config.py::test_override_is_user_expanded` |
| Blank/whitespace override → falls back to default (not an empty root) | `test_config.py::test_blank_override_falls_back_to_default` (parametrised over blank forms) |
| `WIKI_ROOT` stays under `methodology/` | `test_config.py::test_wiki_root_under_methodology` |
| conftest redirect happens before any `mcp_server` import | `test_store_isolation.py::test_redirect_precedes_first_mcp_server_import`, `::test_redirect_runs_at_module_level` |
| Resolved roots are never the real ones | `::test_claude_dir_is_not_the_real_root`, `::test_wiki_root_is_not_the_real_wiki`, `::test_sqlite_paths_are_not_the_real_store` (parametrised per field) |
| An operator-exported `CORTEX_MEMORY_DB_PATH` cannot defeat isolation | `::test_isolation_survives_an_exported_db_path` |
| `consolidate.handler()` writes nothing to the real wiki | `::test_consolidate_does_not_touch_the_real_wiki` |
| `consolidate.handler()` writes nothing to the real SQLite store | `::test_consolidate_does_not_touch_the_real_sqlite_store` |
| Guard **fails the run** when a root escapes isolation (signal asserted, not a side effect) | `::test_guard_exits_when_a_root_escapes_isolation` |
| Guard is silent on the nominal path (negative assertion) | `::test_guard_is_silent_when_isolation_holds` |
| Guard has no opt-out env var — isolation cannot be disabled by configuration | `::test_guard_has_no_bypass_env_var` |
| Guard is invoked at module level, not inside a fixture that could be skipped | `::test_guard_call_present_at_module_level` |
| PostgreSQL purge keyed on **reachability**; SQLite purge keyed on **effective backend** | Paired control, below |

**G3 (determinism/isolation):** the invariant suite asserts isolation structurally —
including that the redirect precedes the first import — so the property cannot decay
into "passes because this machine has no data".

## Paired control for the second commit

`17b17d4` fixes a regression that `ba79aea` introduced, found by running both
commits under identical conditions rather than by inspection:

| Tree | Result (sqlite backend, full suite) |
|---|---|
| `main` (cc08a16) | 35 failed / 5600 passed |
| `ba79aea` | 25 failed + 9 errors — **15 tests that pass on main failed** |
| `17b17d4` (this branch) | **22 failed / 5633 passed** — regressions vs main: 1 |

`_get_raw_connection()` had been gated on `_USE_PG_STORE` (*which store the suite
writes to*). That is the right question for the SQLite purge and the wrong one for
the PostgreSQL purge: dozens of tests carry `skipif(not _USE_PG)` and build
`PgMemoryStore()` in their own fixture, bypassing backend selection — they run
whenever PG is reachable, including under a sqlite-backend run, and they need the
between-test DELETE. The two purges are not alternatives; both are required.

No effect on the PostgreSQL path: there `_USE_PG` and `_USE_PG_STORE` are both true,
so the branch is unchanged from main.

## The one remaining difference — not deferred

`test_recall_include_related.py::test_flat_recall_has_no_related` fails on this branch
and passes on main. It is **not a product regression**: its fixture seeds through
`PgMemoryStore()` while `recall.handler()` reads the resolved (SQLite) store, so its
`assert resp["memories"]` was only ever satisfied by rows **leaked from the preceding
test**. Removing the leak exposed a test that never tested what it claimed. It is one
of the failures triaged in #220 (SQLite full parity) and is fixed there, in this same
series — not parked.
