### PR TITLE
test(mutation): kill check_doc_claims.py's remaining mutants after the #293 split

### DIFF
--- a/scripts/check_doc_claims.py
+++ b/scripts/check_doc_claims.py
@@ -232,6 +232,11 @@ def main() -> int:
     parser.add_argument(
         "--test-count",
         type=int,
+        # Explicit, not load-bearing: argparse already defaults an unset
+        # optional argument with no `default` kwarg at all to None, so a
+        # mutant dropping this line is a documented equivalent (issue #235;
+        # rationale + verification in MainTests.test_the_parser_declares_
+        # the_modules_docstring_and_flag_help's docstring).
         default=None,
         help="live test count (from `pytest --collect-only -q`); skipped when absent",
     )

--- a/tests_py/scripts/test_check_doc_claims.py
+++ b/tests_py/scripts/test_check_doc_claims.py
@@ -9,7 +9,11 @@ being rewritten.
 
 from __future__ import annotations
 
+import argparse
+import contextlib
 import importlib.util
+import io
+import sys
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -76,7 +80,6 @@ _scan_spec = importlib.util.spec_from_file_location(
 )
 doc_claim_scan = importlib.util.module_from_spec(_scan_spec)
 _scan_spec.loader.exec_module(doc_claim_scan)
-
 
 CATALOGUE = (
     "52 standalone tools register unconditionally; 3 more register only when an\n"
@@ -169,6 +172,19 @@ class CanonicalSourceTests(unittest.TestCase):
         with self.assertRaises(gate.ClaimError):
             gate.canonical_reference_count()
 
+    def test_a_references_section_with_no_entries_is_an_error(self):
+        """A heading is a section; a section with nothing under it is not
+
+        a bibliography — without this guard an all-furniture section (only
+        a sub-heading and a separator, no entry) would silently count as
+        zero references rather than failing closed.
+        """
+        self._install(
+            **{"docs/papers/bibliography.md": "# B\n\n## References\n\n### X\n\n---\n"}
+        )
+        with self.assertRaises(gate.ClaimError):
+            gate.canonical_reference_count()
+
     def test_mechanism_count_is_read_from_the_bibliography_header(self):
         self._install(**{"docs/papers/bibliography.md": BIBLIOGRAPHY})
         self.assertEqual(gate.canonical_mechanism_count(), 36)
@@ -185,6 +201,11 @@ class CanonicalSourceTests(unittest.TestCase):
             **{"pyproject.toml": '[project]\nname = "x"\nversion = "4.16.0"\n'}
         )
         self.assertEqual(gate.canonical_version(), "4.16.0")
+
+    def test_missing_version_declaration_is_an_error(self):
+        self._install(**{"pyproject.toml": '[project]\nname = "x"\n'})
+        with self.assertRaises(gate.ClaimError):
+            gate.canonical_version()
 
 
 class CanonicalSourceDirectTests(unittest.TestCase):
@@ -212,8 +233,10 @@ class CanonicalSourceDirectTests(unittest.TestCase):
     missing-section, no-entries, undeclared-mechanism-count,
     missing-version) had no assertion on their exact error message, so a
     mutant that corrupted the message while keeping `assertIn`'s matched
