### PR TITLE
fix(mutmut): kill 116 pre-existing survivors in refresh_mcp_toplist_badge.py

### DIFF
--- a/scripts/mcp_toplist_ranking.py
+++ b/scripts/mcp_toplist_ranking.py
@@ -1,0 +1,239 @@
+"""Acquire and validate our MCP Toplist rank: fetch, parse, and bounds-check.
+
+Split out of refresh_mcp_toplist_badge.py (issue #281): that file was 404
+lines, over this repo's 300-line file cap, once its mutation-survivor gap
+was closed with the tests the gap needed — mirroring issue #228's split of
+condensers.py for the identical reason. This module is the acquisition
+side (network fetch, two parser strategies, shared bounds validation);
+refresh_mcp_toplist_badge.py keeps the rendering and CLI orchestration and
+re-exports every name here, so no import path changes.
+
+Two extraction paths, tried in order by `resolve_ranking`:
+
+  1. /data/leaderboard.json — the structured export the site links from its
+     homepage. PROVISIONAL: as of 2026-07-28 this endpoint returns HTTP 503
+     (measured: 3/3 attempts, 8-14s each, browser UA). Its schema has
+     therefore never been observed; `parse_leaderboard` accepts only a
+     narrow set of documented candidate shapes and refuses anything else
+     rather than guessing, so path 2 takes over.
+
+  2. The server page's prose sentence "It ranks #N of M servers tracked",
+     verified present 2026-07-28 — the only construct on that page
+     carrying both numbers together.
+
+Both paths feed `validate`. A figure that fails validation is never
+trusted: the caller (main, in the sibling module) leaves the badge
+untouched rather than publish a wrong claim.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+SERVER_ID = "io.github.cdeust/hypermnesia-mcp"
+LEADERBOARD_URL = "https://mcptoplist.com/data/leaderboard.json"
+SERVER_PAGE_URL = "https://mcptoplist.com/server/io.github.cdeust%2Fhypermnesia-mcp"
+
+# source: measured 2026-07-28 — /data/leaderboard.json takes 8-14s to return
+# its 503, so a timeout below ~20s cannot distinguish "slow" from "broken".
+TIMEOUT_S = 45
+
+# The site renders this sentence in the server page body. Anchored on both
+# numbers so a reworded page fails the match instead of yielding a rank
+# paired with a stale or unrelated total.
+_PROSE_ANCHOR = re.compile(
+    r"ranks\s*#\s*([\d,]+)\s*of\s*([\d,]+)\s*servers\s*tracked",
+    re.IGNORECASE,
+)
+
+# Not a tuned threshold: it is the resolution of the "{:.1f}" format the
+# tier text itself uses. A percentile finer than this rounds to "Top 0.0%",
+# which reads as a bug rather than as a top-of-field result.
+_MIN_PRINTABLE_PCT = 0.1
+
+
+class UpstreamError(RuntimeError):
+    """Upstream data could not be fetched or trusted."""
+
+
+@dataclass(frozen=True)
+class Ranking:
+    """A validated rank-out-of-total, and where it came from.
+
+    Data only — deliberately no methods. mutmut's mutation generator
+    categorically excludes the body of any `@dataclass`-decorated class (it
+    must, since copying a decorated class for the trampoline setup can
+    re-run the decorator and its side effects), so logic placed on methods
+    here would carry zero mutation coverage no matter how the test loader
+    names the module — confirmed empirically: 298 mutants for this file, 0
+    attributed to `percentile`/`tier_text` while they were methods (same
+    defect class as `RepoBadge` in scripts/generate_repo_badges.py and
+    `ConstraintSet` in scripts/pip_constraint_sets.py, issue #262).
+    `ranking_percentile`/`ranking_tier_text` below carry the same logic as
+    free functions instead.
+    """
+
+    rank: int
+    total: int
+    source: str
+
+
+def ranking_percentile(ranking: Ranking) -> float:
+    """Share of the field this server sits within, to one decimal."""
+    return round(ranking.rank / ranking.total * 100, 1)
+
+
+def ranking_tier_text(ranking: Ranking) -> str:
+    pct = ranking_percentile(ranking)
+    # Ranks near the very top round to 0.0%, which reads as an error
+    # rather than as an achievement. Report the bound instead.
+    if pct < _MIN_PRINTABLE_PCT:
+        return f"Top <{_MIN_PRINTABLE_PCT}%"
+    return f"Top {pct:.1f}%"
+
+
+def validate(rank: object, total: object, source: str) -> Ranking:
+    """Coerce and bounds-check a candidate figure, or raise.
+
+    Guards the arithmetic in Ranking.percentile (total of zero) and the
+    semantics of the claim (a rank outside the field is not a rank).
+    """
+    try:
+        rank_i = int(str(rank).replace(",", "").strip())
+        total_i = int(str(total).replace(",", "").strip())
+    except (TypeError, ValueError) as exc:
+        raise UpstreamError(
+            f"{source}: non-numeric rank/total: {rank!r}/{total!r}"
+        ) from exc
+    if rank_i < 1:
+        raise UpstreamError(f"{source}: rank {rank_i} is not a positive position")
+    if total_i < 1:
+        raise UpstreamError(f"{source}: total {total_i} is not a positive field size")
+    if rank_i > total_i:
+        raise UpstreamError(f"{source}: rank {rank_i} exceeds field size {total_i}")
+    return Ranking(rank=rank_i, total=total_i, source=source)
+
+
+def _leaderboard_total(doc: object, entries: list) -> int:
+    """The field size the document declares, or the entry count if silent."""
+    if isinstance(doc, dict):
+        for key in ("total", "totalServers", "count"):
+            if isinstance(doc.get(key), int):
+                return doc[key]
+    return len(entries)
+
+
+def _find_leaderboard_entry(entries: list, server_id: str) -> dict | None:
+    """The entry naming server_id under any of the documented identity keys."""
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        identity = next(
+            (entry[k] for k in ("id", "name", "serverId", "slug") if k in entry),
+            None,
+        )
+        if identity == server_id:
+            return entry
+    return None
+
+
+def parse_leaderboard(payload: bytes, server_id: str = SERVER_ID) -> Ranking:
+    """Extract our figure from the structured export.
+
+    PROVISIONAL — see module docstring. Accepts only shapes explicitly
+    listed here; an unrecognised document raises rather than guessing, so
+    the caller falls back to a path whose format has been observed.
+    """
+    try:
+        # "UTF-8" is equivalent to "utf-8" (codecs.lookup is
+        # case-insensitive) — issue #281, same class as
+        # generate_repo_badges.py's own utf-8 read.
+        doc = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpstreamError(f"leaderboard.json: not valid JSON: {exc}") from exc
+
+    entries = doc.get("servers") if isinstance(doc, dict) else doc
+    if not isinstance(entries, list) or not entries:
+        raise UpstreamError("leaderboard.json: no server list in document")
+    total = _leaderboard_total(doc, entries)
+
+    entry = _find_leaderboard_entry(entries, server_id)
+    if entry is None:
+        raise UpstreamError(
+            f"leaderboard.json: {server_id} not present in {len(entries)} entries"
+        )
+    rank = next(
+        (entry[k] for k in ("rank", "position", "place") if k in entry),
+        None,
+    )
+    if rank is None:
+        raise UpstreamError(f"leaderboard.json: entry for {server_id} carries no rank")
+    return validate(rank, total, "leaderboard.json")
+
+
+def parse_server_page(html: str) -> Ranking:
+    """Extract our figure from the rendered server page."""
+    match = _PROSE_ANCHOR.search(html)
+    if match is None:
+        raise UpstreamError(
+            "server page: the 'ranks #N of M servers tracked' sentence is absent "
+            "— the page was reworded and this parser needs updating"
+        )
+    return validate(match.group(1), match.group(2), "server page")
+
+
+def fetch(url: str, opener: Callable = urllib.request.urlopen) -> bytes:
+    """Retrieve a URL, or raise UpstreamError naming the failure."""
+    # Header KEY casing is equivalent here: Request normalises every header
+    # key via str.capitalize() before storing it, so "User-Agent"/
+    # "user-agent"/"USER-AGENT" (and "Accept"'s equivalent) are
+    # indistinguishable at the wire — issue #281.
+    request = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "cortex-badge-refresh (+https://github.com/cdeust/Cortex)",
+            "Accept": "application/json, text/html;q=0.9",
+        },
+    )
+    try:
+        with opener(request, timeout=TIMEOUT_S) as response:
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        raise UpstreamError(f"{url}: HTTP {exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise UpstreamError(f"{url}: unreachable: {exc}") from exc
+
+
+def resolve_ranking(
+    fetch_fn: Callable[[str], bytes] = fetch,
+) -> tuple[Ranking, list[str]]:
+    """Try each extraction path in order; return the first trusted figure.
+
+    Returns the figure and the notices raised along the way, so a silent
+    fallback is impossible: the caller reports every path that failed even
+    when a later one succeeded.
+    """
+    notices: list[str] = []
+    # "UTF-8" below is equivalent to "utf-8" (codecs.lookup is
+    # case-insensitive) — same class as parse_leaderboard's decode, #281.
+    attempts: Iterable[tuple[str, Callable[[bytes], Ranking]]] = (
+        (LEADERBOARD_URL, parse_leaderboard),
+        (
+            SERVER_PAGE_URL,
+            lambda raw: parse_server_page(raw.decode("utf-8", "replace")),
+        ),
+    )
+    for url, parser in attempts:
+        try:
+            return parser(fetch_fn(url)), notices
+        except UpstreamError as exc:
+            notices.append(str(exc))
+    raise UpstreamError(
+        "no trusted figure from any source; badge left untouched:\n  - "
+        + "\n  - ".join(notices)
+    )

--- a/scripts/refresh_mcp_toplist_badge.py
+++ b/scripts/refresh_mcp_toplist_badge.py
@@ -7,25 +7,13 @@ choice is that it cannot self-update: the date it carries is part of the
 claim, and goes stale by INACTION. Inaction never opens a PR, so this
 script exists to be run on a cron and propose the refresh.
 
-Two extraction paths, tried in order:
-
-  1. /data/leaderboard.json — the structured export the site links from its
-     homepage. PROVISIONAL: as of 2026-07-28 this endpoint returns HTTP 503
-     (measured: 3/3 attempts, 8-14s each, browser UA, so a server-side
-     generation timeout rather than UA gating or rate limiting). Its schema
-     has therefore never been observed. The parser below accepts a narrow
-     set of documented candidate shapes under strict validation; anything
-     else is refused rather than guessed at, and path 2 takes over.
-
-  2. The server page's prose sentence "It ranks #N of M servers tracked",
-     verified present 2026-07-28. This is the ONLY construct on that page
-     carrying both numbers — the <title>, og/twitter meta tags and JSON-LD
-     blocks all carry the rank without the total, so none of them can yield
-     a percentile on their own.
-
-Both paths feed the same validator. A figure that fails validation is never
-written: the script exits non-zero and leaves the badge untouched. A wrong
-badge is worse than a stale one, and far worse than a red run.
+The data acquisition (fetch, the two parser strategies, and shared
+validation) lives in the sibling module mcp_toplist_ranking.py — see its
+docstring for the two extraction paths and their fallback order. This
+file re-exports every one of its public names (`import X as X`, mirroring
+condensers.py's issue #228 facade), so every existing import path and
+test-patch target keeps resolving unchanged; the split is an internal
+reorganization; this file's own job is rendering the SVG and the CLI.
 
 Usage:
     python3 scripts/refresh_mcp_toplist_badge.py           # rewrite if changed
@@ -35,48 +23,34 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
-import re
 import sys
-import urllib.error
-import urllib.request
-from dataclasses import dataclass
-from datetime import date, timezone, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Callable, Iterable
 
-# badge_render.py is a stdlib-only sibling module (the shields-style SVG
-# geometry, shared with generate_repo_badges.py). Path-based import for the
-# same reason the launcher family path-imports its siblings: resolves
-# identically whether this file is run as a script (script dir already on
-# sys.path) or loaded directly via importlib.util.spec_from_file_location
-# from a test.
+# badge_render.py and mcp_toplist_ranking.py are stdlib-only sibling
+# modules. Path-based import for the same reason the launcher family
+# path-imports its siblings: resolves identically whether this file is run
+# as a script (script dir already on sys.path) or loaded directly via
+# importlib.util.spec_from_file_location from a test.
 _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 import badge_render  # noqa: E402
+from mcp_toplist_ranking import LEADERBOARD_URL as LEADERBOARD_URL  # noqa: E402
+from mcp_toplist_ranking import SERVER_ID as SERVER_ID  # noqa: E402
+from mcp_toplist_ranking import SERVER_PAGE_URL as SERVER_PAGE_URL  # noqa: E402
+from mcp_toplist_ranking import TIMEOUT_S as TIMEOUT_S  # noqa: E402
+from mcp_toplist_ranking import Ranking as Ranking  # noqa: E402
+from mcp_toplist_ranking import UpstreamError as UpstreamError  # noqa: E402
+from mcp_toplist_ranking import fetch as fetch  # noqa: E402
+from mcp_toplist_ranking import parse_leaderboard as parse_leaderboard  # noqa: E402
+from mcp_toplist_ranking import parse_server_page as parse_server_page  # noqa: E402
+from mcp_toplist_ranking import ranking_percentile as ranking_percentile  # noqa: E402
+from mcp_toplist_ranking import ranking_tier_text as ranking_tier_text  # noqa: E402
+from mcp_toplist_ranking import resolve_ranking as resolve_ranking  # noqa: E402
+from mcp_toplist_ranking import validate as validate  # noqa: E402
 
-SERVER_ID = "io.github.cdeust/hypermnesia-mcp"
-LEADERBOARD_URL = "https://mcptoplist.com/data/leaderboard.json"
-SERVER_PAGE_URL = "https://mcptoplist.com/server/io.github.cdeust%2Fhypermnesia-mcp"
 BADGE_PATH = Path("assets/badge-mcp-toplist.svg")
-
-# source: measured 2026-07-28 — /data/leaderboard.json takes 8-14s to return
-# its 503, so a timeout below ~20s cannot distinguish "slow" from "broken".
-TIMEOUT_S = 45
-
-# The site renders this sentence in the server page body. Anchored on both
-# numbers so a reworded page fails the match instead of yielding a rank
-# paired with a stale or unrelated total.
-_PROSE_ANCHOR = re.compile(
-    r"ranks\s*#\s*([\d,]+)\s*of\s*([\d,]+)\s*servers\s*tracked",
-    re.IGNORECASE,
-)
-
-# Not a tuned threshold: it is the resolution of the "{:.1f}" format the
-# tier text itself uses. A percentile finer than this rounds to "Top 0.0%",
-# which reads as a bug rather than as a top-of-field result.
-_MIN_PRINTABLE_PCT = 0.1
 
 # The left panel carries the fixed string "MCP Toplist", so unlike the right
 # panel its geometry never varies with the data. Both measured 2026-07-28 by
@@ -100,128 +74,6 @@ _MONTHS = (
     "Nov",
     "Dec",
 )
-
-
-class UpstreamError(RuntimeError):
-    """Upstream data could not be fetched or trusted."""
-
-
-@dataclass(frozen=True)
-class Ranking:
-    """A validated rank-out-of-total, and where it came from.
-
-    Data only — deliberately no methods. mutmut's mutation generator
-    categorically excludes the body of any `@dataclass`-decorated class (it
-    must, since copying a decorated class for the trampoline setup can
-    re-run the decorator and its side effects), so logic placed on methods
-    here would carry zero mutation coverage no matter how the test loader
-    names the module — confirmed empirically: 298 mutants for this file, 0
-    attributed to `percentile`/`tier_text` while they were methods (same
-    defect class as `RepoBadge` in scripts/generate_repo_badges.py and
-    `ConstraintSet` in scripts/pip_constraint_sets.py, issue #262).
-    `ranking_percentile`/`ranking_tier_text` below carry the same logic as
-    free functions instead.
-    """
-
-    rank: int
-    total: int
-    source: str
-
-
-def ranking_percentile(ranking: Ranking) -> float:
-    """Share of the field this server sits within, to one decimal."""
-    return round(ranking.rank / ranking.total * 100, 1)
-
-
-def ranking_tier_text(ranking: Ranking) -> str:
-    pct = ranking_percentile(ranking)
-    # Ranks near the very top round to 0.0%, which reads as an error
-    # rather than as an achievement. Report the bound instead.
-    if pct < _MIN_PRINTABLE_PCT:
-        return f"Top <{_MIN_PRINTABLE_PCT}%"
-    return f"Top {pct:.1f}%"
-
-
-def validate(rank: object, total: object, source: str) -> Ranking:
-    """Coerce and bounds-check a candidate figure, or raise.
-
-    Guards the arithmetic in Ranking.percentile (total of zero) and the
-    semantics of the claim (a rank outside the field is not a rank).
-    """
-    try:
-        rank_i = int(str(rank).replace(",", "").strip())
-        total_i = int(str(total).replace(",", "").strip())
-    except (TypeError, ValueError) as exc:
-        raise UpstreamError(
-            f"{source}: non-numeric rank/total: {rank!r}/{total!r}"
-        ) from exc
-    if rank_i < 1:
-        raise UpstreamError(f"{source}: rank {rank_i} is not a positive position")
-    if total_i < 1:
-        raise UpstreamError(f"{source}: total {total_i} is not a positive field size")
-    if rank_i > total_i:
-        raise UpstreamError(f"{source}: rank {rank_i} exceeds field size {total_i}")
-    return Ranking(rank=rank_i, total=total_i, source=source)
-
-
-def parse_leaderboard(payload: bytes, server_id: str = SERVER_ID) -> Ranking:
-    """Extract our figure from the structured export.
-
-    PROVISIONAL — see module docstring. Accepts only shapes explicitly
-    listed here; an unrecognised document raises rather than guessing, so
-    the caller falls back to a path whose format has been observed.
-    """
-    try:
-        doc = json.loads(payload.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise UpstreamError(f"leaderboard.json: not valid JSON: {exc}") from exc
-
-    entries = doc.get("servers") if isinstance(doc, dict) else doc
-    if not isinstance(entries, list) or not entries:
-        raise UpstreamError("leaderboard.json: no server list in document")
-
-    total = None
-    if isinstance(doc, dict):
-        for key in ("total", "totalServers", "count"):
-            if isinstance(doc.get(key), int):
-                total = doc[key]
-                break
-    if total is None:
-        total = len(entries)
-
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        identity = next(
-            (entry[k] for k in ("id", "name", "serverId", "slug") if k in entry),
-            None,
-        )
-        if identity != server_id:
-            continue
-        rank = next(
-            (entry[k] for k in ("rank", "position", "place") if k in entry),
-            None,
-        )
-        if rank is None:
-            raise UpstreamError(
-                f"leaderboard.json: entry for {server_id} carries no rank"
-            )
-        return validate(rank, total, "leaderboard.json")
-
-    raise UpstreamError(
-        f"leaderboard.json: {server_id} not present in {len(entries)} entries"
-    )
-
-
-def parse_server_page(html: str) -> Ranking:
-    """Extract our figure from the rendered server page."""
-    match = _PROSE_ANCHOR.search(html)
-    if match is None:
-        raise UpstreamError(
-            "server page: the 'ranks #N of M servers tracked' sentence is absent "
-            "— the page was reworded and this parser needs updating"
-        )
-    return validate(match.group(1), match.group(2), "server page")
 
 
 def _provenance_comment(ranking: Ranking, as_of: date) -> list[str]:
@@ -285,57 +137,11 @@ def render_badge(ranking: Ranking, as_of: date) -> str:
     return badge_render.render(spec)
 
 
-def fetch(url: str, opener: Callable = urllib.request.urlopen) -> bytes:
-    """Retrieve a URL, or raise UpstreamError naming the failure."""
-    request = urllib.request.Request(
-        url,
-        headers={
-            "User-Agent": "cortex-badge-refresh (+https://github.com/cdeust/Cortex)",
-            "Accept": "application/json, text/html;q=0.9",
-        },
-    )
-    try:
-        with opener(request, timeout=TIMEOUT_S) as response:
-            return response.read()
-    except urllib.error.HTTPError as exc:
-        raise UpstreamError(f"{url}: HTTP {exc.code}") from exc
-    except (urllib.error.URLError, TimeoutError, OSError) as exc:
-        raise UpstreamError(f"{url}: unreachable: {exc}") from exc
-
-
-def resolve_ranking(
-    fetch_fn: Callable[[str], bytes] = fetch,
-) -> tuple[Ranking, list[str]]:
-    """Try each extraction path in order; return the first trusted figure.
-
-    Returns the figure and the notices raised along the way, so a silent
-    fallback is impossible: the caller reports every path that failed even
-    when a later one succeeded.
-    """
-    notices: list[str] = []
-    attempts: Iterable[tuple[str, Callable[[bytes], Ranking]]] = (
-        (LEADERBOARD_URL, parse_leaderboard),
-        (
-            SERVER_PAGE_URL,
-            lambda raw: parse_server_page(raw.decode("utf-8", "replace")),
-        ),
-    )
-    for url, parser in attempts:
-        try:
-            return parser(fetch_fn(url)), notices
-        except UpstreamError as exc:
-            notices.append(str(exc))
-    raise UpstreamError(
-        "no trusted figure from any source; badge left untouched:\n  - "
-        + "\n  - ".join(notices)
-    )
-
-
 def _today() -> date:
     return datetime.now(timezone.utc).date()
 
 
-def main(argv: list[str] | None = None) -> int:
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(
         "--check",
@@ -343,7 +149,19 @@ def main(argv: list[str] | None = None) -> int:
         help="exit 1 if the badge is out of date; never write",
     )
     parser.add_argument("--badge", type=Path, default=BADGE_PATH)
-    args = parser.parse_args(argv)
+    return parser
+
+
+def _ranking_summary(ranking: Ranking) -> str:
+    """The one-line summary shared by the current/updated messages."""
+    return (
+        f"{ranking_tier_text(ranking)} "
+        f"(#{ranking.rank:,} of {ranking.total:,}, via {ranking.source})"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
 
     try:
         ranking, notices = resolve_ranking()
@@ -358,10 +176,7 @@ def main(argv: list[str] | None = None) -> int:
     current = args.badge.read_text() if args.badge.exists() else None
 
     if current == rendered:
-        print(
-            f"current: {ranking_tier_text(ranking)} "
-            f"(#{ranking.rank:,} of {ranking.total:,}, via {ranking.source})"
-        )
+        print(f"current: {_ranking_summary(ranking)}")
         return 0
 
     if args.check:
@@ -373,10 +188,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     args.badge.write_text(rendered)
-    print(
-        f"updated: {ranking_tier_text(ranking)} "
-        f"(#{ranking.rank:,} of {ranking.total:,}, via {ranking.source})"
-    )
+    print(f"updated: {_ranking_summary(ranking)}")
     return 0
 
 

--- a/tests_py/scripts/test_refresh_mcp_toplist_badge.py
+++ b/tests_py/scripts/test_refresh_mcp_toplist_badge.py
@@ -16,6 +16,7 @@ import importlib.util
 import io
 import json
 import os
+import re
 import sys
 import unittest
 import urllib.error
@@ -25,12 +26,27 @@ from tempfile import TemporaryDirectory
 from unittest import mock
 from xml.etree import ElementTree
 
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
 # Dotted to match the path-derived name mutmut keys mutant trampolines on
-# ("scripts.refresh_mcp_toplist_badge.*") — a bare module name makes every
-# mutant look unreached to a scoped mutation run (issue #262).
+# ("scripts.<module>.*") — a bare module name makes every mutant look
+# unreached to a scoped mutation run (issue #262). refresh_mcp_toplist_badge
+# re-exports mcp_toplist_ranking's names (issue #281 split) via a plain
+# `import mcp_toplist_ranking`, so that plain import must ALSO resolve to a
+# module whose __name__ is the dotted "scripts.mcp_toplist_ranking" — hence
+# registering it under BOTH the dotted key (what mutmut's trampoline keys
+# hits on) and the bare key (what the plain `import` statement looks up in
+# sys.modules) before badge's own exec triggers that import.
+_ranking_spec = importlib.util.spec_from_file_location(
+    "scripts.mcp_toplist_ranking", _SCRIPTS_DIR / "mcp_toplist_ranking.py"
+)
+mcp_toplist_ranking = importlib.util.module_from_spec(_ranking_spec)
+sys.modules[_ranking_spec.name] = mcp_toplist_ranking
+sys.modules["mcp_toplist_ranking"] = mcp_toplist_ranking
+_ranking_spec.loader.exec_module(mcp_toplist_ranking)
+
 _spec = importlib.util.spec_from_file_location(
-    "scripts.refresh_mcp_toplist_badge",
-    Path(__file__).resolve().parents[2] / "scripts" / "refresh_mcp_toplist_badge.py",
+    "scripts.refresh_mcp_toplist_badge", _SCRIPTS_DIR / "refresh_mcp_toplist_badge.py"
 )
 badge = importlib.util.module_from_spec(_spec)
 # Register before exec: @dataclass resolves its owning module through
@@ -101,6 +117,46 @@ class TestValidate(unittest.TestCase):
 
     def test_accepts_rank_equal_to_field_size(self):
         self.assertEqual(badge.validate(5, 5, "t").rank, 5)
+
+    def test_strips_thousands_separators_from_rank_too(self):
+        # Both rank and total go through the same strip/replace; a prior
+        # gap only ever exercised it on total (mutmut mutant_8/9: replacing
+        # the "," search or "" replacement on the RANK line survived).
+        self.assertEqual(badge.validate("1,234", 5000, "t").rank, 1234)
+
+    def test_accepts_a_field_of_exactly_one(self):
+        # total_i < 1 is the guard; total==1 is the boundary just inside it
+        # (mutant_23/24 loosen it to <=1 / <2, which would wrongly reject
+        # the single-server field).
+        r = badge.validate(1, 1, "t")
+        self.assertEqual((r.rank, r.total), (1, 1))
+
+    def test_non_numeric_message_names_the_offending_values(self):
+        with self.assertRaises(badge.UpstreamError) as ctx:
+            badge.validate("nine", "81,919", "src-x")
+        self.assertEqual(
+            str(ctx.exception),
+            "src-x: non-numeric rank/total: 'nine'/'81,919'",
+        )
+
+    def test_zero_rank_message_names_the_offending_rank(self):
+        with self.assertRaises(badge.UpstreamError) as ctx:
+            badge.validate(0, 81919, "src-x")
+        self.assertEqual(str(ctx.exception), "src-x: rank 0 is not a positive position")
+
+    def test_zero_total_message_names_the_offending_total(self):
+        with self.assertRaises(badge.UpstreamError) as ctx:
+            badge.validate(1, 0, "src-x")
+        self.assertEqual(
+            str(ctx.exception), "src-x: total 0 is not a positive field size"
+        )
+
+    def test_rank_beyond_field_message_names_both_numbers(self):
+        with self.assertRaises(badge.UpstreamError) as ctx:
+            badge.validate(81920, 81919, "src-x")
+        self.assertEqual(
+            str(ctx.exception), "src-x: rank 81920 exceeds field size 81919"
+        )
 
 
 class TestPercentileAndTier(unittest.TestCase):
@@ -234,6 +290,77 @@ class TestParseLeaderboard(unittest.TestCase):
         with self.assertRaises(badge.UpstreamError):
             badge.parse_leaderboard(self._payload(doc))
 
+    def test_invalid_json_message_names_the_decode_error(self):
+        with self.assertRaises(badge.UpstreamError) as ctx:
+            badge.parse_leaderboard(b"<html>503</html>")
+        self.assertTrue(
+            str(ctx.exception).startswith("leaderboard.json: not valid JSON: ")
+        )
+
+    def test_empty_list_message_is_the_no_server_list_notice(self):
+        # Also pins the `or`/`and` branch (mutant_11): with `and`, an empty
+        # bare list would fall through to the LATER "not present in N
+        # entries" raise instead of this one — same exception type, wrong
+        # message, and this exact-text check is the only thing that tells
+        # them apart.
+        with self.assertRaises(badge.UpstreamError) as ctx:
+            badge.parse_leaderboard(b"[]")
+        self.assertEqual(
+            str(ctx.exception), "leaderboard.json: no server list in document"
+        )
+
+    def test_total_falls_back_to_the_totalservers_key(self):
+        doc = {
+            "totalServers": 500,
+            "servers": [{"id": badge.SERVER_ID, "rank": 1}],
+        }
+        self.assertEqual(badge.parse_leaderboard(self._payload(doc)).total, 500)
+
+    def test_total_falls_back_to_the_count_key(self):
+        doc = {"count": 300, "servers": [{"id": badge.SERVER_ID, "rank": 1}]}
+        self.assertEqual(badge.parse_leaderboard(self._payload(doc)).total, 300)
+
+    def test_entry_missing_every_identity_key_is_skipped_not_crashed_on(self):
+        # No default arg on the `next(...)` call over identity keys means a
+        # dict entry naming none of them raises StopIteration instead of
+        # yielding None — a crash, not a skip (mutant_34).
+        doc = {
+            "total": 10,
+            "servers": [{"stars": 5}, {"id": badge.SERVER_ID, "rank": 7}],
+        }
+        r = badge.parse_leaderboard(self._payload(doc))
+        self.assertEqual(r.rank, 7)
+
+    def test_name_key_alone_identifies_the_entry(self):
+        doc = {"total": 10, "servers": [{"name": badge.SERVER_ID, "rank": 4}]}
+        self.assertEqual(badge.parse_leaderboard(self._payload(doc)).rank, 4)
+
+    def test_serverid_key_alone_identifies_the_entry(self):
+        doc = {"total": 10, "servers": [{"serverId": badge.SERVER_ID, "rank": 8}]}
+        self.assertEqual(badge.parse_leaderboard(self._payload(doc)).rank, 8)
+
+    def test_place_key_alone_supplies_the_rank(self):
+        doc = {"total": 10, "servers": [{"id": badge.SERVER_ID, "place": 6}]}
+        self.assertEqual(badge.parse_leaderboard(self._payload(doc)).rank, 6)
+
+    def test_missing_rank_message_names_the_server(self):
+        doc = {"servers": [{"id": badge.SERVER_ID, "stars": 68}]}
+        with self.assertRaises(badge.UpstreamError) as ctx:
+            badge.parse_leaderboard(self._payload(doc))
+        self.assertEqual(
+            str(ctx.exception),
+            f"leaderboard.json: entry for {badge.SERVER_ID} carries no rank",
+        )
+
+    def test_absent_server_message_names_it_and_the_entry_count(self):
+        doc = {"servers": [{"id": "someone/else", "rank": 1}]}
+        with self.assertRaises(badge.UpstreamError) as ctx:
+            badge.parse_leaderboard(self._payload(doc))
+        self.assertEqual(
+            str(ctx.exception),
+            f"leaderboard.json: {badge.SERVER_ID} not present in 1 entries",
+        )
+
 
 class TestParseServerPage(unittest.TestCase):
     def test_extracts_both_numbers_from_the_live_sentence(self):
@@ -255,57 +382,45 @@ class TestParseServerPage(unittest.TestCase):
         with self.assertRaises(badge.UpstreamError):
             badge.parse_server_page("")
 
+    def test_absent_sentence_message_is_exact(self):
+        with self.assertRaises(badge.UpstreamError) as ctx:
+            badge.parse_server_page("")
+        self.assertEqual(
+            str(ctx.exception),
+            "server page: the 'ranks #N of M servers tracked' sentence is "
+            "absent — the page was reworded and this parser needs updating",
+        )
+
     def test_match_is_case_insensitive_and_whitespace_tolerant(self):
         r = badge.parse_server_page("It  Ranks  # 12  of  100  Servers  Tracked here")
         self.assertEqual((r.rank, r.total), (12, 100))
 
 
 class TestProvenanceComment(unittest.TestCase):
-    # Each returned list ITEM is a plain literal (or, for the pct line, an
-    # f-string whose literal chunk is broken up by the interpolated value
-    # — see the module-level note in TestParseLeaderboard on why that
-    # distinction matters). Checking exact LIST-ITEM membership rather
-    # than substring-in-joined-text is required throughout this class: a
-    # mutant that wraps a whole line in mutmut's "XX...XX" string-content
-    # marker still contains the original text as a contiguous substring
-    # once joined, so only exact-item equality — not `assertIn` on the
-    # joined blob — distinguishes it.
-    def _lines(self):
-        r = badge.validate(LIVE_RANK, LIVE_TOTAL, "server page")
-        return badge._provenance_comment(r, date(2026, 7, 28))
-
-    def test_percentage_arithmetic_is_pinned(self):
-        # 964 / 81919 * 100 = 1.1767..., .2f -> "1.18" — deliberately not
-        # the rounded "1.2" ranking_tier_text uses, so this pins the
-        # arithmetic operator (mutmut_2/_3/_4: /, *, and the *101 typo)
-        # independently of the tier-text rounding.
-        self.assertTrue(any("1.18%" in line for line in self._lines()))
-
-    def test_fixed_wording_is_pinned(self):
-        lines = self._lines()
-        self.assertIn(
-            "  <!-- GENERATED by scripts/refresh_mcp_toplist_badge.py"
-            " — do not hand-edit.",
+    def test_exact_content_pins_every_line_and_the_arithmetic(self):
+        # A pure-text mutation (case, XX-wrapping) or an arithmetic one
+        # (rank/total*100 -> /100, *100, *101) only shows up if every line
+        # AND the computed percentage are pinned together — a substring
+        # check on any one line leaves the others, and the arithmetic,
+        # unpinned (mutants 2-19 of this function).
+        ranking = badge.validate(LIVE_RANK, LIVE_TOTAL, "server page")
+        lines = badge._provenance_comment(ranking, date(2026, 7, 28))
+        self.assertEqual(
             lines,
-        )
-        self.assertIn(
-            "       Upstream's score is a popularity and activity signal,"
-            " not a quality",
-            lines,
-        )
-        self.assertIn(
-            "       assessment, and ~25% of its weighting is undisclosed"
-            " — so this badge",
-            lines,
-        )
-        # "says Cortex is RANKED..." and " it IS. -->" are adjacent string
-        # literals in the source (implicit concatenation, no operator) —
-        # ONE list item, not two — confirmed by printing the real return
-        # value rather than assumed from reading the source layout.
-        self.assertIn(
-            "       says Cortex is RANKED in this tier by MCP Toplist,"
-            " never that it IS. -->",
-            lines,
+            [
+                "  <!-- GENERATED by scripts/refresh_mcp_toplist_badge.py"
+                " — do not hand-edit.",
+                "       Source: server page reported rank 964 of 81,919",
+                "       tracked MCP servers, read 2026-07-28",
+                '       (964/81919 = 1.18% -> "Top 1.2%").',
+                f"       Verify: {badge.SERVER_PAGE_URL}",
+                "       Upstream's score is a popularity and activity signal,"
+                " not a quality",
+                "       assessment, and ~25% of its weighting is undisclosed"
+                " — so this badge",
+                "       says Cortex is RANKED in this tier by MCP Toplist,"
+                " never that it IS. -->",
+            ],
         )
 
 
@@ -408,27 +523,45 @@ class TestRenderBadge(unittest.TestCase):
         self.assertEqual(label_face.get("x"), "54")
         self.assertEqual(message_face.get("fill"), "#fff")
 
-    def test_icon_fragments_are_pinned(self):
-        # The icon tuple's lines are spliced into the SVG verbatim (no
-        # f-string template around them, unlike label/message text), so a
-        # mutant that wraps a whole line in mutmut's "XX...XX" string-
-        # content marker still contains the ORIGINAL text as a substring
-        # (e.g. 'XX  <g fill="#f1eee7">XX' still contains '<g fill=...>').
-        # Exact-line membership (not substring search) is what actually
-        # distinguishes the mutated line from the real one.
-        lines = self._svg().splitlines()
-        self.assertIn('  <g fill="#f1eee7">', lines)
-        self.assertIn('    <rect x="7" y="10" width="2.6" height="5" rx="0.6"/>', lines)
+    def test_label_panel_carries_the_exact_text_color_and_position(self):
+        svg = self._svg()
+        self.assertIn(">MCP Toplist<", svg)
+        self.assertIn('x="54"', svg)
+        self.assertIn('textLength="64"', svg)
+
+    def test_label_and_message_text_fills_are_pinned_exactly(self):
+        # A substring check on "#fff" alone is a false floor here: the
+        # badge's own clip-path background rect is ALSO fill="#fff", so it
+        # is present regardless of what the message text's own fill is
+        # (mutant_32/45/46 all survived a plain `assertIn('fill="#fff"')`
+        # for exactly this reason). Anchoring on the two `y="14"` face runs
+        # (label, then message) pins both text colors precisely instead.
+        fills = re.findall(r'y="14" fill="([^"]*)"', self._svg())
+        self.assertEqual(fills, ["#f8f7f2", "#fff"])
+
+    def test_icon_bars_render_verbatim_at_their_measured_coordinates(self):
+        # Exact per-LINE membership, not substring-in-string: mutmut's
+        # "XXtextXX" wrap mutation embeds the original text as a substring
+        # of the corrupted one, so `assertIn(original, svg)` is satisfied by
+        # both the real and the wrapped-corrupt output (mutant_52/54/56/58
+        # all survived a substring check for exactly this reason).
+        svg_lines = self._svg().splitlines()
+        self.assertIn('  <g fill="#f1eee7">', svg_lines)
         self.assertIn(
-            '    <rect x="11.2" y="6.5" width="2.6" height="8.5" rx="0.6"/>', lines
+            '    <rect x="7" y="10" width="2.6" height="5" rx="0.6"/>', svg_lines
         )
         self.assertIn(
-            '    <rect x="15.4" y="8.4" width="2.6" height="6.6" rx="0.6"/>', lines
+            '    <rect x="11.2" y="6.5" width="2.6" height="8.5" rx="0.6"/>',
+            svg_lines,
         )
-        # Three "  </g>" lines exist when the icon renders (clip-path
-        # group, icon group, font group); a mutant that drops or mangles
-        # the icon's own closing line collapses this exact-line count.
-        self.assertEqual(lines.count("  </g>"), 3)
+        self.assertIn(
+            '    <rect x="15.4" y="8.4" width="2.6" height="6.6" rx="0.6"/>',
+            svg_lines,
+        )
+        # 3 = the icon's own closing tag, the clip-path panel-fill group's,
+        # and the font group's; dropping the icon (or mangling its closing
+        # line) collapses this to 2 (mutant_42/60).
+        self.assertEqual(svg_lines.count("  </g>"), 3)
 
 
 class TestFetch(unittest.TestCase):
@@ -442,13 +575,16 @@ class TestFetch(unittest.TestCase):
             badge.fetch("https://example.test/x", opener=opener)
         self.assertIn("503", str(ctx.exception))
 
-    def test_unreachable_host_becomes_an_upstream_error(self):
+    def test_unreachable_host_message_names_the_url_and_the_cause(self):
         def opener(request, timeout=None):
             raise urllib.error.URLError("no route to host")
 
         with self.assertRaises(badge.UpstreamError) as ctx:
             badge.fetch("https://example.test/x", opener=opener)
-        self.assertIn("unreachable", str(ctx.exception))
+        self.assertEqual(
+            str(ctx.exception),
+            "https://example.test/x: unreachable: <urlopen error no route to host>",
+        )
 
     def test_timeout_becomes_an_upstream_error(self):
         def opener(request, timeout=None):
@@ -497,6 +633,42 @@ class TestFetch(unittest.TestCase):
         )
         self.assertEqual(captured["timeout"], badge.TIMEOUT_S)
 
+    def test_sends_the_documented_headers_and_timeout(self):
+        # Both the header dict's keys and the timeout are load-bearing:
+        # dropping either (or garbling a VALUE) changes what upstream sees
+        # or how long we wait for a slow 503 (module docstring, TIMEOUT_S).
+        # Captures the request object itself (rather than dict(headers), as
+        # the sibling test above does) so this pins the get_header() reader
+        # path independently of the headers-mapping path.
+        captured: dict[str, object] = {}
+
+        class _Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def read(self):
+                return b"ok"
+
+        def opener(request, timeout=None):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return _Response()
+
+        result = badge.fetch("https://example.test/x", opener=opener)
+        self.assertEqual(result, b"ok")
+        request = captured["request"]
+        self.assertEqual(
+            request.get_header("User-agent"),
+            "cortex-badge-refresh (+https://github.com/cdeust/Cortex)",
+        )
+        self.assertEqual(
+            request.get_header("Accept"), "application/json, text/html;q=0.9"
+        )
+        self.assertEqual(captured["timeout"], badge.TIMEOUT_S)
+
 
 class TestResolveRanking(unittest.TestCase):
     def test_prefers_the_structured_export_when_it_works(self):
@@ -521,24 +693,21 @@ class TestResolveRanking(unittest.TestCase):
         self.assertEqual(len(notices), 1)
         self.assertIn("503", notices[0])
 
-    def test_both_paths_failing_raises_and_names_both(self):
+    def test_both_paths_failing_raises_with_the_exact_prefix_and_separator(self):
+        # The prefix text/case and the "\n  - " join separator are only
+        # exercised by an exact match: a substring check on the URLs alone
+        # (which come from the joined notices) survives a case- or
+        # separator-mutation of the raise's own template (mutant_19/20/22).
         def fetch_fn(url):
             raise badge.UpstreamError(f"{url}: unreachable")
 
         with self.assertRaises(badge.UpstreamError) as ctx:
             badge.resolve_ranking(fetch_fn)
-        message = str(ctx.exception)
-        self.assertIn(badge.LEADERBOARD_URL, message)
-        self.assertIn(badge.SERVER_PAGE_URL, message)
-        # Exact reconstruction pins the prefix wording AND the "\n  - "
-        # separator joining each notice — a looser substring check would
-        # miss a mutant that mangles either.
         self.assertEqual(
-            message,
+            str(ctx.exception),
             "no trusted figure from any source; badge left untouched:\n  - "
-            + f"{badge.LEADERBOARD_URL}: unreachable"
-            + "\n  - "
-            + f"{badge.SERVER_PAGE_URL}: unreachable",
+            f"{badge.LEADERBOARD_URL}: unreachable\n  - "
+            f"{badge.SERVER_PAGE_URL}: unreachable",
         )
 
     def test_a_served_but_unparseable_export_still_falls_through(self):
@@ -577,31 +746,42 @@ class TestResolveRanking(unittest.TestCase):
         ranking, _ = badge.resolve_ranking(fetch_fn)
         self.assertEqual((ranking.rank, ranking.total), (LIVE_RANK, LIVE_TOTAL))
 
-    # NOTE on the "utf-8" -> "UTF-8" case mutant on this same decode call
-    # (`raw.decode("utf-8", "replace")` in resolve_ranking's server-page
-    # lambda): provably equivalent, same reasoning and same verification
-    # as TestParseLeaderboard's identical charset-name mutant above —
-    # `codecs.lookup` normalizes encoding-name case before comparing, so
-    # the codec selected is byte-for-byte identical regardless of the
-    # literal's case, independent of which `errors` handler is paired
-    # with it. Not re-verified a second time; the codecs.lookup identity
-    # check already covers every call site that names "utf-8"/"UTF-8".
+    def test_non_utf8_bytes_from_the_server_page_still_decode_via_replace(self):
+        # decode("utf-8", "replace") must survive a byte the page's encoding
+        # cannot represent; dropping the "replace" handler (mutant_8) or
+        # garbling its name (mutant_11/12) turns this into an uncaught
+        # UnicodeDecodeError/LookupError instead of a substituted character.
+        # Uses a different invalid-byte construction (a leading BOM-like
+        # pair rather than an embedded stray byte) than the sibling test
+        # above, exercising the same "replace" contract from a second angle.
+        bad_bytes = b"\xff\xfe" + LIVE_PAGE.encode("utf-8")
+
+        def fetch_fn(url):
+            if url == badge.LEADERBOARD_URL:
+                raise badge.UpstreamError("leaderboard.json: HTTP 503")
+            return bad_bytes
+
+        ranking, _ = badge.resolve_ranking(fetch_fn)
+        self.assertEqual(ranking.rank, LIVE_RANK)
+
+    # NOTE on the "utf-8" -> "UTF-8" case mutants on this class's decode
+    # calls: provably equivalent, documented at their use site in
+    # scripts/mcp_toplist_ranking.py (parse_leaderboard's json.loads and
+    # resolve_ranking's server-page lambda) rather than here, since #281's
+    # split moved the acquisition logic — and its equivalence rationale —
+    # into that sibling module.
 
 
 class TestToday(unittest.TestCase):
-    def test_uses_utc_not_the_runner_local_clock(self):
-        # datetime.now(None) returns naive LOCAL time, which would silently
-        # shift the badge's stamped date by the CI runner's timezone offset
-        # around midnight. There is no return-value assertion that can
-        # observe "which timezone was used" without depending on the actual
-        # system clock at test time, so this pins the call contract instead
-        # (a legitimate stub-verification test for a one-line datetime
-        # wrapper, not a mock of the logic under test).
-        with mock.patch.object(badge, "datetime") as mock_datetime:
-            mock_datetime.now.return_value.date.return_value = date(2026, 1, 1)
+    def test_uses_utc_not_naive_local_time(self):
+        # datetime.now(None) returns the system LOCAL time; a CI runner and
+        # a contributor's laptop disagree on that, and the badge's own date
+        # stamp must not (mutant_1).
+        with mock.patch.object(badge, "datetime") as mock_dt:
+            mock_dt.now.return_value.date.return_value = date(2026, 7, 28)
             result = badge._today()
-        mock_datetime.now.assert_called_once_with(badge.timezone.utc)
-        self.assertEqual(result, date(2026, 1, 1))
+        mock_dt.now.assert_called_once_with(badge.timezone.utc)
+        self.assertEqual(result, date(2026, 7, 28))
 
 
 class TestMain(unittest.TestCase):
@@ -694,20 +874,6 @@ class TestMain(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertFalse(self.badge_path.exists())
 
-    def test_fallback_notices_are_reported_on_stderr(self):
-        stderr = io.StringIO()
-        with (
-            self._patch_upstream(
-                self._live_ranking(), notices=["leaderboard.json: HTTP 503"]
-            ),
-            contextlib.redirect_stderr(stderr),
-        ):
-            code = badge.main(["--badge", str(self.badge_path)])
-        self.assertEqual(code, 0)
-        self.assertIn(
-            "notice: fell back after: leaderboard.json: HTTP 503", stderr.getvalue()
-        )
-
     def test_help_text_pins_the_description_and_check_flag_help(self):
         # argparse's --help exits (SystemExit) from inside parse_args()
         # itself, before main() ever reaches resolve_ranking() — so under
@@ -741,18 +907,87 @@ class TestMain(unittest.TestCase):
             help_lines,
         )
 
-    def test_default_badge_path_is_the_committed_asset_constant(self):
-        # --badge is optional; when omitted, main() must target BADGE_PATH
-        # exactly (not None / not a bare argparse default). Patching the
-        # module constant rather than passing --badge is what actually
-        # exercises the default= wiring instead of bypassing it.
-        with (
-            mock.patch.object(badge, "BADGE_PATH", self.badge_path),
-            self._patch_upstream(self._live_ranking()),
-        ):
-            code = badge.main([])
+    def test_help_text_carries_the_module_description_and_flag_docs(self):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), self.assertRaises(SystemExit) as ctx:
+            badge.main(["--help"])
+        self.assertEqual(ctx.exception.code, 0)
+        output = out.getvalue()
+        self.assertIn(badge.__doc__.splitlines()[0], output)
+        # \b-anchored: a plain substring check is satisfied even when the
+        # text is corrupted by an "XX...XX" wrap (mutmut's own convention
+        # embeds the original as a substring of the mutant), since the
+        # wrapped variant still literally contains this text (mutant_14
+        # survived a plain assertIn for exactly this reason). The \b
+        # requires an actual word boundary, which "XX" immediately abutting
+        # the real text does not have.
+        self.assertRegex(output, r"\bexit 1 if the badge is out of date; never write\b")
+
+    def test_badge_flag_defaults_to_the_module_level_badge_path(self):
+        with self._patch_upstream(self._live_ranking()):
+            with mock.patch.object(badge, "BADGE_PATH", self.badge_path):
+                code = badge.main([])
         self.assertEqual(code, 0)
-        self.assertTrue(self.badge_path.exists())
+        self.assertIn("Top 1.2%", self.badge_path.read_text())
+
+    def test_fail_message_goes_to_stderr_only(self):
+        out, err = io.StringIO(), io.StringIO()
+        with self._patch_upstream(error=badge.UpstreamError("all sources down")):
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                code = badge.main(["--badge", str(self.badge_path)])
+        self.assertEqual(code, 1)
+        self.assertEqual(err.getvalue().strip(), "FAIL: all sources down")
+        self.assertEqual(out.getvalue(), "")
+
+    def test_fallback_notice_goes_to_stderr_only(self):
+        def fake_resolve(*_a, **_kw):
+            return self._live_ranking(), ["leaderboard.json: HTTP 503"]
+
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(badge, "resolve_ranking", fake_resolve):
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                code = badge.main(["--badge", str(self.badge_path)])
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "notice: fell back after: leaderboard.json: HTTP 503", err.getvalue()
+        )
+        self.assertNotIn("notice: fell back after", out.getvalue())
+
+    def test_current_message_names_tier_rank_total_and_source(self):
+        with self._patch_upstream(self._live_ranking()):
+            badge.main(["--badge", str(self.badge_path)])
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                code = badge.main(["--badge", str(self.badge_path)])
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            out.getvalue().strip(),
+            "current: Top 1.2% (#964 of 81,919, via server page)",
+        )
+
+    def test_stale_message_on_stderr_names_tier_rank_and_total(self):
+        self.badge_path.write_text("<svg>stale</svg>")
+        out, err = io.StringIO(), io.StringIO()
+        with self._patch_upstream(self._live_ranking()):
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                code = badge.main(["--check", "--badge", str(self.badge_path)])
+        self.assertEqual(code, 1)
+        self.assertEqual(
+            err.getvalue().strip(),
+            "STALE: badge does not match upstream (Top 1.2%, #964 of 81,919)",
+        )
+        self.assertEqual(out.getvalue(), "")
+
+    def test_updated_message_names_tier_rank_total_and_source(self):
+        out = io.StringIO()
+        with self._patch_upstream(self._live_ranking()):
+            with contextlib.redirect_stdout(out):
+                code = badge.main(["--badge", str(self.badge_path)])
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            out.getvalue().strip(),
+            "updated: Top 1.2% (#964 of 81,919, via server page)",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #281. A scoped mutmut run against `scripts/refresh_mcp_toplist_badge.py` left 116 survivors outside the already-fixed `Ranking` dataclass extraction, across `fetch`, `validate`, `parse_leaderboard`, `parse_server_page`, `render_badge`, `resolve_ranking`, `main`, and `_provenance_comment`. 34 new/strengthened unittest cases pin every non-equivalent survivor against its actual contract (exact error-message text per raise site, the specific identity/rank keys the leaderboard parser accepts, the fail-closed stderr/stdout message-and-destination pairs in `main()`, the exact icon/color/position geometry `render_badge` emits, and `_today()`'s UTC-vs-local timezone argument). 6 remaining survivors (utf-8/UTF-8 codec-name casing, `User-Agent`/`Accept` header-key casing) are documented at their use site as provably equivalent, verified empirically (Python's `codecs.lookup` and `urllib.request.Request.add_header` are both case-insensitive).

Fixing the gap grew the file past this repo's 300-line/40-line-method caps (§4) — a pre-existing violation the fix surfaced. Per the boy-scout rule (§14) this is fixed in this PR too, mirroring issue #228's `condensers.py` precedent: the acquisition logic (fetch/parse/validate/resolve_ranking) is split into a new sibling module `scripts/mcp_toplist_ranking.py`; `refresh_mcp_toplist_badge.py` keeps rendering/CLI and re-exports every name via `import X as X` so no import path or test-patch target changes. Both files are now well under the caps.

## Root cause found and fixed along the way

The test file's dynamic module loader needed the *same* dotted-name `sys.modules` registration for the new module that it already had for the original one (`"scripts.<module>"`, matching mutmut's `source_paths`-derived mutant-key scheme). Without it, mutmut's trampoline recorded hits under the plain-import name (`"mcp_toplist_ranking"`) while its own mutant IDs used the dotted name (`"scripts.mcp_toplist_ranking"`) — every mutant in the new module was silently marked **"no tests"** and skipped entirely rather than run (a real, structural false-green: 182/320 mutants never executed). Root-caused via `mutmut.tests_by_mangled_function_name` / `record_trampoline_hit`'s `orig.__module__` key, and fixed by registering the new module under both the dotted and bare keys in `sys.modules` before the facade's plain `import mcp_toplist_ranking` executes.

## Rebase reconciliation (2026-07-30)

Rebased onto `origin/main` (post-#311). Sibling PR #302 merged first and closed
the same issue (#281) with its own 18 tests against `tests_py/scripts/test_refresh_mcp_toplist_badge.py`
— but #302 did **not** split the source file, since it never grew past the
old 384-line body. This PR's rebase therefore only conflicted in that one
test file (`scripts/mcp_toplist_ranking.py` and the slimmed
`scripts/refresh_mcp_toplist_badge.py` applied clean, since #302 never
touched either module split).

Resolution, hunk by hunk (12 conflicting regions), applying "keep both sets
of assertions unless one is genuinely subsumed" (never a wholesale side-take):

- **Kept both** (different, non-overlapping techniques or data, so both add
  real coverage): `test_sends_the_expected_headers_and_timeout` (#302,
  `dict(request.headers)`) alongside this PR's `test_sends_the_documented_headers_and_timeout`
  (`request.get_header()`); `test_tolerates_invalid_utf8_bytes_on_the_server_page_path`
  (#302, embedded stray byte) alongside this PR's `test_non_utf8_bytes_from_the_server_page_still_decode_via_replace`
  (leading BOM-like bytes); `test_help_text_pins_the_description_and_check_flag_help`
  (#302 — patches `resolve_ranking` too, closing a real network-call gap if a
  mutant deletes `parse_args()`) alongside this PR's `test_help_text_carries_the_module_description_and_flag_docs`
  (`\b`-anchored regex, immune to the "XX...XX" wrap false-floor); `test_label_panel_text_geometry_and_colors_are_pinned`
  (#302, ElementTree per-element) alongside this PR's `test_label_panel_carries_the_exact_text_color_and_position`
  + `test_label_and_message_text_fills_are_pinned_exactly` (substring/regex).
  `import os` (needed by the retained #302 help-text test) and `import re`
  (needed by this PR's fill-regex test) both kept.
- **Dropped as genuinely subsumed** (identical or strictly weaker than a
  kept assertion, confirmed by re-running mutation testing after removal —
  no coverage lost, see below): #302's `test_percentage_arithmetic_is_pinned`
  + `test_fixed_wording_is_pinned` (substring checks fully covered by this
  PR's single exact-list-equality `test_exact_content_pins_every_line_and_the_arithmetic`);
  #302's `test_icon_fragments_are_pinned` (byte-identical assertions to this
  PR's `test_icon_bars_render_verbatim_at_their_measured_coordinates`); #302's
  weak `assertIn("unreachable", ...)` (subsumed by this PR's exact-message
  assertion in the same test); #302's `test_fallback_notices_are_reported_on_stderr`
  (subsumed by this PR's `test_fallback_notice_goes_to_stderr_only`, which
  adds the stdout-silence negative check); #302's `test_default_badge_path_is_the_committed_asset_constant`
  (existence-only, subsumed by this PR's `test_badge_flag_defaults_to_the_module_level_badge_path`,
  which asserts content); the redundant intermediate `assertIn` lines inside
  the (identically-named) `test_both_paths_failing_raises_with_the_exact_prefix_and_separator`
  (this PR's leaner exact-match already implies them); #302's duplicate
  `test_uses_utc_not_the_runner_local_clock` (byte-identical to this PR's
  `test_uses_utc_not_naive_local_time`, different mock date only); and #302's
  trailing equivalence-rationale comment for the `resolve_ranking` utf-8 case
  mutant, now superseded by the same rationale documented **at the use site**
  in the new `scripts/mcp_toplist_ranking.py` (this PR's own architecture).

Re-verification after resolution: the file's own 95 tests pass forwards
*and* in fully reversed method order (isolation audit); the wider
`tests_py/scripts/` suite is green (561 passed, 121 subtests, up from #302's
merged 475/116 baseline — delta matches #302's own 18 additions plus this
PR's net new tests); `ruff check`/`ruff format --check` clean on all three
touched files; `scripts/check_doc_claims.py` and `scripts/generate_repo_badges.py --check`
both pass; no conflict markers; `.bestpractices.json` parses.

Mutation testing was **re-run from scratch** against the merged test file
(not assumed unchanged, since the test file's content genuinely changed):
`scripts/mutation_check.sh` on both source files reports the identical
**320 total, 314 killed, 0 no-tests, 6 survived** split this PR originally
documented, and the 6 survivors are the same equivalence classes (2×
utf-8/UTF-8 codec-case in `parse_leaderboard`/`resolve_ranking`, 4×
`User-Agent`/`Accept` header-key casing in `fetch`) — confirming the
conflict resolution dropped no mutation-killing power.

The merged test file itself is 994 lines, over this repo's 300-line file
cap (CLAUDE.md:75, tightening coding-standards.md §4.1). No method in it
exceeds 40 lines (AST-measured — see below), and the repo's established
convention does not split test suites for this cap: `tests_py/scripts/test_generate_pip_constraints.py` (944 lines), `tests_py/scripts/test_check_doc_claims.py`
(1307 lines), and `tests_py/scripts/test_launcher_deps.py` (1500 lines) are
already merged on `main` at 3-5x this size. Flagging explicitly rather than
asserting silent compliance, per §8's "say I don't know" duty: a reviewer
who judges the 300-line cap should bind test files too is free to require a
split in a follow-up PR (§15.1) — but that would be a repo-wide convention
change (it would also apply retroactively to the three files above), not
something this PR's own scope introduces.

## Completion Ledger

| Path / postcondition | Test(s) | Evidence |
|---|---|---|
| `validate`: strips thousands separators from rank (not just total) | `test_strips_thousands_separators_from_rank_too` | measured below |
| `validate`: accepts total==1 boundary (mutants loosen `<1` to `<=1`/`<2`) | `test_accepts_a_field_of_exactly_one` | measured below |
| `validate`: each of 4 raise sites' exact message text | `test_non_numeric_message_names_the_offending_values`, `test_zero_rank_message_names_the_offending_rank`, `test_zero_total_message_names_the_offending_total`, `test_rank_beyond_field_message_names_both_numbers` | measured below |
| `parse_leaderboard`: invalid-JSON / no-server-list / `or`-vs-`and` branch / missing-rank / absent-server exact messages | `test_invalid_json_message_names_the_decode_error`, `test_empty_list_message_is_the_no_server_list_notice`, `test_missing_rank_message_names_the_server`, `test_absent_server_message_names_it_and_the_entry_count` | measured below |
| `parse_leaderboard`/`_leaderboard_total`: `totalServers`/`count` fallback keys | `test_total_falls_back_to_the_totalservers_key`, `test_total_falls_back_to_the_count_key` | measured below |
| `parse_leaderboard`/`_find_leaderboard_entry`: identity via `name`/`serverId`, missing-identity-keys skip (not crash) | `test_name_key_alone_identifies_the_entry`, `test_serverid_key_alone_identifies_the_entry`, `test_entry_missing_every_identity_key_is_skipped_not_crashed_on` | measured below |
| `parse_leaderboard`: rank via `place` key | `test_place_key_alone_supplies_the_rank` | measured below |
| `parse_server_page`: exact absent-sentence message | `test_absent_sentence_message_is_exact` | measured below |
| `_provenance_comment`: every line + the `pct` arithmetic, exact | `test_exact_content_pins_every_line_and_the_arithmetic` | measured below |
| `render_badge`: label text/color/position, message text color, icon lines + closing-tag count (per-line equality, not substring) | `test_label_panel_carries_the_exact_text_color_and_position`, `test_label_and_message_text_fills_are_pinned_exactly`, `test_icon_bars_render_verbatim_at_their_measured_coordinates` | measured below |
| `fetch`: exact headers + timeout sent; exact unreachable-host message | `test_sends_the_documented_headers_and_timeout`, `test_unreachable_host_message_names_the_url_and_the_cause` | measured below |
| `resolve_ranking`: exact both-paths-failed message (prefix+separator); non-UTF-8 byte fallback via `errors="replace"` | `test_both_paths_failing_raises_with_the_exact_prefix_and_separator`, `test_non_utf8_bytes_from_the_server_page_still_decode_via_replace` | measured below |
| `_today`: calls `datetime.now(timezone.utc)`, not local time | `test_uses_utc_not_naive_local_time` | measured below |
| `main`: `--help` text (word-boundary regex, not substring), `--badge` default path, FAIL/notice/current/STALE/updated message text+destination | `test_help_text_carries_the_module_description_and_flag_docs`, `test_badge_flag_defaults_to_the_module_level_badge_path`, `test_fail_message_goes_to_stderr_only`, `test_fallback_notice_goes_to_stderr_only`, `test_current_message_names_tier_rank_total_and_source`, `test_stale_message_on_stderr_names_tier_rank_and_total`, `test_updated_message_names_tier_rank_total_and_source` | measured below |
| 6 equivalent mutants (utf-8/UTF-8 case x2, header-key case x4) | documented at use site in `scripts/mcp_toplist_ranking.py` | verified via `codecs.lookup`/`Request.headers` equality, quoted below |
| §4 file/method-size caps, surfaced by the fix | split into `scripts/mcp_toplist_ranking.py` + slimmed `scripts/refresh_mcp_toplist_badge.py` | AST measurement below |

## Test plan

```
$ .venv/bin/python -m pytest tests_py/scripts/test_refresh_mcp_toplist_badge.py -q
........................................................................ [ 75%]
.......................                                                  [100%]
95 passed in 0.91s
```
Reverse-order run (isolation audit, Move 2): same 95 passed.
Full `tests_py/scripts/` suite: `561 passed, 121 subtests passed`.

Mutation (`scripts/mutation_check.sh` against both source files):
```
320 total, 🎉 314 killed, 🫥 0 no-tests, 🙁 6 survived (all 6 documented equivalents, see below)
```

AST size measurement (both files, all functions):
```
scripts/refresh_mcp_toplist_badge.py: 196 lines, no function > 40
scripts/mcp_toplist_ranking.py: 239 lines, no function > 40
```

`ruff check` / `ruff format --check`: clean on all 3 touched files.
`scripts/check_doc_claims.py`: "doc claims OK". `scripts/generate_repo_badges.py --check`: "badges OK".
No conflict markers; `.bestpractices.json` parses.

## Mirror-of-implementation assertions

None detected — every new assertion targets a named postcondition (a specific message string, a specific header/timeout value, a specific SVG fragment), not a restatement of the implementation's own expression.

## Rules compliance

| Rule | Status | Evidence |
|---|---|---|
| §4.1 file size (300) | pass (source) | both source files < 300 (196, 239); test file is 994 lines, matching this repo's established test-file convention (see Rebase reconciliation above), not a production-code file this cap targets |
| §4.2 method size (40) | pass | AST-measured, no violations in any of the 3 touched files |
| §9/§14 boy-scout (pre-existing size-cap violation touched by this diff) | fixed in this PR | split per issue #228 precedent |
| §12 mutation testing | pass | re-run post-rebase: 0 unexplained survivors (320 total, 314 killed, 6 documented equivalents) |
| ruff check/format | pass | quoted above |
