### PR TITLE
refactor(lint): triage B, RET, DTZ families of issue #239 (3 of 10)

### DIFF
--- a/benchmarks/active_forgetting/run_benchmark.py
+++ b/benchmarks/active_forgetting/run_benchmark.py
@@ -601,7 +601,12 @@ def fixture_hippocampal_dependency_protects() -> dict:
     (the accumulator still grows, just more slowly)."""
     cortical = _trajectory(_S1, PRESSURE_LEAK_LAMBDA, hippocampal_dependency=0.0)
     hippocampal = _trajectory(_S1, PRESSURE_LEAK_LAMBDA, hippocampal_dependency=1.0)
-    less_pressure_every_cycle = all(h < c for h, c in zip(hippocampal, cortical))
+    # strict=True: both trajectories are produced by the same _trajectory
+    # call shape (only hippocampal_dependency differs), so they always
+    # have equal length.
+    less_pressure_every_cycle = all(
+        h < c for h, c in zip(hippocampal, cortical, strict=True)
+    )
     still_growing = hippocampal[-1] > 0.0
     fires_late_or_never = not any(
         a >= PERMANENT_ACCUM_THRESHOLD for a in hippocampal[: _S1["fire_by"]]

--- a/benchmarks/beam/run_benchmark.py
+++ b/benchmarks/beam/run_benchmark.py
@@ -84,8 +84,7 @@ def _get_stage_detector():
     mode = os.environ.get("CORTEX_STAGE_DETECTOR", "oracle")
     if mode == "temporal":
         return TemporalStageDetector(gap_hours=24.0, time_field="created_at")
-    else:
-        return ExplicitStageDetector(field="agent_context")
+    return ExplicitStageDetector(field="agent_context")
 
 
 def _current_stage_for_question(q: dict, conversation_turns: list[dict]) -> str:
@@ -124,8 +123,7 @@ def _current_stage_for_question(q: dict, conversation_turns: list[dict]) -> str:
                 if ts:
                     return f"day-{ts.date().isoformat()}"
                 return last_anchor
-            else:
-                return last_plan if last_plan else last_anchor
+            return last_plan if last_plan else last_anchor
     if mode == "temporal":
         ts = TemporalStageDetector._parse_ts(last_anchor)
         if ts:

--- a/benchmarks/forgetting_curve/curve_fit.py
+++ b/benchmarks/forgetting_curve/curve_fit.py
@@ -46,7 +46,9 @@ def _ols(xs: list[float], ys: list[float]) -> tuple[float, float, float]:
     n = len(xs)
     sx = sum(xs)
     sy = sum(ys)
-    sxy = sum(x * y for x, y in zip(xs, ys))
+    # strict=True: xs/ys are paired observations for OLS; unequal lengths
+    # would mean mismatched (x, y) pairs, a data bug worth raising on.
+    sxy = sum(x * y for x, y in zip(xs, ys, strict=True))
     sx2 = sum(x * x for x in xs)
     denom = n * sx2 - sx * sx
     if abs(denom) < _NEAR_ZERO_TOL:
@@ -55,7 +57,10 @@ def _ols(xs: list[float], ys: list[float]) -> tuple[float, float, float]:
     intercept = (sy - slope * sx) / n
     mean_y = sy / n
     ss_tot = sum((y - mean_y) ** 2 for y in ys)
-    ss_res = sum((y - (intercept + slope * x)) ** 2 for x, y in zip(xs, ys))
+    # strict=True: same paired-observations invariant as sxy above.
+    ss_res = sum(
+        (y - (intercept + slope * x)) ** 2 for x, y in zip(xs, ys, strict=True)
+    )
     r2 = 1.0 - ss_res / ss_tot if ss_tot > _NEAR_ZERO_TOL else 0.0
     return slope, intercept, r2
 

--- a/benchmarks/gate_precision/run_benchmark.py
+++ b/benchmarks/gate_precision/run_benchmark.py
@@ -95,7 +95,11 @@ def extract_corpus(path: Path) -> list[str]:
     seen_keys: set[str] = set()
     corpus: list[str] = []
     for q in questions:
-        for sid, session in zip(q["haystack_session_ids"], q["haystack_sessions"]):
+        # strict=True: both lists come from the same haystack record and
+        # are documented to correspond 1:1 by index.
+        for sid, session in zip(
+            q["haystack_session_ids"], q["haystack_sessions"], strict=True
+        ):
             if sid in seen_sessions:
                 continue
             seen_sessions.add(sid)
@@ -222,7 +226,9 @@ def roc_auc(labels: list[int], scores: list[float]) -> float:
         for k in range(i, j + 1):
             ranks[order[k]] = avg_rank
         i = j + 1
-    rank_sum_pos = sum(r for r, lab in zip(ranks, labels) if lab == 1)
+    # strict=True: ranks has len(scores), and labels/scores are the
+    # function's paired input (one label per score) by contract.
+    rank_sum_pos = sum(r for r, lab in zip(ranks, labels, strict=True) if lab == 1)
     u_stat = rank_sum_pos - n_pos * (n_pos + 1) / 2
     return u_stat / (n_pos * n_neg)
 

--- a/benchmarks/lib/_e2_loaders.py
+++ b/benchmarks/lib/_e2_loaders.py
@@ -57,10 +57,13 @@ def load_longmemeval(seed: int) -> tuple[list[SubsampleItem], list[QueryProbe]]:
     seen: dict[str, SubsampleItem] = {}
     probes: list[QueryProbe] = []
     for item in dataset:
+        # strict=True: all three lists come from the same haystack record
+        # and are documented to correspond 1:1 by index.
         for sess, sid, date_str in zip(
             item["haystack_sessions"],
             item["haystack_session_ids"],
             item["haystack_dates"],
+            strict=True,
         ):
             if sid in seen:
                 continue
@@ -155,7 +158,7 @@ def load_beam_100k(seed: int) -> tuple[list[SubsampleItem], list[QueryProbe]]:
             items.append(SubsampleItem(memory=mem, source_key=key))
         raw_pq = conversation.get("probing_questions", "{}")
         questions = parse_probing_questions(raw_pq)
-        for ability, qs in questions.items():
+        for _ability, qs in questions.items():
             qs_list = qs if isinstance(qs, list) else [qs]
             for q in qs_list:
                 if not isinstance(q, dict):

--- a/benchmarks/lib/_e2_loaders.py
+++ b/benchmarks/lib/_e2_loaders.py
@@ -57,8 +57,7 @@ def load_longmemeval(seed: int) -> tuple[list[SubsampleItem], list[QueryProbe]]:
     seen: dict[str, SubsampleItem] = {}
     probes: list[QueryProbe] = []
     for item in dataset:
-        # strict=True: all three lists come from the same haystack record
-        # and are documented to correspond 1:1 by index.
+        # strict=True: parallel per-record fields, correspond 1:1 by index.
         for sess, sid, date_str in zip(
             item["haystack_sessions"],
             item["haystack_session_ids"],
@@ -69,16 +68,14 @@ def load_longmemeval(seed: int) -> tuple[list[SubsampleItem], list[QueryProbe]]:
                 continue
             content, user_content = session_to_memory_content(sess, sid)
             iso = parse_longmemeval_date(date_str)
-            seen[sid] = SubsampleItem(
-                memory={
-                    "content": content,
-                    "user_content": user_content,
-                    "created_at": iso,
-                    "source": sid,
-                    "tags": ["longmemeval"],
-                },
-                source_key=sid,
-            )
+            mem = {
+                "content": content,
+                "user_content": user_content,
+                "created_at": iso,
+                "source": sid,
+                "tags": ["longmemeval"],
+            }
+            seen[sid] = SubsampleItem(memory=mem, source_key=sid)
         probes.append(
             QueryProbe(
                 query=item["question"], target_source_keys=item["answer_session_ids"]

--- a/benchmarks/lib/ablation_runner.py
+++ b/benchmarks/lib/ablation_runner.py
@@ -310,8 +310,8 @@ def _select_mechanisms(args: argparse.Namespace) -> list[Mechanism]:
     for name in args.mechanism:
         try:
             out.append(Mechanism[name])
-        except KeyError:
-            raise SystemExit(f"unknown mechanism: {name}")
+        except KeyError as exc:
+            raise SystemExit(f"unknown mechanism: {name}") from exc
     return out
 
 

--- a/benchmarks/lib/blend_weight_sweep.py
+++ b/benchmarks/lib/blend_weight_sweep.py
@@ -140,7 +140,9 @@ def build_phase_a_cells() -> list[Cell]:
     cells.append(Cell(idx=0, label="A_center", weights={**DEFAULTS, **PHASE_A_CENTER}))
     for i, combo in enumerate(itertools.product([0, 1], repeat=4), start=1):
         weights = dict(DEFAULTS)
-        for k, hl in zip(keys, combo):
+        # strict=True: keys is a fixed 4-tuple and combo is a
+        # repeat=4 itertools.product entry — always 4 elements each.
+        for k, hl in zip(keys, combo, strict=True):
             weights[k] = PHASE_A_HIGH[k] if hl else PHASE_A_LOW[k]
         label = "A_" + "".join("H" if hl else "L" for hl in combo)
         cells.append(Cell(idx=i, label=label, weights=weights))

--- a/benchmarks/lib/decay_sweep_runner.py
+++ b/benchmarks/lib/decay_sweep_runner.py
@@ -35,7 +35,7 @@ import re
 import sys
 import time
 from contextlib import redirect_stdout
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -243,7 +243,10 @@ def _collect_provenance() -> dict:
 
 
 def run_sweep(lambdas: list[float], quick: bool) -> Path:
-    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    # datetime.now(timezone.utc), not the deprecated utcnow(): strftime here
+    # uses no %z/%Z directive, so the formatted string is identical either
+    # way — this only resolves the deprecation, not the output.
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     out_dir = RESULTS_ROOT / timestamp
     out_dir.mkdir(parents=True, exist_ok=True)
     provenance = _collect_provenance()

--- a/benchmarks/lib/longitudinal_runner.py
+++ b/benchmarks/lib/longitudinal_runner.py
@@ -115,7 +115,9 @@ def _stamp_age(store, mem_ids: list[int], age_days: list[float]) -> None:
     issue one parameterised UPDATE per memory; for 100k rows this takes
     a few seconds but is bounded and deterministic.
     """
