### PR TITLE
fix(mutmut): kill 116 pre-existing survivors in refresh_mcp_toplist_badge.py

### DIFF
--- a/tests_py/scripts/test_refresh_mcp_toplist_badge.py
+++ b/tests_py/scripts/test_refresh_mcp_toplist_badge.py
@@ -11,8 +11,11 @@ so every failure path below asserts the badge is left untouched.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import json
+import os
 import sys
 import unittest
 import urllib.error
@@ -52,9 +55,17 @@ class TestValidate(unittest.TestCase):
     def test_strips_thousands_separators_from_scraped_text(self):
         self.assertEqual(badge.validate("964", "81,919", "t").total, 81919)
 
+    def test_strips_thousands_separators_from_the_rank_too(self):
+        # test_strips_thousands_separators_from_scraped_text only exercises
+        # a comma on the TOTAL side; a mutant that disables comma-stripping
+        # on the RANK side alone (mutmut_8/_9: wrong target string, or the
+        # separator inserted instead of removed) is invisible to it.
+        self.assertEqual(badge.validate("1,234", 2000, "t").rank, 1234)
+
     def test_rejects_non_numeric(self):
-        with self.assertRaises(badge.UpstreamError):
+        with self.assertRaises(badge.UpstreamError) as ctx:
             badge.validate("nine", "81,919", "t")
+        self.assertIn("non-numeric rank/total: 'nine'/'81,919'", str(ctx.exception))
 
     def test_rejects_none(self):
         with self.assertRaises(badge.UpstreamError):
@@ -62,21 +73,31 @@ class TestValidate(unittest.TestCase):
 
     def test_rejects_zero_rank(self):
         # Rank is a 1-based position; 0 signals a parser that matched noise.
-        with self.assertRaises(badge.UpstreamError):
+        with self.assertRaises(badge.UpstreamError) as ctx:
             badge.validate(0, 81919, "t")
+        self.assertIn("rank 0 is not a positive position", str(ctx.exception))
 
     def test_rejects_negative_rank(self):
-        with self.assertRaises(badge.UpstreamError):
+        with self.assertRaises(badge.UpstreamError) as ctx:
             badge.validate(-1, 81919, "t")
+        self.assertIn("rank -1 is not a positive position", str(ctx.exception))
 
     def test_rejects_zero_total_before_it_divides(self):
         # Guards Ranking.percentile against ZeroDivisionError.
-        with self.assertRaises(badge.UpstreamError):
+        with self.assertRaises(badge.UpstreamError) as ctx:
             badge.validate(1, 0, "t")
+        self.assertIn("total 0 is not a positive field size", str(ctx.exception))
+
+    def test_total_of_exactly_one_is_the_boundary_not_the_cutoff(self):
+        # The real guard is total_i < 1; a mutant tightening it to <= 1 or
+        # < 2 would wrongly reject a legitimate single-server field.
+        r = badge.validate(1, 1, "t")
+        self.assertEqual((r.rank, r.total), (1, 1))
 
     def test_rejects_rank_beyond_the_field(self):
-        with self.assertRaises(badge.UpstreamError):
+        with self.assertRaises(badge.UpstreamError) as ctx:
             badge.validate(81920, 81919, "t")
+        self.assertIn("rank 81920 exceeds field size 81919", str(ctx.exception))
 
     def test_accepts_rank_equal_to_field_size(self):
         self.assertEqual(badge.validate(5, 5, "t").rank, 5)
@@ -103,6 +124,16 @@ class TestPercentileAndTier(unittest.TestCase):
 
 
 class TestParseLeaderboard(unittest.TestCase):
+    # NOTE on the "utf-8" -> "UTF-8" case mutant (mutmut on
+    # `payload.decode("utf-8")`): provably equivalent, not merely assumed.
+    # Verified empirically: `codecs.lookup("utf-8") is codecs.lookup("UTF-8")`
+    # is True (Python's codec registry normalizes encoding-name case before
+    # lookup), so `b"...".decode("utf-8") == b"...".decode("UTF-8")` for
+    # every input, valid or invalid. No test can observe a difference
+    # because there isn't one. Same equivalence class as
+    # scripts/generate_repo_badges.py's argparse-default/maxsplit rationale
+    # (PR #283) and TestResolveRanking's identical decode-charset mutant
+    # below.
     def _payload(self, doc) -> bytes:
         return json.dumps(doc).encode()
 
@@ -124,21 +155,37 @@ class TestParseLeaderboard(unittest.TestCase):
 
     def test_absent_server_raises(self):
         doc = {"servers": [{"id": "someone/else", "rank": 1}]}
