### PR TITLE
test(config): silence the three SWIG shutdown warnings by message, not prefix (#223)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,36 @@ timeout_method = "thread"
 # 2026-07-28 while reproducing issue #219: a local run hung >600s because
 # the plugin was not installed).
 required_plugins = ["pytest-timeout", "pytest-asyncio"]
+# Narrow, message-anchored suppression of three DeprecationWarnings emitted by
+# a SWIG-generated extension during import — never by mcp_server.
+#
+# source: SWIG did not set `__module__` on its three support types
+#   (SwigPyObject, SwigPyPacked, swigvarlink); CPython warns about builtin
+#   types lacking it. SWIG 4.4.0 fixes this by moving all three into the SWIG
+#   runtime module — https://github.com/swig/swig/issues/2881. Same defect
+#   tracked downstream at huggingface/transformers#42981 and
+#   facebookresearch/faiss#4481 ("Upgrade to SWIG 4.4").
+#
+# Emitter here is `sentencepiece` (measured 2026-07-28: it is the only
+#   distribution under the interpreter's site-packages containing
+#   `SwigPyObject`, and importing it reproduces all three warnings). It is
+#   NOT a declared Cortex dependency — it appears 0 times in `uv.lock` and
+#   `pyproject.toml` — but `transformers` imports it opportunistically when a
+#   developer's environment happens to provide it, so the warnings surface in
+#   some local runs and not others. That environment-dependence is exactly why
+#   this is pinned by message rather than by module: it must not depend on
+#   which package happens to trigger the import first.
+#
+# Anchored to the three type names, not a `SwigPy.*` prefix: `swigvarlink`
+#   does not share that prefix and would keep leaking through. Any OTHER
+#   DeprecationWarning, including one from our own code, still surfaces.
+#
+# Remove when: `sentencepiece` (or whichever SWIG-built package is installed)
+#   ships wheels built with SWIG >= 4.4.0 — verify with a full-suite run
+#   reporting 0 warnings after deleting this entry.
+filterwarnings = [
+    "ignore:builtin type (SwigPyObject|SwigPyPacked|swigvarlink) has no __module__ attribute:DeprecationWarning",
+]
 markers = [
     "invariants: Phase 0.3+ testable invariant predicates (I1/I2/I3/I4 and parity tests)",
 ]


### PR DESCRIPTION
Closes #223.

## What actually emits them

The issue attributed the warnings to "sentence-transformers' SWIG bindings". Measured today, the emitter is narrower and the count is wrong by one:

- **`sentencepiece`** is the only distribution under the interpreter's `site-packages` containing `SwigPyObject` (`grep -rl SwigPyObject <site-packages>` → `sentencepiece`, and importing it alone reproduces).
- It is **not a Cortex dependency**: `sentencepiece` appears **0 times** in `uv.lock` (1.0 MB) and is absent from `pyproject.toml`. `transformers` imports it opportunistically *when a developer's environment happens to provide it*, which is why the warnings appear in some local runs and never in others.
- There are **three** types, not two. The third, **`swigvarlink`**, is emitted at interpreter shutdown (`sys:1:`) and so never appeared in pytest's in-run `2 warnings` tally.

That third one matters: the regex proposed in the issue, `ignore:builtin type SwigPy.*`, **would not have matched `swigvarlink`** — it does not share the prefix. The entry landed here is anchored to all three type names instead.

## Upstream, with the fixing version

SWIG did not set `__module__` on its three support types; CPython warns about builtin types lacking it. **SWIG 4.4.0** fixes it by moving `SwigPyObject`, `SwigPyPacked` and `SwigVarLink` into the SWIG runtime module.

- swig/swig#2881 — the upstream defect
- huggingface/transformers#42981 — same warnings, downstream
- facebookresearch/faiss#4481 — "[Upgrade to SWIG 4.4]", same fix path

The dependency floor **cannot** be raised past it (criterion 2, first branch): `sentencepiece` is not ours to pin. So the second branch applies — a narrow, message-anchored `filterwarnings` entry with a `# source:` comment and an explicit removal condition.

## Paired control — the suppression is verified, not assumed

Same interpreter (pyenv 3.10.4, the one that reproduces), same test, same isolated store; the only variable is whether the filter is active:

```
=== CONTROL (-o filterwarnings=) ===
5 failed, 2 warnings in 7.73s
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

=== TREATMENT (filter active) ===
5 failed in 6.82s
```

Warnings go 2 → 0, **and** the shutdown `swigvarlink` line disappears — so all three are covered, including the one the issue's proposed regex would have missed.

## Completion Ledger

| §13.1 item | Evidence |
|---|---|
| A1 behaviour works end-to-end | Paired control above: run output quoted, not code read. |
| A2 edge case — a warning type outside the `SwigPy` prefix | `swigvarlink` explicitly enumerated in the pattern; control run proves it was leaking. |
| A3/F1 our own signals still surface | The filter is anchored to the exact message text of three named types. Any other `DeprecationWarning`, including one from `mcp_server`, is untouched — that is the whole reason it is not a blanket entry. |
| A4 trust boundaries | **N/A** — no input handling; a test-config entry. |
| B, C concurrency/resources | **N/A** — no runtime code path added. |
| D1–D3 security | **N/A** — no query, command, or sensitive value touched. |
| E1 compatibility | Additive `[tool.pytest.ini_options]` key; no existing key changed. |
| E3 persisted data | **N/A**. |
| G3 determinism | The suppression is keyed on **message**, not module, precisely so it does not depend on which package triggers the import first — the environment-dependence documented above. |
| G4 negative assertion | The control arm *is* the negative assertion: with the filter cleared, the warnings return. |
| H1 rules pass | Config-only; §2/§4 not engaged. §8 satisfied — every claim above carries its source. |
| H4 docs | The `# source:` block in `pyproject.toml` carries the upstream links and the removal condition; no separate doc claims a warning count. |
| H7 boy-scout (§14) | See below. |

## §14 — the failures visible in that output

The five `test_codebase_alteration.py` failures in both arms are **not** caused by this change and are **not** being waved off as pre-existing. They are a real SQLite-backend parity defect surfaced by the same run:

```
AttributeError: 'SqliteMemoryStore' object has no attribute 'acquire_batch'
mcp_server/handlers/codebase_analyze_helpers.py:412
```

That is exactly the 5-failure `test_codebase_alteration.py` row in **#220**'s table, now with its root cause identified. It is fixed under #220 in this same series — not deferred to a future one.