-    rows = list(zip(mem_ids, age_days))
+    # strict=True: documented precondition above — age_days[i] corresponds
+    # to mem_ids[i] by index.
+    rows = list(zip(mem_ids, age_days, strict=True))
     sql = """
         UPDATE memories SET
             created_at = NOW() - (%s || ' days')::INTERVAL,
@@ -180,7 +182,14 @@ def insert_memories(
     _stamp_age(bench_db._store, mem_ids, age_days)
     print(f"[long] backdate done ({time.time() - t0:.1f}s)")
 
-    return [(uid, mid, b) for uid, mid, b in zip(range(n), mem_ids, bucket_assignments)]
+    # strict=False: ingest_memories_batch's contract does not guarantee
+    # len(mem_ids) == n (the store's write path may merge/dedupe an
+    # insert); truncating to the shorter list here matches current
+    # behavior rather than crashing a long-running benchmark run.
+    return [
+        (uid, mid, b)
+        for uid, mid, b in zip(range(n), mem_ids, bucket_assignments, strict=False)
+    ]
 
 
 # ── Query path ───────────────────────────────────────────────────────────

--- a/benchmarks/lib/longitudinal_runner.py
+++ b/benchmarks/lib/longitudinal_runner.py
@@ -273,7 +273,10 @@ def run(n_memories: int, queries_per_bucket: int, seed: int, quick: bool) -> Pat
     # Import AFTER env override so PgMemoryStore picks up the test DB.
     from benchmarks.lib.bench_db import BenchmarkDB  # noqa: PLC0415 — deferred: module hard-imports pgvector/psycopg/psycopg_pool at top level; hoisting would break installs without it
 
-    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    # datetime.now(timezone.utc), not the deprecated utcnow(): strftime here
+    # uses no %z/%Z directive, so the formatted string is identical either
+    # way — this only resolves the deprecation, not the output.
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     out_dir = RESULTS_ROOT / timestamp
     out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/benchmarks/llm_head_to_head/generator.py
+++ b/benchmarks/llm_head_to_head/generator.py
@@ -185,16 +185,15 @@ def call_generator(
                 return _call_anthropic(
                     model_id, prompt, max_output_tokens, temperature, retries
                 )
-            elif vendor == "google":
+            if vendor == "google":
                 return _call_google(
                     model_id, prompt, max_output_tokens, temperature, retries
                 )
-            elif vendor == "openai":
+            if vendor == "openai":
                 return _call_openai(
                     model_id, prompt, max_output_tokens, temperature, retries
                 )
-            else:
-                raise GeneratorError(f"Unsupported vendor: {vendor}")
+            raise GeneratorError(f"Unsupported vendor: {vendor}")
         except _RetryableError as e:
             last_error = e
             if attempt >= MAX_RETRIES:

--- a/benchmarks/llm_head_to_head/judge.py
+++ b/benchmarks/llm_head_to_head/judge.py
@@ -122,7 +122,7 @@ def render_judge_prompt(
       is excluded from the run).
     """
     by_id = {sid: text for sid, _, text in shuffled}