-        with self.assertRaises(badge.UpstreamError):
+        with self.assertRaises(badge.UpstreamError) as ctx:
             badge.parse_leaderboard(self._payload(doc))
+        self.assertIn(f"{badge.SERVER_ID} not present in 1 entries", str(ctx.exception))
 
     def test_entry_without_a_rank_raises_rather_than_defaulting(self):
         doc = {"servers": [{"id": badge.SERVER_ID, "stars": 68}]}
-        with self.assertRaises(badge.UpstreamError):
+        with self.assertRaises(badge.UpstreamError) as ctx:
             badge.parse_leaderboard(self._payload(doc))
+        self.assertIn(
+            f"entry for {badge.SERVER_ID} carries no rank", str(ctx.exception)
+        )
 
     def test_invalid_json_raises(self):
-        with self.assertRaises(badge.UpstreamError):
+        with self.assertRaises(badge.UpstreamError) as ctx:
             badge.parse_leaderboard(b"<html>503</html>")
+        self.assertIn("not valid JSON", str(ctx.exception))
 
     def test_empty_list_raises(self):
-        with self.assertRaises(badge.UpstreamError):
+        # An empty list IS an isinstance(list) with `not entries` true; a
+        # mutant swapping the guard's `or` for `and` (mutmut_11) still
+        # raises here (falls through to the later "not present" error
+        # instead), so the message content — not just "raises" — is what
+        # distinguishes the two code paths. This message is a plain literal
+        # (no f-string placeholder breaking it up), so an exact match is
+        # required: a substring check of the same text stays a contiguous
+        # substring even inside a whole-string "XX...XX" mutation wrap.
+        with self.assertRaises(badge.UpstreamError) as ctx:
             badge.parse_leaderboard(b"[]")
+        self.assertEqual(
+            str(ctx.exception), "leaderboard.json: no server list in document"
+        )
 
     def test_unrecognised_shape_is_refused_not_guessed(self):
         with self.assertRaises(badge.UpstreamError):
@@ -147,6 +194,40 @@ class TestParseLeaderboard(unittest.TestCase):
     def test_non_dict_entries_are_skipped_not_crashed_on(self):
         doc = {"servers": ["junk", None, {"id": badge.SERVER_ID, "rank": 3}]}
         self.assertEqual(badge.parse_leaderboard(self._payload(doc)).rank, 3)
+
+    def test_identity_key_absent_is_skipped_not_crashed(self):
+        # The identity lookup is `next(generator, None)`; a mutant that
+        # drops the `None` default (mutmut_34) raises StopIteration
+        # instead of skipping an entry with none of the identity keys.
+        doc = {
+            "total": 10,
+            "servers": [{"stars": 68}, {"id": badge.SERVER_ID, "rank": 6}],
+        }
+        self.assertEqual(badge.parse_leaderboard(self._payload(doc)).rank, 6)
+
+    def test_identity_via_name_key(self):
+        doc = {"total": 10, "servers": [{"name": badge.SERVER_ID, "rank": 4}]}
+        self.assertEqual(badge.parse_leaderboard(self._payload(doc)).rank, 4)
+
+    def test_identity_via_server_id_key(self):
+        doc = {"total": 10, "servers": [{"serverId": badge.SERVER_ID, "rank": 5}]}
+        self.assertEqual(badge.parse_leaderboard(self._payload(doc)).rank, 5)
+
+    def test_rank_via_place_key(self):
+        doc = {"total": 10, "servers": [{"id": badge.SERVER_ID, "place": 8}]}
+        self.assertEqual(badge.parse_leaderboard(self._payload(doc)).rank, 8)
+
+    def test_total_from_total_servers_key(self):
+        # No "total" key present, so the loop must fall through to the
+        # exact "totalServers" key (case-sensitive).
+        doc = {"totalServers": 500, "servers": [{"id": badge.SERVER_ID, "rank": 7}]}
+        self.assertEqual(badge.parse_leaderboard(self._payload(doc)).total, 500)
+
+    def test_total_from_count_key(self):
+        # Neither "total" nor "totalServers" present; falls through to
+        # the exact "count" key (case-sensitive).
+        doc = {"count": 250, "servers": [{"id": badge.SERVER_ID, "rank": 3}]}
+        self.assertEqual(badge.parse_leaderboard(self._payload(doc)).total, 250)
 
     def test_rank_beyond_field_is_rejected_by_the_shared_validator(self):
         doc = {"total": 2, "servers": [{"id": badge.SERVER_ID, "rank": 99}]}
@@ -162,8 +243,13 @@ class TestParseServerPage(unittest.TestCase):
     def test_reworded_page_raises_rather_than_matching_loosely(self):
         # The failure mode this guards: a page that still says "#964"
         # somewhere but no longer pairs it with the field size.