-    substring intact still passed. Each below now asserts the message
-    verbatim.
+    substring intact still passed. Every assertion below is exact-match
+    (assertEqual on the full message), not assertIn: a mutant that only
+    wraps a message in stray marker characters still contains any true
+    substring of itself, so only a full comparison catches it.
     """
 
     def test_tool_counts_come_from_the_catalogue(self):
@@ -248,7 +271,11 @@ class CanonicalSourceDirectTests(unittest.TestCase):
         ).read
         with self.assertRaises(doc_claim_sources.ClaimError) as caught:
             doc_claim_sources.canonical_tool_counts(read_fn)
-        self.assertIn("pinned registry test", str(caught.exception))
+        self.assertEqual(
+            str(caught.exception),
+            "docs/mcp-tools.md says 50 standalone tools, but the pinned "
+            "registry test says 52",
+        )
 
     def test_inconsistent_arithmetic_in_the_catalogue_is_an_error(self):
         broken = CATALOGUE.replace("(55 total", "(56 total")
@@ -293,20 +320,24 @@ class CanonicalSourceDirectTests(unittest.TestCase):
         self.assertEqual(doc_claim_sources.canonical_reference_count(read_fn), 2)
 
     def test_the_first_references_heading_is_the_split_point(self):
-        """`split(..., 1)` on the FIRST occurrence, not `rsplit` on the last.
+        """split(..., 1) on the FIRST heading — not rsplit, not unlimited.
 
-        A doubled "## References" heading (a copy-paste mistake, or a nested
-        subsection literally named that) must not silently move which text
-        counts as entries: everything after the first heading is the
-        section, including a second stray heading line (excluded by the `#`
-        filter, same as any other heading) and the entries that follow it.
+        Two REAL headings, not a quoted one: split(maxsplit=1) on the first
+        keeps everything after it, including the second heading's own
+        entries (the heading line itself is filtered as furniture, like
+        any "#"-prefixed line) — 2 entries. rsplit(maxsplit=1) on the LAST
+        heading would keep only the entry after it — 1. The two disagree,
+        which is what makes this fixture distinguish them; a fixture where
+        both give the same count (e.g. a heading merely quoted inside an
+        entry) proves nothing.
         """
         read_fn = _FakeRepo(
             **{
                 "docs/papers/bibliography.md": (
                     "36 mechanisms.\n\n## References\n\n"
-                    "Author, A. (2001). One.\n\n## References\n\n"
-                    "Author, B. (2002). Two.\n"
+                    "Author, A. (2001). Before the second heading.\n\n"
+                    "## References\n\n"
+                    "Author, B. (2002). After the second heading.\n"
                 )
             }
         ).read
