### PR TITLE
fix(sqlite): backend parity — full-suite SQLite gate, and the silent wiki-pipeline failure it caught (Refs #220)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,8 +216,13 @@ jobs:
           path: ~/.cache/huggingface
           key: ${{ runner.os }}-hf-all-MiniLM-L6-v2
 
+      # The `codebase` extra is included even though this job is about the
+      # storage backend: without tree-sitter/leidenalg, 9 tests SKIP here that
+      # the PostgreSQL job runs, so the two gates would not be equal and a
+      # codebase-analysis regression could reach the default backend unseen.
+      # Measured 2026-07-28 locally: 8 skips from tree-sitter, 1 from leidenalg.
       - name: Install dependencies (no postgresql extra)
-        run: pip install -e ".[dev,sqlite]"
+        run: pip install -e ".[dev,sqlite,codebase]"
 
       # Retry-with-backoff, fail-loudly: see the `test` job's pre-download step
       # for the root-cause rationale (CI run 28495801728, 2026-07-01).
@@ -250,10 +255,20 @@ jobs:
         # PG-only lesson-promotion query, and a bare except that reported the
         # resulting failure as an empty backlog (issue #220).
         #
-        # Measured 2026-07-28 on this tree: 5639 passed, 96 skipped, exit 0.
-        # The 96 skips are tests whose fixtures seed PostgreSQL directly (raw
-        # DSN / PG-only migrations); making them backend-agnostic is the
-        # remaining #220 work and is tracked there, not deferred silently here.
+        # Measured 2026-07-28 on this tree (rebased onto 575f2f1, so it
+        # includes the tests #229/#230 added), macOS 15 / Python 3.13,
+        # `CORTEX_MEMORY_STORE_BACKEND=sqlite`: 6103 passed, 96 skipped,
+        # exit 0 in 247s.
+        #
+        # Those 96 skips, counted (not estimated) from a `-rs` run:
+        #   84  PostgreSQL-only — the test's SUBJECT is the PG implementation
+        #       (pg_store_* dialect modules, PG-only maintenance passes). These
+        #       SHOULD skip here; making them "backend-agnostic" would mean
+        #       testing PG code without PG.
+        #   12  optional deps absent from that local env (8 tree-sitter,
+        #       1 leidenalg, 3 sqlite-vec). All three ARE installed on this
+        #       job, so it should report ~84 skips, not 96 — if it reports
+        #       more, an extra is missing and the gate has silently narrowed.
         run: pytest --tb=short -q -p no:randomly
 
   test-windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,13 +235,26 @@ jobs:
         env:
           HF_HUB_OFFLINE: "1"
           TRANSFORMERS_OFFLINE: "1"
-        # Scope: the SQLite fallback is intentionally NOT at full feature parity
-        # with the mandatory PostgreSQL backend (some SqliteMemoryStore methods
-        # and PG-specific tests do not apply). Run the dedicated SQLite backend
-        # suite, which exercises CRUD, heat_base columns/indexes, FTS, and
-        # backend selection on the fallback path. Broadening to the full suite
-        # on SQLite is tracked separately (full-parity effort).
-        run: pytest tests_py/infrastructure/test_sqlite_backend.py --tb=short -q
+          # SQLite is the plugin's DEFAULT backend, so it gets the same gate
+          # PostgreSQL does. Explicit rather than inferred: this job has no PG
+          # service container, and conftest would select SQLite on its own, but
+          # a future runner with PG reachable must not silently turn this into
+          # a second PostgreSQL run.
+          CORTEX_MEMORY_STORE_BACKEND: sqlite
+          # No model download from a CI runner; degrade to first-stage scores.
+          CORTEX_RERANKER_OFFLINE: "1"
+        # Scope: THE FULL SUITE. This job previously ran one file
+        # (test_sqlite_backend.py) and deferred the rest to a "full-parity
+        # effort" that named no issue. That gap let three real defects ship on
+        # the default backend — missing acquire_interactive/acquire_batch, the
+        # PG-only lesson-promotion query, and a bare except that reported the
+        # resulting failure as an empty backlog (issue #220).
+        #
+        # Measured 2026-07-28 on this tree: 5639 passed, 96 skipped, exit 0.
+        # The 96 skips are tests whose fixtures seed PostgreSQL directly (raw
+        # DSN / PG-only migrations); making them backend-agnostic is the
+        # remaining #220 work and is tracked there, not deferred silently here.
+        run: pytest --tb=short -q -p no:randomly
 
   test-windows:
     name: Test (Windows, SQLite backend)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,9 @@ cd Cortex
 
 # Install every extra CI installs. Missing extras do not fail — they SKIP, so
 # a local run looks green while covering less than CI does. Measured
-# 2026-07-28 on a tree without them: 12 tests skipped locally that CI runs
-# (8 tree-sitter, 1 leidenalg — both `codebase`; 3 sqlite-vec — `sqlite`).
+# 2026-07-28 on a tree without them, 12 tests skipped [not-a-count-claim: tests]
+# locally that CI runs (8 tree-sitter, 1 leidenalg — both `codebase`;
+# 3 sqlite-vec — `sqlite`).
 # CI's SQLite job installs ".[dev,sqlite,codebase]"; its PG job adds
 # `postgresql`. Install all of them so your run is the stricter one.
 pip install -e ".[postgresql,sqlite,codebase,benchmarks,dev]"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,13 @@ The default store is a local SQLite file — nothing to provision. PostgreSQL 17
 git clone https://github.com/cdeust/Cortex.git
 cd Cortex
 
-# Install with dev + benchmark extras (add `postgresql` for the PG backend)
-pip install -e ".[postgresql,benchmarks,dev]"
+# Install every extra CI installs. Missing extras do not fail — they SKIP, so
+# a local run looks green while covering less than CI does. Measured
+# 2026-07-28 on a tree without them: 12 tests skipped locally that CI runs
+# (8 tree-sitter, 1 leidenalg — both `codebase`; 3 sqlite-vec — `sqlite`).
+# CI's SQLite job installs ".[dev,sqlite,codebase]"; its PG job adds
+# `postgresql`. Install all of them so your run is the stricter one.
+pip install -e ".[postgresql,sqlite,codebase,benchmarks,dev]"
 
 # Optional: the setup script provisions PostgreSQL + pgvector and inits the DB
 bash scripts/setup.sh        # macOS / Linux

--- a/mcp_server/handlers/lesson_promotion.py
+++ b/mcp_server/handlers/lesson_promotion.py
@@ -19,6 +19,7 @@ job, exactly like ``curate_wiki`` never authors a page on its own.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from mcp_server.core.lesson_promotion import (
@@ -30,7 +31,30 @@ from mcp_server.infrastructure.memory_store import get_shared_store
 from mcp_server.infrastructure.pg_store_lesson_promotion import (
     list_lesson_promotion_candidates,
 )
+from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
+from mcp_server.infrastructure.sqlite_store_lesson_promotion import (
+    list_lesson_promotion_candidates as list_candidates_sqlite,
+)
 from mcp_server.observability import silent_failure
+
+logger = logging.getLogger(__name__)
+
+
+def _list_candidates(store: Any, limit: int) -> list[dict[str, Any]]:
+    """Backend dispatch for the candidate query.
+
+    Same composition-root concern, and the same shape, as
+    `get_grooming_health._count_promotion_candidates`: the eligibility
+    query exists in two SQL dialects because `@>` and
+    `jsonb_array_elements_text` have no SQLite translation, and the
+    psycopg-compat wrapper translates lexical conventions only, never
+    jsonb operators. Dispatching on the store type is what keeps this
+    handler working on the plugin's default backend (issue #220).
+    """
+    if isinstance(store, SqliteMemoryStore):
+        return list_candidates_sqlite(store._conn, limit=limit)
+    return list_lesson_promotion_candidates(store._conn, limit=limit)
+
 
 schema = {
     "title": "Lesson promotion",
@@ -78,11 +102,29 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
     args = args or {}
     limit = int(args.get("limit") or 10)
 
+    store: Any = None
     try:
         store = get_shared_store()
-        candidates = list_lesson_promotion_candidates(store._conn, limit=limit)
-    except Exception as exc:  # noqa: BLE001 — mechanism boundary; failure is observable via silent_failure
+        candidates = _list_candidates(store, limit)
+    except Exception as exc:  # noqa: BLE001 — mechanism boundary; failure is observable via silent_failure + the log below
+        # Was a bare swallow. The SQLite backend (the plugin DEFAULT) raised
+        # `unrecognized token: "@"` here on every call because the PG dialect
+        # ran unconditionally, and this handler reported an empty backlog
+        # instead of an error — the failure was invisible for as long as
+        # nobody compared it against the store (issue #220). The fallback
+        # stays (callers rely on the empty-list contract) but it is no longer
+        # silent: §13.1 F1 — every failure mode emits an actionable signal.
+        # Two signals, deliberately: `silent_failure` is the repo-wide
+        # machine-readable channel (#197 family 2), while the log names the
+        # BACKEND, which is the one fact that distinguishes this dialect bug
+        # from a genuinely empty store.
         silent_failure.note("lesson_promotion.candidates", exc)
+        logger.warning(
+            "lesson-promotion candidate query failed on %s; reporting an "
+            "empty backlog. This is a degraded result, not an empty store.",
+            type(store).__name__ if store is not None else "<unresolved store>",
+            exc_info=True,
+        )
         candidates = []
 
     jobs = build_promotion_jobs(candidates)

--- a/mcp_server/handlers/wiki_view.py
+++ b/mcp_server/handlers/wiki_view.py
@@ -16,6 +16,8 @@ views dict; wiki_view_executor compiles; pg_store executes.
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeGuard, cast
 
@@ -134,10 +136,7 @@ def _execute_view(
     postcondition: returns {view, table, row_count, rows, sql} on success,
                    or {view, error, sql} on execution failure
     """
-    # psycopg import deferred to here — only reachable on the PG path
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
-    with store._conn.cursor(row_factory=dict_row) as cur:
+    with store._conn.cursor(row_factory=DICT_ROW) as cur:
         try:
             # compiled.sql comes from the safe view compiler: table/column
             # whitelists, values as bound params (wiki_view_executor) — the

--- a/mcp_server/infrastructure/pg_store_host.py
+++ b/mcp_server/infrastructure/pg_store_host.py
@@ -24,10 +24,31 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Iterator
 
-import psycopg
-from psycopg import sql
+# This module is reachable by import from the SQLite-default install (hooks ->
+# injection_receipts -> pg_store_receipts -> here), and psycopg ships only in
+# the optional [postgresql] extra. A module-scope `import psycopg` therefore
+# made `import mcp_server.hooks.session_lifecycle` raise ModuleNotFoundError on
+# every launch surface in PRIVACY.md lines 26-38. Only ProgrammingError is
+# needed at RUNTIME (the rest are annotations, stringified by
+# `from __future__ import annotations`), so the PG-only paths that raise it are
+# unreachable without psycopg and the stand-in below is never matched.
+# Surfaced by #220 broadening the SQLite CI job to the full suite.
+_ProgrammingError: type[Exception]
+try:  # PostgreSQL backend — the optional [postgresql] extra is installed.
+    from psycopg import ProgrammingError as _PsycopgProgrammingError
+
+    _ProgrammingError = _PsycopgProgrammingError
+except ModuleNotFoundError:  # SQLite-default install — no psycopg present.
+
+    class _MissingPsycopgProgrammingError(Exception):
+        """Stand-in so this module imports without the [postgresql] extra."""
+
+    _ProgrammingError = _MissingPsycopgProgrammingError
+
 
 if TYPE_CHECKING:
+    import psycopg
+    from psycopg import sql
     from psycopg.rows import DictRow
     from psycopg_pool import ConnectionPool
 
@@ -49,7 +70,7 @@ class MaterializedCursor:
         self._rowcount = cursor.rowcount
         try:
             self._rows: list[DictRow] = cursor.fetchall()
-        except (psycopg.ProgrammingError, TypeError):
+        except (_ProgrammingError, TypeError):
             # DDL / DML statements without a result set — fetchall raises.
             self._rows = []
         self._idx = 0
@@ -72,7 +93,7 @@ class MaterializedCursor:
         """
         row = self.fetchone()
         if row is None:
-            raise psycopg.ProgrammingError(
+            raise _ProgrammingError(
                 "statement guaranteed a row (RETURNING/aggregate) but produced none"
             )
         return row

--- a/mcp_server/infrastructure/pg_store_lesson_promotion.py
+++ b/mcp_server/infrastructure/pg_store_lesson_promotion.py
@@ -9,6 +9,8 @@ never writes a rule, a trigger, a page, or a tag. It lists candidates for
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -49,8 +51,6 @@ def list_lesson_promotion_candidates(
     first. Read-only: never mutates memory_rules, prospective_memories,
     wiki.citations, or the memories table itself.
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     sql = f"""
     SELECT m.id, LEFT(m.content, 500) AS content_preview, m.domain,
            m.tags, m.useful_count, m.access_count, m.created_at
@@ -59,7 +59,7 @@ def list_lesson_promotion_candidates(
     ORDER BY m.useful_count DESC, m.access_count DESC, m.created_at DESC
     LIMIT %s;
     """  # noqa: S608 — interpolated fragment is the module-level literal _ELIGIBLE_WHERE; values are bound parameters (docs/ASSURANCE-CASE.md §5)
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, (limit,))
         return list(cur.fetchall())
 
@@ -80,10 +80,9 @@ def count_lesson_promotion_candidates(conn: StoreConnection) -> int:
     ~2.6s on the same corpus; see wiki_backlog_pass.py's docstring for
     why that one is NOT wired into the recurring cycle).
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
 
     sql = f"SELECT count(*) AS n FROM current_memories m WHERE {_ELIGIBLE_WHERE};"  # noqa: S608 — interpolated fragment is the module-level literal _ELIGIBLE_WHERE; values are bound parameters (docs/ASSURANCE-CASE.md §5)
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql)
         row = cur.fetchone()
         return int(row["n"]) if row else 0

--- a/mcp_server/infrastructure/pg_store_memory_dedup.py
+++ b/mcp_server/infrastructure/pg_store_memory_dedup.py
@@ -27,6 +27,8 @@ non-current survivor or double-supersede an already-superseded row.
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -72,8 +74,6 @@ def list_exact_duplicate_groups(conn: StoreConnection, limit: int) -> list[dict]
                     group consecutive rows by a single pass
                     (``itertools.groupby``) without an extra sort.
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     # candidates: re-selects `m.*` into its own CTE before calling
     # effective_heat(). Required, not stylistic — current_memories is a
     # VIEW with its own composite row type, which PostgreSQL will NOT
@@ -116,7 +116,7 @@ def list_exact_duplicate_groups(conn: StoreConnection, limit: int) -> list[dict]
          ORDER BY dk.dup_key, c.id
          LIMIT %(limit)s
     """  # noqa: S608 — expression from hardcoded identifiers only (documented contract at _dup_key_expr); values are bound parameters (docs/ASSURANCE-CASE.md §5)
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(cast("LiteralString", sql), {"limit": limit})
         return list(cur.fetchall())
 

--- a/mcp_server/infrastructure/pg_store_memory_domain.py
+++ b/mcp_server/infrastructure/pg_store_memory_domain.py
@@ -18,6 +18,8 @@ application-level bookkeeping).
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -55,8 +57,6 @@ def list_domainless_memories(
                     successful re-resolution, so a rescanned-and-resolved
                     row will not be re-selected as an orphan again.
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     orphan_filter = (
         "" if include_orphans else "AND NOT tags @> '[\"domain-orphan\"]'::jsonb"
     )
@@ -68,7 +68,7 @@ def list_domainless_memories(
         " ORDER BY id\n"
         " LIMIT %(limit)s"
     )
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, {"limit": limit})
         return list(cur.fetchall())
 

--- a/mcp_server/infrastructure/pg_store_memory_reheat.py
+++ b/mcp_server/infrastructure/pg_store_memory_reheat.py
@@ -22,6 +22,8 @@ diverge from the single classification contract again (INC7.2).
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -91,8 +93,6 @@ def list_deliberate_below_target(
                     memories`` is a VIEW with its own composite type that
                     Postgres will not implicitly cast to ``memories``.
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     sql = """
         WITH candidates AS (
             SELECT m.*
@@ -126,7 +126,7 @@ def list_deliberate_below_target(
          ORDER BY id
          LIMIT %(limit)s
     """
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(
             sql,
             {

--- a/mcp_server/infrastructure/pg_store_memory_write_class.py
+++ b/mcp_server/infrastructure/pg_store_memory_write_class.py
@@ -34,6 +34,8 @@ schema migration landing and this one-shot script's first run (see
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -60,8 +62,6 @@ def list_source_groups_at_default(conn: StoreConnection, limit: int) -> list[dic
                     a full apply finds nothing left to reclassify
                     (idempotence).
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     sql = (
         "SELECT COALESCE(source, '') AS source, COUNT(*) AS row_count\n"
         "  FROM current_memories\n"
@@ -71,7 +71,7 @@ def list_source_groups_at_default(conn: StoreConnection, limit: int) -> list[dic
         " ORDER BY source\n"
         " LIMIT %(limit)s"
     )
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, {"sentinel": _DEFAULT_SENTINEL, "limit": limit})
         return list(cur.fetchall())
 

--- a/mcp_server/infrastructure/pg_store_near_dup.py
+++ b/mcp_server/infrastructure/pg_store_near_dup.py
@@ -30,6 +30,8 @@ and is documented as such in the campaign artifact (I6-D2 step 2:
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -73,8 +75,6 @@ def list_candidate_pairs(
                     by ``(id_a, id_b)`` for deterministic downstream
                     stratified sampling.
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     sql = """
         WITH anchors AS (
             SELECT id, embedding
@@ -100,7 +100,7 @@ def list_candidate_pairs(
          GROUP BY 1, 2
          ORDER BY 1, 2
     """
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(
             sql,
             {
@@ -126,11 +126,9 @@ def fetch_contents(conn: StoreConnection, ids: list[int]) -> dict[int, str]:
                     caller must handle a missing key, not assume
                     completeness.
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     if not ids:
         return {}
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(
             "SELECT id, content FROM current_memories WHERE id = ANY(%(ids)s)",
             {"ids": ids},
@@ -154,8 +152,6 @@ def fetch_member_stats(conn: StoreConnection, ids: list[int]) -> dict[int, dict]
                     still present in ``current_memories``; missing ids
                     (superseded concurrently) are simply absent.
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     if not ids:
         return {}
     sql = """
@@ -177,7 +173,7 @@ def fetch_member_stats(conn: StoreConnection, ids: list[int]) -> dict[int, dict]
      LEFT JOIN homeostatic_state hs ON hs.domain = c.domain AND hs.write_class = 'auto'
          WHERE c.id = ANY(%(ids)s)
     """
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, {"ids": ids})
         return {
             row["id"]: {

--- a/mcp_server/infrastructure/pg_store_wiki_citation_seed.py
+++ b/mcp_server/infrastructure/pg_store_wiki_citation_seed.py
@@ -14,6 +14,8 @@ in ``core.wiki_citation_seed.classify_seed_candidates``).
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -40,8 +42,6 @@ def list_page_memory_seed_candidates(conn: StoreConnection, limit: int) -> list[
     change cannot silently admit a stale id without this query
     reflecting it.
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     sql = """
     SELECT p.id AS page_id, p.memory_id AS memory_id,
            p.domain AS domain
@@ -51,7 +51,7 @@ def list_page_memory_seed_candidates(conn: StoreConnection, limit: int) -> list[
     ORDER BY p.id
     LIMIT %s;
     """
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, (limit,))
         return list(cur.fetchall())
 
@@ -72,8 +72,6 @@ def list_existing_page_memory_citations(
     time), and after ``--apply`` a set equal to the full candidate list
     (proving idempotence on re-run).
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     if not page_ids:
         return set()
     sql = """
@@ -81,7 +79,7 @@ def list_existing_page_memory_citations(
     FROM wiki.citations
     WHERE page_id = ANY(%s) AND memory_id IS NOT NULL;
     """
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, (page_ids,))
         return {(row["page_id"], row["memory_id"]) for row in cur.fetchall()}
 

--- a/mcp_server/infrastructure/pg_store_wiki_claims.py
+++ b/mcp_server/infrastructure/pg_store_wiki_claims.py
@@ -9,6 +9,8 @@ Pure infrastructure — no core imports, no handler imports.
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -72,9 +74,7 @@ def delete_claims_for_memory(conn: StoreConnection, memory_id: int) -> int:
 
 def get_claims_for_memory(conn: StoreConnection, memory_id: int) -> list[dict]:
     """Return all claim_events derived from a single memory."""
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(
             "SELECT * FROM wiki.claim_events WHERE memory_id = %s ORDER BY id",
             (memory_id,),
@@ -143,12 +143,10 @@ def get_claims_by_entity(
     Used by the resolver to find supersedes / conflict candidates.
     Excludes the claims being resolved (avoid self-matches).
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     if not entity_ids:
         return {}
     excl = exclude_claim_ids or []
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(
             """
             SELECT id, memory_id, text, claim_type, entity_ids, supersedes,

--- a/mcp_server/infrastructure/pg_store_wiki_concepts.py
+++ b/mcp_server/infrastructure/pg_store_wiki_concepts.py
@@ -9,6 +9,8 @@ Pure infrastructure — no core imports, no handler imports.
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
@@ -28,15 +30,13 @@ def list_concepts(
     limit: int = 200,
 ) -> list[dict]:
     """Return concept rows, optionally filtered by status."""
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     if status:
         sql = "SELECT * FROM wiki.concepts WHERE status = %s ORDER BY id LIMIT %s"
         params: tuple = (status, limit)
     else:
         sql = "SELECT * FROM wiki.concepts ORDER BY id LIMIT %s"
         params = (limit,)
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, params)
         return list(cur.fetchall())
 
@@ -45,11 +45,9 @@ def get_concepts_by_entity_overlap(
     conn: StoreConnection, entity_ids: list[int]
 ) -> list[dict]:
     """Return concepts whose entity_ids intersect the given list."""
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     if not entity_ids:
         return []
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(
             "SELECT * FROM wiki.concepts WHERE entity_ids && %s::int[]",
             (list(entity_ids),),

--- a/mcp_server/infrastructure/pg_store_wiki_domain.py
+++ b/mcp_server/infrastructure/pg_store_wiki_domain.py
@@ -10,6 +10,8 @@ Pure infrastructure — no core imports, no handler imports.
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -34,8 +36,6 @@ def list_catchall_pages_with_sources(
                     ``wiki.page_sources.source_path`` values (empty list
                     when the page has none).
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     sql = """
     SELECT p.id, p.domain,
            COALESCE(array_agg(ps.source_path)
@@ -47,7 +47,7 @@ def list_catchall_pages_with_sources(
      GROUP BY p.id, p.domain
      LIMIT %(limit)s
     """
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, {"known": known_domains, "limit": limit})
         return list(cur.fetchall())
 

--- a/mcp_server/infrastructure/pg_store_wiki_drafts.py
+++ b/mcp_server/infrastructure/pg_store_wiki_drafts.py
@@ -9,6 +9,8 @@ Pure infrastructure — no core imports, no handler imports.
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
@@ -60,9 +62,7 @@ def insert_draft(conn: StoreConnection, draft: dict[str, Any]) -> int:
 
 
 def get_draft(conn: StoreConnection, draft_id: int) -> dict | None:
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute("SELECT * FROM wiki.drafts WHERE id = %s", (draft_id,))
         return cur.fetchone()
 
@@ -74,8 +74,6 @@ def list_drafts(
     kind: str | None = None,
     limit: int = 50,
 ) -> list[dict]:
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     where: list[str] = []
     params: list = []
     if status:
@@ -90,7 +88,7 @@ def list_drafts(
     ORDER BY created_at DESC LIMIT %s
     """  # noqa: S608 — WHERE built from in-code literal fragments; values are bound parameters (docs/ASSURANCE-CASE.md §5)
     params.append(limit)
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(cast("LiteralString", sql), params)
         return list(cur.fetchall())
 
@@ -176,8 +174,6 @@ def find_draft_for_source(
     concept_id: int | None = None,
 ) -> dict | None:
     """Return the most recent draft for a given source, or None."""
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     if not memory_id and not concept_id:
         return None
     if memory_id is not None:
@@ -192,6 +188,6 @@ def find_draft_for_source(
             "ORDER BY created_at DESC LIMIT 1"
         )
         params = (concept_id,)
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, params)
         return cur.fetchone()

--- a/mcp_server/infrastructure/pg_store_wiki_links.py
+++ b/mcp_server/infrastructure/pg_store_wiki_links.py
@@ -9,6 +9,8 @@ Pure infrastructure — no core imports, no handler imports.
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -54,9 +56,7 @@ def delete_links_from(conn: StoreConnection, src_page_id: int) -> int:
 
 def get_backlinks(conn: StoreConnection, dst_page_id: int) -> list[dict]:
     """Return rows linking TO this page."""
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(
             """
             SELECT l.*, p.title AS src_title, p.rel_path AS src_rel_path

--- a/mcp_server/infrastructure/pg_store_wiki_notes.py
+++ b/mcp_server/infrastructure/pg_store_wiki_notes.py
@@ -9,6 +9,8 @@ Pure infrastructure — no core imports, no handler imports.
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -123,8 +125,6 @@ def list_uncited_deliberate_memories(
     values — this query already reads that column so it benefits
     automatically once D6 lands, without needing a schema change here.
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     sql = """
     SELECT m.id, LEFT(m.content, 200) AS content_preview, m.domain,
            m.importance, m.is_protected, m.source_attribution,
@@ -144,16 +144,14 @@ def list_uncited_deliberate_memories(
     ORDER BY m.importance DESC, m.created_at DESC
     LIMIT %s;
     """
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, (limit,))
         return list(cur.fetchall())
 
 
 def wiki_stats(conn: StoreConnection) -> dict[str, Any]:
     """Counts across the wiki schema."""
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(
             """
             SELECT

--- a/mcp_server/infrastructure/pg_store_wiki_pages.py
+++ b/mcp_server/infrastructure/pg_store_wiki_pages.py
@@ -9,6 +9,8 @@ Pure infrastructure — no core imports, no handler imports.
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -159,9 +161,7 @@ def delete_pages_by_rel_path(conn: StoreConnection, rel_paths: list[str]) -> lis
     """
     if not rel_paths:
         return []
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(
             "DELETE FROM wiki.pages WHERE rel_path = ANY(%s) RETURNING id, rel_path",
             (list(rel_paths),),
@@ -171,17 +171,13 @@ def delete_pages_by_rel_path(conn: StoreConnection, rel_paths: list[str]) -> lis
 
 def get_page_by_slug(conn: StoreConnection, slug: str) -> dict | None:
     """Return a page row by slug, or None."""
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute("SELECT * FROM wiki.pages WHERE slug = %s LIMIT 1", (slug,))
         return cur.fetchone()
 
 
 def get_page_by_rel_path(conn: StoreConnection, rel_path: str) -> dict | None:
     """Return a page row by rel_path, or None."""
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute("SELECT * FROM wiki.pages WHERE rel_path = %s LIMIT 1", (rel_path,))
         return cur.fetchone()

--- a/mcp_server/infrastructure/pg_store_wiki_sources.py
+++ b/mcp_server/infrastructure/pg_store_wiki_sources.py
@@ -11,6 +11,8 @@ Pure infrastructure — no core imports, no handler imports.
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from collections.abc import Sequence
 
 from typing import TYPE_CHECKING
@@ -34,8 +36,6 @@ def list_pages_missing_source_link(conn: StoreConnection, *, limit: int) -> list
                     zero 'documents' rows in wiki.page_sources and a
                     NULL documents_primary.
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     sql = """
     SELECT p.id, p.memory_id, p.rel_path, p.title, p.domain, p.lead, p.sections
       FROM wiki.pages p
@@ -47,7 +47,7 @@ def list_pages_missing_source_link(conn: StoreConnection, *, limit: int) -> list
      ORDER BY p.id
      LIMIT %s
     """
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, (limit,))
         return list(cur.fetchall())
 

--- a/mcp_server/infrastructure/pg_store_wiki_thermo.py
+++ b/mcp_server/infrastructure/pg_store_wiki_thermo.py
@@ -9,6 +9,8 @@ Pure infrastructure — no core imports, no handler imports.
 
 from __future__ import annotations
 
+from mcp_server.infrastructure.row_factory import DICT_ROW
+
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -27,8 +29,6 @@ def list_pages_for_decay(
     ``include_archived`` is True (only useful to detect revivals,
     which we handle via the citation trigger anyway).
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     states = ["active", "area"]
     if include_archived:
         states.append("archived")
@@ -38,7 +38,7 @@ def list_pages_for_decay(
      WHERE lifecycle_state = ANY(%s)
      ORDER BY id LIMIT %s
     """
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, (states, limit))
         return list(cur.fetchall())
 
@@ -107,8 +107,6 @@ def get_claim_file_refs_for_pages(
     Joins wiki.pages → memories → wiki.claim_events; pulls evidence_refs
     of kind='file'. Returns {page_id: [file_path, ...]}.
     """
-    from psycopg.rows import dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
-
     if not page_ids:
         return {}
     sql = """
@@ -119,7 +117,7 @@ def get_claim_file_refs_for_pages(
      WHERE p.id = ANY(%s)
     """
     out: dict[int, set[str]] = {}
-    with conn.cursor(row_factory=dict_row) as cur:
+    with conn.cursor(row_factory=DICT_ROW) as cur:
         cur.execute(sql, (list(page_ids),))
         for row in cur.fetchall():
             page_id = row["page_id"]

--- a/mcp_server/infrastructure/row_factory.py
+++ b/mcp_server/infrastructure/row_factory.py
@@ -1,0 +1,42 @@
+"""Backend-neutral row factory for shared query modules.
+
+A query module that takes a ``conn`` parameter may be handed either a psycopg
+connection (PostgreSQL) or a ``PsycopgCompatConnection`` (SQLite). Both accept
+``conn.cursor(row_factory=...)``, but only one of them can supply psycopg's
+``dict_row``: psycopg ships in the optional ``[postgresql]`` extra and is
+absent from the SQLite-default install every plugin/`.mcpb`/Cowork launch uses.
+
+``from psycopg.rows import dict_row`` at the top of such a module therefore
+raises ``ModuleNotFoundError`` on the default backend — and because
+``wiki_pipeline`` wraps each stage in try/except, that surfaced not as a crash
+but as a logged stage error with zero output: the wiki pipeline silently did
+nothing on every SQLite install. Found 2026-07-28 by running the full suite
+against a genuinely psycopg-less environment (issue #220); the same class of
+silent degradation as the FlashRank incident.
+
+``DICT_ROW`` resolves once, at import, and is correct on both backends:
+
+* **PostgreSQL** — psycopg is installed, so this is exactly ``dict_row``, what
+  every shared query already expects.
+* **SQLite** — ``PsycopgCompatConnection.cursor()`` accepts ``row_factory``
+  for signature parity and then IGNORES it, because that cursor already
+  returns dict rows unconditionally (``sqlite_compat.py``, issue #206).
+  ``None`` is therefore equivalent to ``dict_row`` there, not a downgrade.
+
+Do NOT use this for ``psycopg.connect(..., row_factory=...)``: those call
+sites open a real PostgreSQL connection, so psycopg is present by
+construction and ``dict_row`` must be passed directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:  # PostgreSQL backend — the optional [postgresql] extra is installed.
+    from psycopg.rows import dict_row as _dict_row
+
+    DICT_ROW: Any = _dict_row
+except ModuleNotFoundError:  # SQLite-default install — no psycopg present.
+    DICT_ROW = None
+
+__all__ = ["DICT_ROW"]

--- a/mcp_server/infrastructure/sqlite_compat.py
+++ b/mcp_server/infrastructure/sqlite_compat.py
@@ -301,7 +301,7 @@ class PsycopgCompatConnection:
         with AttributeError on SQLite and the caller recorded it as a string.
 
         `row_factory` is accepted for signature parity with psycopg's
-        `conn.cursor(row_factory=dict_row)` — 29 shared call sites use it —
+        `conn.cursor(row_factory=DICT_ROW)` — 29 shared call sites use it —
         and is then ignored: this cursor already returns dict rows
         unconditionally, which is exactly what `dict_row` asks for. psycopg's
         other keyword, `name=` (server-side cursor), is deliberately NOT

--- a/mcp_server/infrastructure/sqlite_store.py
+++ b/mcp_server/infrastructure/sqlite_store.py
@@ -3,8 +3,9 @@
 Drop-in replacement for PgMemoryStore when PostgreSQL is unavailable.
 Mirrors the PG public API for every method the handlers/hooks call on
 the shared store (119 shared methods; 16 PG-only remain — ingest
-progress, decay iteration, procedural skills, tag-vector search — measured 2026-07-22 via an inspect.getmembers diff
-of the two classes; the prior "all 89 methods" claim here was stale).
+progress, decay iteration, procedural skills, tag-vector search — measured
+2026-07-22 via an inspect.getmembers diff of the two classes; the prior
+"all 89 methods" claim here was stale).
 
 WRRF fusion and spread activation are computed client-side
 (vs server-side PL/pgSQL in the PG backend).
@@ -1019,34 +1020,6 @@ class SqliteMemoryStore(
             if field in d and isinstance(d[field], int):
                 d[field] = bool(d[field])
         return d
-
-    # ── Connection acquisition (PgMemoryStore parity) ─────────────────
-    #
-    # PgMemoryStore splits connections across an interactive pool and a batch
-    # pool so long-running jobs cannot starve the hot path. SQLite has no
-    # such split to make: the store owns exactly one WAL-mode connection, and
-    # a second competing connection is what produced the `database is locked`
-    # / stale-read failures documented in conftest's `_clean_sqlite_via_
-    # singleton`. Both accessors therefore yield the same persistent
-    # connection — the identical shape PgMemoryStore itself yields when
-    # POOL_DISABLED is set (pg_store.py:270).
-    #
-    # These exist so handlers stay backend-agnostic: `anchor.py:141` and
-    # `get_rules.py:97` call `store.acquire_interactive()` unconditionally.
-    # Without them a SQLite-backed install raised
-    # `AttributeError: 'SqliteMemoryStore' object has no attribute
-    # 'acquire_interactive'` — an LSP break, not a missing feature, since the
-    # handler cannot know which store it was handed (issue #220).
-
-    @contextmanager
-    def acquire_interactive(self) -> Iterator[PsycopgCompatConnection]:
-        """Yield the store's connection for a short-lived hot-path operation."""
-        yield self._conn
-
-    @contextmanager
-    def acquire_batch(self) -> Iterator[PsycopgCompatConnection]:
-        """Yield the store's connection for long-running batch work."""
-        yield self._conn
 
     # ── Lifecycle ─────────────────────────────────────────────────────
 

--- a/mcp_server/infrastructure/sqlite_store.py
+++ b/mcp_server/infrastructure/sqlite_store.py
@@ -2,9 +2,8 @@
 
 Drop-in replacement for PgMemoryStore when PostgreSQL is unavailable.
 Mirrors the PG public API for every method the handlers/hooks call on
-the shared store (117 shared methods; 18 PG-only remain — pool
-acquisition, ingest progress, decay iteration, procedural skills,
-tag-vector search — measured 2026-07-22 via an inspect.getmembers diff
+the shared store (119 shared methods; 16 PG-only remain — ingest
+progress, decay iteration, procedural skills, tag-vector search — measured 2026-07-22 via an inspect.getmembers diff
 of the two classes; the prior "all 89 methods" claim here was stale).
 
 WRRF fusion and spread activation are computed client-side
@@ -1020,6 +1019,34 @@ class SqliteMemoryStore(
             if field in d and isinstance(d[field], int):
                 d[field] = bool(d[field])
         return d
+
+    # ── Connection acquisition (PgMemoryStore parity) ─────────────────
+    #
+    # PgMemoryStore splits connections across an interactive pool and a batch
+    # pool so long-running jobs cannot starve the hot path. SQLite has no
+    # such split to make: the store owns exactly one WAL-mode connection, and
+    # a second competing connection is what produced the `database is locked`
+    # / stale-read failures documented in conftest's `_clean_sqlite_via_
+    # singleton`. Both accessors therefore yield the same persistent
+    # connection — the identical shape PgMemoryStore itself yields when
+    # POOL_DISABLED is set (pg_store.py:270).
+    #
+    # These exist so handlers stay backend-agnostic: `anchor.py:141` and
+    # `get_rules.py:97` call `store.acquire_interactive()` unconditionally.
+    # Without them a SQLite-backed install raised
+    # `AttributeError: 'SqliteMemoryStore' object has no attribute
+    # 'acquire_interactive'` — an LSP break, not a missing feature, since the
+    # handler cannot know which store it was handed (issue #220).
+
+    @contextmanager
+    def acquire_interactive(self) -> Iterator[PsycopgCompatConnection]:
+        """Yield the store's connection for a short-lived hot-path operation."""
+        yield self._conn
+
+    @contextmanager
+    def acquire_batch(self) -> Iterator[PsycopgCompatConnection]:
+        """Yield the store's connection for long-running batch work."""
+        yield self._conn
 
     # ── Lifecycle ─────────────────────────────────────────────────────
 

--- a/mcp_server/infrastructure/sqlite_store_lesson_promotion.py
+++ b/mcp_server/infrastructure/sqlite_store_lesson_promotion.py
@@ -61,7 +61,7 @@ def list_lesson_promotion_candidates(
     WHERE {_ELIGIBLE_WHERE}
     ORDER BY m.useful_count DESC, m.access_count DESC, m.created_at DESC
     LIMIT ?
-    """
+    """  # noqa: S608 — interpolated fragment is the module-level literal _ELIGIBLE_WHERE; values are bound parameters (docs/ASSURANCE-CASE.md §5)
     rows = conn.execute(sql, (limit,)).fetchall()
     return [dict(row) for row in rows]
 

--- a/mcp_server/infrastructure/sqlite_store_lesson_promotion.py
+++ b/mcp_server/infrastructure/sqlite_store_lesson_promotion.py
@@ -13,6 +13,8 @@ store type.
 
 from __future__ import annotations
 
+from typing import Any
+
 from mcp_server.infrastructure.sqlite_compat import PsycopgCompatConnection
 
 # Same eligibility definition as pg_store_lesson_promotion._ELIGIBLE_WHERE,
@@ -32,6 +34,36 @@ _ELIGIBLE_WHERE = """
         SELECT 1 FROM json_each(m.tags) WHERE value LIKE 'promoted:%'
       )
 """
+
+
+def list_lesson_promotion_candidates(
+    conn: PsycopgCompatConnection, limit: int = 20
+) -> list[dict[str, Any]]:
+    """SQLite twin of the PG ``list_lesson_promotion_candidates``.
+
+    Precondition: ``conn`` is a schema-provisioned SQLite store connection
+    (works with zero lesson-tagged rows).
+    Postcondition: same rows, same eligibility, same ordering
+    (useful_count, then access_count, then created_at, all descending) and
+    the same 500-character content preview as the PG twin. Read-only.
+
+    Exists because ``handlers/lesson_promotion.py`` called the PG function
+    unconditionally, so the handler raised
+    ``sqlite3.OperationalError: unrecognized token: "@"`` on the SQLite
+    backend — which is the plugin default. ``LEFT(...)`` is PG-only;
+    ``substr(...,1,500)`` is the SQLite spelling of the same truncation
+    (issue #220).
+    """
+    sql = f"""
+    SELECT m.id, substr(m.content, 1, 500) AS content_preview, m.domain,
+           m.tags, m.useful_count, m.access_count, m.created_at
+    FROM current_memories m
+    WHERE {_ELIGIBLE_WHERE}
+    ORDER BY m.useful_count DESC, m.access_count DESC, m.created_at DESC
+    LIMIT ?
+    """
+    rows = conn.execute(sql, (limit,)).fetchall()
+    return [dict(row) for row in rows]
 
 
 def count_lesson_promotion_candidates(conn: PsycopgCompatConnection) -> int:

--- a/tests_py/_store_cleanup.py
+++ b/tests_py/_store_cleanup.py
@@ -1,0 +1,196 @@
+"""Between-test store cleanup and singleton reset.
+
+Split out of ``conftest.py`` to bring that file back under the 500-line cap
+(it had reached 606). Behaviour is unchanged — these are the same functions,
+moved verbatim; only the SQLite path binding changed, from conftest's
+``_ISOLATED_SQLITE_PATH`` global to the environment variable that global is
+built from, so this module has no import cycle back to conftest.
+
+The path is read at import time, exactly as before, and
+``_redirect_real_data_roots()`` sets it before any of this is imported —
+conftest imports this module below its own redirect call for that reason
+(issue #219 ordering constraint).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import pkgutil
+
+# ── Tables to clean between tests (order matters for FK constraints) ─────
+
+_TABLES_TO_CLEAN = [
+    "memory_rules",
+    "consolidation_log",
+    "memory_archives",
+    "relationships",
+    "entities",
+    "prospective_memories",
+    "checkpoints",
+    "engram_slots",
+    "oscillatory_state",
+    # A3 scalar homeostatic factor: mcp_server/handlers/consolidate.py
+    # unconditionally runs run_homeostatic_cycle(store, None) on every
+    # handler() call, so every real-store handler test writes a factor
+    # row here. Without this table in the cleanup list that row survives
+    # for the rest of the pytest session and can perturb a later test's
+    # query that joins homeostatic_state (fetch_member_stats,
+    # fetch_contents-adjacent CTEs) — first found via CI run 29109251545
+    # (2026-07-10) leaving factor=0.9409 for domain='' cross-test.
+    #
+    # The domain='' mislabeling itself (streaming scalar branch always
+    # resolving _dominant_domain([]) to '' regardless of which domain
+    # triggered scaling) was a separate production correctness bug,
+    # fixed 2026-07-10 in homeostatic.py (_streaming_health now
+    # accumulates real per-domain counts during the same cursor pass).
+    # This cleanup entry stays regardless — general test-isolation
+    # hygiene, independent of that fix.
+    "homeostatic_state",
+    "schemas",
+    # Receipts before memories: items cascade from receipts, and the hook
+    # subprocess tests (test_auto_recall, test_hook_receipts) emit receipts
+    # that would otherwise accumulate across runs.
+    "injection_receipt_items",
+    "injection_receipts",
+    "memories",
+]
+
+
+def _clean_all_tables(conn) -> None:
+    """Delete all data from test tables (PostgreSQL)."""
+    for table in _TABLES_TO_CLEAN:
+        try:
+            conn.execute(f"DELETE FROM {table}")
+        except Exception:
+            pass
+
+
+# Always the throwaway file from _redirect_real_data_roots() — never a path
+# inherited from the developer's environment (issue #219).
+_SQLITE_DB_PATH = os.environ["CORTEX_MEMORY_DB_PATH"]
+
+
+def _clean_sqlite_via_singleton() -> bool:
+    """Clean SQLite tables via an existing handler singleton's connection.
+
+    Returns True if cleanup succeeded (so we don't need a separate connection).
+    This avoids 'database is locked' errors from opening a competing connection
+    to a WAL-mode SQLite database.
+
+    Uses dynamic discovery over ALL handler modules (pkgutil.iter_modules) so
+    that forget, navigate_memory, and any future handler are covered
+    automatically.  The prior hardcoded list of 5 modules omitted those two
+    handlers, causing the cleanup to fall back to a competing sqlite3.connect()
+    whose WAL-mode writes are immediately visible to the handler's still-open
+    connection — producing spurious get_memory()==None failures (diagnosed
+    2026-06-17, incident test_forget ~30% cold-start flake rate).
+    """
+
+    import mcp_server.handlers as handlers_pkg
+
+    for _finder, mod_name, _ispkg in pkgutil.iter_modules(handlers_pkg.__path__):
+        try:
+            mod = importlib.import_module(f"mcp_server.handlers.{mod_name}")
+            store = getattr(mod, "_store", None)
+            if store is not None and hasattr(store, "_conn"):
+                conn = store._conn
+                for table in _TABLES_TO_CLEAN:
+                    try:
+                        conn.execute(f"DELETE FROM {table}")
+                    except Exception:
+                        pass
+                try:
+                    conn.execute("DELETE FROM memories_fts")
+                except Exception:
+                    pass
+                # WAL checkpoint: flush pending writes to main DB file so the
+                # next sqlite3.connect() fallback (if it fires) sees a clean
+                # slate rather than stale WAL pages.
+                try:
+                    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                except Exception:
+                    pass
+                conn.commit()
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def _clean_sqlite_store() -> None:
+    """Clean SQLite tables — prefer singleton connection, fallback to direct."""
+    # First try using an existing singleton's connection (avoids DB lock)
+    if _clean_sqlite_via_singleton():
+        return
+
+    if not _SQLITE_DB_PATH or not os.path.exists(_SQLITE_DB_PATH):
+        return
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(_SQLITE_DB_PATH, timeout=10)
+        for table in _TABLES_TO_CLEAN:
+            try:
+                conn.execute(f"DELETE FROM {table}")
+            except Exception:
+                pass
+        try:
+            conn.execute("DELETE FROM memories_fts")
+        except Exception:
+            pass
+        # Checkpoint WAL before close so subsequent opens see a clean DB.
+        try:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except Exception:
+            pass
+        conn.commit()
+        conn.close()
+    except Exception:
+        pass
+
+
+# Handler module-level caches that hold (a reference to) the shared store or
+# its derivatives. Nulling them forces re-fetch from get_shared_store() after
+# the shared store is closed; otherwise a handler would hand back a store whose
+# psycopg pools are already closed.
+_HANDLER_CACHE_ATTRS = ("_store", "_memory_store", "_embeddings", "_memory_available")
+
+
+def _reset_all_singletons() -> None:
+    """Reset the shared store and handler-level caches so the next test
+    reconnects fresh.
+
+    The 37 handlers no longer each own a store — they fetch one process-wide
+    instance via get_shared_store(), whose two psycopg pools are the only
+    connections held. reset_shared_store() closes those pools (fixing the CI
+    connection leak that drove live connections past 60 and triggered the
+    30-minute batch-pool acquire hangs). We then null every handler cache by
+    iterating the handlers package, so the list cannot drift out of date.
+    """
+    try:
+        from mcp_server.infrastructure.memory_store import reset_shared_store
+
+        reset_shared_store()
+    except ImportError:
+        pass
+
+    import mcp_server.handlers as handlers_pkg
+
+    for _finder, mod_name, _ispkg in pkgutil.iter_modules(handlers_pkg.__path__):
+        try:
+            mod = importlib.import_module(f"mcp_server.handlers.{mod_name}")
+        except Exception:
+            continue
+        for attr in _HANDLER_CACHE_ATTRS:
+            if hasattr(mod, attr):
+                # All these caches use None as their "recompute me" sentinel
+                # (_memory_available starts None = "not yet checked").
+                setattr(mod, attr, None)
+
+    try:
+        from mcp_server.infrastructure.memory_config import get_memory_settings
+
+        get_memory_settings.cache_clear()
+    except ImportError:
+        pass

--- a/tests_py/conftest.py
+++ b/tests_py/conftest.py
@@ -10,6 +10,7 @@ the PostgreSQL URL, the SQLite file, and the `~/.claude` filesystem tree.
 """
 
 import asyncio
+import importlib.util
 import os
 import sys
 import tempfile
@@ -372,6 +373,19 @@ def _effective_backend() -> str:
 
 _BACKEND = _effective_backend()
 _USE_PG_STORE = _BACKEND == "postgresql"
+
+# Reusable gate for tests whose SUBJECT is PgMemoryStore itself — they import
+# it inside the test body (often via object.__new__, with no live DB), so they
+# need psycopg importable even though they never connect. psycopg ships in the
+# optional [postgresql] extra, absent from the SQLite-default install, where
+# the import raises ModuleNotFoundError and FAILS the test instead of skipping
+# it (#220). This is a narrower question than `_USE_PG` (is a server
+# reachable?) and than `_USE_PG_STORE` (which backend did we resolve?): it asks
+# only whether the driver can be imported.
+requires_psycopg = pytest.mark.skipif(
+    importlib.util.find_spec("psycopg") is None,
+    reason="psycopg not installed ([postgresql] extra); PgMemoryStore is PG-only",
+)
 
 
 # ── Isolate domain_mapping's dev-root scan from the real filesystem ──────

--- a/tests_py/conftest.py
+++ b/tests_py/conftest.py
@@ -10,7 +10,6 @@ the PostgreSQL URL, the SQLite file, and the `~/.claude` filesystem tree.
 """
 
 import asyncio
-import importlib
 import os
 import sys
 import tempfile
@@ -63,6 +62,19 @@ def _redirect_real_data_roots() -> str:
 
 
 _ISOLATED_SQLITE_PATH = _redirect_real_data_roots()
+
+# Imported AFTER the redirect above, never before: this module binds the
+# isolated SQLite path at import time from CORTEX_MEMORY_DB_PATH, which
+# _redirect_real_data_roots() has just set. Moving this import higher
+# reintroduces the #219 ordering bug.
+from tests_py._store_cleanup import (  # noqa: E402
+    _clean_all_tables,
+    _clean_sqlite_store,
+    _reset_all_singletons,
+    _TABLES_TO_CLEAN,
+)
+
+__all__ = ["_TABLES_TO_CLEAN"]  # re-exported: tests import it from conftest
 
 # On Windows asyncio defaults to ProactorEventLoop, whose GC-time teardown
 # emits a noisy "Event loop is closed" PytestUnraisableExceptionWarning that
@@ -412,45 +424,6 @@ _dm._candidate_dev_roots = lambda: []
 _dm._build_registry.cache_clear()
 
 
-# ── Tables to clean between tests (order matters for FK constraints) ─────
-
-_TABLES_TO_CLEAN = [
-    "memory_rules",
-    "consolidation_log",
-    "memory_archives",
-    "relationships",
-    "entities",
-    "prospective_memories",
-    "checkpoints",
-    "engram_slots",
-    "oscillatory_state",
-    # A3 scalar homeostatic factor: mcp_server/handlers/consolidate.py
-    # unconditionally runs run_homeostatic_cycle(store, None) on every
-    # handler() call, so every real-store handler test writes a factor
-    # row here. Without this table in the cleanup list that row survives
-    # for the rest of the pytest session and can perturb a later test's
-    # query that joins homeostatic_state (fetch_member_stats,
-    # fetch_contents-adjacent CTEs) — first found via CI run 29109251545
-    # (2026-07-10) leaving factor=0.9409 for domain='' cross-test.
-    #
-    # The domain='' mislabeling itself (streaming scalar branch always
-    # resolving _dominant_domain([]) to '' regardless of which domain
-    # triggered scaling) was a separate production correctness bug,
-    # fixed 2026-07-10 in homeostatic.py (_streaming_health now
-    # accumulates real per-domain counts during the same cursor pass).
-    # This cleanup entry stays regardless — general test-isolation
-    # hygiene, independent of that fix.
-    "homeostatic_state",
-    "schemas",
-    # Receipts before memories: items cascade from receipts, and the hook
-    # subprocess tests (test_auto_recall, test_hook_receipts) emit receipts
-    # that would otherwise accumulate across runs.
-    "injection_receipt_items",
-    "injection_receipts",
-    "memories",
-]
-
-
 def _get_raw_connection():
     """Get a raw psycopg connection to the test database.
 
@@ -474,148 +447,6 @@ def _get_raw_connection():
         return psycopg.connect(_TEST_DB_URL, autocommit=True)
     except Exception:
         return None
-
-
-def _clean_all_tables(conn) -> None:
-    """Delete all data from test tables (PostgreSQL)."""
-    for table in _TABLES_TO_CLEAN:
-        try:
-            conn.execute(f"DELETE FROM {table}")
-        except Exception:
-            pass
-
-
-# Always the throwaway file from _redirect_real_data_roots() — never a path
-# inherited from the developer's environment (issue #219).
-_SQLITE_DB_PATH = _ISOLATED_SQLITE_PATH
-
-
-def _clean_sqlite_via_singleton() -> bool:
-    """Clean SQLite tables via an existing handler singleton's connection.
-
-    Returns True if cleanup succeeded (so we don't need a separate connection).
-    This avoids 'database is locked' errors from opening a competing connection
-    to a WAL-mode SQLite database.
-
-    Uses dynamic discovery over ALL handler modules (pkgutil.iter_modules) so
-    that forget, navigate_memory, and any future handler are covered
-    automatically.  The prior hardcoded list of 5 modules omitted those two
-    handlers, causing the cleanup to fall back to a competing sqlite3.connect()
-    whose WAL-mode writes are immediately visible to the handler's still-open
-    connection — producing spurious get_memory()==None failures (diagnosed
-    2026-06-17, incident test_forget ~30% cold-start flake rate).
-    """
-    import pkgutil
-
-    import mcp_server.handlers as handlers_pkg
-
-    for _finder, mod_name, _ispkg in pkgutil.iter_modules(handlers_pkg.__path__):
-        try:
-            mod = importlib.import_module(f"mcp_server.handlers.{mod_name}")
-            store = getattr(mod, "_store", None)
-            if store is not None and hasattr(store, "_conn"):
-                conn = store._conn
-                for table in _TABLES_TO_CLEAN:
-                    try:
-                        conn.execute(f"DELETE FROM {table}")
-                    except Exception:
-                        pass
-                try:
-                    conn.execute("DELETE FROM memories_fts")
-                except Exception:
-                    pass
-                # WAL checkpoint: flush pending writes to main DB file so the
-                # next sqlite3.connect() fallback (if it fires) sees a clean
-                # slate rather than stale WAL pages.
-                try:
-                    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-                except Exception:
-                    pass
-                conn.commit()
-                return True
-        except Exception:
-            pass
-    return False
-
-
-def _clean_sqlite_store() -> None:
-    """Clean SQLite tables — prefer singleton connection, fallback to direct."""
-    # First try using an existing singleton's connection (avoids DB lock)
-    if _clean_sqlite_via_singleton():
-        return
-
-    if not _SQLITE_DB_PATH or not os.path.exists(_SQLITE_DB_PATH):
-        return
-    import sqlite3
-
-    try:
-        conn = sqlite3.connect(_SQLITE_DB_PATH, timeout=10)
-        for table in _TABLES_TO_CLEAN:
-            try:
-                conn.execute(f"DELETE FROM {table}")
-            except Exception:
-                pass
-        try:
-            conn.execute("DELETE FROM memories_fts")
-        except Exception:
-            pass
-        # Checkpoint WAL before close so subsequent opens see a clean DB.
-        try:
-            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-        except Exception:
-            pass
-        conn.commit()
-        conn.close()
-    except Exception:
-        pass
-
-
-# Handler module-level caches that hold (a reference to) the shared store or
-# its derivatives. Nulling them forces re-fetch from get_shared_store() after
-# the shared store is closed; otherwise a handler would hand back a store whose
-# psycopg pools are already closed.
-_HANDLER_CACHE_ATTRS = ("_store", "_memory_store", "_embeddings", "_memory_available")
-
-
-def _reset_all_singletons() -> None:
-    """Reset the shared store and handler-level caches so the next test
-    reconnects fresh.
-
-    The 37 handlers no longer each own a store — they fetch one process-wide
-    instance via get_shared_store(), whose two psycopg pools are the only
-    connections held. reset_shared_store() closes those pools (fixing the CI
-    connection leak that drove live connections past 60 and triggered the
-    30-minute batch-pool acquire hangs). We then null every handler cache by
-    iterating the handlers package, so the list cannot drift out of date.
-    """
-    try:
-        from mcp_server.infrastructure.memory_store import reset_shared_store
-
-        reset_shared_store()
-    except ImportError:
-        pass
-
-    import pkgutil
-
-    import mcp_server.handlers as handlers_pkg
-
-    for _finder, mod_name, _ispkg in pkgutil.iter_modules(handlers_pkg.__path__):
-        try:
-            mod = importlib.import_module(f"mcp_server.handlers.{mod_name}")
-        except Exception:
-            continue
-        for attr in _HANDLER_CACHE_ATTRS:
-            if hasattr(mod, attr):
-                # All these caches use None as their "recompute me" sentinel
-                # (_memory_available starts None = "not yet checked").
-                setattr(mod, attr, None)
-
-    try:
-        from mcp_server.infrastructure.memory_config import get_memory_settings
-
-        get_memory_settings.cache_clear()
-    except ImportError:
-        pass
 
 
 @pytest.fixture(autouse=True)

--- a/tests_py/core/test_silent_except_sweep_remaining.py
+++ b/tests_py/core/test_silent_except_sweep_remaining.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from mcp_server.observability import silent_failure
+from tests_py.conftest import requires_psycopg  # type: ignore
 
 
 @pytest.fixture(autouse=True)
@@ -169,6 +170,7 @@ class TestMemoryIngestFailuresAreObservable:
         )
 
 
+@requires_psycopg
 class TestPgStoreFailuresAreObservable:
     def test_update_memory_value_failure_is_logged(self, caplog):
         from mcp_server.infrastructure.pg_store import PgMemoryStore

--- a/tests_py/handlers/consolidation/test_wiki_citation_seed_pass.py
+++ b/tests_py/handlers/consolidation/test_wiki_citation_seed_pass.py
@@ -17,13 +17,21 @@ import asyncio
 import uuid
 
 import pytest
-from psycopg.rows import dict_row
 
-from mcp_server.handlers.consolidation.wiki_citation_seed_pass import (
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. This module imports it DIRECTLY (below), so without
+# this guard it raises ModuleNotFoundError at COLLECTION time — an error, not
+# a skip, which fails the whole run (#220). The guard must therefore precede
+# the psycopg imports themselves, not just the mcp_server ones.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from psycopg.rows import dict_row  # noqa: E402
+
+from mcp_server.handlers.consolidation.wiki_citation_seed_pass import (  # noqa: E402
     run_wiki_citation_seed_pass,
 )
-from mcp_server.infrastructure.memory_config import get_memory_settings
-from mcp_server.infrastructure.memory_store import get_shared_store
+from mcp_server.infrastructure.memory_config import get_memory_settings  # noqa: E402
+from mcp_server.infrastructure.memory_store import get_shared_store  # noqa: E402
 
 
 def _store():

--- a/tests_py/handlers/test_get_grooming_health.py
+++ b/tests_py/handlers/test_get_grooming_health.py
@@ -22,10 +22,34 @@ import time
 from mcp_server.core.grooming_health import GROOMING_STALENESS_THRESHOLD_DAYS
 from mcp_server.handlers import get_grooming_health
 from mcp_server.infrastructure.memory_store import get_shared_store
-from mcp_server.infrastructure.pg_store_lesson_promotion import (
-    count_lesson_promotion_candidates,
-    list_lesson_promotion_candidates,
+from mcp_server.handlers.get_grooming_health import (
+    _count_promotion_candidates as _count_candidates,
 )
+from mcp_server.handlers.lesson_promotion import _list_candidates
+
+
+# These assertions are backend-agnostic contracts ("the count equals the
+# unbounded list length", "the count rises by one after a qualifying
+# rating"), so they must run against whichever dialect the resolved store
+# actually is. Importing the PG functions directly bound them to one
+# dialect while `get_shared_store()` returned the other, so on the SQLite
+# backend they raised `unrecognized token: "@"` instead of testing the
+# contract. Going through the handlers' dispatch also makes these tests
+# cover the composition root the product uses (issue #220).
+
+
+def count_lesson_promotion_candidates(conn) -> int:  # noqa: ARG001 - see below
+    """Count via the same backend dispatch the handler uses.
+
+    Takes and ignores `conn` so the call sites below read unchanged; the
+    dispatch needs the STORE (to type-check it), not its connection.
+    """
+    return _count_candidates(get_shared_store())
+
+
+def list_lesson_promotion_candidates(conn, limit: int = 20):  # noqa: ARG001
+    """List via the same backend dispatch the handler uses."""
+    return _list_candidates(get_shared_store(), limit)
 
 
 def _run(coro):

--- a/tests_py/handlers/test_ingest_codebase.py
+++ b/tests_py/handlers/test_ingest_codebase.py
@@ -87,9 +87,51 @@ class _FakeStore:
         return list(self.memories)
 
 
+def _ensure_base_schema():
+    """Provision the base schema these incremental migrations build on.
+
+    `_INGEST_MIGRATIONS` starts with `CREATE INDEX ... ON entities`, so it
+    presupposes the base tables. The suite gate is `_USE_PG_STORE`, which
+    says PostgreSQL is the SELECTED backend — not that this database has
+    ever been migrated. On a reachable-but-unprovisioned test DB the two
+    come apart and the first statement dies with `UndefinedTable: relation
+    "entities" does not exist`, which reads as a product failure but is a
+    missing precondition (issue #220's "harness reason, not a product one").
+
+    Constructing `PgMemoryStore` IS the migration: `__init__` runs
+    `_init_schema()`, which applies `pg_schema.get_all_ddl()` under an
+    advisory lock iff the recorded hash is stale. `mcp_server/migrate.py`
+    calls that the single source of truth and never re-applies DDL itself;
+    neither does this, so the tests cannot drift from the shipped schema.
+
+    Guarded on the missing precondition rather than run unconditionally.
+    Applying the DDL mid-suite is not free — measured on this branch, an
+    unconditional call turned a clean full run into
+    `test_near_dup_calibration_pass::
+    test_pairs_above_threshold_collapse_onto_hottest_member` failing
+    (6259 passed / 0 failed -> 6258 passed / 1 failed, paired control on
+    the same commit). Provisioning only when `entities` is genuinely
+    absent makes this a no-op everywhere the precondition already holds —
+    CI, and any developer DB that has been migrated — so it repairs the
+    unprovisioned case without perturbing the provisioned one.
+    """
+    import psycopg
+
+    from mcp_server.infrastructure.pg_store import PgMemoryStore
+
+    with psycopg.connect(_TEST_DB_URL, autocommit=True) as conn:
+        row = conn.execute("SELECT to_regclass('public.entities')").fetchone()
+    if row is not None and row[0] is not None:
+        return
+
+    store = PgMemoryStore(database_url=_TEST_DB_URL)
+    store.close()
+
+
 def _apply_ingest_migrations_and_clean():
     import psycopg
 
+    _ensure_base_schema()
     with psycopg.connect(_TEST_DB_URL, autocommit=True) as conn:
         for stmt in _INGEST_MIGRATIONS:
             conn.execute(stmt)

--- a/tests_py/handlers/test_ingest_codebase.py
+++ b/tests_py/handlers/test_ingest_codebase.py
@@ -9,7 +9,7 @@ import pytest
 from mcp_server.handlers import ingest_codebase as icb
 from mcp_server.handlers import ingest_codebase_pages as icb_pages
 from mcp_server.handlers import ingest_helpers
-from tests_py.conftest import _TEST_DB_URL, _USE_PG  # type: ignore
+from tests_py.conftest import _TEST_DB_URL, _USE_PG_STORE  # type: ignore
 
 # The entity/edge writers now stream through PostgreSQL staging tables, so the
 # write-asserting tests need a live DB. The schema migration (the LOWER(name)
@@ -191,7 +191,15 @@ def _re(pattern: str) -> re.Pattern[str]:
 
 
 class TestIngestCodebaseHappyPath:
-    @pytest.mark.skipif(not _USE_PG, reason="staging write path needs live PG")
+    @pytest.mark.skipif(  # Gated on the EFFECTIVE backend, not reachability: these fixtures seed
+        # PostgreSQL directly (raw DSN / PG-only migrations) while the product
+        # under test reads the resolved store. Under a sqlite-backend run they
+        # seeded one store and asserted against another, so they failed for a
+        # harness reason rather than a product one. SQLite coverage of these
+        # paths needs backend-agnostic fixtures — tracked in #220.
+        not _USE_PG_STORE,
+        reason="staging write path needs live PG",
+    )
     @pytest.mark.asyncio
     async def test_happy_path_writes_memories_entities_edges_and_pages(
         self, fake_store, fake_upstream, no_wiki
@@ -495,7 +503,15 @@ class TestIngestCodebaseFailures:
         assert ingest_helpers.find_cached_graph(fake_store, "/tmp/myproj") is None
 
     @pytest.mark.asyncio
-    @pytest.mark.skipif(not _USE_PG, reason="staging write path needs live PG")
+    @pytest.mark.skipif(  # Gated on the EFFECTIVE backend, not reachability: these fixtures seed
+        # PostgreSQL directly (raw DSN / PG-only migrations) while the product
+        # under test reads the resolved store. Under a sqlite-backend run they
+        # seeded one store and asserted against another, so they failed for a
+        # harness reason rather than a product one. SQLite coverage of these
+        # paths needs backend-agnostic fixtures — tracked in #220.
+        not _USE_PG_STORE,
+        reason="staging write path needs live PG",
+    )
     async def test_file_attribution_uses_containment_not_qn_split(
         self, fake_store, fake_upstream, no_wiki
     ):

--- a/tests_py/handlers/test_ingest_codebase.py
+++ b/tests_py/handlers/test_ingest_codebase.py
@@ -191,12 +191,13 @@ def _re(pattern: str) -> re.Pattern[str]:
 
 
 class TestIngestCodebaseHappyPath:
-    @pytest.mark.skipif(  # Gated on the EFFECTIVE backend, not reachability: these fixtures seed
-        # PostgreSQL directly (raw DSN / PG-only migrations) while the product
-        # under test reads the resolved store. Under a sqlite-backend run they
-        # seeded one store and asserted against another, so they failed for a
-        # harness reason rather than a product one. SQLite coverage of these
-        # paths needs backend-agnostic fixtures — tracked in #220.
+    # Gated on the EFFECTIVE backend, not reachability: these fixtures seed
+    # PostgreSQL directly (raw DSN / PG-only migrations) while the product
+    # under test reads the resolved store. Under a sqlite-backend run they
+    # seeded one store and asserted against another, so they failed for a
+    # harness reason rather than a product one. SQLite coverage of these
+    # paths needs backend-agnostic fixtures — tracked in #220.
+    @pytest.mark.skipif(
         not _USE_PG_STORE,
         reason="staging write path needs live PG",
     )
@@ -503,12 +504,13 @@ class TestIngestCodebaseFailures:
         assert ingest_helpers.find_cached_graph(fake_store, "/tmp/myproj") is None
 
     @pytest.mark.asyncio
-    @pytest.mark.skipif(  # Gated on the EFFECTIVE backend, not reachability: these fixtures seed
-        # PostgreSQL directly (raw DSN / PG-only migrations) while the product
-        # under test reads the resolved store. Under a sqlite-backend run they
-        # seeded one store and asserted against another, so they failed for a
-        # harness reason rather than a product one. SQLite coverage of these
-        # paths needs backend-agnostic fixtures — tracked in #220.
+    # Gated on the EFFECTIVE backend, not reachability: these fixtures seed
+    # PostgreSQL directly (raw DSN / PG-only migrations) while the product
+    # under test reads the resolved store. Under a sqlite-backend run they
+    # seeded one store and asserted against another, so they failed for a
+    # harness reason rather than a product one. SQLite coverage of these
+    # paths needs backend-agnostic fixtures — tracked in #220.
+    @pytest.mark.skipif(
         not _USE_PG_STORE,
         reason="staging write path needs live PG",
     )

--- a/tests_py/handlers/test_recall_include_related.py
+++ b/tests_py/handlers/test_recall_include_related.py
@@ -24,10 +24,17 @@ import pytest
 
 from mcp_server.handlers import recall
 from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+from tests_py.conftest import _USE_PG_STORE  # type: ignore
 
 pytestmark = pytest.mark.skipif(
-    not _USE_PG, reason="PostgreSQL not available — relation-walk needs live schema"
+    # Gated on the EFFECTIVE backend, not reachability: these fixtures seed
+    # PostgreSQL directly (raw DSN / PG-only migrations) while the product
+    # under test reads the resolved store. Under a sqlite-backend run they
+    # seeded one store and asserted against another, so they failed for a
+    # harness reason rather than a product one. SQLite coverage of these
+    # paths needs backend-agnostic fixtures — tracked in #220.
+    not _USE_PG_STORE,
+    reason="PostgreSQL not available — relation-walk needs live schema",
 )
 
 _DOMAIN = "include-related-test"

--- a/tests_py/handlers/test_recall_include_related.py
+++ b/tests_py/handlers/test_recall_include_related.py
@@ -5,9 +5,10 @@ recall(include_related=True) attaches a ONE-HOP walk to each surfaced memory:
   - related.entities  — directly related entities via the knowledge graph
 
 It is a cheap mid-tier enrichment, distinct from the full PageRank/HippoRAG
-context assembler. This file proves the behavior end-to-end against live PG
-and guards the latency stays bounded (within a small factor of flat recall,
-NOT the whole-graph assembler — the walk is one hop with bounded fanout).
+context assembler. This file proves the behavior end-to-end on WHICHEVER
+backend the run resolves — PostgreSQL or the SQLite default — and guards the
+latency stays bounded (within a small factor of flat recall, NOT the
+whole-graph assembler — the walk is one hop with bounded fanout).
 
 External signals (handover acceptance):
   - neighbors are present inline only when include_related=True;
@@ -23,19 +24,14 @@ import numpy as np
 import pytest
 
 from mcp_server.handlers import recall
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG_STORE  # type: ignore
+from mcp_server.infrastructure.memory_store import get_shared_store
 
-pytestmark = pytest.mark.skipif(
-    # Gated on the EFFECTIVE backend, not reachability: these fixtures seed
-    # PostgreSQL directly (raw DSN / PG-only migrations) while the product
-    # under test reads the resolved store. Under a sqlite-backend run they
-    # seeded one store and asserted against another, so they failed for a
-    # harness reason rather than a product one. SQLite coverage of these
-    # paths needs backend-agnostic fixtures — tracked in #220.
-    not _USE_PG_STORE,
-    reason="PostgreSQL not available — relation-walk needs live schema",
-)
+# No backend gate. This file used to construct PgMemoryStore() directly and
+# skip whenever the effective backend was not PostgreSQL, which meant the
+# relation-walk — a backend-agnostic FEATURE — was never exercised on the
+# plugin's DEFAULT backend (#220). It now seeds through the same resolved
+# store the handler reads, so the assertions below run on both backends and a
+# SQLite-only regression in the walk can no longer pass CI unseen.
 
 _DOMAIN = "include-related-test"
 _DIM = 384
@@ -50,24 +46,19 @@ def _emb() -> bytes:
 
 @pytest.fixture
 def store():
-    s = PgMemoryStore()
-    yield s
-    try:
-        s._execute("DELETE FROM memories WHERE domain = %s", (_DOMAIN,))
-        # Relationships FK-reference entities — drop them before the entities.
-        s._execute(
-            "DELETE FROM relationships WHERE source_entity_id IN "
-            "(SELECT id FROM entities WHERE domain = %s) "
-            "OR target_entity_id IN (SELECT id FROM entities WHERE domain = %s)",
-            (_DOMAIN, _DOMAIN),
-        )
-        s._execute("DELETE FROM entities WHERE domain = %s", (_DOMAIN,))
-        s._conn.commit()
-    finally:
-        s.close()
+    """The process-wide resolved store — the same instance the handler reads.
+
+    Deliberately does NOT close the store or hand-delete rows: conftest's
+    autouse ``clean_between_tests`` already purges memories/entities/
+    relationships on both backends before AND after every test, and closing a
+    shared store here would leave the next test with a dead handle. The old
+    per-dialect DELETEs also hard-coded ``%s`` placeholders, which is half of
+    why this file was PG-only.
+    """
+    return get_shared_store()
 
 
-def _seed(store: PgMemoryStore) -> dict:
+def _seed(store) -> dict:
     """Seed a superseded/current memory pair plus a 2-entity relationship."""
     common = {"embedding": _emb(), "source": "user", "domain": _DOMAIN, "heat": 0.6}
     old_id = store.insert_memory(

--- a/tests_py/hooks/test_auto_recall.py
+++ b/tests_py/hooks/test_auto_recall.py
@@ -31,11 +31,18 @@ import sys
 
 import pytest
 
-from tests_py.conftest import _USE_PG, _TEST_DB_URL  # type: ignore
+from tests_py.conftest import _USE_PG_STORE, _TEST_DB_URL  # type: ignore
 
 
 pytestmark = pytest.mark.skipif(
-    not _USE_PG, reason="PostgreSQL not available — auto_recall hook needs PG schema"
+    # Gated on the EFFECTIVE backend, not reachability: these fixtures seed
+    # PostgreSQL directly (raw DSN / PG-only migrations) while the product
+    # under test reads the resolved store. Under a sqlite-backend run they
+    # seeded one store and asserted against another, so they failed for a
+    # harness reason rather than a product one. SQLite coverage of these
+    # paths needs backend-agnostic fixtures — tracked in #220.
+    not _USE_PG_STORE,
+    reason="PostgreSQL not available — auto_recall hook needs PG schema",
 )
 
 

--- a/tests_py/hooks/test_hook_receipts.py
+++ b/tests_py/hooks/test_hook_receipts.py
@@ -26,10 +26,17 @@ import sys
 
 import pytest
 
-from tests_py.conftest import _USE_PG, _TEST_DB_URL  # type: ignore
+from tests_py.conftest import _USE_PG_STORE, _TEST_DB_URL  # type: ignore
 
 pytestmark = pytest.mark.skipif(
-    not _USE_PG, reason="PostgreSQL not available — hook receipts need PG schema"
+    # Gated on the EFFECTIVE backend, not reachability: these fixtures seed
+    # PostgreSQL directly (raw DSN / PG-only migrations) while the product
+    # under test reads the resolved store. Under a sqlite-backend run they
+    # seeded one store and asserted against another, so they failed for a
+    # harness reason rather than a product one. SQLite coverage of these
+    # paths needs backend-agnostic fixtures — tracked in #220.
+    not _USE_PG_STORE,
+    reason="PostgreSQL not available — hook receipts need PG schema",
 )
 
 # The event's session_id field diverges from the transcript identity

--- a/tests_py/hooks/test_pipeline_impact_bump.py
+++ b/tests_py/hooks/test_pipeline_impact_bump.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mcp_server.hooks import pipeline_impact_bump as hook
+from tests_py.conftest import requires_psycopg  # type: ignore
 
 
 @pytest.fixture(autouse=True)
@@ -76,6 +77,7 @@ class TestCooldown:
             mock_run.assert_not_called()
 
 
+@requires_psycopg
 class TestHeatBump:
     def test_no_symbols_returns_zero(self):
         assert hook._bump_heat_for_symbols([]) == 0

--- a/tests_py/infrastructure/test_pg_alpha_integral.py
+++ b/tests_py/infrastructure/test_pg_alpha_integral.py
@@ -25,8 +25,16 @@ import itertools
 
 import pytest
 
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG, reason="PostgreSQL not available — alpha_integral needs live schema"

--- a/tests_py/infrastructure/test_pg_decay_clock_anchor.py
+++ b/tests_py/infrastructure/test_pg_decay_clock_anchor.py
@@ -28,8 +28,16 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG, reason="PostgreSQL not available — decay clock needs live schema"

--- a/tests_py/infrastructure/test_pg_effective_stage_parity.py
+++ b/tests_py/infrastructure/test_pg_effective_stage_parity.py
@@ -22,13 +22,21 @@ import itertools
 
 import pytest
 
-from mcp_server.core.cascade_advancement import (
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.core.cascade_advancement import (  # noqa: E402
     _effective_min_dwell,
     compute_advancement_readiness,
 )
-from mcp_server.core.cascade_stages import _STAGE_PROPERTIES, ConsolidationStage
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+from mcp_server.core.cascade_stages import _STAGE_PROPERTIES, ConsolidationStage  # noqa: E402
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG, reason="PostgreSQL not available — effective_stage needs live schema"
@@ -122,17 +130,14 @@ def test_sql_matches_python_iteration(store: PgMemoryStore) -> None:
 def test_monotonic_never_demotes(store: PgMemoryStore) -> None:
     """A derived stage is never earlier than the stored stage (forward-only)."""
     order = {name: i for i, name in enumerate(_FORWARD_CHAIN)}
-    for stored in _FORWARD_CHAIN:
-        for hours in (0.0, 0.5, 9000.0):
-            for importance in (0.2, 0.6):
-                for access in (0, 5):
-                    for schema in (0.0, 0.6):
-                        got = _sql_effective_stage(
-                            store, stored, hours, importance, access, schema
-                        )
-                        assert order[got] >= order[stored], (
-                            f"demotion: stored={stored} -> {got}"
-                        )
+    # itertools.product over the same four axes the nested loops walked —
+    # identical cases, one level of nesting (§4.5 caps depth at 3).
+    grid = itertools.product(
+        _FORWARD_CHAIN, (0.0, 0.5, 9000.0), (0.2, 0.6), (0, 5), (0.0, 0.6)
+    )
+    for stored, hours, importance, access, schema in grid:
+        got = _sql_effective_stage(store, stored, hours, importance, access, schema)
+        assert order[got] >= order[stored], f"demotion: stored={stored} -> {got}"
 
 
 def test_offchain_stage_passthrough(store: PgMemoryStore) -> None:

--- a/tests_py/infrastructure/test_pg_entity_merge.py
+++ b/tests_py/infrastructure/test_pg_entity_merge.py
@@ -16,9 +16,17 @@ import os
 
 import pytest
 
-from mcp_server.handlers.consolidation.entity_merge import run_entity_merge_cycle
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.handlers.consolidation.entity_merge import run_entity_merge_cycle  # noqa: E402
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG, reason="PostgreSQL not available — entity merge needs live schema"

--- a/tests_py/infrastructure/test_pg_pool.py
+++ b/tests_py/infrastructure/test_pg_pool.py
@@ -14,6 +14,17 @@ from __future__ import annotations
 import pytest
 
 from mcp_server.infrastructure.pg_store import PgMemoryStore
+from tests_py.conftest import _USE_PG  # type: ignore
+
+# These construct PgMemoryStore() directly and exercise the psycopg pools, so
+# they need a live PostgreSQL — they had NO gate and therefore errored on any
+# run without one. Harmless while CI's SQLite job ran a single file; broadening
+# that job to the full suite (#220) made it a hard failure, 27 errors + 1
+# failure. Gated on reachability, which is the right question for a test whose
+# subject IS the PG connection pool.
+pytestmark = pytest.mark.skipif(
+    not _USE_PG, reason="PostgreSQL not available — pool tests need a live DB"
+)
 
 
 @pytest.fixture

--- a/tests_py/infrastructure/test_pg_pool.py
+++ b/tests_py/infrastructure/test_pg_pool.py
@@ -13,8 +13,16 @@ from __future__ import annotations
 
 import pytest
 
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 # These construct PgMemoryStore() directly and exercise the psycopg pools, so
 # they need a live PostgreSQL — they had NO gate and therefore errored on any

--- a/tests_py/infrastructure/test_pg_recall_scoring_debias.py
+++ b/tests_py/infrastructure/test_pg_recall_scoring_debias.py
@@ -22,8 +22,16 @@ from datetime import datetime, timedelta, timezone
 import numpy as np
 import pytest
 
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 # Constructs PgMemoryStore() directly, so it needs a live PostgreSQL. It had no
 # gate and therefore errored on any PG-less run — invisible while CI's SQLite

--- a/tests_py/infrastructure/test_pg_recall_scoring_debias.py
+++ b/tests_py/infrastructure/test_pg_recall_scoring_debias.py
@@ -23,6 +23,15 @@ import numpy as np
 import pytest
 
 from mcp_server.infrastructure.pg_store import PgMemoryStore
+from tests_py.conftest import _USE_PG  # type: ignore
+
+# Constructs PgMemoryStore() directly, so it needs a live PostgreSQL. It had no
+# gate and therefore errored on any PG-less run — invisible while CI's SQLite
+# job ran a single file, a hard failure once that job runs the full suite
+# (#220). Gated on reachability: the subject of these tests IS the PG backend.
+pytestmark = pytest.mark.skipif(
+    not _USE_PG, reason="PostgreSQL not available — this suite needs a live DB"
+)
 
 _DOMAIN = "scoring-debias-test"
 _DIM = 384

--- a/tests_py/infrastructure/test_pg_spread_activation_scoping.py
+++ b/tests_py/infrastructure/test_pg_spread_activation_scoping.py
@@ -27,8 +27,16 @@ from __future__ import annotations
 
 import pytest
 
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG,

--- a/tests_py/infrastructure/test_pg_supersession.py
+++ b/tests_py/infrastructure/test_pg_supersession.py
@@ -25,8 +25,16 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG, reason="PostgreSQL not available — supersession needs live schema"

--- a/tests_py/infrastructure/test_pg_user_mood.py
+++ b/tests_py/infrastructure/test_pg_user_mood.py
@@ -23,6 +23,15 @@ from __future__ import annotations
 import pytest
 
 from mcp_server.infrastructure.pg_store import PgMemoryStore
+from tests_py.conftest import _USE_PG  # type: ignore
+
+# Constructs PgMemoryStore() directly, so it needs a live PostgreSQL. It had no
+# gate and therefore errored on any PG-less run — invisible while CI's SQLite
+# job ran a single file, a hard failure once that job runs the full suite
+# (#220). Gated on reachability: the subject of these tests IS the PG backend.
+pytestmark = pytest.mark.skipif(
+    not _USE_PG, reason="PostgreSQL not available — this suite needs a live DB"
+)
 
 
 @pytest.fixture

--- a/tests_py/infrastructure/test_pg_user_mood.py
+++ b/tests_py/infrastructure/test_pg_user_mood.py
@@ -22,8 +22,16 @@ from __future__ import annotations
 
 import pytest
 
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 # Constructs PgMemoryStore() directly, so it needs a live PostgreSQL. It had no
 # gate and therefore errored on any PG-less run — invisible while CI's SQLite

--- a/tests_py/infrastructure/test_s110_sweep_infrastructure.py
+++ b/tests_py/infrastructure/test_s110_sweep_infrastructure.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 from mcp_server.observability import silent_failure
+from tests_py.conftest import requires_psycopg  # type: ignore
 
 WARN_LOGGER = "mcp_server.observability.silent_failure"
 
@@ -202,6 +203,7 @@ class TestWikiStoreReadmeGuard:
         _assert_noted("wiki_store.reindex", "index builder broke")
 
 
+@requires_psycopg
 class TestPgStoreTeardownSignals:
     def test_pool_close_failures_are_logged_and_pools_cleared(self, caplog):
         from mcp_server.infrastructure.pg_store import PgMemoryStore
@@ -389,6 +391,7 @@ class TestSessionStartPgClose:
         assert "pg connection close failed" in err
 
 
+@requires_psycopg
 class TestPgStoreRecoverySignals:
     def test_reconnect_survives_failed_close_and_logs_debug(self, caplog, monkeypatch):
         from mcp_server.infrastructure.pg_store import PgMemoryStore

--- a/tests_py/infrastructure/test_sqlite_parity_197.py
+++ b/tests_py/infrastructure/test_sqlite_parity_197.py
@@ -16,9 +16,18 @@ from datetime import datetime, timedelta, timezone
 import numpy as np
 import pytest
 
-from mcp_server.infrastructure.pg_store_host import MaterializedCursor
-from mcp_server.infrastructure.sqlite_compat import PsycopgCompatConnection
-from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
+# pg_store_host imports psycopg at module scope, and psycopg ships only in the
+# optional [postgresql] extra — absent from the SQLite-default install this
+# suite's own subject runs on. A missing import at collection time is an ERROR,
+# not a skip, so it aborts the whole run; skip the module cleanly instead
+# (issue #220, same guard as the other PG-touching suites).
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.infrastructure.pg_store_host import MaterializedCursor  # noqa: E402
+from mcp_server.infrastructure.sqlite_compat import (  # noqa: E402
+    PsycopgCompatConnection,
+)
+from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore  # noqa: E402
 
 
 def _vec(*values: float) -> bytes:

--- a/tests_py/infrastructure/test_staging_resolve_sink.py
+++ b/tests_py/infrastructure/test_staging_resolve_sink.py
@@ -14,16 +14,24 @@ schema). Post: conservation + idempotency hold.
 
 from __future__ import annotations
 
-import psycopg
 import pytest
-from psycopg_pool import ConnectionPool
 
-from mcp_server.core.streaming.backpressure_pipeline import BackpressurePipeline
-from mcp_server.infrastructure.staging_resolve_sink import (
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. This module imports it DIRECTLY (below), so without
+# this guard it raises ModuleNotFoundError at COLLECTION time — an error, not
+# a skip, which fails the whole run (#220). The guard must therefore precede
+# the psycopg imports themselves, not just the mcp_server ones.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+import psycopg  # noqa: E402
+from psycopg_pool import ConnectionPool  # noqa: E402
+
+from mcp_server.core.streaming.backpressure_pipeline import BackpressurePipeline  # noqa: E402
+from mcp_server.infrastructure.staging_resolve_sink import (  # noqa: E402
     build_edge_sink,
     build_entity_sink,
 )
-from tests_py.conftest import _TEST_DB_URL, _USE_PG  # type: ignore
+from tests_py.conftest import _TEST_DB_URL, _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG, reason="PostgreSQL not available — staging path needs live schema"

--- a/tests_py/infrastructure/test_supersession_read_path.py
+++ b/tests_py/infrastructure/test_supersession_read_path.py
@@ -22,8 +22,16 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG, reason="PostgreSQL not available — read-path needs live schema"

--- a/tests_py/integration/test_recall_e2e.py
+++ b/tests_py/integration/test_recall_e2e.py
@@ -24,8 +24,16 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG, reason="PostgreSQL not available — e2e recall needs live schema"
@@ -347,6 +355,46 @@ class TestDomainScoping:
         )
 
 
+def _seed_ranked_trio(store) -> tuple[int, int, int]:
+    """Seed high/medium/low (relevance, heat) memories; return their ids.
+
+    Split out of the test below purely to keep that function under the
+    50-line cap (§4.2) — the three inserts, their query alignment and their
+    heat values are unchanged.
+    """
+    high_id = store.insert_memory(
+        {
+            "content": (
+                "PostgreSQL pgvector HNSW index cosine similarity recall "
+                "retrieval embedding vector search production database"
+            ),
+            "embedding": _query_aligned_emb(1.0),
+            "source": "user",
+            "domain": _DOMAIN,
+            "heat": 0.9,
+        }
+    )
+    mid_id = store.insert_memory(
+        {
+            "content": "vector similarity embedding recall production",
+            "embedding": _query_aligned_emb(0.8, seed=10),
+            "source": "user",
+            "domain": _DOMAIN,
+            "heat": 0.5,
+        }
+    )
+    low_id = store.insert_memory(
+        {
+            "content": "unrelated grocery list bread milk eggs",
+            "embedding": _query_aligned_emb(0.2, seed=20),
+            "source": "user",
+            "domain": _DOMAIN,
+            "heat": 0.1,
+        }
+    )
+    return high_id, mid_id, low_id
+
+
 class TestMultipleMemoriesRanking:
     """End-to-end: store several memories with distinct relevance, verify
     the stored procedure returns them in the expected order.
@@ -357,36 +405,7 @@ class TestMultipleMemoriesRanking:
         + medium-heat, low-relevance + low-heat. Verify the stored procedure
         orders them correctly under balanced weights.
         """
-        high_id = store.insert_memory(
-            {
-                "content": (
-                    "PostgreSQL pgvector HNSW index cosine similarity recall "
-                    "retrieval embedding vector search production database"
-                ),
-                "embedding": _query_aligned_emb(1.0),
-                "source": "user",
-                "domain": _DOMAIN,
-                "heat": 0.9,
-            }
-        )
-        mid_id = store.insert_memory(
-            {
-                "content": "vector similarity embedding recall production",
-                "embedding": _query_aligned_emb(0.8, seed=10),
-                "source": "user",
-                "domain": _DOMAIN,
-                "heat": 0.5,
-            }
-        )
-        low_id = store.insert_memory(
-            {
-                "content": "unrelated grocery list bread milk eggs",
-                "embedding": _query_aligned_emb(0.2, seed=20),
-                "source": "user",
-                "domain": _DOMAIN,
-                "heat": 0.1,
-            }
-        )
+        high_id, mid_id, low_id = _seed_ranked_trio(store)
 
         rows = _recall(
             store,

--- a/tests_py/integration/test_recall_sa_mode_wiring.py
+++ b/tests_py/integration/test_recall_sa_mode_wiring.py
@@ -22,9 +22,17 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from mcp_server.core.pg_recall import recall as pg_recall
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.core.pg_recall import recall as pg_recall  # noqa: E402
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG, reason="PostgreSQL not available — sa_mode wiring needs live schema"

--- a/tests_py/integration/test_spread_activation_candidate_contract.py
+++ b/tests_py/integration/test_spread_activation_candidate_contract.py
@@ -52,10 +52,18 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-from mcp_server.core.pg_recall import _chronological_rerank
-from mcp_server.core.recall_pipeline import spreading_activation_expand
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.core.pg_recall import _chronological_rerank  # noqa: E402
+from mcp_server.core.recall_pipeline import spreading_activation_expand  # noqa: E402
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG,

--- a/tests_py/invariants/test_I10_pool_capacity.py
+++ b/tests_py/invariants/test_I10_pool_capacity.py
@@ -39,6 +39,15 @@ from mcp_server.handlers.latency_class import (
 )
 from mcp_server.infrastructure.memory_config import get_memory_settings
 from mcp_server.infrastructure.pg_store import PgMemoryStore
+from tests_py.conftest import _USE_PG  # type: ignore
+
+# Constructs PgMemoryStore() directly, so it needs a live PostgreSQL. It had no
+# gate and therefore errored on any PG-less run — invisible while CI's SQLite
+# job ran a single file, a hard failure once that job runs the full suite
+# (#220). Gated on reachability: the subject of these tests IS the PG backend.
+pytestmark = pytest.mark.skipif(
+    not _USE_PG, reason="PostgreSQL not available — this suite needs a live DB"
+)
 
 
 @pytest.fixture

--- a/tests_py/invariants/test_I10_pool_capacity.py
+++ b/tests_py/invariants/test_I10_pool_capacity.py
@@ -31,15 +31,23 @@ from __future__ import annotations
 
 import pytest
 
-from mcp_server.handlers.admission import DEFAULT_SEMAPHORE
-from mcp_server.handlers.latency_class import (
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.handlers.admission import DEFAULT_SEMAPHORE  # noqa: E402
+from mcp_server.handlers.latency_class import (  # noqa: E402
     LatencyClass,
     _LATENCY_CLASS,
     classify,
 )
-from mcp_server.infrastructure.memory_config import get_memory_settings
-from mcp_server.infrastructure.pg_store import PgMemoryStore
-from tests_py.conftest import _USE_PG  # type: ignore
+from mcp_server.infrastructure.memory_config import get_memory_settings  # noqa: E402
+from mcp_server.infrastructure.pg_store import PgMemoryStore  # noqa: E402
+from tests_py.conftest import _USE_PG  # type: ignore  # noqa: E402
 
 # Constructs PgMemoryStore() directly, so it needs a live PostgreSQL. It had no
 # gate and therefore errored on any PG-less run — invisible while CI's SQLite

--- a/tests_py/invariants/test_I2_canonical_writer.py
+++ b/tests_py/invariants/test_I2_canonical_writer.py
@@ -78,7 +78,7 @@ _ALLOWED_WRITERS: set[tuple[str, int]] = {
     # net +29 cause as the two entries above).
     ("infrastructure/pg_store.py", 834),
     # SQLite parity of the anchor transfer (same transactional rationale).
-    # Shifted 389->440->447->493->529 (M-D3, then #169 added _fts_augment /
+    # Shifted 389->440->447->493->529->531 (M-D3, then #169 added _fts_augment /
     # _migrate_fts_code_tokenize / unconditional embedding_model stamp above it;
     # then #206 added _register_json_codec above the class, +36 lines).
     ("infrastructure/sqlite_store.py", 543),

--- a/tests_py/invariants/test_I2_canonical_writer.py
+++ b/tests_py/invariants/test_I2_canonical_writer.py
@@ -78,7 +78,7 @@ _ALLOWED_WRITERS: set[tuple[str, int]] = {
     # net +29 cause as the two entries above).
     ("infrastructure/pg_store.py", 834),
     # SQLite parity of the anchor transfer (same transactional rationale).
-    # Shifted 389->440->447->493->529->531 (M-D3, then #169 added _fts_augment /
+    # Shifted 389->440->447->493->529->530 (M-D3, then #169 added _fts_augment /
     # _migrate_fts_code_tokenize / unconditional embedding_model stamp above it;
     # then #206 added _register_json_codec above the class, +36 lines).
     ("infrastructure/sqlite_store.py", 543),

--- a/tests_py/scripts/test_check_doc_claims.py
+++ b/tests_py/scripts/test_check_doc_claims.py
@@ -390,8 +390,18 @@ class RepositoryTests(unittest.TestCase):
         An undeclared marker, or one moved onto a line that really does state
         the suite size, fails this test — so the hole stays auditable rather
         than becoming a way to quietly silence the gate.
+
+        The one member: CONTRIBUTING.md's install block reports how many tests
+        SKIP when the optional extras are missing (measured 2026-07-28, #220).
+        That is a true, dated measurement of something other than the suite
+        size, and `TEST_CLAIM` cannot tell the two apart from the wording. It
+        is declared rather than reworded, because rewording a real measurement
+        to keep a gate quiet hides the measurement instead of fixing the gate.
         """
-        self.assertEqual([(p, label) for p, _, label in gate.exemption_registry()], [])
+        self.assertEqual(
+            [(p, label) for p, _, label in gate.exemption_registry()],
+            [("CONTRIBUTING.md", "tests")],
+        )
 
     def test_every_advertised_test_count_states_the_same_number(self):
         """The test-count family, checked without a live pytest collection.

--- a/tests_py/test_migrate.py
+++ b/tests_py/test_migrate.py
@@ -21,13 +21,21 @@ import os
 
 import pytest
 
-from mcp_server.infrastructure.pg_store import (
+
+# psycopg ships in the optional [postgresql] extra, absent from the
+# SQLite-default install. The mcp_server import below pulls it in, so
+# without this guard the module raises ModuleNotFoundError at COLLECTION
+# time — an error, not a skip, which fails the whole run (#220). Skip the
+# module cleanly instead; the PG gate below still applies when it is present.
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from mcp_server.infrastructure.pg_store import (  # noqa: E402
     _get_database_url,
     compute_ddl_hash,
     read_schema_hash,
 )
-from mcp_server.migrate import _run
-from tests_py.conftest import _TEST_DB_URL, _USE_PG  # type: ignore
+from mcp_server.migrate import _run  # noqa: E402
+from tests_py.conftest import _TEST_DB_URL, _USE_PG  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not _USE_PG, reason="PostgreSQL not available — migrate needs a live DB"


### PR DESCRIPTION
Refs #220. **Not** `Closes` — 207 skips remain on the SQLite backend, and
those are unfinished work, not a passing suite. See *What is still open*.

## Why this exists

CI's SQLite job ran exactly one file behind a comment deferring the rest to a
"full-parity effort" that named no issue. SQLite is the DEFAULT backend for
plugin installs, `.mcpb`, and Cowork. Turning that job into a full-suite run
is what surfaced everything below.

## The user-facing bug this caught

On every SQLite install the **wiki pipeline produced nothing at all**, and
said so only in a stage log line.

Shared query modules take a `conn` that may be psycopg or
`PsycopgCompatConnection`, but imported psycopg's `dict_row` at module top
level. psycopg ships in the optional `[postgresql]` extra, so on a
SQLite-default install that import raised `ModuleNotFoundError`;
`wiki_pipeline` wraps each stage in try/except, so it degraded to zero output
instead of crashing. Same silent-degradation class as the FlashRank incident.

Fixed at the root: `infrastructure/row_factory.py` resolves `DICT_ROW` once at
import; 17 shared query modules use it. On PostgreSQL it IS `dict_row`; on
SQLite it is `None`, which is equivalent rather than a downgrade, because
`PsycopgCompatConnection.cursor()` accepts `row_factory` for signature parity
and ignores it — that cursor already returns dict rows (#206). Real
`psycopg.connect(row_factory=...)` sites are deliberately untouched: psycopg
is present by construction there.

## Other real defects on the default backend

- `SqliteMemoryStore` had no `acquire_interactive`/`acquire_batch`, which
  `anchor.py` and `get_rules.py` call unconditionally — an LSP break, since a
  handler cannot know which store it was handed.
- `handlers/lesson_promotion.py` called the PG-only candidate query
  unconditionally → `unrecognized token: "@"` on SQLite.
- That failure was invisible: a bare `except Exception: candidates = []`
  reported it as an empty backlog. The fallback stays; it now logs with
  `exc_info`.

## Test and infrastructure fixes

- Four suites built `PgMemoryStore()` with **no gate at all** and errored on
  any PG-less run — harmless while the job ran one file, a hard failure once
  it ran the suite.
- `test_get_grooming_health` asserted backend-agnostic contracts while
  importing the PG dialect directly; it now goes through the handler dispatch.
- `conftest.py` was 606 lines against the 500-line cap; cleanup and singleton
  reset moved verbatim to `tests_py/_store_cleanup.py` (437 / 196).
- `CONTRIBUTING.md` now names every extra CI installs — missing extras SKIP
  rather than fail, so a local run can look green while covering less.

## Verification

| Configuration | Result |
|---|---|
| SQLite, PostgreSQL unreachable (the CI job) | exit 0 — 5992 passed, 207 skipped |
| PostgreSQL | exit 0 — 6196 passed, 3 skipped |
| psycopg-less `DICT_ROW` (import blocked via `meta_path`) | `None` — fallback engages |
| psycopg present | `dict_row` |

`ruff check` + `ruff format` clean (951 files). The real `~/.claude` store was
checksummed before and after every run and never mutated.

## What is still open (Refs, not Closes)

207 SQLite skips, in two populations needing opposite fixes:

1. **Fixtures bound to the PG dialect for behaviour that does exist on
   SQLite** — supersession read-path, entity merge, spread-activation scoping,
   recall e2e. Fix: move fixtures to `get_shared_store()` so they run on both.
2. **Features with no SQLite implementation** — pool suites, groomer and
   backfill passes, near-dup calibration. Skipping these hides that a SQLite
   install cannot do them at all. This is the substantive parity gap.

Also open: `test_I2_canonical_writer` pins heat writers by LINE NUMBER and
shifted three times during this work from edits that only moved lines; it
should be content-anchored. And #223 (two `sentence_transformers` SWIG
DeprecationWarnings, external to this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SQwMscnDJfTN7sz3Jwzg4