-        with self.assertRaises(badge.UpstreamError):
+        with self.assertRaises(badge.UpstreamError) as ctx:
             badge.parse_server_page("<title>Cortex - MCP Server #964</title>")
+        self.assertEqual(
+            str(ctx.exception),
+            "server page: the 'ranks #N of M servers tracked' sentence is absent "
+            "— the page was reworded and this parser needs updating",
+        )
 
     def test_empty_document_raises(self):
         with self.assertRaises(badge.UpstreamError):
@@ -172,6 +258,55 @@ class TestParseServerPage(unittest.TestCase):
     def test_match_is_case_insensitive_and_whitespace_tolerant(self):
         r = badge.parse_server_page("It  Ranks  # 12  of  100  Servers  Tracked here")
         self.assertEqual((r.rank, r.total), (12, 100))
+
+
+class TestProvenanceComment(unittest.TestCase):
+    # Each returned list ITEM is a plain literal (or, for the pct line, an
+    # f-string whose literal chunk is broken up by the interpolated value
+    # — see the module-level note in TestParseLeaderboard on why that
+    # distinction matters). Checking exact LIST-ITEM membership rather
+    # than substring-in-joined-text is required throughout this class: a
+    # mutant that wraps a whole line in mutmut's "XX...XX" string-content
+    # marker still contains the original text as a contiguous substring
+    # once joined, so only exact-item equality — not `assertIn` on the
+    # joined blob — distinguishes it.
+    def _lines(self):
+        r = badge.validate(LIVE_RANK, LIVE_TOTAL, "server page")
+        return badge._provenance_comment(r, date(2026, 7, 28))
+
+    def test_percentage_arithmetic_is_pinned(self):
+        # 964 / 81919 * 100 = 1.1767..., .2f -> "1.18" — deliberately not
+        # the rounded "1.2" ranking_tier_text uses, so this pins the
+        # arithmetic operator (mutmut_2/_3/_4: /, *, and the *101 typo)
+        # independently of the tier-text rounding.
+        self.assertTrue(any("1.18%" in line for line in self._lines()))
+
+    def test_fixed_wording_is_pinned(self):
+        lines = self._lines()
+        self.assertIn(
+            "  <!-- GENERATED by scripts/refresh_mcp_toplist_badge.py"
+            " — do not hand-edit.",
+            lines,
+        )
+        self.assertIn(
+            "       Upstream's score is a popularity and activity signal,"
+            " not a quality",
+            lines,
+        )
+        self.assertIn(
+            "       assessment, and ~25% of its weighting is undisclosed"
+            " — so this badge",
+            lines,
+        )
+        # "says Cortex is RANKED..." and " it IS. -->" are adjacent string
+        # literals in the source (implicit concatenation, no operator) —
+        # ONE list item, not two — confirmed by printing the real return
+        # value rather than assumed from reading the source layout.
+        self.assertIn(
+            "       says Cortex is RANKED in this tier by MCP Toplist,"
+            " never that it IS. -->",
+            lines,
+        )
 
 
 class TestRenderBadge(unittest.TestCase):
@@ -251,6 +386,50 @@ class TestRenderBadge(unittest.TestCase):
         root = ElementTree.fromstring(self._svg())
         self.assertEqual(root.get("width"), "216")
 
+    def test_label_panel_text_geometry_and_colors_are_pinned(self):
+        # Each of these is an explicit (not derived) Panel field per
+        # badge_render.Panel's own docstring; nothing here re-derives them,
+        # so only an exact-value assertion pins a wrong constant. Parsed
+        # via ElementTree (not a raw substring search): the clipPath
+        # background rect ALSO carries a literal fill="#fff" for an
+        # unrelated reason, so a naive `assertIn('fill="#fff"', svg)`
+        # would pass even with message_text_fill mutated to None — the
+        # message <text> element's OWN fill attribute is what must be
+        # checked, not "does this string appear anywhere".
+        root = ElementTree.fromstring(self._svg())
+        ns = "{http://www.w3.org/2000/svg}"
+        texts = list(root.iter(f"{ns}text"))
+        # render() emits [label-shadow, label-face, message-shadow,
+        # message-face] in that order.
+        label_face, message_face = texts[1], texts[3]
+        self.assertEqual(label_face.text, "MCP Toplist")
+        self.assertEqual(label_face.get("fill"), "#f8f7f2")
+        self.assertEqual(label_face.get("textLength"), "64")
+        self.assertEqual(label_face.get("x"), "54")
+        self.assertEqual(message_face.get("fill"), "#fff")
+
+    def test_icon_fragments_are_pinned(self):
+        # The icon tuple's lines are spliced into the SVG verbatim (no
+        # f-string template around them, unlike label/message text), so a
+        # mutant that wraps a whole line in mutmut's "XX...XX" string-
+        # content marker still contains the ORIGINAL text as a substring
+        # (e.g. 'XX  <g fill="#f1eee7">XX' still contains '<g fill=...>').
+        # Exact-line membership (not substring search) is what actually
+        # distinguishes the mutated line from the real one.
+        lines = self._svg().splitlines()
+        self.assertIn('  <g fill="#f1eee7">', lines)
+        self.assertIn('    <rect x="7" y="10" width="2.6" height="5" rx="0.6"/>', lines)
+        self.assertIn(
+            '    <rect x="11.2" y="6.5" width="2.6" height="8.5" rx="0.6"/>', lines
+        )
+        self.assertIn(
+            '    <rect x="15.4" y="8.4" width="2.6" height="6.6" rx="0.6"/>', lines
+        )
+        # Three "  </g>" lines exist when the icon renders (clip-path
+        # group, icon group, font group); a mutant that drops or mangles
+        # the icon's own closing line collapses this exact-line count.
+        self.assertEqual(lines.count("  </g>"), 3)
+
 
 class TestFetch(unittest.TestCase):
     def test_http_error_becomes_an_upstream_error_naming_the_code(self):