@@ -1301,6 +1332,153 @@ class StructuralIntegrityTests(unittest.TestCase):
         """
         self.assertEqual(gate.check_no_conflict_markers(), [])
         self.assertEqual(gate.check_scanned_json_parses(), [])
+
+
+@contextlib.contextmanager
+def _spying_on_argparse_construction():
+    """Capture ArgumentParser(**kwargs) and add_argument("--test-count", **kwargs).
+
+    A plain `mock.patch.object(ArgumentParser, "__init__", spy)` recurses:
+    the spy's own delegation to the real `__init__` is looked up through
+    `type(self)`, which is the (already-patched) class again. Binding the
+    ORIGINAL unbound method once, before patching, and calling that fixed
+    reference — never `super()` or `ArgumentParser.__init__` again inside
+    the spy — is what avoids it.
+    """
+    captured: dict[str, object] = {}
+    help_kwargs: dict[str, object] = {}
+    real_init = argparse.ArgumentParser.__init__
+    real_add = argparse.ArgumentParser.add_argument
+
+    def spy_init(self, *args, **kwargs):
+        captured.update(kwargs)
+        return real_init(self, *args, **kwargs)
+
+    def spy_add(self, *args, **kwargs):
+        if args and args[0] == "--test-count":
+            help_kwargs.update(kwargs)
+        return real_add(self, *args, **kwargs)
+
+    with (
+        mock.patch.object(argparse.ArgumentParser, "__init__", spy_init),
+        mock.patch.object(argparse.ArgumentParser, "add_argument", spy_add),
+    ):
+        yield captured, help_kwargs
+
+
+class MainTests(unittest.TestCase):
+    """gate.main() end to end: argparse, exit codes, and the two failure arms.
+
+    Every test above proves collect_failures/exemption_registry themselves
+    are correct; none of them ever called main() — its own dispatch (which
+    exit code, which stream) had zero mutation coverage (issue #235).
+    """
+
+    def setUp(self):
+        self._argv = sys.argv[:]
+
+    def tearDown(self):
+        sys.argv = self._argv
+
+    def _run(self, argv_tail):
+        sys.argv = ["check_doc_claims.py", *argv_tail]
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = gate.main()
+        return code, out.getvalue(), err.getvalue()
+
+    def test_a_claim_error_aborts_to_stderr_with_exit_code_2(self):
+        with mock.patch.object(
+            gate, "collect_failures", side_effect=gate.ClaimError("boom")
+        ):
+            code, out, err = self._run([])
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("doc-claim gate could not run: boom", err)
+
+    def test_failures_are_reported_to_stderr_with_exit_code_1(self):
+        with mock.patch.object(gate, "collect_failures", return_value=["a: bad"]):
+            code, out, err = self._run([])
+        self.assertEqual(code, 1)
+        self.assertEqual(out, "")
+        # Exact match, not assertIn: a mutant that reworded the header (e.g.
+        # wrapped it in stray marker characters) still contains any true
+        # substring of itself, so only a full-line comparison catches it.
+        self.assertEqual(
+            err, "Documentation claims disagree with the repository:\n  a: bad\n"
+        )
+
+    def test_success_reports_exemption_count_and_exit_code_0(self):
+        with (
+            mock.patch.object(gate, "collect_failures", return_value=[]),
+            mock.patch.object(
+                gate, "exemption_registry", return_value=[("DOC.md", 3, "tests")]
+            ),
+        ):
+            code, out, err = self._run([])
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        self.assertIn("doc claims OK (1 declared not-a-claim exemption(s))", out)
+        self.assertIn("DOC.md:3: exempt from the tests claim", out)
+
+    def test_success_with_no_exemptions_reports_a_zero_count(self):
+        with (
+            mock.patch.object(gate, "collect_failures", return_value=[]),
+            mock.patch.object(gate, "exemption_registry", return_value=[]),
+        ):
+            code, out, _ = self._run([])
+        self.assertEqual(code, 0)
+        self.assertIn("doc claims OK (0 declared not-a-claim exemption(s))", out)
+
+    def test_the_test_count_flag_is_parsed_and_forwarded(self):
+        with (
+            mock.patch.object(gate, "collect_failures", return_value=[]) as collect,
+            mock.patch.object(gate, "exemption_registry", return_value=[]),
+        ):
+            self._run(["--test-count", "6628"])
+        collect.assert_called_once_with(6628)
+
+    def test_without_the_flag_test_count_is_none(self):
+        with (
+            mock.patch.object(gate, "collect_failures", return_value=[]) as collect,
+            mock.patch.object(gate, "exemption_registry", return_value=[]),
+        ):
+            self._run([])
+        collect.assert_called_once_with(None)
+
+    def test_the_parser_declares_the_modules_docstring_and_flag_help(self):
+        """Pins argparse's own construction, not just its parsed effect.
+
+        A mutant that dropped `description=__doc__` or reworded the
+        --test-count help string would leave every exit-code test above
+        unaffected — main() never surfaces either string to a caller
+        that doesn't ask argparse directly. Exact-match, not assertIn: a
+        mutant that only wraps the help string in stray marker characters
+        still contains the true substring, so a full comparison is what
+        catches it.
+
+        `default` is asserted too, but is a documented-equivalent mutant
+        target, not a killed one: dropping the explicit `default=None`
+        kwarg changes nothing observable, because argparse already
+        defaults an unset optional argument with no `default` kwarg at
+        all to `None` (verified: `ArgumentParser().add_argument("--x",
+        type=int).default is None`) — the mutant is caught here only in
+        the sense that the assertion still holds, not that removing the
+        kwarg would make it fail.
+        """
+        with (
+            _spying_on_argparse_construction() as (captured, help_kwargs),
+            mock.patch.object(gate, "collect_failures", return_value=[]),
+            mock.patch.object(gate, "exemption_registry", return_value=[]),
+        ):
+            self._run([])
+
+        self.assertEqual(captured.get("description"), gate.__doc__)
+        self.assertEqual(
+            help_kwargs.get("help"),
+            "live test count (from `pytest --collect-only -q`); skipped when absent",
+        )
+        self.assertIsNone(help_kwargs.get("default"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #235.

Issue #235's acceptance criteria ("0 surviving non-equivalent mutants in
`scripts/check_doc_claims.py`") could not be honestly verified as-is against
current `main`. PR #294 (merged earlier the same day) split
`check_doc_claims.py` into `doc_claim_sources.py` / `doc_claim_scan.py` /
`doc_claim_structural.py`, moving #235's four named `canonical_*` functions
into `doc_claim_sources.py`. Re-measuring with a fresh scoped `mutmut` run
(`scripts/mutation_check.sh tests_py/scripts/test_check_doc_claims.py
scripts/check_doc_claims.py scripts/doc_claim_sources.py
scripts/doc_claim_scan.py scripts/doc_claim_structural.py`) showed every one
of `doc_claim_sources.py`'s 108 mutants as `no tests` — not `killed`, not
`survived`. mutmut simply could not attribute a single mutant to the tests
that exercise this module.

**Root cause**: `check_doc_claims.py`'s `import doc_claim_sources` is a bare
import, so every function's `__module__` is `"doc_claim_sources"`, not the
dotted `"scripts.doc_claim_sources"` mutmut's trampoline derives from the
file's path and expects. This is the exact defect class #294 already fixed
for `doc_claim_structural.py` (and filed as #292 for the modules it didn't
get to — `doc_claim_scan.py` and three of `doc_claim_structural.py`'s four
other functions, none of them named by #235, left to #292 as originally
scoped). `CanonicalSourceTests`'s existing `gate.*` calls DO exercise
`doc_claim_sources.py`'s code — real behavioural coverage — mutmut just
couldn't see it.

## Fix

Loaded `doc_claim_sources.py` under its own dotted name in the test file
(mirroring the existing `doc_claim_structural` precedent) and added
`CanonicalSourceDirectTests`, calling through that reference with an
explicit `read_fn` — the same pattern `CheckBadgeFloorDirectTests` already
established for `check_badge_floor`. This alone dropped
`doc_claim_sources.py`'s mutants from 108 "no tests" to 0 attributable, and
revealed **22 real survivors** underneath the attribution gap:

- Every message-content mutant (mutmut's string-literal "wrap in `XX`"
  mutation) survived because the existing assertions used `assertIn`, which
  still matches a message wrapped in stray marker characters. Switched to
  `assertEqual` on the full raised message throughout the new direct tests.
- `canonical_mechanism_count` and `canonical_version` had **no direct
  happy-path test at all** — added both.
- `canonical_reference_count`'s `split(marker, 1)` vs an `rsplit`/unlimited-
  split mutant needed a fixture where the two semantics actually disagree:
  a bibliography with **two real** `"## References"` headings, whose entry
  counts differ between split-on-first (2) and split-on-last (1). An
  earlier attempt (a heading merely quoted inside one entry) gave the same
  count either way and proved nothing — replaced.

`check_doc_claims.py`'s own `main()` — in scope since #235's criterion names
the whole file — had **zero test coverage** (37 "no tests" mutants; nothing
called `gate.main()` before this PR). Added `MainTests` covering every exit
code (0/1/2) and stream, `--test-count` parsing/forwarding, and the parser's
own construction (`description=__doc__`, the `--test-count` help string) via
a `_spying_on_argparse_construction` context manager, extracted as a shared
helper because inlining the spy machinery took the last test method to 47
lines (over this repo's 40-line method cap).

One remaining mutant — dropping `--test-count`'s explicit `default=None` —
is a **documented equivalent**, not killed: argparse already defaults an
unset optional argument with no `default` kwarg at all to `None`
(`ArgumentParser().add_argument("--x", type=int).default is None`), so the
mutation changes nothing observable. Rationale recorded both at the use
site (`scripts/check_doc_claims.py`) and in the killing test's own
docstring (§12.1 — no silent "ignore").

## Mutation testing (§12)

Scoped to `check_doc_claims.py` + all three #293-split modules, against
`tests_py/scripts/test_check_doc_claims.py`, mutmut invoked directly
against the shared `.venv` (`uv run` recreates an incomplete venv missing
`required_plugins` — issue #262/#283). Re-measured twice for stability
after the fix (identical both times):

```
final: 385 mutants — 384 killed, 0 no tests, 1 survived (documented equivalent)
$ python -m mutmut results | grep survived
    scripts.check_doc_claims.x_main__mutmut_8: survived   # documented equivalent, see above
```

Numbers updated post-rebase (see "Rebase reconciliation" below): the 88
"no tests" mutants this PR originally left in `doc_claim_scan.py` and
`doc_claim_structural.py`'s other functions (#292 scope, untouched here)
are gone from the count because sibling PR #305 — merged to `main`
independently, closing #292 — already fixed that same dotted-name
attribution gap for those two modules before this branch rebased onto it.
Re-run against current `main` + this PR's tests: 0 "no tests" remain
anywhere in scope, only the one pre-known documented-equivalent survivor.

## Rebase reconciliation (2026-07-30)

Rebased onto current `main` (`e275362`). One conflict, in
`tests_py/scripts/test_check_doc_claims.py`: sibling PR #304 (merged first,
also closing #235 under its own, narrower reading of the acceptance
criteria) added its own `CanonicalSourceDirectTests` covering the same four
`doc_claim_sources.py` functions, plus `DocClaimScanDirectTests` and
`StructuralDirectTests` for #292's remaining scope — none of which this
branch had. `scripts/check_doc_claims.py`'s `+5`-line comment (the
`default=None` equivalence rationale) merged automatically with no
conflict.

Resolved by merging, not picking a side:
- `DocClaimScanDirectTests` and `StructuralDirectTests` (main-only, #292
  scope): kept as-is — no equivalent in this branch.
- `MainTests` and its `_spying_on_argparse_construction` helper
  (this-branch-only): kept as-is — no equivalent on `main`.
- `CanonicalSourceDirectTests` (defined by BOTH sides, same class name,
  overlapping method names — a silent last-definition-wins shadow if left
  unmerged): merged into one class. Method-by-method, most pairs were
  behaviourally identical modulo fixture text (kept the version with the
  clearer docstring); one pair genuinely differed in strength —
  `test_catalogue_drifting_from_the_pinned_registry_test_is_an_error` used
  `assertIn` on `main`'s copy vs. exact `assertEqual` on this branch's —
  kept the exact-match version (this branch's), since it's strictly
  stronger and this PR's own docstring already argues for exact-match
  throughout the class. No assertion was dropped; the two main-only tests
  (`test_reference_count_is_the_number_of_entries_not_the_advertised_number`,
  `test_reference_entries_exclude_headings_and_separators`) are preserved.
- Confirmed no duplicate method names remain (`ast`-walked the file for
  same-class duplicate `FunctionDef` names — none) and no conflict markers
  remain anywhere in the tree.

Net effect measured against current `main`: `test_check_doc_claims.py` goes
from 1307 to 1485 lines (+178 net, after removing ~143 lines of duplicate
class body that a naive concatenation would have kept dead); no method
exceeds 40 lines. The file was already over the 300-line file cap on `main`
before this rebase (1307 lines) — per the coordinator's standing waiver,
this pre-existing §4.1 breach is tracked under #298 and is not a new issue;
growing it further here is the mandated result of preserving both PRs'
independently-reviewed test additions per the "keep both sets of assertions
unless subsumed" instruction, not discretionary scope creep. No method-size
(§4.2) debt was introduced or found.

## Completion Ledger

| Path / behavior | Test |
|---|---|
| `canonical_tool_counts` happy path (direct) | `CanonicalSourceDirectTests.test_tool_counts_come_from_the_catalogue` |
| `canonical_tool_counts` drift-vs-pinned-registry message (exact) | `test_catalogue_drifting_from_the_pinned_registry_test_is_an_error` |
| `canonical_tool_counts` arithmetic-mismatch message (exact) | `test_inconsistent_arithmetic_in_the_catalogue_is_an_error` |
| `canonical_tool_counts` missing-sentence message (exact) | `test_missing_standalone_total_sentence_is_an_error` |
| `canonical_tool_counts` missing-pinned-test message (exact) | `test_missing_pinned_registry_test_is_an_error` |
| `canonical_reference_count` split-on-FIRST-heading (not rsplit) | `test_the_first_references_heading_is_the_split_point` |
| `canonical_reference_count` missing-section message (exact) | `test_bibliography_without_a_references_section_is_an_error` |
| `canonical_reference_count` no-entries message (exact) | `test_a_references_section_with_no_entries_is_an_error` |
| `canonical_mechanism_count` happy path (direct, was missing) | `test_mechanism_count_is_read_from_the_bibliography_header` |
| `canonical_mechanism_count` undeclared message (exact) | `test_undeclared_mechanism_count_is_an_error` |
| `canonical_version` happy path (direct, was missing) | `test_version_comes_from_pyproject` |
| `canonical_version` missing-declaration message (exact) | `test_missing_version_declaration_is_an_error` |
| `main()`: ClaimError abort, exit 2 | `MainTests.test_a_claim_error_aborts_to_stderr_with_exit_code_2` |
| `main()`: failures report, exit 1 (exact stderr) | `test_failures_are_reported_to_stderr_with_exit_code_1` |
| `main()`: success + exemption count, exit 0 | `test_success_reports_exemption_count_and_exit_code_0`, `test_success_with_no_exemptions_reports_a_zero_count` |
| `main()`: `--test-count` parsed/forwarded | `test_the_test_count_flag_is_parsed_and_forwarded`, `test_without_the_flag_test_count_is_none` |
| `main()`: parser description + help text (exact) | `test_the_parser_declares_the_modules_docstring_and_flag_help` |
| `default=None` equivalence (argparse implicit default) | documented at use site + in the test above's docstring |

## Test plan (post-rebase, this PR's actual pushed head `27b7fdd`)

- [x] `pytest tests_py/scripts/test_check_doc_claims.py` — 110 passed, 14 subtests
- [x] `pytest tests_py/scripts/` (sibling scope) — 545 passed, 121 subtests
- [x] `ruff check .` (whole repo, not just touched files) — clean, no other seen defects
- [x] `ruff format --check` on touched files — clean
- [x] `python scripts/check_doc_claims.py` — `doc claims OK (1 declared not-a-claim exemption(s))`
- [x] `python scripts/generate_repo_badges.py --check` — `badges OK (4 checked)`; no doc/badge edits needed (monotone floor, #293)
- [x] Scoped mutation (mutmut invoked directly against a symlinked shared `.venv`, not `uv run`'s own incomplete sync — see above): 385 mutants, 384 killed, 0 no-tests, 1 documented equivalent, 0 unexplained survivors. Reproduced twice.
- [x] AST size gate on touched files: no function/method over 40 lines. `tests_py/scripts/test_check_doc_claims.py` is 1485 lines, over the 300-line §4.1 cap — pre-existing on `main` before this rebase (1307 lines already over cap); covered by the coordinator's standing waiver and tracked under #298, not a new issue (see "Rebase reconciliation").
- [x] No conflict markers anywhere in the tree; `.bestpractices.json` parses
- [x] `pyproject.toml`'s transient `[tool.mutmut]` scoping restored to its committed baseline after every scoped mutation run (diff against `origin/main...HEAD` for this file: empty)
- [x] `git diff origin/main...HEAD --stat`: `scripts/check_doc_claims.py` (+5), `tests_py/scripts/test_check_doc_claims.py` (+196/-13) — matches the merged, deduplicated content described above

Co-Authored-By: Claude <noreply@anthropic.com>
