### PR TITLE
test(scripts): kill check_doc_claims.py's 25 surviving mutants for real (#235)

### DIFF
--- a/tests_py/scripts/test_check_doc_claims.py
+++ b/tests_py/scripts/test_check_doc_claims.py
@@ -44,6 +44,26 @@ _dcs_spec = importlib.util.spec_from_file_location(
 doc_claim_structural = importlib.util.module_from_spec(_dcs_spec)
 _dcs_spec.loader.exec_module(doc_claim_structural)
 
+# Same defect, same fix, for scripts/doc_claim_sources.py (issue #235): its
+# four canonical-source readers are the exact functions #235's originating
+# mutation run found 23 of its 25 survivors in (canonical_reference_count,
+# canonical_tool_counts, canonical_version, canonical_mechanism_count — `read`
+# itself stayed behind in check_doc_claims.py, correctly attributed already).
+# A scoped mutmut run after #294's split reported every one of these as "no
+# tests" rather than "survived" — that is this same bare-import __module__
+# mismatch (issue #292), not evidence the 25 gaps were closed: check_
+# doc_claims.py's own bare `import doc_claim_sources` gives every function in
+# it `__module__ == "doc_claim_sources"`, which mutmut's trampoline never
+# matches, so no test — however thorough — could have activated a single one
+# of its mutants through that copy. CanonicalSourceDirectTests below calls
+# through THIS dotted-loaded reference instead, so a mutant here is actually
+# exercised and can actually be killed.
+_dcso_spec = importlib.util.spec_from_file_location(
+    "scripts.doc_claim_sources", _SCRIPTS / "doc_claim_sources.py"
+)
+doc_claim_sources = importlib.util.module_from_spec(_dcso_spec)
+_dcso_spec.loader.exec_module(doc_claim_sources)
+
 
 CATALOGUE = (
     "52 standalone tools register unconditionally; 3 more register only when an\n"
@@ -152,6 +172,186 @@ class CanonicalSourceTests(unittest.TestCase):
             **{"pyproject.toml": '[project]\nname = "x"\nversion = "4.16.0"\n'}
         )
         self.assertEqual(gate.canonical_version(), "4.16.0")
+
+
+class CanonicalSourceDirectTests(unittest.TestCase):
+    """Direct tests of scripts/doc_claim_sources.py (issue #235).
+
+    CanonicalSourceTests above exercises these same functions, but only
+    through `gate.canonical_tool_counts()` et al. — real behavioural
+    coverage, zero mutation coverage. check_doc_claims.py reaches
+    doc_claim_sources.py through a bare `import doc_claim_sources`, which
+    gives every function in it `__module__ == "doc_claim_sources"` —
+    never the dotted `"scripts.doc_claim_sources"` mutmut's trampoline
+    expects (see the module-level dotted-load comment above) — so a
+    scoped mutmut run after #294's split reported every one of these
+    functions' mutants as "no tests" rather than "survived". That is the
+    same attribution defect #292 tracks for this file, not evidence that
+    #235's originating 25 survivors were closed: an uncalled trampoline
+    cannot report a kill either way. These tests call through the
+    dotted-loaded `doc_claim_sources` reference with an explicit
+    `read_fn` (the functions already take one — no `gate.read`
+    monkeypatch needed), so a mutant here is actually reachable.
+
+    Re-running the scoped mutation check after adding these surfaced the
+    same class of gap #235's original table named: several branches
+    (missing-sentence, arithmetic-mismatch, missing-pinned-test,
+    missing-section, no-entries, undeclared-mechanism-count,
+    missing-version) had no assertion on their exact error message, so a
+    mutant that corrupted the message while keeping `assertIn`'s matched
+    substring intact still passed. Each below now asserts the message
+    verbatim.
+    """
+
+    def test_tool_counts_come_from_the_catalogue(self):
+        read_fn = _FakeRepo(
+            **{"docs/mcp-tools.md": CATALOGUE, "tests_py/test_main.py": PINNED_TEST}
+        ).read
+        self.assertEqual(doc_claim_sources.canonical_tool_counts(read_fn), (52, 55))
+
+    def test_missing_standalone_total_sentence_is_an_error(self):
+        """No header sentence at all is a different failure than a wrong
+        number in it — the message must name the file and what was expected.
+        """
+        read_fn = _FakeRepo(
+            **{
+                "docs/mcp-tools.md": "No counts stated here.\n",
+                "tests_py/test_main.py": PINNED_TEST,
+            }
+        ).read
+        with self.assertRaises(doc_claim_sources.ClaimError) as caught:
+            doc_claim_sources.canonical_tool_counts(read_fn)
+        self.assertEqual(
+            str(caught.exception),
+            "docs/mcp-tools.md: standalone/total tool sentence not found",
+        )
+
+    def test_catalogue_drifting_from_the_pinned_registry_test_is_an_error(self):
+        drifted = CATALOGUE.replace("52 standalone", "50 standalone").replace(
+            "(55 total", "(53 total"
+        )
+        read_fn = _FakeRepo(
+            **{"docs/mcp-tools.md": drifted, "tests_py/test_main.py": PINNED_TEST}
+        ).read
+        with self.assertRaises(doc_claim_sources.ClaimError) as caught:
+            doc_claim_sources.canonical_tool_counts(read_fn)
+        self.assertIn("pinned registry test", str(caught.exception))
+
+    def test_inconsistent_arithmetic_in_the_catalogue_is_an_error(self):
+        broken = CATALOGUE.replace("(55 total", "(56 total")
+        read_fn = _FakeRepo(
+            **{"docs/mcp-tools.md": broken, "tests_py/test_main.py": PINNED_TEST}
+        ).read
+        with self.assertRaises(doc_claim_sources.ClaimError) as caught:
+            doc_claim_sources.canonical_tool_counts(read_fn)
+        self.assertEqual(str(caught.exception), "docs/mcp-tools.md: 52 + 3 != 56")
+
+    def test_missing_pinned_registry_test_is_an_error(self):
+        """Distinct from the drift case above: here the pinned test itself
+        is gone (renamed, deleted), not merely disagreeing with the catalogue.
+        """
+        read_fn = _FakeRepo(
+            **{
+                "docs/mcp-tools.md": CATALOGUE,
+                "tests_py/test_main.py": "def test_something_else(self):\n",
+            }
+        ).read
+        with self.assertRaises(doc_claim_sources.ClaimError) as caught:
+            doc_claim_sources.canonical_tool_counts(read_fn)
+        self.assertEqual(
+            str(caught.exception),
+            "tests_py/test_main.py: pinned tool-count test not found",
+        )
+
+    def test_reference_count_is_the_number_of_entries_not_the_advertised_number(self):
+        read_fn = _FakeRepo(**{"docs/papers/bibliography.md": BIBLIOGRAPHY}).read
+        self.assertEqual(doc_claim_sources.canonical_reference_count(read_fn), 2)
+
+    def test_reference_entries_exclude_headings_and_separators(self):
+        read_fn = _FakeRepo(
+            **{
+                "docs/papers/bibliography.md": (
+                    "36 mechanisms.\n\n## References\n\n"
+                    "### Neuroscience\n\n---\n\n"
+                    "Author, A. (2001). One.\n\nAuthor, B. (2002). Two.\n"
+                )
+            }
+        ).read
+        self.assertEqual(doc_claim_sources.canonical_reference_count(read_fn), 2)
+
+    def test_the_first_references_heading_is_the_split_point(self):
+        """`split(..., 1)` on the FIRST occurrence, not `rsplit` on the last.
+
+        A doubled "## References" heading (a copy-paste mistake, or a nested
+        subsection literally named that) must not silently move which text
+        counts as entries: everything after the first heading is the
+        section, including a second stray heading line (excluded by the `#`
+        filter, same as any other heading) and the entries that follow it.
+        """
+        read_fn = _FakeRepo(
+            **{
+                "docs/papers/bibliography.md": (
+                    "36 mechanisms.\n\n## References\n\n"
+                    "Author, A. (2001). One.\n\n## References\n\n"
+                    "Author, B. (2002). Two.\n"
+                )
+            }
+        ).read
+        self.assertEqual(doc_claim_sources.canonical_reference_count(read_fn), 2)
+
+    def test_bibliography_without_a_references_section_is_an_error(self):
+        read_fn = _FakeRepo(**{"docs/papers/bibliography.md": "# Bibliography\n"}).read
+        with self.assertRaises(doc_claim_sources.ClaimError) as caught:
+            doc_claim_sources.canonical_reference_count(read_fn)
+        self.assertEqual(
+            str(caught.exception),
+            "docs/papers/bibliography.md: '## References' section not found",
+        )
+
+    def test_a_references_section_with_no_entries_is_an_error(self):
+        """A heading with nothing under it — only furniture, no citations."""
+        read_fn = _FakeRepo(
+            **{
+                "docs/papers/bibliography.md": (
+                    "36 mechanisms.\n\n## References\n\n### Neuroscience\n\n---\n"
+                )
+            }
+        ).read
+        with self.assertRaises(doc_claim_sources.ClaimError) as caught:
+            doc_claim_sources.canonical_reference_count(read_fn)
+        self.assertEqual(
+            str(caught.exception),
+            "docs/papers/bibliography.md: no reference entries found",
+        )
+
+    def test_mechanism_count_is_read_from_the_bibliography_header(self):
+        read_fn = _FakeRepo(**{"docs/papers/bibliography.md": BIBLIOGRAPHY}).read
+        self.assertEqual(doc_claim_sources.canonical_mechanism_count(read_fn), 36)
+
+    def test_undeclared_mechanism_count_is_an_error(self):
+        read_fn = _FakeRepo(
+            **{"docs/papers/bibliography.md": "# B\n\n## References\n\nA. (1)\n"}
+        ).read
+        with self.assertRaises(doc_claim_sources.ClaimError) as caught:
+            doc_claim_sources.canonical_mechanism_count(read_fn)
+        self.assertEqual(
+            str(caught.exception),
+            "docs/papers/bibliography.md: no mechanism count declared",
+        )
+
+    def test_version_comes_from_pyproject(self):
+        read_fn = _FakeRepo(
+            **{"pyproject.toml": '[project]\nname = "x"\nversion = "4.16.0"\n'}
+        ).read
+        self.assertEqual(doc_claim_sources.canonical_version(read_fn), "4.16.0")
+
+    def test_missing_version_declaration_is_an_error(self):
+        read_fn = _FakeRepo(**{"pyproject.toml": '[project]\nname = "x"\n'}).read
+        with self.assertRaises(doc_claim_sources.ClaimError) as caught:
+            doc_claim_sources.canonical_version(read_fn)
+        self.assertEqual(
+            str(caught.exception), "pyproject.toml: [project].version not found"
+        )
 
 
 class ScanTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Closes #235.

Issue #235's originating mutation run found 25 survivors in
`check_doc_claims.py`'s canonical-source helpers (`canonical_reference_count`
10, `canonical_tool_counts` 7, `canonical_version` 3, `canonical_mechanism_count`
3, `read` 2). Before it could be fixed, #294 merged and split the file into
`check_doc_claims.py` / `doc_claim_sources.py` / `doc_claim_scan.py` /
`doc_claim_structural.py` — moving all four `canonical_*` helpers into
`doc_claim_sources.py`.