@@ -267,8 +446,9 @@ class TestFetch(unittest.TestCase):
         def opener(request, timeout=None):
             raise urllib.error.URLError("no route to host")
 
-        with self.assertRaises(badge.UpstreamError):
+        with self.assertRaises(badge.UpstreamError) as ctx:
             badge.fetch("https://example.test/x", opener=opener)
+        self.assertIn("unreachable", str(ctx.exception))
 
     def test_timeout_becomes_an_upstream_error(self):
         def opener(request, timeout=None):
@@ -276,6 +456,46 @@ class TestFetch(unittest.TestCase):
 
         with self.assertRaises(badge.UpstreamError):
             badge.fetch("https://example.test/x", opener=opener)
+
+    def test_sends_the_expected_headers_and_timeout(self):
+        # NOTE on header-key CASE mutants NOT covered here: urllib.request.
+        # Request.add_header() normalizes every header key via .capitalize()
+        # regardless of the source dict's key casing — verified empirically:
+        # "User-Agent".capitalize() == "user-agent".capitalize() ==
+        # "USER-AGENT".capitalize() == "User-agent", and likewise "Accept"/
+        # "accept"/"ACCEPT" all capitalize() to "Accept". A mutant that only
+        # changes the case of these two header-key literals is therefore
+        # provably equivalent (identical wire behavior); mutmut's own "XX...
+        # XX" marker mutations of the same keys ARE real (they change the
+        # actual normalized key) and are what this test's exact-value
+        # assertions below catch.
+        captured = {}
+
+        class _Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return False
+
+            def read(self):
+                return b"ok"
+
+        def opener(request, timeout=None):
+            captured["headers"] = dict(request.headers)
+            captured["timeout"] = timeout
+            return _Response()
+
+        result = badge.fetch("https://example.test/x", opener=opener)
+        self.assertEqual(result, b"ok")
+        self.assertEqual(
+            captured["headers"].get("User-agent"),
+            "cortex-badge-refresh (+https://github.com/cdeust/Cortex)",
+        )
+        self.assertEqual(
+            captured["headers"].get("Accept"), "application/json, text/html;q=0.9"
+        )
+        self.assertEqual(captured["timeout"], badge.TIMEOUT_S)
 
 
 class TestResolveRanking(unittest.TestCase):
@@ -310,6 +530,16 @@ class TestResolveRanking(unittest.TestCase):
         message = str(ctx.exception)
         self.assertIn(badge.LEADERBOARD_URL, message)
         self.assertIn(badge.SERVER_PAGE_URL, message)
+        # Exact reconstruction pins the prefix wording AND the "\n  - "
+        # separator joining each notice — a looser substring check would
+        # miss a mutant that mangles either.
+        self.assertEqual(
+            message,
+            "no trusted figure from any source; badge left untouched:\n  - "
+            + f"{badge.LEADERBOARD_URL}: unreachable"
+            + "\n  - "
+            + f"{badge.SERVER_PAGE_URL}: unreachable",
+        )
 
     def test_a_served_but_unparseable_export_still_falls_through(self):
         def fetch_fn(url):
@@ -323,6 +553,56 @@ class TestResolveRanking(unittest.TestCase):
         self.assertEqual(ranking.source, "server page")
         self.assertTrue(notices)
 
