### PR TITLE
docs(security): state the change-control posture and why Code-Review cannot pass

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,6 +60,39 @@ As of issue #178, every Cortex release ships with verifiable provenance
   Scorecard via `scorecard.yml`. The Scorecard number is a recorded baseline,
   not a badge.
 
+- **Change control** — `main` is protected: direct pushes are refused, every
+  change lands through a pull request, and eleven status checks are *required*
+  to pass before merge (`Lint`, `Type Check`, `Build Package`, `CodeQL`,
+  `Docker Smoke`, `Test` on Python 3.10–3.13, `Test (SQLite backend)`, and
+  `Test (Windows, SQLite backend)`). Force-pushes and branch deletion are
+  blocked, and conversation resolution is required.
+
+### Why Scorecard's Code-Review check will not go green here
+
+Scorecard's `Code-Review` check scores a changeset as reviewed only when it
+carries an **approving review from someone other than its author**. Cortex has
+one maintainer, and GitHub structurally forbids approving your own pull request.
+The check is therefore **unattainable by construction**, not unimplemented — no
+configuration of this repository can satisfy it while it has a single
+maintainer.
+
+What is implemented instead is every part of the control that does not require a
+second human: the pull-request requirement above (so no change reaches `main`
+unreviewed by *machine* gates), the required-checks list, and the automated
+analysis (CodeQL, Scorecard, Dependabot). The required approving-review count is
+deliberately set to **0** rather than 1: at 1, a solo maintainer cannot merge at
+all, so the setting would be traded for a repository that cannot ship — security
+theatre that reduces real safety by pushing work outside the PR flow.
+
+**The residual risk is real and is not claimed away:** a logic error that all
+eleven automated gates accept will reach `main` without a second pair of human
+eyes. Mitigation is the gate breadth above plus post-merge scanning; the honest
+statement is that human code review is *absent*, not *satisfied*. This is why
+the corresponding Scorecard alert is dismissed as "won't fix" rather than left
+open — an alert that can never be actioned is noise that hides actionable ones.
+It becomes actionable the moment a second maintainer joins, at which point the
+approving-review count should be raised to 1 and this paragraph deleted.
+
 **What this does NOT claim.** Provenance proves *who built the artifact and
 from which commit*, not that the source is free of defects; and it is worth
 nothing to a user who does not run the verification commands above. The


### PR DESCRIPTION
Prepares the dismissal of Scorecard alert #126 (`Code-Review`, High) by recording the rationale somewhere a 280-character dismissal comment cannot.

## Why this alert cannot be actioned

Scorecard's `Code-Review` check scores a changeset as reviewed only when it carries an **approving review from someone other than its author**. Cortex has one maintainer; GitHub structurally forbids self-approval. The check is unattainable **by construction**, not unimplemented.

## What actually changed

| Change | Where |
|---|---|
| `main` now requires a pull request, `required_approving_review_count: 0` | repo branch protection (applied and verified) |
| Change-control posture documented (PR requirement + the 11 required checks + force-push/deletion blocks) | `SECURITY.md` |
| Residual risk stated plainly, with its exit condition | `SECURITY.md` |

The approving-review count is deliberately **0**, not 1. At 1 a solo maintainer cannot merge at all — the setting would trade the control for a repository that cannot ship, pushing work outside the PR flow entirely. That is a net *reduction* in safety.

## The honest part

`SECURITY.md` now says, in the file itself: a logic error that all eleven automated gates accept will reach `main` without a second pair of human eyes. Human code review is **absent, not satisfied**. The alert is dismissed as "won't fix" because an alert that can never be actioned is noise that hides actionable ones — and the doc names the exit condition (second maintainer joins → raise the count to 1, delete the paragraph).

## Completion Ledger

| §13.1 item | State |
|---|---|
| A1–A6 correctness, B concurrency, C resources | **N/A** — documentation change plus a repository setting; no code path introduced, no branch, no error arm. |
| D3 secrets / least privilege | **N/A** — nothing sensitive touched. The branch-protection change only *restricts* access. |
| E1–E4 interfaces | **N/A** — no API, schema, or persisted data touched. |
| F1–F2 observability | **N/A** — no failure mode introduced. |
| G1 path→test ledger | **N/A** — zero code paths in the diff. |
| G5 gates pass on touched files | Markdown only; `Lint`/`Type Check` do not read `SECURITY.md`, and CI runs them regardless. |
| H1 rules pass | No code; §2 layering and §4 sizes not engaged. |
| H2 readable | The section states the constraint, the compensating control, the residual risk, and the exit condition — the four things a reader needs. |
| H4 docs updated with the behaviour change | This PR **is** the doc update; the setting and the prose land together. |
| H7 boy-scout (§14) | No lint/format/warning defect observed in `SECURITY.md` during this change. |

**Verification of the setting** (not just the prose) — the API returned `{"checks":11,"pr_reviews":0}` after applying the protection payload, confirming 11 required status checks and a PR requirement at 0 approvals.

Alert #126 is dismissed once this merges, so the dismissal comment's pointer to `SECURITY.md` resolves on `main`.