**Re-measuring against current main first** (per this issue's own instruction):
a fresh scoped `mutmut` run reports **0 survived** — but that number is
misleading, not a genuine pass. `check_doc_claims.py` reaches
`doc_claim_sources.py` through a bare `import doc_claim_sources`, which gives
every function in that file `__module__ == "doc_claim_sources"` — never the
dotted `"scripts.doc_claim_sources"` mutmut's trampoline expects. This is the
exact bare-import attribution defect issue #292 already tracks (and had
flagged `doc_claim_sources.py` as "not yet verified, assumed affected"). All
108 of `doc_claim_sources.py`'s mutants were showing **"no tests"** — an
uncalled trampoline, not a verified kill — so #235's specific acceptance
criterion ("0 surviving non-equivalent mutants ... in the canonical-source
helpers") was **unverifiable** on main, not actually satisfied. Closing the
issue on the strength of "0 survived" alone would have been trusting a
measurement the tooling could not make.

## Fix

`tests_py/scripts/test_check_doc_claims.py` now loads `doc_claim_sources.py` a
second time under its own dotted name (`"scripts.doc_claim_sources"`) — the
same pattern already established in this file for
`doc_claim_structural.check_badge_floor` — and a new
`CanonicalSourceDirectTests` class calls through that reference with an
explicit `read_fn` (these functions already take one; no `gate.read`
monkeypatch needed).

Re-running the scoped mutation check after adding it: all 108 previously
invisible mutants become reachable, and **every one is killed**. Final:
**260 killed / 125 no-tests / 0 survived** across the four files (up from
152/233/0). The remaining 125 "no tests" are pre-existing, already-filed scope
— `doc_claim_scan.py`'s functions, `doc_claim_structural.py`'s other functions
(`check_badge`, `check_no_hotlinked_badges`, `check_no_conflict_markers`,
`check_scanned_json_parses`), and `check_doc_claims.py`'s `main()` — all named
in issue #292's "Remaining scope", untouched by this PR (no new issue opened;
#292 already covers it).

Several of the newly-reachable mutants needed an **exact-message** assertion
where the existing behavioural tests only checked a substring (`assertIn`) or
just the return value — missing-sentence, arithmetic-mismatch,
missing-pinned-test, missing-section, no-entries-found,
undeclared-mechanism-count, missing-version-declaration. These are the same
gap class #235's own table named (e.g. `canonical_version()`'s "not found" arm
had no test at all). No equivalent mutants were needed — every real gap was
killable once the message was pinned.