+    def test_tolerates_invalid_utf8_bytes_on_the_server_page_path(self):
+        # The server-page decode uses errors="replace" specifically so a
+        # stray non-UTF-8 byte elsewhere on the page (ads, analytics
+        # snippets, etc.) cannot take down parsing of the one sentence we
+        # need. Proven empirically: with an ACTUAL invalid byte present,
+        # "replace" substitutes U+FFFD and succeeds, "strict" (the
+        # implicit default when the errors arg is dropped) raises
+        # UnicodeDecodeError, and an unregistered handler name (mutmut's
+        # "XXreplaceXX" / "REPLACE" mutants) raises LookupError — but ONLY
+        # when a real decode error occurs; on all-valid-UTF-8 input (every
+        # other test in this file) the errors handler is never invoked at
+        # all, so this is the only test that can distinguish them.
+        garbled = (
+            "<!-- ".encode() + b"\xff" + " garbled -->".encode() + LIVE_PAGE.encode()
+        )
+
+        def fetch_fn(url):
+            if url == badge.LEADERBOARD_URL:
+                raise badge.UpstreamError("leaderboard.json: HTTP 503")
+            return garbled
+
+        ranking, _ = badge.resolve_ranking(fetch_fn)
+        self.assertEqual((ranking.rank, ranking.total), (LIVE_RANK, LIVE_TOTAL))
+
+    # NOTE on the "utf-8" -> "UTF-8" case mutant on this same decode call
+    # (`raw.decode("utf-8", "replace")` in resolve_ranking's server-page
+    # lambda): provably equivalent, same reasoning and same verification
+    # as TestParseLeaderboard's identical charset-name mutant above —
+    # `codecs.lookup` normalizes encoding-name case before comparing, so
+    # the codec selected is byte-for-byte identical regardless of the
+    # literal's case, independent of which `errors` handler is paired
+    # with it. Not re-verified a second time; the codecs.lookup identity
+    # check already covers every call site that names "utf-8"/"UTF-8".
+
+
+class TestToday(unittest.TestCase):
+    def test_uses_utc_not_the_runner_local_clock(self):
+        # datetime.now(None) returns naive LOCAL time, which would silently
+        # shift the badge's stamped date by the CI runner's timezone offset
+        # around midnight. There is no return-value assertion that can
+        # observe "which timezone was used" without depending on the actual
+        # system clock at test time, so this pins the call contract instead
+        # (a legitimate stub-verification test for a one-line datetime
+        # wrapper, not a mock of the logic under test).
+        with mock.patch.object(badge, "datetime") as mock_datetime:
+            mock_datetime.now.return_value.date.return_value = date(2026, 1, 1)
+            result = badge._today()
+        mock_datetime.now.assert_called_once_with(badge.timezone.utc)
+        self.assertEqual(result, date(2026, 1, 1))
+
 
 class TestMain(unittest.TestCase):
     def setUp(self):
@@ -330,11 +610,11 @@ class TestMain(unittest.TestCase):
         self.badge_path = Path(self._tmp.name) / "badge.svg"
         self.addCleanup(self._tmp.cleanup)
 
-    def _patch_upstream(self, ranking=None, error=None):
+    def _patch_upstream(self, ranking=None, error=None, notices=None):
         def fake_resolve(*_args, **_kwargs):
             if error is not None:
                 raise error
-            return ranking, []
+            return ranking, notices if notices is not None else []
 
         return mock.patch.object(badge, "resolve_ranking", fake_resolve)
 
@@ -342,10 +622,17 @@ class TestMain(unittest.TestCase):
         return badge.validate(LIVE_RANK, LIVE_TOTAL, "server page")
 
     def test_writes_the_badge_when_absent(self):
-        with self._patch_upstream(self._live_ranking()):
+        stdout = io.StringIO()
+        with (
+            self._patch_upstream(self._live_ranking()),
+            contextlib.redirect_stdout(stdout),
+        ):
             code = badge.main(["--badge", str(self.badge_path)])
         self.assertEqual(code, 0)
         self.assertIn("Top 1.2%", self.badge_path.read_text())
+        self.assertIn(
+            "updated: Top 1.2% (#964 of 81,919, via server page)", stdout.getvalue()
+        )
 
     def test_is_idempotent_when_already_current(self):
         with self._patch_upstream(self._live_ranking()):
@@ -355,6 +642,17 @@ class TestMain(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertEqual(self.badge_path.read_text(), first)
 
+    def test_current_status_message_is_printed(self):
+        stdout = io.StringIO()
+        with self._patch_upstream(self._live_ranking()):
+            badge.main(["--badge", str(self.badge_path)])
+            with contextlib.redirect_stdout(stdout):
+                code = badge.main(["--badge", str(self.badge_path)])
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "current: Top 1.2% (#964 of 81,919, via server page)", stdout.getvalue()
+        )
+
     def test_check_mode_passes_on_a_current_badge(self):
         with self._patch_upstream(self._live_ranking()):
             badge.main(["--badge", str(self.badge_path)])
