### PR TITLE
ci: bump ci.yml's Node20 actions to their Node24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       DATABASE_URL: postgresql://cortex:cortex@localhost:5432/cortex
 
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -67,7 +67,7 @@ jobs:
           PGPASSWORD=cortex psql -h localhost -U cortex -d cortex -c "SELECT version();"
 
       - name: Cache pip
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
@@ -75,7 +75,7 @@ jobs:
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
 
       - name: Cache HuggingFace models
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/huggingface
           key: ${{ runner.os }}-hf-all-MiniLM-L6-v2
@@ -89,7 +89,7 @@ jobs:
       # whole suite at 300s, while every other leg happened to download fine.
       # Cache the model so the fetch happens once, not once per leg.
       - name: Cache FlashRank reranker model
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/flashrank
           key: ${{ runner.os }}-flashrank-ms-marco-MiniLM-L-12-v2
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload coverage
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: coverage.xml
@@ -199,7 +199,7 @@ jobs:
       CORTEX_MEMORY_STORE_BACKEND: sqlite
 
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -207,7 +207,7 @@ jobs:
           python-version: "3.12"
 
       - name: Cache pip
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-3.12-sqlite-${{ hashFiles('pyproject.toml') }}
@@ -215,7 +215,7 @@ jobs:
             ${{ runner.os }}-pip-3.12-sqlite-
 
       - name: Cache HuggingFace models
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/huggingface
           key: ${{ runner.os }}-hf-all-MiniLM-L6-v2
@@ -288,7 +288,7 @@ jobs:
       CORTEX_MEMORY_STORE_BACKEND: sqlite
 
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -296,7 +296,7 @@ jobs:
           python-version: "3.12"
 
       - name: Cache HuggingFace models
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/huggingface
           key: ${{ runner.os }}-hf-all-MiniLM-L6-v2
@@ -372,7 +372,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -412,7 +412,7 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -449,7 +449,7 @@ jobs:
     name: Build Package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -463,7 +463,7 @@ jobs:
         run: python -m build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -480,7 +480,7 @@ jobs:
     # the production image; nothing else runs the image with psycopg absent
     # and no DATABASE_URL. continue-on-error is intentionally NOT set.
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -495,7 +495,7 @@ jobs:
       # (https://github.com/docker/build-push-action#cache-backend-api),
       # type=gha is the documented zero-config option for GHA runners.
       - name: Build image (buildx, GHA layer cache)
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## Why