-    filled = (
+    return (
         template.replace("{QUESTION}", question)
         .replace("{ABILITY}", ability)
         .replace("{GOLD}", gold or "[NO ANSWER]")
@@ -132,7 +132,6 @@ def render_judge_prompt(
         .replace("{CAND_3}", by_id.get(3, "[no candidate]"))
         .replace("{CAND_4}", by_id.get(4, "[no candidate]"))
     )
-    return filled
 
 
 def parse_judge_output(

--- a/benchmarks/longmemeval/run_benchmark.py
+++ b/benchmarks/longmemeval/run_benchmark.py
@@ -248,8 +248,10 @@ def run_benchmark(
                 db.clear()
 
                 memories = []
-                for si, (session, sid, date_str) in enumerate(
-                    zip(haystack_sessions, haystack_sids, haystack_dates)
+                # strict=True: the three haystack lists are parallel,
+                # loaded together from the same question record.
+                for _si, (session, sid, date_str) in enumerate(
+                    zip(haystack_sessions, haystack_sids, haystack_dates, strict=True)
                 ):
                     content, user_content = session_to_memory_content(session, sid)
                     date_iso = parse_longmemeval_date(date_str)

--- a/benchmarks/longmemeval/run_benchmark.py
+++ b/benchmarks/longmemeval/run_benchmark.py
@@ -48,7 +48,10 @@ def parse_longmemeval_date(date_str: str) -> str:
     """Parse LongMemEval date format '2023/04/10 (Mon) 17:50' to ISO 8601."""
     try:
         cleaned = re.sub(r"\s*\(\w+\)\s*", " ", date_str).strip()
-        dt = datetime.strptime(cleaned, "%Y/%m/%d %H:%M")
+        # noqa DTZ007: the format string has no %z because the source data
+        # never carries one; the very next line stamps tzinfo=UTC, so the
+        # value this function returns is always aware.
+        dt = datetime.strptime(cleaned, "%Y/%m/%d %H:%M")  # noqa: DTZ007
         return dt.replace(tzinfo=timezone.utc).isoformat()
     except (ValueError, TypeError):
         return datetime.now(timezone.utc).isoformat()

--- a/benchmarks/longmemeval/run_sqlite_fallback_bench.py
+++ b/benchmarks/longmemeval/run_sqlite_fallback_bench.py
@@ -84,10 +84,13 @@ def _load_question(store: SqliteMemoryStore, item: dict, eng) -> dict[int, str]:
     """Load one question's haystack into ``store``; return memory_id → sid."""
     question_date = parse_longmemeval_date(item["question_date"])
     id_to_sid: dict[int, str] = {}
+    # strict=True: all three lists come from the same haystack record and
+    # are documented to correspond 1:1 by index.
     for session, sid, date_str in zip(
         item["haystack_sessions"],
         item["haystack_session_ids"],
         item["haystack_dates"],
+        strict=True,
     ):
         content, _ = session_to_memory_content(session, sid)
         date_iso = parse_longmemeval_date(date_str)

--- a/benchmarks/memoryagentbench/run_benchmark.py
+++ b/benchmarks/memoryagentbench/run_benchmark.py
@@ -158,7 +158,11 @@ def run_benchmark(splits: list[str] | None = None, limit: int | None = None):
 
             (row.get("metadata", {}).get("source", "") if row.get("metadata") else "")
 
-            for q_idx, (question, answer_list) in enumerate(zip(questions, answers)):
+            # strict=True: questions/answers are the dataset's paired
+            # per-item fields, always equal length.
+            for _q_idx, (question, answer_list) in enumerate(
+                zip(questions, answers, strict=True)
+            ):
                 if not question or not answer_list:
                     continue
 

--- a/benchmarks/spell_alteration/run_benchmark.py
+++ b/benchmarks/spell_alteration/run_benchmark.py
@@ -115,7 +115,9 @@ def replace_spells(
 ) -> tuple[str, dict[str, str]]:
     """Replace target spell names with fakes. Returns (text, map)."""
     mapping: dict[str, str] = {}
-    for orig, fake in zip(targets, fakes):
+    # strict=True: the only caller passes targets=rng.sample(eligible, 2)
+    # and fakes=FAKE_NAMES (a fixed 2-element list) — always equal length.
+    for orig, fake in zip(targets, fakes, strict=True):
         mapping[orig] = fake
         text = re.sub(re.escape(orig), fake, text, flags=re.IGNORECASE)
     return text, mapping

--- a/benchmarks/supersession_gate/guard_chunk_granularity.py
+++ b/benchmarks/supersession_gate/guard_chunk_granularity.py
@@ -81,7 +81,9 @@ def main() -> int:
         # Decompose every session into chunks; remember each chunk's origin sid.
         chunk_texts: list[str] = []
         chunk_sid: list[str] = []
-        for sess, sid in zip(sessions, sids):
+        # strict=True: sessions/sids are both read from the same
+        # haystack record's parallel fields.
+        for sess, sid in zip(sessions, sids, strict=True):
             stext = session_text(sess)
             chunks = decompose_memory(stext)
             for c in chunks:

--- a/mcp_server/core/attentional_control.py
+++ b/mcp_server/core/attentional_control.py
@@ -184,7 +184,9 @@ def allocate_attention(
     # Bottom-up salience: importance + |valence|, scaled. Lets an unbidden but
     # salient item compete for the spotlight (stimulus-driven capture).
     logits: list[float] = []
-    for score, it in zip(top_down, items):
+    # strict=True: top_down is built one score per item three lines above,
+    # so the lengths are always equal by construction.
+    for score, it in zip(top_down, items, strict=True):
         importance = float(it.get("importance", 0.0) or 0.0)
         valence = abs(float(it.get("valence", 0.0) or 0.0))
         salience = 0.5 * importance + 0.5 * valence

--- a/mcp_server/core/attentional_control.py
+++ b/mcp_server/core/attentional_control.py
@@ -185,7 +185,12 @@ def allocate_attention(
     # salient item compete for the spotlight (stimulus-driven capture).
     logits: list[float] = []
     # strict=True: top_down is built one score per item three lines above,
-    # so the lengths are always equal by construction.
+    # so the lengths are always equal by construction. Documented
+    # equivalent mutant (coding-standards.md §12.1): allocate_attention's
+    # earlier `if len(precomputed_scores) != n: raise` (see above) makes a
+    # top_down/items length mismatch unreachable through this function's
+    # public entry point, so no test can distinguish strict=True from
+    # strict=False/None here without bypassing that guard directly.
     for score, it in zip(top_down, items, strict=True):
         importance = float(it.get("importance", 0.0) or 0.0)
         valence = abs(float(it.get("valence", 0.0) or 0.0))

--- a/mcp_server/core/causal_graph.py
+++ b/mcp_server/core/causal_graph.py
@@ -76,7 +76,7 @@ def compute_temporal_precedence(
 
     if time_a < time_b:
         return "a_before_b"
-    elif time_b < time_a:
+    if time_b < time_a:
         return "b_before_a"
     return None
 

--- a/mcp_server/core/compression.py
+++ b/mcp_server/core/compression.py
@@ -153,10 +153,9 @@ def get_compression_schedule(
 
     if hours_elapsed < gist_age_hours * resistance:
         return 0
-    elif hours_elapsed < tag_age_hours * resistance:
+    if hours_elapsed < tag_age_hours * resistance:
         return 1
-    else:
-        return 2
+    return 2
 
 
 def _select_gist_sentences(

--- a/mcp_server/core/context_assembly/stage_detector.py
+++ b/mcp_server/core/context_assembly/stage_detector.py
@@ -170,7 +170,15 @@ class TemporalStageDetector(StageDetector):
                     }
                     month_num = month_abbrs.get(month_name.lower())
                     if month_num:
-                        return datetime(year, month_num, day)
+                        # naive by design: matches the sibling ISO branch
+                        # above, which is naive too whenever `value` lacks
+                        # an explicit offset (date-only ISO strings).
+                        # Making only this fallback aware would introduce a
+                        # new naive/aware mismatch across the two parsing
+                        # paths — a behavior change out of scope for a lint
+                        # refactor; unifying tz-awareness belongs in a
+                        # dedicated fix.
+                        return datetime(year, month_num, day)  # noqa: DTZ001
             except (ValueError, IndexError):
                 pass
         return None

--- a/mcp_server/core/curation.py
+++ b/mcp_server/core/curation.py
@@ -48,10 +48,9 @@ def decide_curation_action(
     """
     if similarity >= merge_threshold and has_textual_overlap:
         return "merge"
-    elif similarity >= link_low:
+    if similarity >= link_low:
         return "link"
-    else:
-        return "create"
+    return "create"
 
 
 def compute_textual_overlap(content_a: str, content_b: str) -> float:

--- a/mcp_server/core/distillation.py
+++ b/mcp_server/core/distillation.py
@@ -266,7 +266,7 @@ def build_co_access_dossiers(
     uf = _UnionFind()
     weight_sum: dict[int, float] = {}
     weight_count: dict[int, float] = {}
-    for a, b, w in pairs:
+    for a, b, _w in pairs:
         uf.union(a, b)
     # Sort edges by proximity descending so the truncation below keeps the
     # strongest-linked members first within an oversized component.

--- a/mcp_server/core/dual_store_cls.py
+++ b/mcp_server/core/dual_store_cls.py
@@ -105,7 +105,6 @@ def auto_weight(query: str) -> tuple[float, float]:
 
     if has_specific:
         return 2.0, 1.0
-    elif has_semantic:
+    if has_semantic:
         return 1.0, 2.0
-    else:
-        return 1.0, 1.0
+    return 1.0, 1.0

--- a/mcp_server/core/entity_dedup_filters.py
+++ b/mcp_server/core/entity_dedup_filters.py
@@ -139,7 +139,9 @@ def is_structural_identifier(label: str) -> bool:
 
 def _common_prefix_len(a: str, b: str) -> int:
     p = 0
-    for ca, cb in zip(a, b):
+    # strict=False: a common-prefix scan is defined precisely for strings of
+    # differing length (it stops at the shorter one).
+    for ca, cb in zip(a, b, strict=False):
         if ca != cb:
             break
         p += 1

--- a/mcp_server/core/fractal.py
+++ b/mcp_server/core/fractal.py
@@ -101,10 +101,9 @@ def compute_level_weights(query: str) -> tuple[float, float, float]:
 
     if word_count < _SHORT_QUERY_WORDS:
         return 0.3, 0.5, 1.0
-    elif word_count > _LONG_QUERY_WORDS:
+    if word_count > _LONG_QUERY_WORDS:
         return 1.0, 0.5, 0.3
-    else:
-        return 0.7, 0.7, 0.7
+    return 0.7, 0.7, 0.7
 
 
 # ── Scoring ──────────────────────────────────────────────────────────────
@@ -235,7 +234,7 @@ def drill_down(
                 children.append(child)
         return children
 
-    elif cluster["level"] == 1:
+    if cluster["level"] == 1:
         return [{"memory_id": mid} for mid in cluster.get("memory_ids", [])]
 
     return []

--- a/mcp_server/core/hdc_encoder.py
+++ b/mcp_server/core/hdc_encoder.py
@@ -89,8 +89,7 @@ def bundle(vectors: list[np.ndarray]) -> np.ndarray:
     tiebreak = np.where(tiebreak == 0, -1, 1).astype(np.float32)
 
     result = np.sign(summed)
-    result = np.where(result == 0, tiebreak, result).astype(np.float32)
-    return result
+    return np.where(result == 0, tiebreak, result).astype(np.float32)
 
 
 def permute(v: np.ndarray, n: int = 1) -> np.ndarray:

--- a/mcp_server/core/recall_pipeline.py
+++ b/mcp_server/core/recall_pipeline.py
@@ -1140,7 +1140,9 @@ def attentional_focus_rerank(
     # per-item weights as a soft re-weight, never truncating recall.
     alloc = allocate_attention(query, items, capacity=n)
     baseline = 1.0 / n
-    for c, attn in zip(candidates, alloc.weights):
+    # strict=True: allocate_attention always returns one weight per input
+    # item (items has len(candidates) by construction above).
+    for c, attn in zip(candidates, alloc.weights, strict=True):
         base = c.get("score", 0.0) or 0.0
         c["score"] = base * (1.0 + weight * (attn - baseline))
 

--- a/mcp_server/core/recall_pipeline.py
+++ b/mcp_server/core/recall_pipeline.py
@@ -1141,7 +1141,11 @@ def attentional_focus_rerank(
     alloc = allocate_attention(query, items, capacity=n)
     baseline = 1.0 / n
     # strict=True: allocate_attention always returns one weight per input
-    # item (items has len(candidates) by construction above).
+    # item (items has len(candidates) by construction above). Documented
+    # equivalent mutant (coding-standards.md §12.1): allocate_attention's
+    # own internal precondition (see attentional_control.py) makes this
+    # length mismatch unreachable, so strict=True vs strict=False/None is
+    # not observable through this call.
     for c, attn in zip(candidates, alloc.weights, strict=True):
         base = c.get("score", 0.0) or 0.0
         c["score"] = base * (1.0 + weight * (attn - baseline))

--- a/mcp_server/core/streaming/adaptive_writer.py
+++ b/mcp_server/core/streaming/adaptive_writer.py
@@ -157,7 +157,7 @@ def _drain_worker(
             item = q.get()
             if item is _SENTINEL:
                 break
-            _safe(lambda: writer.add_many(item), "worker", result, lock)
+            _safe(lambda item=item: writer.add_many(item), "worker", result, lock)
         _safe(writer.flush_remaining, "worker-flush", result, lock)
     finally:
         with lock:

--- a/mcp_server/core/tabular_encoding.py
+++ b/mcp_server/core/tabular_encoding.py
@@ -122,7 +122,9 @@ def decode_tabular(columns: list[str], rows: list[list[Any]]) -> list[dict]:
     explicit ``None`` the encoder wrote). Used by round-trip tests and any
     client that prefers objects.
     """
-    return [dict(zip(columns, row)) for row in rows]
+    # strict=True: the documented precondition above already requires every
+    # row to have length len(columns).
+    return [dict(zip(columns, row, strict=True)) for row in rows]
 
 
 def encode_within_budget(

--- a/mcp_server/core/temporal.py
+++ b/mcp_server/core/temporal.py
@@ -110,11 +110,22 @@ _EMBEDDED_ISO_RE = re.compile(r"(\d{4})-(\d{2})-(\d{2})")
 
 
 def _try_parse_named_date(date_str: str) -> datetime | None:
-    """Try DD Month YYYY and Month DD, YYYY formats."""
+    """Try DD Month YYYY and Month DD, YYYY formats.
+
+    Deliberately naive (noqa DTZ001 x3 below): every caller (parse_date,
+    compute_date_distance_score) only ever diffs two datetimes produced by
+    THIS module's own date-only parsing — no time-of-day, no tzinfo, on
+    either side of the subtraction. Making one of the three literal
+    ``datetime(...)`` constructions here aware while parse_date's ISO
+    branch (date-only, always naive after its ``.split("T")[0]``) stays
+    naive would raise on the very comparisons this function exists to
+    support. Unifying tz-awareness across the ISO and named-date paths is
+    a design change belonging in a dedicated fix, not this lint refactor.
+    """
     m = _DD_MONTH_YYYY_RE.match(date_str)
     if m:
         try:
-            return datetime(
+            return datetime(  # noqa: DTZ001
                 int(m.group(3)), _MONTH_NAMES[m.group(2).lower()], int(m.group(1))
             )
         except (ValueError, KeyError):
@@ -122,7 +133,7 @@ def _try_parse_named_date(date_str: str) -> datetime | None:
     m = _MONTH_DD_YYYY_RE.match(date_str)
     if m:
         try:
-            return datetime(
+            return datetime(  # noqa: DTZ001
                 int(m.group(3)), _MONTH_NAMES[m.group(1).lower()], int(m.group(2))
             )
         except (ValueError, KeyError):
@@ -130,7 +141,9 @@ def _try_parse_named_date(date_str: str) -> datetime | None:
     m = _EMBEDDED_ISO_RE.search(date_str)
     if m:
         try:
-            return datetime(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+            return datetime(  # noqa: DTZ001
+                int(m.group(1)), int(m.group(2)), int(m.group(3))
+            )
         except ValueError:
             pass
     return None

--- a/mcp_server/core/wiki_drift.py
+++ b/mcp_server/core/wiki_drift.py
@@ -241,7 +241,7 @@ def _file_exists_under(source_root: str, cited: str) -> bool:
     # turning one consolidate cycle into a multi-minute stall. The skip set is
     # the single source of truth for "not a source tree".
 
-    for dirpath, dirnames, filenames in os.walk(source_root):
+    for _dirpath, dirnames, filenames in os.walk(source_root):
         dirnames[:] = [
             d for d in dirnames if d not in _SKIP_DIRECTORIES and not d.startswith(".")
         ]

--- a/mcp_server/core/wiki_schema_loader.py
+++ b/mcp_server/core/wiki_schema_loader.py
@@ -156,7 +156,9 @@ def parse_rules_table(body: str) -> list[ClassifierRule]:
         cells = [c.strip() for c in row.split("|")]
         if len(cells) != len(header_cells):
             continue
-        r = dict(zip(header_cells, cells))
+        # strict=True: the length check immediately above already guarantees
+        # equal lengths here.
+        r = dict(zip(header_cells, cells, strict=True))
         if not r.get("pattern") or not r.get("kind"):
             continue
         target = r.get("target") or None

--- a/mcp_server/core/wiki_schema_loader.py
+++ b/mcp_server/core/wiki_schema_loader.py
@@ -157,7 +157,10 @@ def parse_rules_table(body: str) -> list[ClassifierRule]:
         if len(cells) != len(header_cells):
             continue
         # strict=True: the length check immediately above already guarantees
-        # equal lengths here.
+        # equal lengths here. Documented equivalent mutant
+        # (coding-standards.md §12.1): the `continue` on the preceding line
+        # makes a mismatch unreachable at this point, so strict=True vs
+        # strict=False/None is not observable.
         r = dict(zip(header_cells, cells, strict=True))
         if not r.get("pattern") or not r.get("kind"):
             continue

--- a/mcp_server/handlers/_telemetry_wrap.py
+++ b/mcp_server/handlers/_telemetry_wrap.py
@@ -66,7 +66,11 @@ def instrument(
         result: dict[str, Any] = {}
         try:
             result = await fn(args)
-            return result
+            # The assignment above is not redundant: `result` also feeds
+            # `finally`'s `_result_count(result, ...)` telemetry sample.
+            # Inlining this into `return await fn(args)` would leave
+            # `result` at its pre-declared `{}` for that read.
+            return result  # noqa: RET504 — read by finally's telemetry sample
         except Exception:
             ok = False
             raise

--- a/mcp_server/handlers/checkpoint.py
+++ b/mcp_server/handlers/checkpoint.py
@@ -199,10 +199,9 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
 
     if action == "save":
         return _save_checkpoint(args)
-    elif action == "restore":
+    if action == "restore":
         return _restore_context(args)
-    else:
-        return {"error": f"Unknown action: {action}"}
+    return {"error": f"Unknown action: {action}"}
 
 
 def _resolve_session_id(explicit: str | None) -> str:

--- a/mcp_server/handlers/explore_features.py
+++ b/mcp_server/handlers/explore_features.py
@@ -149,14 +149,13 @@ async def handler(args: dict) -> dict:
 
     if mode == "features":
         return _handle_features(profiles)
-    elif mode == "attribution":
+    if mode == "attribution":
         return _handle_attribution(profiles, domain)
-    elif mode == "persona":
+    if mode == "persona":
         return _handle_persona(profiles, domain)
-    elif mode == "crosscoder":
+    if mode == "crosscoder":
         return _handle_crosscoder(profiles, domain, compare_domain)
-    else:
-        return {"status": "error", "message": f"Unknown mode: {mode}"}
+    return {"status": "error", "message": f"Unknown mode: {mode}"}
 
 
 def _resolve_feature_dictionary(profiles: dict) -> FeatureDictionary:

--- a/mcp_server/handlers/get_project_story.py
+++ b/mcp_server/handlers/get_project_story.py
@@ -102,37 +102,35 @@ def _period_cutoff(period: str) -> datetime:
     now = datetime.now(timezone.utc)
     if period == "day":
         return now - timedelta(days=1)
-    elif period == "week":
+    if period == "week":
         return now - timedelta(weeks=1)
-    elif period == "month":
+    if period == "month":
         return now - timedelta(days=30)
-    else:  # "all"
-        return datetime(2000, 1, 1, tzinfo=timezone.utc)
+    # "all"
+    return datetime(2000, 1, 1, tzinfo=timezone.utc)
 
 
 def _bucket_label(dt: datetime, period: str) -> str:
     """Return a human-readable bucket label for a datetime."""
     if period == "day":
         return dt.strftime("%H:00")
-    elif period == "week":
+    if period == "week":
         return dt.strftime("%A %b %d")
-    elif period == "month":
+    if period == "month":
         return dt.strftime("Week of %b %d")
-    else:
-        return dt.strftime("%B %Y")
+    return dt.strftime("%B %Y")
 
 
 def _bucket_key(dt: datetime, period: str) -> str:
     """Sortable bucket key."""
     if period == "day":
         return dt.strftime("%Y%m%d%H")
-    elif period == "week":
+    if period == "week":
         return dt.strftime("%Y%m%d")
-    elif period == "month":
+    if period == "month":
         year, week, _ = dt.isocalendar()
         return f"{year}{week:02d}"
-    else:
-        return dt.strftime("%Y%m")
+    return dt.strftime("%Y%m")
 
 
 def _extract_headline(text: str) -> str:

--- a/mcp_server/handlers/ingest_codebase_cypher.py
+++ b/mcp_server/handlers/ingest_codebase_cypher.py
@@ -262,7 +262,10 @@ async def fetch_symbols_page(
             "visibility",
         ]
         for row in result.get("rows") or []:
-            record = dict(zip(columns, row))
+            # strict=False: columns/row cross an external MCP tool-call
+            # boundary (`_run_query`); a shape drift there should degrade
+            # to a partial record, not raise, matching prior behavior.
+            record = dict(zip(columns, row, strict=False))
             qn = record.get("qualified_name") or record.get("name")
             if not qn:
                 continue

--- a/mcp_server/handlers/narrative.py
+++ b/mcp_server/handlers/narrative.py
@@ -95,8 +95,7 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
             "memory_count": len(memories),
         }
 
-    result = generate_narrative(
+    return generate_narrative(
         memories,
         directory=directory or domain,
     )
-    return result

--- a/mcp_server/handlers/recall.py
+++ b/mcp_server/handlers/recall.py
@@ -687,8 +687,7 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
     # objects to record ids), re-checking the SAME budget. On homogeneous
     # sets this declares field names once instead of per memory; json is the
     # default escape hatch. Truncated items keep their id in either encoding.
-    resp = encode_within_budget(resp, "memories", fmt, settings.MAX_RESPONSE_CHARS)
-    return resp
+    return encode_within_budget(resp, "memories", fmt, settings.MAX_RESPONSE_CHARS)
 
 
 # Telemetry-instrumented public entry. Wrapper records latency, byte

--- a/mcp_server/handlers/recall_helpers.py
+++ b/mcp_server/handlers/recall_helpers.py
@@ -73,6 +73,10 @@ def compute_text_signals(
     docs = [m.get("content", "") for m in hot_mems]
     # strict=True: compute_bm25_scores returns exactly len(docs) scores,
     # and docs/ids are both derived from hot_mems one-to-one above.
+    # Documented equivalent mutant (coding-standards.md §12.1): the
+    # `if not q_terms or not documents: return [0.0] * len(documents)`
+    # branch in compute_bm25_scores guarantees this by construction, so
+    # strict=True vs strict=False/None is not observable here.
     bm25 = [
         (mid, s)
         for mid, s in zip(ids, compute_bm25_scores(query, docs), strict=True)

--- a/mcp_server/handlers/recall_helpers.py
+++ b/mcp_server/handlers/recall_helpers.py
@@ -71,7 +71,13 @@ def compute_text_signals(
         return [], []
     ids = [m["id"] for m in hot_mems]
     docs = [m.get("content", "") for m in hot_mems]
-    bm25 = [(mid, s) for mid, s in zip(ids, compute_bm25_scores(query, docs)) if s > 0]
+    # strict=True: compute_bm25_scores returns exactly len(docs) scores,
+    # and docs/ids are both derived from hot_mems one-to-one above.
+    bm25 = [
+        (mid, s)
+        for mid, s in zip(ids, compute_bm25_scores(query, docs), strict=True)
+        if s > 0
+    ]
     ngram = [
         (m["id"], compute_ngram_score(query, m.get("content", ""))) for m in hot_mems
     ]

--- a/mcp_server/handlers/recall_hierarchical.py
+++ b/mcp_server/handlers/recall_hierarchical.py
@@ -303,8 +303,15 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
         "results": results,
         "total": len(results),
         "query_word_count": len(query.split()),
+        # strict=True: compute_level_weights' return type is a fixed
+        # 3-tuple (L0, L1, L2 weights), always matching the 3-element
+        # literal on the left.
         "level_weights": dict(
-            zip(["L0", "L1", "L2"], fractal.compute_level_weights(query))
+            zip(
+                ["L0", "L1", "L2"],
+                fractal.compute_level_weights(query),
+                strict=True,
+            )
         ),
         "hierarchy": {"stats": hierarchy.get("stats", {})},
     }

--- a/mcp_server/handlers/recall_hierarchical.py
+++ b/mcp_server/handlers/recall_hierarchical.py
@@ -305,7 +305,10 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
         "query_word_count": len(query.split()),
         # strict=True: compute_level_weights' return type is a fixed
         # 3-tuple (L0, L1, L2 weights), always matching the 3-element
-        # literal on the left.
+        # literal on the left. Documented equivalent mutant
+        # (coding-standards.md §12.1): the tuple-typed return makes a
+        # length mismatch unreachable, so strict=True vs strict=False/None
+        # is not observable through this call.
         "level_weights": dict(
             zip(
                 ["L0", "L1", "L2"],

--- a/mcp_server/handlers/remember.py
+++ b/mcp_server/handlers/remember.py
@@ -163,7 +163,9 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
     try:
         write_class_module.validate_write_class(write_class_arg)
     except ValueError as exc:
-        raise ValidationError(str(exc), {"tool": "remember", "field": "write_class"})
+        raise ValidationError(
+            str(exc), {"tool": "remember", "field": "write_class"}
+        ) from exc
     resolved_write_class = write_class_module.classify_write_class(
         {"write_class": write_class_arg, "source": source}
     )

--- a/mcp_server/hooks/session_start.py
+++ b/mcp_server/hooks/session_start.py
@@ -115,10 +115,9 @@ def _connect_pg():
         import psycopg  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
         from psycopg.rows import DictRow, dict_row  # noqa: PLC0415 — optional dependency ([postgresql] extra); imported where used so environments without it keep working
 
-        conn = psycopg.Connection[DictRow].connect(
+        return psycopg.Connection[DictRow].connect(
             _DATABASE_URL, row_factory=dict_row, autocommit=True
         )
-        return conn
     except Exception as exc:  # noqa: BLE001 — hook boundary — failure is logged to the hook log; the hook stays non-fatal
         _log(f"PostgreSQL connect failed: {exc}")
         return None

--- a/mcp_server/infrastructure/mcp_client.py
+++ b/mcp_server/infrastructure/mcp_client.py
@@ -161,11 +161,11 @@ class MCPClient:
                 ),
                 timeout=self._connect_timeout_ms / 1000,
             )
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as exc:
             raise McpConnectionError(
                 f"Connect timeout after {self._connect_timeout_ms}ms",
                 {"command": command, "args": args},
-            )
+            ) from exc
         except Exception as e:
             raise McpConnectionError(
                 f"Failed to spawn: {e}",
@@ -366,7 +366,7 @@ class MCPClient:
         start = loop.time()
         try:
             return await asyncio.wait_for(future, timeout=effective_timeout)
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as exc:
             self._pending.pop(req_id, None)
             elapsed = loop.time() - start
             raise McpConnectionError(
@@ -377,7 +377,7 @@ class MCPClient:
                 f"than the OS pipe buffer, or the reader loop is no longer "
                 f"draining its stdout.",
                 {"method": method, "elapsed_s": round(elapsed, 1)},
-            )
+            ) from exc
 
     def _notify(self, method: str, params: dict | None = None) -> None:
         msg: dict[str, Any] = {"jsonrpc": "2.0", "method": method}

--- a/mcp_server/infrastructure/sqlite_sql_translate.py
+++ b/mcp_server/infrastructure/sqlite_sql_translate.py
@@ -160,11 +160,9 @@ def _translate_sql(sql: str) -> str:
     # BIGINT[] columns are stored as JSON TEXT under SQLite; PostgreSQL
     # returns NULL for an empty array here, json_array_length returns 0 —
     # both are falsy against the `> 0` predicate every call site uses.
-    out = re.sub(
+    return re.sub(
         r"\barray_length\s*\(\s*([a-z_.]+)\s*,\s*1\s*\)",
         r"json_array_length(\1)",
         out,
         flags=re.IGNORECASE,
     )
-
-    return out

--- a/mcp_server/shared/content_hardening.py
+++ b/mcp_server/shared/content_hardening.py
@@ -60,8 +60,7 @@ def harden_content(content: str, *, max_bytes: int = CONTENT_MAX_BYTES) -> str:
 
     hardened = _strip_control_chars(content)
     hardened = unicodedata.normalize("NFC", hardened)
-    hardened = _cap_bytes(hardened, max_bytes)
-    return hardened
+    return _cap_bytes(hardened, max_bytes)
 
 
 def _strip_control_chars(s: str) -> str:

--- a/mcp_server/shared/domain_mapping.py
+++ b/mcp_server/shared/domain_mapping.py
@@ -174,7 +174,9 @@ def _shared_prefix(a: str, b: str) -> str:
     parts_a = a.split("-")
     parts_b = b.split("-")
     common: list[str] = []
-    for pa, pb in zip(parts_a, parts_b):
+    # strict=False: a common-prefix scan over two hyphen-split domain ids of
+    # potentially different segment counts is defined to stop at the shorter.
+    for pa, pb in zip(parts_a, parts_b, strict=False):
         if pa == pb:
             common.append(pa)
         else:

--- a/mcp_server/shared/redaction.py
+++ b/mcp_server/shared/redaction.py
@@ -105,7 +105,7 @@ def redact_url(url: str) -> str:
     if not userinfo_changed and not query_changed:
         return url  # postcondition: no password anywhere — unchanged
 
-    redacted = urllib.parse.urlunparse(
+    return urllib.parse.urlunparse(
         (
             parsed.scheme,
             netloc,
@@ -115,7 +115,6 @@ def redact_url(url: str) -> str:
             parsed.fragment,
         )
     )
-    return redacted
 
 
 # ── Self-check assertions (run once at import; caught by python3 -m py_compile
@@ -238,6 +237,4 @@ def scrub_secrets(text: str) -> str:
     def _redact_url_match(m: re.Match) -> str:
         return redact_url(m.group(0))
 
-    text = _RE_EMBEDDED_URL.sub(_redact_url_match, text)
-
-    return text
+    return _RE_EMBEDDED_URL.sub(_redact_url_match, text)

--- a/mcp_server/shared/string_distance.py
+++ b/mcp_server/shared/string_distance.py
@@ -89,7 +89,9 @@ def jaro_winkler_similarity(s1: str, s2: str) -> float:
     """
     jaro = jaro_similarity(s1, s2)
     prefix = 0
-    for c1, c2 in zip(s1, s2):
+    # strict=False: Jaro-Winkler's common-prefix scan is defined for strings
+    # of differing length (it stops at the shorter one).
+    for c1, c2 in zip(s1, s2, strict=False):
         if c1 != c2:
             break
         prefix += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,6 +309,37 @@ select = [
     # `# noqa: S608 — <mechanism>` naming which of those forms it uses, so
     # any NEW string-built SQL fails CI until it states its mechanism.
     "S608",
+    # B (bugbear) (issue #239, family 1 of the continuation program): 16
+    # findings in mcp_server/ (the issue's measurement scope) plus 25 more
+    # once the repo-wide select picked up benchmarks/, scripts/, and
+    # tests_py/ (41 total, source: `ruff check . --select B` after
+    # enabling) — every one triaged individually, no blanket ignores.
+    #   B905 zip-without-strict (26 sites across the repo): every site now
+    #     states strict=True or strict=False explicitly. True where the
+    #     surrounding code already guarantees equal-length iterables
+    #     (built from the same source one-to-one, an already-checked
+    #     length, or a documented index-correspondence precondition);
+    #     False where unequal length is the intended behavior
+    #     (common-prefix scans over independent strings, a pairwise
+    #     traj/traj[1:] walk) or the inputs cross an external MCP
+    #     tool-call / store-write boundary whose shape drift should
+    #     degrade gracefully rather than raise.
+    #   B904 raise-without-from (5 sites): every re-wrap in an `except`
+    #     now chains `from <exc>`, preserving the original traceback as
+    #     `__cause__` — an additive diagnostic, not an observable
+    #     behavior change for any caller catching the wrapping type.
+    #   B007 unused-loop-control-variable (9 sites) / B023
+    #     function-uses-loop-variable (1 site): renamed to `_`-prefixed,
+    #     or bound as a lambda default argument, at the exact sites
+    #     ruff flagged — no other lines touched.
+    #   B015 pointless-comparison (1 site, a test): a discarded `x is None`
+    #     expression asserted nothing; removed rather than promoted to a
+    #     new assertion (which would be new test coverage, not a refactor).
+    #   B017 assert-blind-exception (3 sites, tests): narrowed to the
+    #     concrete exception type each site's code path actually raises
+    #     (confirmed by reproduction — sqlite3.ProgrammingError,
+    #     mcp.shared.exceptions.McpError).
+    "B",
 ]
 # ── Families deliberately NOT selected (issue #197, criterion 1) ────────────
 # Counts measured against mcp_server/ 2026-07-28, ruff 0.15.20 — what
@@ -339,12 +370,12 @@ select = [
 #     contract-lie defect classes this program exists for; each is a
 #     dedicated-PR-sized diff under the fix-with-landing bar.
 #
-# (c) JUDGEMENT families not yet triaged — B (16), TRY (163), RET (20),
-#     ARG (53), PTH (91), N (43), ERA (43), FBT (254), DTZ (4), S beyond
-#     S110/S608 (34): tracked as the program's continuation in issue #239.
-#     Enabling any of them without the per-finding triage the first six
-#     families received would mean blanket ignores — the exact anti-pattern
-#     this explicit select list exists to prevent.
+# (c) JUDGEMENT families not yet triaged — TRY (163), RET (20), ARG (53),
+#     PTH (91), N (43), ERA (43), FBT (254), DTZ (4), S beyond S110/S608
+#     (34): tracked as the program's continuation in issue #239 (B landed
+#     above). Enabling any of them without the per-finding triage the
+#     landed families received would mean blanket ignores — the exact
+#     anti-pattern this explicit select list exists to prevent.
 
 [tool.ruff.lint.per-file-ignores]
 # Test code: try/except/pass and broad excepts in tests are deliberate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,6 +351,33 @@ select = [
     # zero out that count. Documented in place with `# noqa: RET504`
     # rather than fixed, since fixing it would be a behavior change.
     "RET",
+    # DTZ (naive datetime) (issue #239, family 3): 4 findings in
+    # mcp_server/ + 12 more repo-wide (16 total, 3 rule variants).
+    #   DTZ003 datetime.utcnow() (2 sites, benchmarks/): replaced with
+    #     datetime.now(timezone.utc) — the deprecated call fed only a
+    #     %-directive-free strftime(), so the formatted string is
+    #     byte-identical either way; this resolves the deprecation with
+    #     zero output change.
+    #   DTZ007 strptime without %z (1 site, benchmarks/): the parsed value
+    #     is stamped `tzinfo=timezone.utc` on the very next line, so the
+    #     function's actual return value is always aware — documented
+    #     in place with `# noqa: DTZ007`.
+    #   DTZ001 datetime() without tzinfo (13 sites, core/temporal.py +
+    #     core/context_assembly/stage_detector.py + their test files):
+    #     these two parsers are naive-by-design — every caller only ever
+    #     diffs two datetimes THIS module produced (date-only, no
+    #     time-of-day), and the sibling ISO-parse branch in each is
+    #     naive too whenever the input lacks an explicit offset. Making
+    #     one branch aware while its sibling stays naive would raise on
+    #     the very comparisons these functions exist to support;
+    #     unifying tz-awareness across both parsing paths is a design
+    #     change for a dedicated fix, not this lint refactor. Documented
+    #     in place with `# noqa: DTZ001` at each site (production) or a
+    #     class-level docstring note (tests, whose literals are expected
+    #     outputs/inputs for the same naive contract) — one exception,
+    #     `test_sqlite_datetime_adapter_260.py`, where the naive input IS
+    #     the test's stated point (round-tripping a tzinfo-less datetime).
+    "DTZ",
 ]
 # ── Families deliberately NOT selected (issue #197, criterion 1) ────────────
 # Counts measured against mcp_server/ 2026-07-28, ruff 0.15.20 — what
@@ -382,8 +409,8 @@ select = [
 #     dedicated-PR-sized diff under the fix-with-landing bar.
 #
 # (c) JUDGEMENT families not yet triaged — TRY (163), ARG (53), PTH (91),
-#     N (43), ERA (43), FBT (254), DTZ (4), S beyond S110/S608 (34):
-#     tracked as the program's continuation in issue #239 (B, RET landed
+#     N (43), ERA (43), FBT (254), S beyond S110/S608 (34): tracked as
+#     the program's continuation in issue #239 (B, RET, DTZ landed
 #     above). Enabling any of them without the per-finding triage the
 #     landed families received would mean blanket ignores — the exact
 #     anti-pattern this explicit select list exists to prevent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,6 +340,17 @@ select = [
     #     (confirmed by reproduction — sqlite3.ProgrammingError,
     #     mcp.shared.exceptions.McpError).
     "B",
+    # RET (return discipline) (issue #239, family 2): 20 findings in
+    # mcp_server/ + 9 more repo-wide (29 total). 25 of the 29 were RET505
+    # (superfluous else/elif after return) — mechanical, ruff's own `--fix`
+    # applied every one unchanged in meaning. The remaining RET504
+    # (unnecessary assignment before return) sites were inlined by hand
+    # EXCEPT one: `_telemetry_wrap.py`'s `result = await fn(args); return
+    # result` looks identical to the others but `result` is also read by
+    # the `finally` block's telemetry sample — inlining would silently
+    # zero out that count. Documented in place with `# noqa: RET504`
+    # rather than fixed, since fixing it would be a behavior change.
+    "RET",
 ]
 # ── Families deliberately NOT selected (issue #197, criterion 1) ────────────
 # Counts measured against mcp_server/ 2026-07-28, ruff 0.15.20 — what
@@ -370,9 +381,9 @@ select = [
 #     contract-lie defect classes this program exists for; each is a
 #     dedicated-PR-sized diff under the fix-with-landing bar.
 #
-# (c) JUDGEMENT families not yet triaged — TRY (163), RET (20), ARG (53),
-#     PTH (91), N (43), ERA (43), FBT (254), DTZ (4), S beyond S110/S608
-#     (34): tracked as the program's continuation in issue #239 (B landed
+# (c) JUDGEMENT families not yet triaged — TRY (163), ARG (53), PTH (91),
+#     N (43), ERA (43), FBT (254), DTZ (4), S beyond S110/S608 (34):
+#     tracked as the program's continuation in issue #239 (B, RET landed
 #     above). Enabling any of them without the per-finding triage the
 #     landed families received would mean blanket ignores — the exact
 #     anti-pattern this explicit select list exists to prevent.

--- a/scripts/badge_render.py
+++ b/scripts/badge_render.py
@@ -183,5 +183,7 @@ def render(spec: BadgeSpec) -> str:
     try:
         ElementTree.fromstring(svg)
     except ElementTree.ParseError as error:
-        raise BadgeMarkupError(f"rendered badge is not well-formed XML: {error}")
+        raise BadgeMarkupError(
+            f"rendered badge is not well-formed XML: {error}"
+        ) from error
     return svg

--- a/scripts/wiki_pilot_migration.py
+++ b/scripts/wiki_pilot_migration.py
@@ -255,7 +255,7 @@ def _stratified_sample(
     per_kind = max(sample_size // n_kinds, 1)
     sampled: list[Path] = []
     leftover_quota = sample_size
-    for kind, files in by_kind.items():
+    for _kind, files in by_kind.items():
         take = min(per_kind, len(files), leftover_quota)
         sampled.extend(rng.sample(files, take))
         leftover_quota -= take

--- a/tests_py/benchmarks/benchmark_harness.py
+++ b/tests_py/benchmarks/benchmark_harness.py
@@ -870,7 +870,7 @@ def benchmark_pattern_separation() -> dict[str, dict[str, float]]:
     base /= np.linalg.norm(base)
 
     similar_embeddings = []
-    for i in range(5):
+    for _i in range(5):
         noise = (
             np.random.randn(dim).astype(np.float32) * 0.05
         )  # Very small noise → high similarity
@@ -1079,7 +1079,12 @@ def _table(headers: list[str], rows: list[list]) -> str:
         max(len(str(h)), *(len(str(r[i])) for r in rows)) for i, h in enumerate(headers)
     ]
     sep = "|" + "|".join("-" * (w + 2) for w in widths) + "|"
-    header = "|" + "|".join(f" {h:<{w}} " for h, w in zip(headers, widths)) + "|"
+    # strict=True: widths is computed one entry per header just above.
+    header = (
+        "|"
+        + "|".join(f" {h:<{w}} " for h, w in zip(headers, widths, strict=True))
+        + "|"
+    )
     body = "\n".join(
         "|" + "|".join(f" {str(r[i]):<{w}} " for i, w in enumerate(widths)) + "|"
         for r in rows

--- a/tests_py/benchmarks/test_spell_alteration.py
+++ b/tests_py/benchmarks/test_spell_alteration.py
@@ -231,7 +231,7 @@ class TestSpellAlteration:
             store = _get_store()
 
             # Each fake is stored
-            for i, target in enumerate(targets):
+            for i, _target in enumerate(targets):
                 fake = FAKE_SPELLS[i]
                 fake_rows = _query_store_for_spell(store, fake["name"])
                 assert len(fake_rows) == 1, f"Fake {fake['name']} not found"

--- a/tests_py/core/context_assembly/test_stage_detector.py
+++ b/tests_py/core/context_assembly/test_stage_detector.py
@@ -57,10 +57,15 @@ class TestExplicitStageDetector:
 
 
 class TestTemporalStageDetectorParsing:
+    """noqa DTZ001 throughout this class: `_parse_ts` is naive-by-design
+    (see its docstring in stage_detector.py) — these literal
+    ``datetime(...)`` values are expected outputs compared against it, or
+    inputs fed straight back through, so they stay naive too."""
+
     def test_parse_iso_date_string(self):
         det = TemporalStageDetector()
         ts = det._parse_ts("2024-03-15")
-        assert ts == datetime(2024, 3, 15)
+        assert ts == datetime(2024, 3, 15)  # noqa: DTZ001
 
     def test_parse_iso_datetime_with_z_suffix(self):
         det = TemporalStageDetector()
@@ -71,16 +76,16 @@ class TestTemporalStageDetectorParsing:
     def test_parse_beam_month_name_format(self):
         det = TemporalStageDetector()
         ts = det._parse_ts("March-15-2024")
-        assert ts == datetime(2024, 3, 15)
+        assert ts == datetime(2024, 3, 15)  # noqa: DTZ001
 
     def test_parse_beam_format_case_insensitive(self):
         det = TemporalStageDetector()
         ts = det._parse_ts("march-15-2024")
-        assert ts == datetime(2024, 3, 15)
+        assert ts == datetime(2024, 3, 15)  # noqa: DTZ001
 
     def test_parse_datetime_object_passthrough(self):
         det = TemporalStageDetector()
-        dt = datetime(2024, 1, 1)
+        dt = datetime(2024, 1, 1)  # noqa: DTZ001
         assert det._parse_ts(dt) is dt
 
     def test_parse_none_returns_none(self):

--- a/tests_py/core/test_attentional_control_readside.py
+++ b/tests_py/core/test_attentional_control_readside.py
@@ -73,7 +73,8 @@ def test_no_signal_is_identity_scores_and_order():
     ]
     out = rp.attentional_focus_rerank(copy.deepcopy(before), "wholly unrelated words")
     assert [c["memory_id"] for c in out] == [1, 2, 3]
-    for o, b in zip(out, before):
+    # strict=True: out is a rerank (same-length reorder) of before.
+    for o, b in zip(out, before, strict=True):
         assert abs(o["score"] - b["score"]) < 1e-12
 
 
@@ -97,7 +98,8 @@ def test_uniform_salience_and_no_query_is_identity():
     ]
     out = rp.attentional_focus_rerank(copy.deepcopy(before), "")  # empty query
     assert [c["memory_id"] for c in out] == [1, 2]
-    for o, b in zip(out, before):
+    # strict=True: out is a rerank (same-length reorder) of before.
+    for o, b in zip(out, before, strict=True):
         assert abs(o["score"] - b["score"]) < 1e-12
 
 

--- a/tests_py/core/test_fractal.py
+++ b/tests_py/core/test_fractal.py
@@ -35,7 +35,8 @@ def _cosine_sim(a, b):
         return 0.0
     va = struct.unpack(f"{DIM}f", a[: DIM * 4])
     vb = struct.unpack(f"{DIM}f", b[: DIM * 4])
-    dot = sum(x * y for x, y in zip(va, vb))
+    # strict=True: both vectors are unpacked with the same fixed DIM count.
+    dot = sum(x * y for x, y in zip(va, vb, strict=True))
     na = sum(x * x for x in va) ** 0.5
     nb = sum(x * x for x in vb) ** 0.5
     if na == 0 or nb == 0:

--- a/tests_py/core/test_precision_weighted_errors.py
+++ b/tests_py/core/test_precision_weighted_errors.py
@@ -29,7 +29,8 @@ class TestNeuromodulatePrecisions:
         precs = [1.0, 1.0, 1.0]
         low = neuromodulate_precisions(precs, ne_level=0.5)
         high = neuromodulate_precisions(precs, ne_level=1.8)
-        assert all(hi > lo for hi, lo in zip(high, low))
+        # strict=True: neuromodulate_precisions returns one value per input.
+        assert all(hi > lo for hi, lo in zip(high, low, strict=True))
 
     def test_high_ach_boosts_bottom_up(self):
         precs = [1.0, 1.0, 1.0]
@@ -55,13 +56,21 @@ class TestUpdatePrecisionState:
     def test_small_errors_increase_precision(self):
         state = PrecisionState(level_precisions=[1.0, 1.0, 1.0])
         updated = update_precision_state(state, [0.01, 0.01, 0.01])
-        for old, new in zip(state.level_precisions, updated.level_precisions):
+        # strict=True: update_precision_state returns the same number of
+        # level_precisions it was given.
+        for old, new in zip(
+            state.level_precisions, updated.level_precisions, strict=True
+        ):
             assert new > old
 
     def test_large_errors_decrease_precision(self):
         state = PrecisionState(level_precisions=[3.0, 3.0, 3.0])
         updated = update_precision_state(state, [5.0, 5.0, 5.0])
-        for old, new in zip(state.level_precisions, updated.level_precisions):
+        # strict=True: update_precision_state returns the same number of
+        # level_precisions it was given.
+        for old, new in zip(
+            state.level_precisions, updated.level_precisions, strict=True
+        ):
             assert new < old
 
     def test_increments_prediction_history(self):

--- a/tests_py/core/test_tabular_encoding.py
+++ b/tests_py/core/test_tabular_encoding.py
@@ -10,6 +10,8 @@ that exceeds the response-budget cap).
 
 from __future__ import annotations
 
+import pytest
+
 from mcp_server.core.response_budget import serialized_length
 from mcp_server.core.tabular_encoding import (
     FORMAT_JSON,
@@ -226,3 +228,32 @@ def test_tabular_declined_when_it_would_overflow_tiny_budget() -> None:
         out = encode_within_budget(obj_payload, "memories", FORMAT_TABULAR, budget)
         assert out["format"] == FORMAT_JSON
         assert serialized_length(out) <= budget
+
+
+def test_tabular_accepted_at_exact_budget_boundary() -> None:
+    """Boundary: budget_chars exactly equal to the tabular form's serialized
+    length must still ACCEPT tabular — the re-check is strictly '>', not
+    '>=' (a budget the candidate exactly fits is not an overflow). A scoped
+    mutation run (issue #239, B905 family) flipped '>' to '>=' and no
+    existing test failed, proving this boundary was unpinned."""
+    items = [_mem("1", "a")]
+    obj_payload = {"memories": list(items), "count": 1}
+    columns = derive_columns(items)
+    tab_candidate = {
+        **obj_payload,
+        "memories": encode_rows(items, columns),
+        "columns": columns,
+        "format": FORMAT_TABULAR,
+    }
+    exact_budget = serialized_length(tab_candidate)
+    out = encode_within_budget(obj_payload, "memories", FORMAT_TABULAR, exact_budget)
+    assert out["format"] == FORMAT_TABULAR
+
+
+def test_decode_tabular_raises_on_length_mismatch() -> None:
+    """decode_tabular's documented precondition (every row has len(columns))
+    is enforced via zip(columns, row, strict=True). A scoped mutation run
+    (issue #239, B905 family) surfaced strict=True/False/None as equally
+    untested; this pins the precondition-violation path to a real error."""
+    with pytest.raises(ValueError):
+        decode_tabular(["a", "b"], [[1]])

--- a/tests_py/core/test_tabular_encoding.py
+++ b/tests_py/core/test_tabular_encoding.py
@@ -111,7 +111,9 @@ def test_field_set_equality_union_columns(_none=None) -> None:
     assert set(columns) == union
 
     decoded = decode_tabular(columns, rows)
-    for original, back in zip(items, decoded):
+    # strict=True: decode_tabular returns one dict per row, and rows was
+    # built one-per-item by encode_rows above.
+    for original, back in zip(items, decoded, strict=True):
         # Every field present in the original is recovered with its value.
         assert all(back[k] == original[k] for k in original)
 

--- a/tests_py/core/test_temporal.py
+++ b/tests_py/core/test_temporal.py
@@ -16,17 +16,22 @@ from mcp_server.core.temporal import (
 
 
 class TestParseDate:
+    """noqa DTZ001 throughout this class: parse_date is naive-by-design
+    (see core/temporal.py's _try_parse_named_date docstring) — these
+    literal ``datetime(...)`` values are expected outputs compared against
+    it, so they must stay naive too."""
+
     def test_iso(self):
         dt = parse_date("2024-03-15")
-        assert dt == datetime(2024, 3, 15)
+        assert dt == datetime(2024, 3, 15)  # noqa: DTZ001
 
     def test_dd_month_yyyy(self):
         dt = parse_date("15 March 2024")
-        assert dt == datetime(2024, 3, 15)
+        assert dt == datetime(2024, 3, 15)  # noqa: DTZ001
 
     def test_month_dd_yyyy(self):
         dt = parse_date("March 15, 2024")
-        assert dt == datetime(2024, 3, 15)
+        assert dt == datetime(2024, 3, 15)  # noqa: DTZ001
 
     def test_empty(self):
         assert parse_date("") is None
@@ -37,12 +42,12 @@ class TestParseDate:
 
     def test_embedded_iso(self):
         dt = parse_date("Created on 2024-06-01 at noon")
-        assert dt == datetime(2024, 6, 1)
+        assert dt == datetime(2024, 6, 1)  # noqa: DTZ001
 
     def test_iso_datetime_is_truncated_to_its_date(self):
         """The 'T' split is what makes this a DATE parser: the time is cut,
         not carried, so hint distances compare days against days."""
-        assert parse_date("2024-03-15T10:30:00Z") == datetime(2024, 3, 15)
+        assert parse_date("2024-03-15T10:30:00Z") == datetime(2024, 3, 15)  # noqa: DTZ001
 
     def test_space_separated_utc_designator(self):
         """No 'T' to split on, so the 'Z' → '+00:00' rewrite is what makes

--- a/tests_py/core/test_tripartite_synapse.py
+++ b/tests_py/core/test_tripartite_synapse.py
@@ -53,7 +53,8 @@ class TestCalciumWave:
     def test_wave_propagates(self):
         neighbors = [0.0, 0.1, 0.0]
         updated = propagate_calcium_wave(0.8, neighbors)
-        assert all(u >= n for u, n in zip(updated, neighbors))
+        # strict=True: propagate_calcium_wave returns one value per neighbor.
+        assert all(u >= n for u, n in zip(updated, neighbors, strict=True))
 
     def test_no_wave_below_threshold(self):
         neighbors = [0.0, 0.1, 0.0]

--- a/tests_py/core/test_write_class.py
+++ b/tests_py/core/test_write_class.py
@@ -198,7 +198,7 @@ class TestValidateWriteClass:
     ``classify_write_class`` fallback tested above."""
 
     def test_none_is_accepted_no_raise(self):
-        validate_write_class(None) is None  # no exception
+        validate_write_class(None)  # no exception
 
     def test_each_known_class_is_accepted(self):
         for cls in ALL_WRITE_CLASSES:

--- a/tests_py/handlers/test_recall_tabular_format.py
+++ b/tests_py/handlers/test_recall_tabular_format.py
@@ -114,7 +114,8 @@ def test_tabular_has_no_information_loss_vs_json(
     decoded = decode_tabular(tab_out["columns"], tab_out["memories"])
     json_mems = json_out["memories"]
     assert len(decoded) == len(json_mems)
-    for obj, back in zip(json_mems, decoded):
+    # strict=True: equal length already asserted immediately above.
+    for obj, back in zip(json_mems, decoded, strict=True):
         assert set(back.keys()) >= set(obj.keys())
         assert all(back[k] == obj[k] for k in obj)
 

--- a/tests_py/handlers/test_wiki_pipeline_sqlite.py
+++ b/tests_py/handlers/test_wiki_pipeline_sqlite.py
@@ -22,6 +22,7 @@ the handlers' own `_get_store()` is what is under test.
 from __future__ import annotations
 
 import logging
+import sqlite3
 
 import pytest
 
@@ -359,7 +360,7 @@ def test_cursor_closes_on_context_exit():
     conn = _compat_conn()
     with conn.cursor() as cur:
         cur.execute("SELECT 1 AS n")
-    with pytest.raises(Exception):
+    with pytest.raises(sqlite3.ProgrammingError):
         cur.execute("SELECT 1")
 
 

--- a/tests_py/infrastructure/test_pg_alpha_integral.py
+++ b/tests_py/infrastructure/test_pg_alpha_integral.py
@@ -208,7 +208,9 @@ def test_effective_heat_is_monotone_non_increasing(store: PgMemoryStore) -> None
     """
     for label, (imp, acc, sch) in _PROFILES.items():
         traj = _probe_heat_trajectory(store, imp, acc, sch)
-        for (t_prev, h_prev), (t_cur, h_cur) in zip(traj, traj[1:]):
+        # strict=False: this is a deliberate pairwise (offset-by-one) walk
+        # over traj — traj[1:] is always exactly one element shorter.
+        for (t_prev, h_prev), (t_cur, h_cur) in zip(traj, traj[1:], strict=False):
             # Allow float4 round-trip noise; a real bump (≥1e-6) must not occur.
             assert h_cur <= h_prev + 1e-6, (
                 f"{label}: heat rose with age {t_prev}h={h_prev:.8f} → "

--- a/tests_py/infrastructure/test_schema_integrity.py
+++ b/tests_py/infrastructure/test_schema_integrity.py
@@ -120,8 +120,7 @@ def _prepare_for_explain(blob: str) -> str:
     # Replace f-string-style braces with NULL.
     sql = _PYFMT_BRACES.sub("NULL", sql)
     # Replace psycopg %s placeholders with safely-typed NULL.
-    sql = _PG_PARAM.sub("NULL", sql)
-    return sql
+    return _PG_PARAM.sub("NULL", sql)
 
 
 # Blob fingerprints we have manually reviewed and confirmed benign.

--- a/tests_py/infrastructure/test_sqlite_datetime_adapter_260.py
+++ b/tests_py/infrastructure/test_sqlite_datetime_adapter_260.py
@@ -45,7 +45,7 @@ class TestAdaptDatetimeIso:
 
     def test_naive_datetime_round_trips_through_isoformat(self):
         """No tzinfo is still a valid `datetime`; the adapter must not raise."""
-        value = datetime(2026, 7, 29, 12, 34, 56)
+        value = datetime(2026, 7, 29, 12, 34, 56)  # noqa: DTZ001 — naive-input is the point of this test
         assert _adapt_datetime_iso(value) == "2026-07-29T12:34:56"
 
 

--- a/tests_py/infrastructure/test_workflow_graph_source_ast.py
+++ b/tests_py/infrastructure/test_workflow_graph_source_ast.py
@@ -80,8 +80,7 @@ class _RecordingBridge:
 
 
 def _make_source(bridge) -> WorkflowGraphASTSource:
-    src = WorkflowGraphASTSource(bridge=bridge)
-    return src
+    return WorkflowGraphASTSource(bridge=bridge)
 
 
 class TestIncrementalYield:

--- a/tests_py/infrastructure/test_workflow_graph_source_ast.py
+++ b/tests_py/infrastructure/test_workflow_graph_source_ast.py
@@ -93,7 +93,7 @@ class TestIncrementalYield:
         try:
             seen_query_counts: list[int] = []
             batch_count = 0
-            for batch in src.iter_symbols(["/abs/pkg/mod.py"]):
+            for _batch in src.iter_symbols(["/abs/pkg/mod.py"]):
                 # At the moment we receive a batch, the number of queries
                 # issued so far is recorded. If the source fetched everything
                 # up-front, this would equal the TOTAL query count on the very

--- a/tests_py/invariants/test_phase2_parity.py
+++ b/tests_py/invariants/test_phase2_parity.py
@@ -314,12 +314,15 @@ def _setup_fixture() -> tuple[list[dict], list[dict]]:
     finally:
         conn.close()
 
+    # strict=True: mem_ids/ent_ids were each appended exactly once per
+    # fixture row in the insert loops above — always equal length.
     memories = [
         {"id": mid, "content": content, "heat": 0.5}
-        for mid, content in zip(mem_ids, _FIXTURE_MEMORIES)
+        for mid, content in zip(mem_ids, _FIXTURE_MEMORIES, strict=True)
     ]
     entities = [
-        {"id": eid, "name": name} for eid, (name, _) in zip(ent_ids, _FIXTURE_ENTITIES)
+        {"id": eid, "name": name}
+        for eid, (name, _) in zip(ent_ids, _FIXTURE_ENTITIES, strict=True)
     ]
     return memories, entities
 

--- a/tests_py/scripts/test_launcher_deps.py
+++ b/tests_py/scripts/test_launcher_deps.py
@@ -781,7 +781,7 @@ def test_ensure_deps_writes_stamp_directly_when_dist_info_already_satisfies(
     ever calling pip or the lock."""
     deps_dir = tmp_path / "deps"
     deps_dir.mkdir()
-    for name, spec in deps_mod._BASE_PACKAGES:
+    for _name, spec in deps_mod._BASE_PACKAGES:
         dist_name, version = deps_mod._parse_pip_spec(spec)
         _make_dist_info(deps_dir, dist_name, version)
 

--- a/tests_py/test_mcp_prompts.py
+++ b/tests_py/test_mcp_prompts.py
@@ -6,6 +6,7 @@ import asyncio
 
 import pytest
 from fastmcp import Client, FastMCP
+from mcp.shared.exceptions import McpError
 
 from mcp_server import mcp_prompts, tool_profiles
 from mcp_server.__main__ import merged_schemas, register_all
@@ -115,7 +116,7 @@ def test_unknown_prompt_name_errors():
     async def call(c):
         return await c.get_prompt("no_such_prompt", {})
 
-    with pytest.raises(Exception):
+    with pytest.raises(McpError):
         _run(server, call)
 
 
@@ -125,7 +126,7 @@ def test_missing_required_argument_errors():
     async def call(c):
         return await c.get_prompt("session_recall", {})  # 'project' required
 
-    with pytest.raises(Exception):
+    with pytest.raises(McpError):
         _run(server, call)
 
 


### PR DESCRIPTION
## Summary

Progresses #239 (does NOT close it — see "What remains" below). Continuation of the issue #197 maximal-strictness lint program. Enables and individually triages three rule families end-to-end, repo-wide (not just the issue's `mcp_server/`-scoped measurement):

| family | issue-measured (`mcp_server/`) | actual repo-wide | disposition |
|---|---|---|---|
| B (bugbear) | 16 | 41 | every finding fixed (`strict=`, `from <exc>`, `_`-renames, dead-comparison removal, exception narrowing) |
| RET (return discipline) | 20 | 29 | 25 auto-fixed (ruff `--fix`, dead-branch removal), 4 inlined by hand, 1 documented `noqa` (fixing it would change behavior) |
| DTZ (naive datetime) | 4 | 16 | 2 fixed (deprecated `utcnow()`), 1 documented `noqa` (already-aware two-line pattern), 13 documented `noqa`/docstring-note (two parsers are naive-by-design; unifying tz-awareness is a design change, not a lint refactor) |

Zero blanket ignores. `pyproject.toml`'s `[tool.ruff.lint] select` gains `B`, `RET`, `DTZ`, each with an itemized rationale comment matching the existing `S110`/`BLE001`/`PLR2004`/`PLC0415`/`S608` style.

**Why the counts jump 2-4x**: the issue's counts were measured against `mcp_server/` only; enabling a rule via `[tool.ruff.lint] select` applies repo-wide (`tests_py/`, `benchmarks/`, `scripts/`) except where `per-file-ignores` narrows it. This is disclosed, not hidden — see "What remains" for why it matters for sequencing the rest of #239.

## What remains (sequenced, not deferred — see #239's own acceptance criteria: "sequenced PRs are fine, an issue is not")

7 families are NOT yet triaged: **TRY** (163 in `mcp_server/`), **ARG** (53 → **672 repo-wide**, confirmed by enabling it — dominated by test-double/fixture signatures matching a production interface, e.g. `iter_memories_for_decay(self, chunk_size)` stub methods), **PTH** (91), **N** (43), **ERA** (43), **FBT** (254), **S-rest** (34). Total ≈680 more findings.

Two of these surfaced genuine judgment calls during triage that make "just push through fast" the wrong call:
- One `ARG001` site (`write_gate.compute_embedding_novelty`) turned out to be **dead code** (zero production callers — confirmed by grep) that would need deleting, not just triaging.
- Several others (`detect_blind_spots(profiles=...)`, `compute_reconsolidation_action(query=...)`) accept real, non-trivial values from every caller yet never consume them — genuinely ambiguous between "vestigial, safe to trim" and "missing implementation" (out of a refactorer's scope to guess at). These need per-site research at the same depth as this PR's `strict=`/`noqa` choices, which is why ARG alone won't fit in "the next PR" either — it needs the same rigor demonstrated here, at ~9x the volume once tests_py/ is included.

Given genuine volume (confirmed empirically, not estimated) and the judgment-call density found in the first ~10% of just the ARG family, completing all 7 remaining families with the same non-blanket-ignore rigor is multiple more PRs of this size. Filing them as an issue is explicitly against the parent issue's own text; these will land as sequenced PRs against #239 citing this PR.

## Fowler catalog entries applied (one family per commit)
1. `c390190` — B: Introduce Explicit Parameter (`strict=`), Preserve Whole Object (`from <exc>`), Rename Variable to `_`, Remove Dead Code, Extract Named Exception Type.
2. `cb31181` — RET: Consolidate Duplicate Conditional Fragments / Remove Dead Code (ruff `--fix`), Inline Variable.
3. `2c5921f` — DTZ: Replace Deprecated Call, document-at-use-site.
4. `90f6a8b` — Extract Variable (a pre-push AST-size-gate correction: the B commit's comment pushed one function from 40→43 lines; fixed to land back at cap).
5. `986e170` — kill 2 mutation survivors the B-family `strict=` change surfaced (one directly caused by the change, one pre-existing but seen via the same mutation run — coding-standards.md §14.1).
6. `26652a3` — document 4 more `strict=True` sites as provable equivalent mutants (traced each: the length mismatch is foreclosed by an earlier check in the same/a callee function).

## Completion Ledger (coding-standards.md §13.2)

| Path introduced by this diff | Asserting evidence |
|---|---|
| `strict=True` sites (10 in `mcp_server/`, 16 more repo-wide) | per-site comment naming why; 2 sites additionally covered by new regression tests (`test_decode_tabular_raises_on_length_mismatch`, `test_tabular_accepted_at_exact_budget_boundary`); 5 sites documented as provable equivalent mutants after mutation-testing verification |
| `strict=False` sites (16) | per-site comment naming why (common-prefix scans, pairwise walks, external-boundary degrade-gracefully) |
| `from <exc>` sites (5) | existing exception-handling tests still pass; traceback-only change, no assertable behavior delta |
| `_`-renamed unused-loop-var sites (10) | existing tests unchanged, still pass |
| `B015` dead-comparison removal (1) | test still passes (removed code had zero effect) |
| `B017` narrowed exception types (3) | reproduced the actual exception each site raises before narrowing (`sqlite3.ProgrammingError`, `mcp.shared.exceptions.McpError`) |
| RET504/RET505 inlining (29) | existing tests unchanged, still pass |
| DTZ003/007/001 fixes+docs (16) | `datetime.utcnow()→now(timezone.utc)` sites: byte-identical `strftime()` output verified; naive-by-design sites: read both sibling parsing branches to confirm the naive contract holds symmetrically |
| `encode_within_budget`'s `>`/`>=` boundary (pre-existing, seen via own mutation run) | new `test_tabular_accepted_at_exact_budget_boundary` |

## Test baseline / verification (coding-standards.md §7 Move)
- `pytest -q` before: 6821 passed, 5 skipped, 116 subtests (179.75s)
- `pytest -q` after: 6823 passed (2 new regression tests, both characterizing NEW behavior this PR's B905 fix introduces — not modifications to existing assertions), 5 skipped, 116 subtests (180.93s)
- `ruff check .` / `ruff format --check .`: clean, repo-wide
- `scripts/check_doc_claims.py` / `scripts/generate_repo_badges.py --check`: clean
- Scoped mutation testing (`scripts/mutation_check.sh`) run on `tabular_encoding.py` and `attentional_control.py`: 0 non-equivalent survivors after the fixes/documentation above
- AST size gate (300/40 caps): one NEW violation introduced by the B commit (`_e2_loaders.py::load_longmemeval`, 40→43) — fixed in `90f6a8b`, back to 40. ~13 ALREADY-over-cap functions grew by 1-8 lines each from added `strict=`/`noqa` comments (pre-existing debt, e.g. `recall_pipeline.py` is 1388 lines with 12 already-over-cap functions) — disclosed, not silently absorbed; decomposing these is a dedicated Move-3 effort disproportionate to a lint-family PR.

## Boy-scout check (coding-standards.md §14)
- Seen in touched material: `write_gate.py`'s ambiguous unused-arg case (investigated, NOT touched — genuinely ambiguous between dead-code and missing-impl, correctly out of a refactorer's scope, left for the ARG-family follow-up PR where it's already flagged above); ~40 pre-existing mutation survivors in `allocate_attention`'s salience-formula constants (unrelated to this change, disclosed above, not fixed — decomposition-scale effort).
- Fixed in this PR: the 1 NEW size-cap violation this PR caused; the 1 mutation survivor this PR's own change caused; the 1 pre-existing mutation survivor this PR's own verification step surfaced (`encode_within_budget`'s boundary).
- Bypass used: none.

Closes: none (see "What remains"). Progresses #239.

Co-Authored-By: Claude <noreply@anthropic.com>