@@ -363,25 +661,98 @@ class TestMain(unittest.TestCase):
 
     def test_check_mode_fails_on_a_stale_badge_without_writing(self):
         self.badge_path.write_text("<svg>stale</svg>")
-        with self._patch_upstream(self._live_ranking()):
+        stderr = io.StringIO()
+        with (
+            self._patch_upstream(self._live_ranking()),
+            contextlib.redirect_stderr(stderr),
+        ):
             code = badge.main(["--check", "--badge", str(self.badge_path)])
         self.assertEqual(code, 1)
         self.assertEqual(self.badge_path.read_text(), "<svg>stale</svg>")
+        self.assertIn(
+            "STALE: badge does not match upstream (Top 1.2%, #964 of 81,919)",
+            stderr.getvalue(),
+        )
 
     def test_upstream_failure_exits_nonzero_and_leaves_the_badge_untouched(self):
         # The central fail-closed guarantee: a broken upstream must never be
         # able to blank or corrupt a published claim.
         self.badge_path.write_text("<svg>previous</svg>")
-        with self._patch_upstream(error=badge.UpstreamError("all sources down")):
+        stderr = io.StringIO()
+        with (
+            self._patch_upstream(error=badge.UpstreamError("all sources down")),
+            contextlib.redirect_stderr(stderr),
+        ):
             code = badge.main(["--badge", str(self.badge_path)])
         self.assertEqual(code, 1)
         self.assertEqual(self.badge_path.read_text(), "<svg>previous</svg>")
+        self.assertIn("FAIL: all sources down", stderr.getvalue())
 
     def test_upstream_failure_does_not_create_a_badge_from_nothing(self):
         with self._patch_upstream(error=badge.UpstreamError("all sources down")):
             code = badge.main(["--badge", str(self.badge_path)])
         self.assertEqual(code, 1)
         self.assertFalse(self.badge_path.exists())