## Acceptance criteria (from #235)

- [x] 0 surviving non-equivalent mutants in `scripts/check_doc_claims.py`
      (+ its extracted siblings `doc_claim_sources.py`/`doc_claim_scan.py`/
      `doc_claim_structural.py`, which now carry the logic #235's table
      named) — **verified**, not just measured: 0 survived, and the 108
      previously-unattributed mutants are now demonstrably reachable and
      killed, not silently uncounted.
- [x] Any mutant judged equivalent is documented with a written rationale —
      N/A, no equivalent mutants remained after fixing attribution; all real
      gaps were killed outright.
- [x] `canonical_reference_count`'s entry filter is pinned against a
      bibliography containing headings, separators and blank lines — already
      covered by `test_reference_entries_exclude_headings_and_separators`
      (headings `###`, separator `---`, and blank lines between entries all
      present in that fixture), now also exercised directly (mutation-level,
      not just behaviourally) via `CanonicalSourceDirectTests`.

## Completion Ledger

| Path introduced | Test asserting it |
|---|---|
| Dotted-load of `doc_claim_sources.py` under `"scripts.doc_claim_sources"` | Module-level fixture; exercised by every test in `CanonicalSourceDirectTests` |
| `canonical_tool_counts()`: catalogue read + happy path (direct) | `CanonicalSourceDirectTests.test_tool_counts_come_from_the_catalogue` |
| `canonical_tool_counts()`: missing header sentence, exact message | `test_missing_standalone_total_sentence_is_an_error` |
| `canonical_tool_counts()`: catalogue/pinned-test drift | `test_catalogue_drifting_from_the_pinned_registry_test_is_an_error` |
| `canonical_tool_counts()`: arithmetic mismatch, exact message | `test_inconsistent_arithmetic_in_the_catalogue_is_an_error` |
| `canonical_tool_counts()`: missing pinned test, exact message | `test_missing_pinned_registry_test_is_an_error` |
| `canonical_reference_count()`: happy path (direct) | `test_reference_count_is_the_number_of_entries_not_the_advertised_number` |
| `canonical_reference_count()`: headings/separators excluded (direct) | `test_reference_entries_exclude_headings_and_separators` |
| `canonical_reference_count()`: split-first-not-last semantics | `test_the_first_references_heading_is_the_split_point` |
| `canonical_reference_count()`: missing section, exact message | `test_bibliography_without_a_references_section_is_an_error` |
| `canonical_reference_count()`: no entries found, exact message | `test_a_references_section_with_no_entries_is_an_error` |
| `canonical_mechanism_count()`: happy path (direct) | `test_mechanism_count_is_read_from_the_bibliography_header` |
| `canonical_mechanism_count()`: undeclared count, exact message | `test_undeclared_mechanism_count_is_an_error` |
| `canonical_version()`: happy path (direct) | `test_version_comes_from_pyproject` |
| `canonical_version()`: missing declaration, exact message | `test_missing_version_declaration_is_an_error` |