§14 boy-scout. Every job in `ci.yml` prints this, including on green runs of `main` — run
[30444807541](https://github.com/cdeust/Cortex/actions/runs/30444807541):

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830, actions/checkout@11d5960a326750d5838078e36cf38b85af677262, actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02.
Node.js 20 is deprecated. ... actions/checkout@11d5960a326750d5838078e36cf38b85af677262, docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8.
```

GitHub is currently *forcing* these onto Node24 and will stop
([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

**Scope discipline:** bumped exactly the four actions that warning line names, in the one workflow whose
runs named them. `actions/setup-python` and `docker/setup-buildx-action` are *not* named and are *not*
touched — both already declare `node24`. Nothing was bumped on inference.

## What changed

`.github/workflows/ci.yml` only — 16 lines, all `uses:` pins, nothing else:

| action | from | to | sites |
|---|---|---|---|
| `actions/checkout` | `11d5960a…` v4 | `3d3c42e5…` **v7.0.1** | 7 |
| `actions/cache` | `0057852b…` v4 | `55cc8345…` **v6.1.0** | 6 |
| `actions/upload-artifact` | `ea165f8d…` v4 | `043fb46d…` **v7.0.1** | 2 |
| `docker/build-push-action` | `10e90e36…` v6 | `53b7df96…` **v7.3.0** | 1 |

`3d3c42e5…` was already in use at `scorecard.yml:47`, so it is a known-good pin in this repo.

## Breaking-change assessment (every intervening major read, not skimmed)

| major | change | impact here |
|---|---|---|
| checkout v5.0.0 | Node24 runtime; min runner 2.327.1 | none — GitHub-hosted runners |
| checkout v6.0.0 | persists creds to a separate file ([#2286](https://github.com/actions/checkout/pull/2286)) | none — `ci.yml` has no `persist-cred*`, no `git push`, no `extraheader`, no submodules (grep: 0 hits) |
| checkout v7.0.0 | blocks fork-PR checkout for `pull_request_target` / `workflow_run`; ESM | none — `ci.yml` triggers are `push` / `pull_request` / `workflow_dispatch` only |
| cache v5.0.0 | Node24 | none |
| cache v6.0.0 | ESM migration | none — only `path` / `key` / `restore-keys` used, all unchanged |
| cache v6.1.0 | read-only cache access handling | none |
| upload-artifact v5/v6 | Node24 (v6 makes it the default) | none |
| upload-artifact v7.0.0 | adds opt-in `archive:` input; ESM | none — `archive` defaults to `true` (v4 behaviour); only `name` / `path` used |
| build-push-action v7.0.0 | Node24; **removes** `DOCKER_BUILD_NO_SUMMARY` + `DOCKER_BUILD_EXPORT_RETENTION_DAYS`; removes legacy export-build summary | none — `git grep` for both envs: **0 hits** repo-wide. Inputs used (`context`, `file`, `tags`, `load`, `cache-from`, `cache-to`) all still supported |

`actions/cache` v5.1.0 is a *backport* on the v5 line published after v6.1.0 — v6.1.0 is the newest major.
Verified by `published_at`, not by list order.

## Completion Ledger

### Path enumeration
This diff introduces no code paths — it is 16 `uses:` pin substitutions in one YAML file. The "paths"
are the 16 action invocations; each is exercised by the CI run on this PR. Ledger rows below map each
§13.1 item to its evidence.

| # | Item | Evidence |
|---|---|---|
| A1 | Happy path exercised end-to-end | Full CI matrix runs on this PR against the bumped pins — see check results below. Every one of the 16 sites executes (checkout in all 7 jobs, cache in test/test-sqlite/test-windows, upload-artifact in test + build, build-push-action in docker-smoke). |
| A2 | Edge cases | Enumerated as "each intervening major of each action". Table above; each row has a grep or a trigger-list backing it. |
| A3 | Failure paths | N/A — a pin substitution has no error arm. The failure mode *is* "the action breaks", which CI exercises directly. |
| A4 | Boundary validation | `runs.using` read from `action.yml` **at the target SHA** for all 17 distinct `uses:` in the repo, not from the version comment: all four new pins report `node24`. |
| A5 | Invariants | Two, both asserted: (i) every `uses:` remains a 40-hex SHA; (ii) Scorecard Pinned-Dependencies does not regress. Outputs quoted below. |
| A6 | Idempotency | N/A — declarative pin. |
| B1–B3 | Concurrency | N/A — no concurrency touched. `ci.yml`'s `concurrency:` block is unmodified. |
| C1–C3 | Resources / perf | `actions/cache`'s key derivation is unchanged (same `path`/`key`/`restore-keys`), so warm caches carry over. Worst case is one cold cache run — slower, not incorrect. |
| D1–D3 | Security | Strictly improved: all four targets are newer, still hash-pinned. No secrets touched; `permissions: contents: read` unchanged. |
| E1 | API/schema | No input added, removed or renamed — see breaking-change table. |
| E2 | Downstream consumers | The consumers are `ci.yml`'s own jobs. All 7 named and their inputs checked against each action's current schema. `scripts/docker_smoke.sh --skip-build` consumes build-push-action's `load: true` output; `load` is still supported in v7.3.0. |
| E3 | Persisted data | N/A. |
| E4 | Cross-platform | `test-windows` (windows runner) and 6 ubuntu jobs both run checkout+cache at the new pins — see check results. |
| F1/F2 | Observability | This PR *is* the signal fix: the observable effect is the disappearance of the deprecation line. Asserted by `grep -c` on the real run log (below), not by reading YAML. |
| G1 | Path→test ledger | This table. |
| G2 | Regression test | The defect is a CI-emitted warning; the regression check is `grep -c 'forced to run on Node.js 24'` on this PR's run == 0, against 5 distinct lines on the pre-fix run 30444807541. |
| G3 | Deterministic | CI runs are the test; no local fixtures. |
| G4 | Negative assertion | The core assertion here *is* negative (zero warning lines) — quoted below with its pre-fix control. |
| G5 | Gates pass | `actionlint`, `check_doc_claims.py`, `generate_repo_badges.py --check` — outputs below. |
| H1 | Standards | YAML config change; §4 size limits N/A. No new constants. |
| H2 | Readable | Trailing `# vX.Y.Z` comments updated in the same edit (`.github/dependabot.yml` convention). |
| H3 | Conventions | Matches the existing `@<40-hex> # <tag>` style already used by `setup-python`, `setup-buildx-action`, `scorecard.yml`. |
| H4 | CHANGELOG | N/A — no consumer-observable behaviour change; CI-internal only. |
| H5 | Commit hygiene | One conventional commit, no formatting noise. |
| H6 | CI green on pushed tree | See below. |
| **H7** | **Boy-scout (§14)** | Every seen defect treated or issued — see next section. |

### H7 — seen defects

| seen | disposition |
|---|---|
| Node20 warning in `ci.yml`'s own runs | **fixed here** |
| Same warning in `scorecard.yml`, `marketplace-pins.yml`, `release.yml` runs; same pins in `publish-ccplugins.yml`, `mcp-toplist-badge.yml`, `sync-ccplugins-fork.yml`; and `fuzz.yml` on unmerged #244 | **deferred → #246**, outside this change's blast radius (tag/push/schedule-triggered; none run by this PR's CI). Includes the `release.yml` upload/download-artifact round trip, which no PR-triggered workflow exercises — bumping it blind here would be the green-PR-red-main trap. |
| 5 `actionlint`/shellcheck findings in `release.yml` + `sync-ccplugins-fork.yml` (incl. an `SC2034` unused loop counter) | **deferred → #247**, outside blast radius. Byte-identical on `main` and this branch, and `actionlint` is not wired into CI's `Lint` job at all — #247 also covers wiring it. |

No unfixed, un-issued seen defect remains.

## Verification (quoted output)

**1. SHAs re-resolved at edit time**, then confirmed to be real commits:

```
actions/checkout          v7.0.1  3d3c42e5aac5ba805825da76410c181273ba90b1  2026-07-17T18:45:11Z
actions/cache             v6.1.0  55cc8345863c7cc4c66a329aec7e433d2d1c52a9  2026-06-23T20:30:28Z
actions/upload-artifact   v7.0.1  043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  2026-04-10T16:08:32Z
docker/build-push-action  v7.3.0  53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  2026-07-01T14:11:18Z
```

**2. `runs.using` read from `action.yml` at each pinned SHA** (all 17 distinct `uses:` in the repo):

```
actions/cache                      55cc8345  node24
actions/checkout                   3d3c42e5  node24
actions/upload-artifact            043fb46d  node24
docker/build-push-action           53b7df96  node24
docker/setup-buildx-action         bb05f3f5  node24     (unchanged, already node24)
actions/setup-python               5fda3b95  node24     (unchanged, already node24)
...
actions/cache                      0057852b  node20  <-- remaining, release.yml     -> #246
actions/checkout                   11d5960a  node20  <-- remaining, 5 workflows     -> #246
actions/download-artifact          d3f86a10  node20  <-- remaining, release.yml     -> #246
actions/upload-artifact            ea165f8d  node20  <-- remaining, release.yml     -> #246
github/codeql-action/upload-sarif  4187e74d  node20  <-- remaining, scorecard.yml   -> #246
```

`ci.yml` node20 sites: **0**.

**3. Every pin is still a 40-hex SHA** (a tag pin would mint a fresh Pinned-Dependencies alert):

```
$ grep -rhoE '^\s*(- )?uses: [^ ]+' .github/workflows/ | sed 's/^\s*//; s/^- //' | sort -u | grep -vE '@[0-9a-f]{40}$'
PASS: all uses: are SHA-pinned
```

**4. Scorecard Pinned-Dependencies — paired control**, real scorecard binary, both trees mounted under
`$HOME` (Colima bind-mounts nothing else):

```
$ docker run --rm -e GITHUB_AUTH_TOKEN -v <tree>:/src gcr.io/openssf/scorecard:stable \
    --local /src --checks=Pinned-Dependencies --show-details --format json

control (origin/main f606c37): Pinned-Dependencies 4 | 27 detail lines
branch  (fe5c9a3):             Pinned-Dependencies 4 | 27 detail lines

$ diff control.txt branch.txt
IDENTICAL

Info:   9 out of   9 third-party GitHubAction dependencies pinned
Info:  41 out of  41 GitHub-owned GitHubAction dependencies pinned
```

Score 4 is `main`'s pre-existing pip/npm state (PR #244's domain) and is **unchanged** by this PR —
zero GitHub-Action pinning findings on either side.