+
+    def test_fallback_notices_are_reported_on_stderr(self):
+        stderr = io.StringIO()
+        with (
+            self._patch_upstream(
+                self._live_ranking(), notices=["leaderboard.json: HTTP 503"]
+            ),
+            contextlib.redirect_stderr(stderr),
+        ):
+            code = badge.main(["--badge", str(self.badge_path)])
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "notice: fell back after: leaderboard.json: HTTP 503", stderr.getvalue()
+        )
+
+    def test_help_text_pins_the_description_and_check_flag_help(self):
+        # argparse's --help exits (SystemExit) from inside parse_args()
+        # itself, before main() ever reaches resolve_ranking() — so under
+        # the real code, patching resolve_ranking here changes nothing
+        # observable. But a mutant that deletes the `parser.parse_args()`
+        # call entirely (never raising SystemExit at all) falls through
+        # into resolve_ranking() for real, which — unpatched — is a live
+        # network call whose outcome (and therefore this test's pass/fail)
+        # depends on the sandbox's network reachability at run time.
+        # Patching it removes that nondeterminism regardless of which
+        # mutant is under test (reproduced: mutmut flagged this exact
+        # mutant "suspicious" — an inconsistent verdict across its own
+        # dual-run check — before this fix).
+        stdout = io.StringIO()
+        with (
+            self._patch_upstream(self._live_ranking()),
+            mock.patch.dict(os.environ, {"COLUMNS": "80"}),
+            contextlib.redirect_stdout(stdout),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            badge.main(["--help"])
+        self.assertEqual(ctx.exception.code, 0)
+        help_lines = stdout.getvalue().splitlines()
+        self.assertIn(badge.__doc__.splitlines()[0], help_lines)
+        # Exact-line membership, not substring-in-blob: this help string is
+        # a plain literal with no f-string placeholder to break up a
+        # whole-string "XX...XX" mutation wrap, so only exact equality (of
+        # the whole rendered line) catches it.
+        self.assertIn(
+            "  --check        exit 1 if the badge is out of date; never write",
+            help_lines,
+        )
+
+    def test_default_badge_path_is_the_committed_asset_constant(self):
+        # --badge is optional; when omitted, main() must target BADGE_PATH
+        # exactly (not None / not a bare argparse default). Patching the
+        # module constant rather than passing --badge is what actually
+        # exercises the default= wiring instead of bypassing it.
+        with (
+            mock.patch.object(badge, "BADGE_PATH", self.badge_path),
+            self._patch_upstream(self._live_ranking()),
+        ):
+            code = badge.main([])
+        self.assertEqual(code, 0)
+        self.assertTrue(self.badge_path.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Issue #281 filed 116 pre-existing mutation survivors in
`scripts/refresh_mcp_toplist_badge.py` (found while fixing #262's
dataclass-exclusion defect in the same file — that fix, `Ranking`'s
`percentile()`/`tier_text()` extraction to free functions, already
shipped in #283 and is untouched here). This PR kills all 116, adding
18 new tests and strengthening several existing assertions from
"raises" to "raises with this exact message/value/attribute".

Reproduced the exact baseline first (`scripts/mutation_check.sh
tests_py/scripts/test_refresh_mcp_toplist_badge.py
scripts/refresh_mcp_toplist_badge.py`, run against the shared venv
directly since `uv run mutmut run` needs its own synced env in a fresh
worktree): 314 mutants, 198 killed, 116 survived — matching the issue's
tally and per-function breakdown exactly (fetch 15, main 22,
parse_leaderboard 21, parse_server_page 6, render_badge 20,
resolve_ranking 7, validate 8, `_provenance_comment` 16, `_today` 1).

## What killed the 116

- **`validate`**: comma-formatted RANK (not just total), a total=1
  boundary test (guards against `<=1`/`<2` tightening the real `<1`
  guard), and exact failure-message assertions on every raise site.
- **`parse_leaderboard`**: exact messages on "no server list"/"no
  rank"/"not present" raises; new tests for the `totalServers`/`count`
  total-key fallbacks, the `name`/`serverId` identity-key fallbacks, the
  `place` rank-key fallback, and a `next(gen, None)`-without-default
  StopIteration gap (an entry dict with none of the identity keys).
- **`parse_server_page`**: exact reworded-page error message.
- **`_provenance_comment`** (new `TestProvenanceComment` — this function
  had zero direct tests before): exact percentage arithmetic (`1.18%`,
  deliberately distinct from the rounded `1.2%` tier text) and exact
  wording on every fixed comment line.
- **`render_badge`**: label/message SVG color+geometry pinned via
  `ElementTree` parsing (NOT substring search — a naive
  `assertIn('fill="#fff"', svg)` passes even with
  `message_text_fill=None`, because the badge's own clip-path rect
  *also* carries a literal `fill="#fff"` for an unrelated reason); icon
  fragments pinned via exact-line membership (the icon tuple's lines
  are spliced into the SVG verbatim, not through an f-string template,
  so a whole-line `"XX...XX"` wrap still contains the plain substring
  and only exact-line equality catches it).
- **`fetch`**: a new test capturing the actual `Request` object and
  `timeout` kwarg from a fake opener, asserting the exact header values
  and timeout constant sent.
- **`resolve_ranking`**: exact reconstruction of the "no trusted
  figure..." message (prefix + `"\n  - "` separator); a new test
  feeding a genuinely invalid UTF-8 byte through the server-page path,
  proving `errors="replace"` is honored (verified empirically first:
  Python only validates/invokes the `errors` handler when an actual
  decode error occurs — on all-valid input, `"replace"` vs a typo'd
  handler name vs the implicit `"strict"` default are indistinguishable,
  so every other test in the file could not have caught this).
- **`_today`**: a stub-verification test asserting `datetime.now()` is
  called with `timezone.utc` specifically (a legitimate test of a
  one-line wrapper's argument-forwarding contract — there's no
  return-value assertion that can observe "which timezone" without
  depending on the system clock at test time).
- **`main`**: `--help` output pins the docstring description and the
  `--check` flag's exact help line; every print statement's exact
  message text AND destination stream (stdout vs stderr) is now
  asserted, not just the return code; a new test patches `BADGE_PATH`
  to verify the `--badge` flag's default is wired correctly.

## Two mutation-testing lessons this file makes concrete (documented inline)

1. A substring assertion of a **plain, non-interpolated literal**
   cannot detect mutmut's whole-string `"XX...XX"` wrap: the original
   text stays a contiguous substring of the wrapped one. Only exact
   equality (or exact list-item / exact-line membership) catches it.
   Caught this the hard way: my first pass used `assertIn` for the
   provenance-comment wording and the `parse_leaderboard` "no server
   list" message, and 7 of those mutants survived a second mutation run
   despite the assertions "logically" covering them.
2. The `--help` test originally relied on argparse's own `SystemExit`
   firing before `main()` ever reached `resolve_ranking()`. A mutant
   deleting the `parser.parse_args()` call fell through into a REAL,
   unpatched HTTP fetch — mutmut correctly flagged it **"suspicious"**
   (an inconsistent verdict across its own dual-run check) rather than
   a clean survivor. Fixed by patching `resolve_ranking()` in that test
   too, so the test is hermetic regardless of which mutant runs.

## Final tally: 314 mutants, 308 killed, 6 documented-equivalent survivors

All 6 verified empirically (not assumed) before being left undischarged:

| Mutant | Change | Why equivalent |
|---|---|---|
| `parse_leaderboard` mutmut_5 | `"utf-8"` → `"UTF-8"` | `codecs.lookup("utf-8") is codecs.lookup("UTF-8")` → `True`; decode output is byte-for-byte identical for every input |
| `resolve_ranking` mutmut_10 | `"utf-8"` → `"UTF-8"` (page-decode path) | same codec-lookup identity, independent of the `errors` handler paired with it |
| `fetch` mutmut_7 | `"User-Agent"` → `"user-agent"` | `"User-Agent".capitalize() == "user-agent".capitalize() == "User-agent"` — `urllib.request.Request.add_header` normalizes the key regardless of source casing |
| `fetch` mutmut_8 | `"User-Agent"` → `"USER-AGENT"` | same `.capitalize()` normalization |
| `fetch` mutmut_13 | `"Accept"` → `"accept"` | `"Accept".capitalize() == "accept".capitalize() == "Accept"` |
| `fetch` mutmut_14 | `"Accept"` → `"ACCEPT"` | same |

Each is documented inline at its test-file use site (not just in this
PR body) with the verification command/reasoning, per coding-standards
§12.1.

No change to `Ranking`/`ranking_percentile`/`ranking_tier_text` (fixed
in #283) or any other source file — this PR only touches
`tests_py/scripts/test_refresh_mcp_toplist_badge.py`.

## Completion Ledger

| Item | Evidence |
|---|---|
| Baseline reproduced | `scripts/mutation_check.sh` run: 314 mutants / 198 killed / 116 survived — exact match to issue #281's tally and per-function breakdown |
| Every one of the 116 survivors killed or documented equivalent | Final run: 314 mutants / 308 killed / 6 documented-equivalent survivors (table above); each equivalence verified via a standalone `python3 -c` repro (codecs.lookup identity, str.capitalize() identity) before being accepted, not asserted from memory |
| No change to `Ranking`/dataclass extraction | `git diff --stat` shows only `tests_py/scripts/test_refresh_mcp_toplist_badge.py` touched |
| Full test suite green | `pytest -q`: 6840 passed, 5 skipped, 116 subtests passed, 0 failed |
| Target file's own suite | `pytest tests_py/scripts/test_refresh_mcp_toplist_badge.py -q`: 70 passed (51 baseline + 18 new methods + 1 split-out from an over-cap method) |
| §4.2 method-size cap (40 lines) | AST sweep: 0 functions over cap in the touched file (one new test was originally 41 lines; split into `test_percentage_arithmetic_is_pinned` + `test_fixed_wording_is_pinned`) |
| §4.1 file-size cap | File is 759 lines; test files in this repo routinely exceed the 300-line source convention when organized by fixture grouping — precedent: `test_launcher_deps.py` (1500), `test_mcp_client.py` (1408), `test_write_gate.py` (998), and the direct sibling `test_generate_repo_badges.py` (613, same badge-gate pattern) |
| `ruff check` clean | `ruff check tests_py/scripts/test_refresh_mcp_toplist_badge.py` → "All checks passed!" |
| `ruff format --check` clean | Ran, 1 file needed reformatting, applied, re-verified clean |
| `check_doc_claims.py` | "doc claims OK (1 declared not-a-claim exemption(s))" |
| `generate_repo_badges.py --check` | "badges OK (4 checked)"; also ran without `--check`: "0 of 4 badge(s) changed" — the monotone test-count floor already covers this increase, no SVG regeneration needed |
| No conflict markers / `.bestpractices.json` parses | Verified — 0 markers (the `===` matches found are pre-existing docstring table separators, not conflict markers); JSON loads cleanly |
| Boy-scout (§14) | No defects seen in touched material beyond the one I introduced and fixed myself (the 41-line test method, split before push) |

## Test plan
- [x] Reproduced the exact 116-survivor baseline before writing any test
- [x] All 116 survivors individually classified (killed via new/strengthened test, or documented equivalent with independent verification)
- [x] `pytest tests_py/scripts/test_refresh_mcp_toplist_badge.py -q` — 70 passed
- [x] Full suite `pytest -q` — 6840 passed, 5 skipped, 0 failed
- [x] `ruff check` + `ruff format --check` clean on the touched file
- [x] `scripts/check_doc_claims.py` + `scripts/generate_repo_badges.py --check` green
- [x] Re-ran the scoped mutation pass a second time post-formatting to confirm the 6-survivor tally is stable (not an artifact of one run)

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Yu6EnWspTfqHoGkExyS6u