## Test plan

- [x] `pytest tests_py/scripts/test_check_doc_claims.py` — 70 passed, 9 subtests
- [x] `pytest tests_py/scripts/` (full sibling scope) — 458 passed, 116 subtests
- [x] Full suite: **6835 passed, 5 skipped**, 0 failed
- [x] `ruff check` + `ruff format --check` on the touched file — clean
- [x] `python scripts/check_doc_claims.py --test-count 6840` — `doc claims OK (1 declared not-a-claim exemption(s))`
- [x] `python scripts/generate_repo_badges.py --check --test-count 6840` — `badges OK (5 checked)` (the tests badge is a monotone floor — 6788 <= 6840 — so no regeneration is needed for a tests-only PR)
- [x] `pyrightconfig.json` excludes `tests_py`/`scripts` from the zero-diagnostic gate — N/A for this change
- [x] No conflict markers introduced; `.bestpractices.json` still parses
- [x] Scoped `mutmut` re-run (`tests_py/scripts/test_check_doc_claims.py` against `scripts/check_doc_claims.py` + `doc_claim_sources.py` + `doc_claim_scan.py` + `doc_claim_structural.py`): **260 killed / 125 no-tests (pre-existing #292 scope) / 0 survived, 0 unexplained**
- [x] `pyproject.toml`'s committed `[tool.mutmut]` scope (`mcp_server/shared/json_native.py`) untouched — every scoped run restored it via `scripts/mutation_check.sh`'s own trap/cleanup

## AST size gate (coding-standards.md §4, this repo's 300/40 tightening)

```
$ python3 - tests_py/scripts/test_check_doc_claims.py <<'PY'
import ast, pathlib, sys
for f in sys.argv[1:]:
    src = pathlib.Path(f).read_text(); n = len(src.splitlines())
    if n > 300: print(f"FILE OVER CAP: {f} = {n}")
    for node in ast.walk(ast.parse(src)):
        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
            ln = (node.end_lineno or node.lineno) - node.lineno + 1
            if ln > 40: print(f"FN OVER CAP: {f}::{node.name} = {ln}")
PY
FILE OVER CAP: tests_py/scripts/test_check_doc_claims.py = 920
```
File-level cap: this test file was already at 721 lines before this PR (organized
by one `unittest.TestCase` class per function/concern — the repo's own
`test_generate_pip_constraints.py` (944), `test_launcher_deps.py` (1500), and
`test_generate_repo_badges.py` (613) are the same, pre-existing pattern for
this test tree). No new method is over the 40-line cap (the AST walk above
reports zero `FN OVER CAP` lines).

## Boy-scout items (coding-standards.md §14)

None seen beyond this issue's own subject in the touched file. The
`doc_claim_scan.py`/`doc_claim_structural.py`/`main()` attribution gaps this
PR's investigation surfaced are pre-existing and already tracked by issue
#292 (filed, with acceptance criteria) — left untouched per §14.3 (outside
this change's blast radius; #235's acceptance criteria name only the
canonical-source helpers, not the whole file's mutation coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Yu6EnWspTfqHoGkExyS6u