**5. Workflow lint / repo gates:**

```
$ actionlint          # byte-identical output on main and branch; exit 0
$ python3 scripts/check_doc_claims.py
doc claims OK (1 declared not-a-claim exemption(s))
$ python3 scripts/generate_repo_badges.py --check
badges OK (4 checked)
```

All 7 workflow files parse as YAML.

**6. The warning is gone from a real run** (CI run
[30451082329](https://github.com/cdeust/Cortex/actions/runs/30451082329), conclusion `success`,
head `fe5c9a3`), against the pre-fix control run 30444807541 on `main`:

```
$ gh run view <id> --log | grep -cE 'T[0-9:.]+Z ##\[warning\]Node\.js 20 is deprecated'

run 30444807541 (main f606c37, PRE-FIX) : 10
run 30451082329 (fe5c9a3,    POST-FIX)  :  0
```

> **Caveat worth recording.** The naive `grep -ci 'forced to run on Node.js 24'` reports **1** on the
> post-fix run, and that 1 is a false positive: `docker/build-push-action` v7 dumps the GitHub event
> payload into the Docker Smoke job log, so **this PR description's own quoted warning text** appears in
> the log as a JSON string. The real runner warning is always its own line, emitted as
> `<timestamp> ##[warning]Node.js 20 is deprecated…`; anchoring the match to that prefix separates the
> two. Count of genuine runner-emitted warnings is **0**.

**7. All 14 checks green on the exact pushed tree** (`fe5c9a3`, PR head SHA confirmed equal to local
`HEAD`):

```
pass  Analyze (actions)          pass  Test (Python 3.10)
pass  Analyze (javascript-typescript)  pass  Test (Python 3.11)
pass  Analyze (python)           pass  Test (Python 3.12)
pass  Build Package              pass  Test (Python 3.13)
pass  CodeQL                     pass  Test (SQLite backend)
pass  Docker Smoke (bare-container DB-less contract)
pass  Lint                       pass  Test (Windows, SQLite backend)
pass  Type Check
tally: pass=14
```

`Docker Smoke` is the one that exercises `docker/build-push-action` v7.3.0 end to end
(build → `load: true` → `scripts/docker_smoke.sh --skip-build`); `Test (Windows, SQLite backend)`
exercises checkout+cache at the new pins on a non-Linux runner.

## Sequencing note

The plan sequenced this after PR #244 (both touch `ci.yml`). #244 is currently `CONFLICTING` with a red
`Test (Python 3.10)`, so waiting would have parked a treated defect indefinitely. This PR is instead cut
from `origin/main` and touches **only** `uses:` lines — a disjoint line set from #244's pip-install
pinning, so it does not add to that PR's existing conflict surface. #244 must adopt the same four SHAs
for `fuzz.yml` (tracked in #246).

Refs #246, #247
