### PR TITLE
refactor(lint): triage N, ERA families of issue #239 (2 of 7)

### DIFF
--- a/docs/program/github-reply-issue-14-a3-delivery.md
+++ b/docs/program/github-reply-issue-14-a3-delivery.md
@@ -38,7 +38,7 @@ not a stored state vector**:
   (`bump_heat_raw` + `update_memories_heat_batch`). I2 invariant
   allow-list shrunk from 11 to 7 sites, all on `heat_base`. Legacy
   `SET heat = ...` pattern fenced off by
-  `test_I2_no_legacy_heat_column_writes`.
+  `test_i2_no_legacy_heat_column_writes`.
 - Anchor, preemptive_context, mark_stale, pg_store, sqlite_store all
   refactored to the single A3 path. Zero flag-branching in Python —
   the kill switch is a DDL-level `effective_heat_frozen()` swap per

--- a/mcp_server/core/attribution_tracer.py
+++ b/mcp_server/core/attribution_tracer.py
@@ -240,7 +240,7 @@ def _compute_feature_edges(
 
     edges: list[AttributionEdge] = []
     for feature in dictionary.features:
-        for ts in feature.topSignals or []:
+        for ts in feature.top_signals or []:
             classifier_for = _get_classifier_for_signal(ts.signal)
             if classifier_for:
                 edges.append(
@@ -265,13 +265,13 @@ def compute_edge_weights(
     profile: dict,
     dictionary: FeatureDictionary | None,
 ) -> list[AttributionEdge]:
-    EPSILON = 0.1
-    MAX_SAMPLES = 20
+    epsilon = 0.1
+    max_samples = 20
 
-    mean_baseline = _compute_mean_baseline(conversations, MAX_SAMPLES)
+    mean_baseline = _compute_mean_baseline(conversations, max_samples)
 
     edges: list[AttributionEdge] = []
-    edges.extend(_compute_input_to_extractor_edges(mean_baseline, EPSILON))
+    edges.extend(_compute_input_to_extractor_edges(mean_baseline, epsilon))
 
     # Extractor -> Classifier edges
     for extractor, classifiers in _EXTRACTOR_CLASSIFIER_MAP.items():

--- a/mcp_server/core/blindspot_patterns.py
+++ b/mcp_server/core/blindspot_patterns.py
@@ -17,7 +17,7 @@ _GLOBAL_EXPLORATION_NORM = 0.4  # global share making zero exploration a gap
 _MIN_GLOBAL_EXPLORATION = 0.2  # global floor for the below-average check
 _GLOBAL_DURATION_NORM = 0.3  # global share making a missing bucket a gap
 # source: session-length buckets documented in the count_duration_buckets
-# docstring ("short (<10 min) and long (>30 min)")
+# docstring ("short (<10 min) and long (>30 min)")  # noqa: ERA001
 _SHORT_SESSION_MINUTES = 10
 _LONG_SESSION_MINUTES = 30
 

--- a/mcp_server/core/consolidation_engine.py
+++ b/mcp_server/core/consolidation_engine.py
@@ -362,7 +362,7 @@ def summarize_action_group(
 
 
 # source: graduation conditions documented in the should_reclassify
-# docstring ("Accessed >= 5 times", ">= 3 related semantic memories");
+# docstring ("Accessed >= 5 times", ">= 3 related semantic memories");  # noqa: ERA001
 # tuning provenance not recorded
 _MIN_ACCESSES_FOR_SEMANTIC = 5
 _MIN_RELATED_SEMANTICS = 3

--- a/mcp_server/core/content_cues.py
+++ b/mcp_server/core/content_cues.py
@@ -60,7 +60,7 @@ _STRUCTURAL_ERROR_PATTERNS: tuple[str, ...] = (
     r"File \"[^\"]+\", line \d+",
     # JVM / Node stack frame: "at pkg.Cls.m(File.java:42)" /
     # "at fn (/app/x.js:10:5)".
-    # sources: java.lang.Throwable#printStackTrace javadoc;
+    # sources: java.lang.Throwable#printStackTrace javadoc;  # noqa: ERA001
     # https://v8.dev/docs/stack-trace-api
     r"\bat [^\s(]+ ?\([^()]*:\d+(?::\d+)?\)",
     # CamelCase exception class identifiers (ValueError,
@@ -80,7 +80,7 @@ _DECISION_PATTERNS: dict[str, str] = {
     "en": r"\b(?:decided|chose|switched|migrated|selected|picked|opted)\b",
     # es: decidí/decidimos/decidido, decisión, elegí/elegimos/elegido,
     #     eligió, escogimos/escogido, optamos/opté/optó/optado,
-    #     seleccionó/seleccionado, cambiamos/cambié/cambió (switched)
+    #     seleccionó/seleccionado, cambiamos/cambié/cambió (switched)  # noqa: ERA001
     "es": (
         r"\bdecid\w*|\bdecisi[oó]n\w*|\beleg[ií]\w*|\beligi\w*|\bescog\w*"
         r"|\bopt(?:amos|é|ó|ado|aron)\b|\bseleccion\w*"
@@ -88,20 +88,21 @@ _DECISION_PATTERNS: dict[str, str] = {
     ),
     # pt: decidimos/decidiu/decidido, decisão/decisões, escolhemos/escolhido/
     #     escolha, optamos/optou/optado, selecionou/selecionado,
-    #     migramos/migrou/migrado, mudamos (switched)
+    #     migramos/migrou/migrado, mudamos (switched)  # noqa: ERA001
     "pt": (
         r"\bdecid\w*|\bdecis[aã]o\b|\bdecis[oõ]es\b|\bescolh\w*"
         r"|\bopt(?:amos|ou|ado|aram)\b|\bselecion\w*"
         r"|\bmigr(?:amos|ou|ado|aram)\b|\bmudamos\b"
     ),
     # fr: décidé/décidons (accented or not), décision, choisi/choisie/
-    #     choisissons, opté, sélectionné, migré/migration, basculé (switched)
+    #     choisissons, opté, sélectionné, migré/migration,
+    #     basculé (switched)  # noqa: ERA001 -- multi-language prose gloss, not code
     "fr": (
         r"\bd[ée]cid\w*|\bd[ée]cisi\w*|\bchoisi\w*|\bopt[ée]\b"
         r"|\bs[ée]lectionn\w*|\bmigr[ée]\w*|\bbascul[ée]\w*"
     ),
     # de: entschied/entschieden, Entscheidung, gewählt, ausgewählt,
-    #     entschlossen, migriert, gewechselt/umgestiegen (switched)
+    #     entschlossen, migriert, gewechselt/umgestiegen (switched)  # noqa: ERA001
     "de": (
         r"\bentschied\w*|\bentscheidung\w*|\bgew[äa]hlt\b|\bausgew[äa]hlt\b"
         r"|\bentschlossen\b|\bmigriert\w*|\bgewechselt\b|\bumgestiegen\b"
@@ -143,7 +144,7 @@ _ERROR_PATTERNS: dict[str, str] = {
         r"|\brot[oa]s?\b|\brechazad\w*|\bca[ií]da\b"
     ),
     # pt: erro(s), exceção/exceções, falha/falhou/falhado, quebrado (broken),
-    #     rejeitado, travou (froze/crashed)
+    #     rejeitado, travou (froze/crashed)  # noqa: ERA001 -- language gloss, not code
     "pt": (
         r"\berros?\b|\bexce[çc][aã]o\w*|\bexce[çc][oõ]es\b|\bfalh\w*"
         r"|\bquebrad\w*|\brejeitad\w*|\btravou\b"
@@ -170,11 +171,13 @@ _ERROR_PATTERNS: dict[str, str] = {
         r"|\bтайм-?аут\w*"
     ),
     # ja: エラー (error), 例外 (exception), 失敗 (failure), バグ (bug),
-    #     クラッシュ (crash), タイムアウト (timeout), 拒否 (denied/rejected),
-    #     壊れ (broken), 不具合 (defect/glitch)
+    #     クラッシュ (crash), タイムアウト (timeout),  # noqa: ERA001
+    #     拒否 (denied/rejected),  # noqa: ERA001
+    #     壊れ (broken), 不具合 (defect/glitch)  # noqa: ERA001
     "ja": r"エラー|例外|失敗|バグ|クラッシュ|タイムアウト|拒否|壊れ|不具合",
     # ro: eroare/erori, excepție/excepția, eșuat/eșec (accented or not),
-    #     defect, stricat (broken), respins (rejected), căzut (crashed/down)
+    #     defect, stricat (broken), respins (rejected),  # noqa: ERA001 -- gloss
+    #     căzut (crashed/down)  # noqa: ERA001 -- language gloss, not code
     "ro": (
         r"\beroare\b|\berori\w*|\bexcep[țt]i\w*|\be[șs]uat\w*|\be[șs]ec\w*"
         r"|\bdefect\w*|\bstricat\w*|\brespins\w*|\bc[ăa]zut\w*"
@@ -186,7 +189,7 @@ _SUCCESS_PATTERNS: dict[str, str] = {
     # en: verbatim pre-#158 _SUCCESS_KW (write_gate.py) — regression anchor
     "en": r"\b(?:fixed|resolved|succeeded|passed|completed|done)\b",
     # es: arreglado/arreglamos/arreglé, resuelto/resolvimos, éxito/exitoso,
-    #     completado, corregido/corregimos, funcionó, aprobado (passed),
+    #     completado, corregido/corregimos, funcionó, aprobado (passed),  # noqa: ERA001
     #     terminado
     "es": (
         r"\barregl\w*|\bresuelt\w*|\bresolvi\w*|\b[ée]xito\w*|\bexitos\w*"
@@ -194,7 +197,7 @@ _SUCCESS_PATTERNS: dict[str, str] = {
         r"|\baprobad\w*|\bterminad\w*"
     ),
     # pt: consertado, corrigido, resolvido/resolvemos, sucesso(s),
-    #     concluído, aprovado (passed), funcionou
+    #     concluído, aprovado (passed), funcionou  # noqa: ERA001 -- gloss, not code
     "pt": (
         r"\bconsertad\w*|\bcorrigid\w*|\bresolvid\w*|\bresolvemos\b"
         r"|\bsucessos?\b|\bconclu[ií]d\w*|\baprovad\w*|\bfuncionou\b"
@@ -206,7 +209,7 @@ _SUCCESS_PATTERNS: dict[str, str] = {
         r"|\bachev[ée]\w*|\br[ée]par[ée]\w*"
     ),
     # de: behoben, gelöst, erfolgreich, abgeschlossen, repariert,
-    #     bestanden (passed), funktioniert
+    #     bestanden (passed), funktioniert  # noqa: ERA001 -- language gloss, not code
     "de": (
         r"\bbehoben\b|\bgel[öo]st\b|\berfolgreich\w*|\babgeschlossen\b"
         r"|\brepariert\w*|\bbestanden\b|\bfunktioniert\w*"
@@ -220,7 +223,7 @@ _SUCCESS_PATTERNS: dict[str, str] = {
         r"|\bзаверш\w*|\bпочин\w*|\bзаработал\w*|\bготово\b"
     ),
     # ja: 修正 (fix), 解決 (resolved), 成功 (success), 完了 (completed),
-    #     直した/直しました (fixed)
+    #     直した/直しました (fixed)  # noqa: ERA001
     "ja": r"修正|解決|成功|完了|直した|直しました",
     # ro: reparat, rezolvat/rezolvăm, reușit (accented or not), succes,
     #     finalizat, corectat, funcționează (it works)

--- a/mcp_server/core/decay_cycle.py
+++ b/mcp_server/core/decay_cycle.py
@@ -148,8 +148,8 @@ def compute_actr_base_level(
     Returns raw activation (can be negative = below retrieval threshold).
     """
     n = max(1, access_count)
-    L = max(_MIN_LIFETIME_HOURS, lifetime_hours)
-    return math.log(n) - d * math.log(L)
+    clamped_lifetime_hours = max(_MIN_LIFETIME_HOURS, lifetime_hours)
+    return math.log(n) - d * math.log(clamped_lifetime_hours)
 
 
 def actr_activation_to_heat(

--- a/mcp_server/core/draft_synthesizer.py
+++ b/mcp_server/core/draft_synthesizer.py
@@ -207,7 +207,7 @@ def _format_claims_as_prose(claims: list[dict]) -> str:
 # provenance not recorded at introduction
 _TITLE_SENTENCE_SCAN_CHARS = 120
 # source: title cap documented in _derive_title docstring
-# ("Cap at 80 chars on word boundary")
+# ("Cap at 80 chars on word boundary")  # noqa: ERA001 -- docstring citation, not code
 _TITLE_MAX_CHARS = 80
 
 

--- a/mcp_server/core/grooming_health.py
+++ b/mcp_server/core/grooming_health.py
@@ -30,7 +30,7 @@ from typing import Any
 #     FROM consolidation_log
 #   ), gaps AS (
 #     SELECT d - lag(d) OVER (ORDER BY d) AS gap FROM days
-#   )
+#   )  # noqa: ERA001 -- sec8 SQL provenance for the constant below, not code
 #   SELECT percentile_cont(0.9) WITHIN GROUP (
 #            ORDER BY EXTRACT(EPOCH FROM gap) / 86400.0
 #          ) AS p90_gap_days

--- a/mcp_server/core/homeostatic_health.py
+++ b/mcp_server/core/homeostatic_health.py
@@ -265,7 +265,7 @@ def _merge_chunk_moments(
     delta_n = delta / n_ab
     delta_n2 = delta_n * delta_n
     na_nb = n * n_b
-    # M4_ab = M4_a + M4_b
+    # M4_ab = M4_a + M4_b  # noqa: ERA001 -- Pebay 2008 M4 formula doc, not code
     #   + δ^4 · n_a·n_b·(n_a² - n_a·n_b + n_b²) / n_ab^3
     #   + 6·δ²·(n_a²·M2_b + n_b²·M2_a) / n_ab²
     #   + 4·δ·(n_a·M3_b - n_b·M3_a) / n_ab

--- a/mcp_server/core/interference_detection.py
+++ b/mcp_server/core/interference_detection.py
@@ -68,7 +68,7 @@ _NEAR_DUPLICATE_SIMILARITY = 0.9
 _COLD_HEAT = 0.2
 
 # source: hand-tuned threshold documented at the use site
-# ("below 0.2 risk is negligible")
+# ("below 0.2 risk is negligible")  # noqa: ERA001 -- docstring citation, not code
 _NEGLIGIBLE_RISK = 0.2
 
 

--- a/mcp_server/core/pg_recall.py
+++ b/mcp_server/core/pg_recall.py
@@ -513,12 +513,12 @@ def recall(
     # training pairs but doesn't generalize to BEAM evaluation queries —
     # 32% of real relevant passages get filtered as irrelevant.
     # Critically: it does NOT improve abstention category (still 0.100).
-    # Re-enable when v0.2 ships with cross-validated training data.
-    # Code path preserved for future use:
-    # from mcp_server.core.abstention_gate import filter_by_abstention
-    # filtered, _ = filter_by_abstention(
-    #     query, candidates, threshold=0.45, keep_at_least=1)
-    # candidates = filtered
+    # Re-enable when v0.2 ships with cross-validated training data (the
+    # abstention_gate module and its tests stay in the tree for that;
+    # see mcp_server/core/abstention_gate.py — ERA001 (issue #239):
+    # a disabled call site is not the same as dead code, but the call
+    # is not currently wired, so no commented-out invocation is kept
+    # here — re-enabling means writing the real call, not uncommenting.
 
     # 8. MMR diversity reranking — DISABLED after ablation (see above).
     # Carbonell & Goldstein (SIGIR 1998) MMR trades precision for coverage.

--- a/mcp_server/core/pg_recall.py
+++ b/mcp_server/core/pg_recall.py
@@ -490,11 +490,11 @@ def recall(
     # preference memories from being drowned out by episodic memories.
     # Reserves 2 slots for tag-matched memories when intent matches.
     # Validated approach (BEAM 0.546 overall — see README ablation log).
-    _TYPE_INTENTS = {
+    _type_intents = {
         QueryIntent.INSTRUCTION: "instruction",
         QueryIntent.PREFERENCE: "preference",
     }
-    tag_for_intent = _TYPE_INTENTS.get(intent)
+    tag_for_intent = _type_intents.get(intent)
     if tag_for_intent and store and q_emb and hasattr(store, "search_by_tag_vector"):
         existing_ids = {c["memory_id"] for c in candidates}
         typed = store.search_by_tag_vector(

--- a/mcp_server/core/platt_calibration.py
+++ b/mcp_server/core/platt_calibration.py
@@ -90,7 +90,7 @@ def _sigmoid(x: float) -> float:
     return ex / (1.0 + ex)
 
 
-def _predict_platt(A: float, B: float, s: float) -> float:
+def _predict_platt(A: float, B: float, s: float) -> float:  # noqa: N803 -- Platt 1999 notation
     """Predicted P(useful | s) under parameters (A, B)."""
     return _sigmoid(-(A * s + B))
 
@@ -144,7 +144,7 @@ def fit_platt(
     n_pos = sum(labels)
     n_neg = n - n_pos
     prior1 = (n_pos + 1.0) / (n + 2.0)  # Laplace-smoothed base rate.
-    A, B = 0.0, math.log((n_neg + 1.0) / (n_pos + 1.0))
+    A, B = 0.0, math.log((n_neg + 1.0) / (n_pos + 1.0))  # noqa: N806 -- Platt 1999 notation
 
     for _ in range(max_iter):
         # Accumulate gradient and Hessian.
@@ -174,8 +174,8 @@ def fit_platt(
         inv = 1.0 / det
         d_a = inv * (h_bb * g_a - h_ab * g_b)
         d_b = inv * (-h_ab * g_a + h_aa * g_b)
-        A -= d_a
-        B -= d_b
+        A -= d_a  # noqa: N806 -- Platt 1999 notation
+        B -= d_b  # noqa: N806 -- Platt 1999 notation
 
     # Guard: reject non-finite parameters.
     if not (math.isfinite(A) and math.isfinite(B)):

--- a/mcp_server/core/profile_assembler.py
+++ b/mcp_server/core/profile_assembler.py
@@ -163,17 +163,17 @@ def _build_feature_dictionary(
         "K": fd.K,
         "D": fd.D,
         "sparsity": fd.sparsity,
-        "signalNames": fd.signalNames,
+        "signalNames": fd.signal_names,
         "features": [
             {
                 "index": f.index,
                 "label": f.label,
                 "description": f.description,
-                "topSignals": [ts.model_dump() for ts in f.topSignals],
+                "topSignals": [ts.model_dump() for ts in f.top_signals],
             }
             for f in fd.features
         ],
-        "learnedFromSessions": fd.learnedFromSessions,
+        "learnedFromSessions": fd.learned_from_sessions,
         "_raw": fd,
     }
 

--- a/mcp_server/core/sparse_dictionary.py
+++ b/mcp_server/core/sparse_dictionary.py
@@ -158,7 +158,7 @@ def learn_dictionary(
     Falls back to the seed dictionary if fewer than 10 conversations.
     """
     options = options or {}
-    K = options.get("K", 15)
+    k_atoms = options.get("K", 15)
     sparsity = options.get("sparsity", 3)
     iterations = options.get("iterations", 5)
 
@@ -166,7 +166,7 @@ def learn_dictionary(
         return build_seed_dictionary()
 
     data = [extract_session_activation(c) for c in conversations]
-    atoms = _initialize_atoms(data, K)
+    atoms = _initialize_atoms(data, k_atoms)
     atoms = _update_dictionary(data, atoms, sparsity, iterations, D)
 
     features = [label_feature(direction, idx) for idx, direction in enumerate(atoms)]

--- a/mcp_server/core/sparse_dictionary_learning.py
+++ b/mcp_server/core/sparse_dictionary_learning.py
@@ -34,24 +34,24 @@ _SINGULAR_DET_EPSILON = 1e-12
 
 
 def _solve_least_squares_1(
-    G: list[list[float]],
+    gram: list[list[float]],
     h: list[float],
 ) -> list[float]:
     """Solve 1x1 least-squares system."""
-    return [h[0] / G[0][0]] if G[0][0] != 0 else [0]
+    return [h[0] / gram[0][0]] if gram[0][0] != 0 else [0]
 
 
 def _solve_least_squares_2(
-    G: list[list[float]],
+    gram: list[list[float]],
     h: list[float],
 ) -> list[float]:
     """Solve 2x2 least-squares system via Cramer's rule."""
-    det = G[0][0] * G[1][1] - G[0][1] * G[1][0]
+    det = gram[0][0] * gram[1][1] - gram[0][1] * gram[1][0]
     if abs(det) < _SINGULAR_DET_EPSILON:
         return [0, 0]
     return [
-        (h[0] * G[1][1] - h[1] * G[0][1]) / det,
-        (G[0][0] * h[1] - G[1][0] * h[0]) / det,
+        (h[0] * gram[1][1] - h[1] * gram[0][1]) / det,
+        (gram[0][0] * h[1] - gram[1][0] * h[0]) / det,
     ]
 
 
@@ -65,19 +65,19 @@ def _det3(m: list[list[float]]) -> float:
 
 
 def _solve_least_squares_3(
-    G: list[list[float]],
+    gram: list[list[float]],
     h: list[float],
 ) -> list[float]:
     """Solve 3x3 least-squares system via Cramer's rule."""
-    det_g = _det3(G)
+    det_g = _det3(gram)
     if abs(det_g) < _SINGULAR_DET_EPSILON:
         return [0, 0, 0]
     result = []
     for col in range(3):
-        M = [row[:] for row in G]
+        trial_matrix = [row[:] for row in gram]
         for row in range(3):
-            M[row][col] = h[row]
-        result.append(_det3(M) / det_g)
+            trial_matrix[row][col] = h[row]
+        result.append(_det3(trial_matrix) / det_g)
     return result
 
 
@@ -100,7 +100,7 @@ def _solve_least_squares(
     if n == 0:
         return []
 
-    G = [
+    gram = [
         [dot(atoms[selected[i]], atoms[selected[j]]) for j in range(n)]
         for i in range(n)
     ]
@@ -108,7 +108,7 @@ def _solve_least_squares(
 
     solver = _LS_SOLVERS.get(n)
     if solver is not None:
-        return solver(G, h)
+        return solver(gram, h)
 
     return [0] * n
 
@@ -130,14 +130,14 @@ def omp(
     Returns:
         Dict with 'indices', 'coefficients', and 'residual'.
     """
-    K = len(atoms)
+    n_atoms = len(atoms)
     residual = list(signal)
     selected_indices: list[int] = []
 
     for _ in range(sparsity):
         best_corr = -1.0
         best_idx = -1
-        for k in range(K):
+        for k in range(n_atoms):
             if k in selected_indices:
                 continue
             corr = abs(dot(residual, atoms[k]))
@@ -169,12 +169,12 @@ def omp(
 
 def initialize_atoms(
     data: list[list[float]],
-    K: int,
+    k: int,
 ) -> list[list[float]]:
     """Select K diverse atoms from data using maximin distance."""
     if not data:
         return []
-    effective_k = min(K, len(data))
+    effective_k = min(k, len(data))
     selected = [0]
     min_dist = [float("inf")] * len(data)
 
@@ -209,14 +209,14 @@ def _compute_atom_contribution(
     encodings: list[dict[str, Any]],
     atoms: list[list[float]],
     atom_index: int,
-    D: int,
+    dim: int,
 ) -> list[float]:
     """Sum partial reconstructions for users of a given atom."""
     users = _find_atom_users(encodings, atom_index)
     if not users:
-        return zeros(D)
+        return zeros(dim)
 
-    contribution = zeros(D)
+    contribution = zeros(dim)
     for user in users:
         partial = list(data[user["dataIdx"]])
         enc = encodings[user["dataIdx"]]
@@ -224,7 +224,7 @@ def _compute_atom_contribution(
             if aidx == atom_index:
                 continue
             partial = subtract(partial, scale(atoms[aidx], enc["coefficients"][j]))
-        for d_idx in range(D):
+        for d_idx in range(dim):
             contribution[d_idx] += partial[d_idx]
 
     return contribution
@@ -248,7 +248,7 @@ def update_dictionary(
     atoms: list[list[float]],
     sparsity: int,
     iterations: int,
-    D: int,
+    dim: int,
 ) -> list[list[float]]:
     """Run K-SVD iterations to refine dictionary atoms.
 
@@ -267,7 +267,7 @@ def update_dictionary(
                 encodings,
                 atoms,
                 k,
-                D,
+                dim,
             )
             new_atom = normalize(contribution)
             if norm(new_atom) > 0:

--- a/mcp_server/core/tabular_encoding.py
+++ b/mcp_server/core/tabular_encoding.py
@@ -45,9 +45,10 @@ FORMAT_JSON = "json"
 FORMAT_TABULAR = "tabular"
 
 # Chars the self-describing ``format`` field adds to a payload in the worst
-# case (``,"format":"tabular"``). This transform runs AFTER ``bound_payload``
-# has already filled the payload up to the budget, so the field it appends
-# would overshoot the host cap unless that many chars were reserved first.
+# case (``,"format":"tabular"``). This transform runs AFTER  # noqa: ERA001
+# ``bound_payload`` has already filled the payload up to the budget, so the
+# field it appends would overshoot the host cap unless that many chars were
+# reserved first.
 # Callers bound against ``reserved_budget(cap)`` so the appended field lands
 # inside the cap. source: exact serialized length of the widest ``format``
 # key/value pair (the ``columns`` header is not reserved here — the tabular

--- a/mcp_server/core/titans_memory.py
+++ b/mcp_server/core/titans_memory.py
@@ -130,7 +130,7 @@ class TitansMemory:
             v = torch.stack(vs).mean(dim=0)
 
             # Compute loss: l = ||M @ k - v||^2
-            M = self._M.clone().requires_grad_(True)
+            M = self._M.clone().requires_grad_(True)  # noqa: N806 -- Titans paper notation
             prediction = M @ k
             loss = torch.sum((prediction - v) ** 2)
 
@@ -190,7 +190,7 @@ class TitansMemory:
             v = torch.stack(vs).mean(dim=0)
 
             # Compute gradient
-            M = self._M.clone().requires_grad_(True)
+            M = self._M.clone().requires_grad_(True)  # noqa: N806 -- Titans paper notation
             prediction = M @ k
             loss = torch.sum((prediction - v) ** 2)
             loss.backward()

--- a/mcp_server/core/wiki_classifier.py
+++ b/mcp_server/core/wiki_classifier.py
@@ -213,7 +213,7 @@ def _classify_to_legacy_kind(content: str, tags: list[str] | None = None) -> str
     # admitted by the gate and the provenance facet downstream marks it
     # as auto-generated.
     tag_set = tag_set_pre
-    _EXPLICIT_KNOWLEDGE_TAGS = {
+    _explicit_knowledge_tags = {
         # Legacy knowledge tags.
         "decision",
         "adr",
@@ -243,7 +243,7 @@ def _classify_to_legacy_kind(content: str, tags: list[str] | None = None) -> str
         # (architecture / services / api / data-flow per project), not
         # via per-file dumps.
     }
-    has_explicit_tag = bool(tag_set & _EXPLICIT_KNOWLEDGE_TAGS)
+    has_explicit_tag = bool(tag_set & _explicit_knowledge_tags)
 
     # Gate 3 — Positive scoring (only when no explicit knowledge tag)
     if not has_explicit_tag:

--- a/mcp_server/core/wiki_index.py
+++ b/mcp_server/core/wiki_index.py
@@ -44,7 +44,7 @@ def build_index(page_paths: list[str]) -> str:
     for kind, domain, filename, path in entries:
         tree.setdefault(domain, {}).setdefault(kind, []).append((filename, path))
 
-    _KIND_LABELS = {
+    _kind_labels = {
         "adr": "Architecture Decisions",
         "specs": "Specifications",
         "guides": "Guides & How-To",
@@ -75,7 +75,7 @@ def build_index(page_paths: list[str]) -> str:
             pages = kinds.get(kind, [])
             if not pages:
                 continue
-            kind_label = _KIND_LABELS.get(kind, kind.title())
+            kind_label = _kind_labels.get(kind, kind.title())
             lines.append(f"### {kind_label}")
             lines.append("")
             for filename, path in sorted(pages):

--- a/mcp_server/core/wiki_stub_detector.py
+++ b/mcp_server/core/wiki_stub_detector.py
@@ -139,8 +139,8 @@ def placeholder_count(body: str) -> int:
 # template synthesizers) that produced one file-doc per source file
 # with body shape:
 #
-#     # File: foo.py
-#     Language: python
+#     # File: foo.py  # noqa: ERA001 -- stub-shape doc, not code
+#     Language: python  # noqa: ERA001 -- stub-shape doc, not code
 #     Purpose: foo.py — one-liner.
 #     ## Imports
 #     - bar

--- a/mcp_server/core/wiki_view_executor.py
+++ b/mcp_server/core/wiki_view_executor.py
@@ -138,11 +138,11 @@ def compiled_view_ok(compiled: "CompiledView") -> bool:
 # ── YAML-ish parser ──────────────────────────────────────────────────
 #
 # Same minimal style as the rest of Cortex (no PyYAML dep). Supports:
-#   key: value               # scalar
-#   key: [a, b, c]           # inline list
+#   key: value               # scalar  # noqa: ERA001 -- YAML-ish syntax doc, not code
+#   key: [a, b, c]           # inline list  # noqa: ERA001 -- syntax doc, not code
 #   key:                     # nested dict (one level only)
-#     inner_key: value
-#     inner_key2: value
+#     inner_key: value  # noqa: ERA001 -- YAML-ish syntax doc, not code
+#     inner_key2: value  # noqa: ERA001 -- YAML-ish syntax doc, not code
 
 # Keys are matched with a tight anchored pattern that cannot backtrack
 # quadratically: `[A-Za-z_][A-Za-z0-9_]*` on bounded input. For the

--- a/mcp_server/handlers/consolidation/authoring_prompts.py
+++ b/mcp_server/handlers/consolidation/authoring_prompts.py
@@ -433,7 +433,7 @@ def _parse_sectioned_response(response: str, gaps: list[str]) -> dict[str, str]:
         return out
     # Split on the delimiter line, preserve the slug.
     parts = re.split(r"^<<<([\w-]+)>>>\s*$", response, flags=re.MULTILINE)
-    # parts = [preamble, slug1, body1, slug2, body2, ...]
+    # parts = [preamble, slug1, body1, slug2, body2, ...]  # noqa: ERA001
     for i in range(1, len(parts), 2):
         slug = parts[i].strip()
         body = parts[i + 1].strip() if i + 1 < len(parts) else ""

--- a/mcp_server/handlers/consolidation/compression.py
+++ b/mcp_server/handlers/consolidation/compression.py
@@ -84,7 +84,7 @@ def _compress_memory(
         if target_level >= 1 and current_level == 0:
             # Preconditions:
             #   - mem["content"] is the original full text.
-            #   - current_level == 0.
+            #   - current_level == 0.  # noqa: ERA001 -- precondition doc, not code
             # Postconditions (if target_level == 1): memory written at level 1;
             #   exactly 1 encode() call.
             # Postconditions (if target_level >= 2): memory written at level 2;

--- a/mcp_server/handlers/explore_features.py
+++ b/mcp_server/handlers/explore_features.py
@@ -181,13 +181,13 @@ def _handle_features(profiles: dict) -> dict:
             "K": d.K,
             "D": d.D,
             "sparsity": d.sparsity,
-            "learnedFromSessions": d.learnedFromSessions,
+            "learnedFromSessions": d.learned_from_sessions,
             "features": [
                 {
                     "index": f.index,
                     "label": f.label,
                     "description": f.description,
-                    "topSignals": [ts.model_dump() for ts in f.topSignals],
+                    "topSignals": [ts.model_dump() for ts in f.top_signals],
                 }
                 for f in d.features
             ],
@@ -233,7 +233,7 @@ def _handle_attribution(profiles: dict, domain: str | None) -> dict:
     return {
         "status": "ok",
         "domain": domain_id,
-        "graph": graph.model_dump(),
+        "graph": graph.model_dump(by_alias=True),
     }
 
 

--- a/mcp_server/handlers/ingest_findings.py
+++ b/mcp_server/handlers/ingest_findings.py
@@ -32,7 +32,7 @@ from typing import Any
 
 from mcp_server.handlers._tool_meta import IDEMPOTENT_WRITE
 from mcp_server.handlers.ingest_findings_artifacts import (
-    MalformedArtifact,
+    MalformedArtifactError,
     load_finding,
     read_index,
 )
@@ -139,7 +139,7 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
 
     try:
         index = read_index(output_dir, run_id)
-    except MalformedArtifact as exc:
+    except MalformedArtifactError as exc:
         return {"ingested": False, "reason": "index_unreadable", "error": str(exc)}
 
     conn = store._conn
@@ -148,7 +148,7 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
     for finding_id in sorted(index.get("findings", {})):
         try:
             finding = load_finding(output_dir, run_id, finding_id)
-        except MalformedArtifact as exc:
+        except MalformedArtifactError as exc:
             errors.append(f"{finding_id}: {exc}")
             continue
         try:

--- a/mcp_server/handlers/ingest_findings_artifacts.py
+++ b/mcp_server/handlers/ingest_findings_artifacts.py
@@ -40,7 +40,7 @@ _RECEIPT_SPECS: tuple[tuple[str, str], ...] = (
 )
 
 
-class MalformedArtifact(Exception):
+class MalformedArtifactError(Exception):
     """Raised when a required artifact file exists but does not parse."""
 
 
@@ -111,26 +111,29 @@ def _sha256_bytes(data: bytes) -> str:
 def _read_json(path: Path) -> tuple[dict[str, Any], str]:
     """Read + parse one JSON artifact; returns (parsed, sha256_of_raw_bytes).
 
-    Raises MalformedArtifact on I/O failure or invalid JSON.
+    Raises MalformedArtifactError on I/O failure or invalid JSON.
     """
     try:
         raw_bytes = path.read_bytes()
     except OSError as exc:
-        raise MalformedArtifact(f"cannot read {path}: {exc}") from exc
+        raise MalformedArtifactError(f"cannot read {path}: {exc}") from exc
     try:
         return json.loads(raw_bytes), _sha256_bytes(raw_bytes)
     except ValueError as exc:
-        raise MalformedArtifact(f"invalid JSON in {path}: {exc}") from exc
+        raise MalformedArtifactError(f"invalid JSON in {path}: {exc}") from exc
 
 
 def read_index(output_dir: Path, run_id: str) -> dict[str, Any]:
-    """Read ``runs/<run_id>/index.json``. Raises MalformedArtifact if absent/bad."""
+    """Read ``runs/<run_id>/index.json``.
+
+    Raises MalformedArtifactError if absent/bad.
+    """
     index_path = output_dir / "runs" / run_id / INDEX_FILE_NAME
     if not index_path.exists():
-        raise MalformedArtifact(f"no index.json at {index_path}")
+        raise MalformedArtifactError(f"no index.json at {index_path}")
     data, _ = _read_json(index_path)
     if "findings" not in data:
-        raise MalformedArtifact(f"index.json at {index_path} has no 'findings' key")
+        raise MalformedArtifactError(f"index.json at {index_path} has no 'findings'")
     return data
 
 
@@ -195,7 +198,7 @@ def _extract_file_paths(finding_dir: Path) -> list[str]:
         return []
     try:
         raw, _ = _read_json(path)
-    except MalformedArtifact:
+    except MalformedArtifactError:
         return []
     matched = (
         raw.get("report", {}).get("matched_symbols") or raw.get("matched_symbols") or []
@@ -222,7 +225,7 @@ def load_finding(output_dir: Path, run_id: str, finding_id: str) -> FindingRecor
     finding_dir = _finding_dir(output_dir, run_id, finding_id)
     refined_path = finding_dir / REFINED_FILE_NAME
     if not refined_path.exists():
-        raise MalformedArtifact(f"no {REFINED_FILE_NAME} at {finding_dir}")
+        raise MalformedArtifactError(f"no {REFINED_FILE_NAME} at {finding_dir}")
     refined, _ = _read_json(refined_path)
     extracted = refined.get("extracted", {})
     raw_source_path = extracted.get("source_path")

--- a/mcp_server/handlers/wiki_adr.py
+++ b/mcp_server/handlers/wiki_adr.py
@@ -13,7 +13,7 @@ from mcp_server.core.wiki_layout import adr_filename, page_path, slugify
 from mcp_server.core.wiki_pages import ADR_STATUSES, build_adr
 from mcp_server.infrastructure.config import WIKI_ROOT
 from mcp_server.infrastructure.wiki_store import (
-    WikiExists,
+    WikiExistsError,
     next_adr_number,
     write_page,
 )
@@ -162,7 +162,7 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
 
     try:
         result = write_page(WIKI_ROOT, rel_path, content, mode="create")
-    except WikiExists:
+    except WikiExistsError:
         return {"error": f"ADR already exists: {rel_path}"}
     except (ValueError, OSError) as exc:
         return {"error": f"write failed: {exc}"}

--- a/mcp_server/handlers/wiki_link.py
+++ b/mcp_server/handlers/wiki_link.py
@@ -11,7 +11,7 @@ from typing import Any
 from mcp_server.core.wiki_links import LinkEntry, RELATIONS, apply_link, inverse_of
 from mcp_server.infrastructure.config import WIKI_ROOT
 from mcp_server.infrastructure.wiki_store import (
-    WikiMissing,
+    WikiMissingError,
     read_page,
     write_page,
 )
@@ -75,7 +75,7 @@ schema = {
 def _update_page(rel_path: str, entry: LinkEntry) -> None:
     current = read_page(WIKI_ROOT, rel_path)
     if current is None:
-        raise WikiMissing(rel_path)
+        raise WikiMissingError(rel_path)
     updated = apply_link(current, entry)
     write_page(WIKI_ROOT, rel_path, updated, mode="replace")
 
@@ -95,7 +95,7 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
         _update_page(
             to_path, LinkEntry(relation=inverse_of(relation), target=from_path)
         )
-    except WikiMissing as missing:
+    except WikiMissingError as missing:
         return {"error": f"page not found: {missing}"}
     except (ValueError, OSError) as exc:
         return {"error": f"link failed: {exc}"}

--- a/mcp_server/handlers/wiki_migrate.py
+++ b/mcp_server/handlers/wiki_migrate.py
@@ -424,10 +424,9 @@ def migrate_wiki(wiki_root: Path | str, conn, *, dry_run: bool = True) -> dict:
     purge_summary = purge_ghost_pages(conn, rel_paths, dry_run=dry_run)
 
     # dry_run must be transactionally neutral end-to-end: passes 1-3
-    # (upsert_page, delete_links_from/upsert_link,
-    # resolve_unresolved_links) write through the same `conn` as pass 4
-    # and have no dry_run gate of their own — only pass 4 checks dry_run
-    # internally (see
+    # (upsert_page, delete_links_from/upsert_link, resolve_unresolved_links) write
+    # through the same `conn` as pass 4 and have no dry_run gate of their own —
+    # only pass 4 checks dry_run internally (see
     # purge_ghost_pages). Committing unconditionally here previously made
     # `--dry-run` persist passes 1-3 despite the name (issue #105). Roll
     # back everything this call wrote when dry_run is requested; commit

--- a/mcp_server/handlers/wiki_migrate.py
+++ b/mcp_server/handlers/wiki_migrate.py
@@ -66,7 +66,7 @@ _DOMAIN_PATH_PARTS = 3
 # 'evergreen', the column default) plus 'living' (emitted by
 # core/auto_curator.py:475,538 and handlers/consolidation/page_io.py:376)
 # plus every kind-specific ADR/specs status in STATUS_VALUES
-# (core/wiki_templates.py). Frontmatter is FS-authored and not itself
+# (core/wiki_templates.py). Frontmatter is FS-authored and not itself  # noqa: ERA001
 # constrained, so any value outside this union must be caught here — the
 # system boundary (coding-standards.md 3.2) — before it reaches the DB.
 _LEGACY_MATURITY_STATUSES = frozenset({"seedling", "budding", "evergreen", "living"})
@@ -424,9 +424,10 @@ def migrate_wiki(wiki_root: Path | str, conn, *, dry_run: bool = True) -> dict:
     purge_summary = purge_ghost_pages(conn, rel_paths, dry_run=dry_run)
 
     # dry_run must be transactionally neutral end-to-end: passes 1-3
-    # (upsert_page, delete_links_from/upsert_link, resolve_unresolved_links)
-    # write through the same `conn` as pass 4 and have no dry_run gate of
-    # their own — only pass 4 checks dry_run internally (see
+    # (upsert_page, delete_links_from/upsert_link,
+    # resolve_unresolved_links) write through the same `conn` as pass 4
+    # and have no dry_run gate of their own — only pass 4 checks dry_run
+    # internally (see
     # purge_ghost_pages). Committing unconditionally here previously made
     # `--dry-run` persist passes 1-3 despite the name (issue #105). Roll
     # back everything this call wrote when dry_run is requested; commit

--- a/mcp_server/handlers/wiki_rename.py
+++ b/mcp_server/handlers/wiki_rename.py
@@ -35,7 +35,7 @@ from mcp_server.core.wiki_redirect import (
 )
 from mcp_server.handlers._tool_meta import IDEMPOTENT_WRITE
 from mcp_server.infrastructure.config import WIKI_ROOT
-from mcp_server.infrastructure.wiki_store import WikiExists, read_page, write_page
+from mcp_server.infrastructure.wiki_store import WikiExistsError, read_page, write_page
 
 
 schema = {
@@ -132,7 +132,7 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
     write_mode = "replace" if overwrite_dest else "create"
     try:
         write_page(WIKI_ROOT, to_path, source_content, mode=write_mode)
-    except WikiExists:
+    except WikiExistsError:
         return {
             "error": (
                 f"destination already exists: {to_path} — pass overwrite_dest "

--- a/mcp_server/handlers/wiki_write.py
+++ b/mcp_server/handlers/wiki_write.py
@@ -48,8 +48,8 @@ from mcp_server.infrastructure.memory_store import get_shared_store
 from mcp_server.infrastructure.pg_store_wiki import insert_citation, upsert_page
 from mcp_server.infrastructure.session_registry import current_window_session
 from mcp_server.infrastructure.wiki_store import (
-    WikiExists,
-    WikiMissing,
+    WikiExistsError,
+    WikiMissingError,
     write_page,
 )
 
@@ -302,9 +302,9 @@ async def write_governed_page(
     """
     try:
         result = write_page(root, rel_path, content, mode=mode)
-    except WikiExists:
+    except WikiExistsError:
         return {"error": f"page already exists: {rel_path}"}
-    except WikiMissing:
+    except WikiMissingError:
         return {"error": f"page does not exist: {rel_path}"}
     except UnclosedFrontmatterError:
         # Propagate uncaught (see docstring) — narrower than the ValueError

--- a/mcp_server/hooks/session_lifecycle.py
+++ b/mcp_server/hooks/session_lifecycle.py
@@ -106,7 +106,7 @@ def _resolve_domain(event: dict[str, Any], profiles: dict) -> str:
 
 
 # source: session-length gates documented in _run_consolidation docstring
-# ("engineering heuristics — thresholds not paper-prescribed")
+# ("engineering heuristics — thresholds not paper-prescribed")  # noqa: ERA001
 _SHORT_SESSION_TURNS = 5
 _LONG_SESSION_TURNS = 20
 

--- a/mcp_server/infrastructure/ap_sync_loop.py
+++ b/mcp_server/infrastructure/ap_sync_loop.py
@@ -143,13 +143,13 @@ class _SyncLoop:
         a truncated full list).
         """
         loop = self._ensure_loop()
-        _SENTINEL = object()
+        _sentinel = object()
 
         async def _step():
             try:
                 return await agen.__anext__()
             except StopAsyncIteration:
-                return _SENTINEL
+                return _sentinel
 
         while True:
             future = asyncio.run_coroutine_threadsafe(_step(), loop)
@@ -161,7 +161,7 @@ class _SyncLoop:
                     "AP reader-thread step exceeded "
                     f"{_ap_sync_timeout_s():.0f}s — subprocess presumed wedged"
                 ) from exc
-            if item is _SENTINEL:
+            if item is _sentinel:
                 return
             yield item
 

--- a/mcp_server/infrastructure/groomer_coordinator.py
+++ b/mcp_server/infrastructure/groomer_coordinator.py
@@ -41,7 +41,7 @@ from pathlib import Path
 from mcp_server.infrastructure.groomer_coordinator_io import (
     atomic_write_json,
     atomic_write_text,
-    decision_lock,
+    DecisionLock,
     parse_iso,
     pid_alive,
 )
@@ -207,7 +207,7 @@ class GroomerCoordinator:
         """
         self.base_dir.mkdir(parents=True, exist_ok=True)
         now = now or datetime.now(timezone.utc)
-        with decision_lock(self.lock_path) as acquired:
+        with DecisionLock(self.lock_path) as acquired:
             if not acquired:
                 return SKIPPED_LOCKED
             if self.is_groomer_running():

--- a/mcp_server/infrastructure/groomer_coordinator_io.py
+++ b/mcp_server/infrastructure/groomer_coordinator_io.py
@@ -78,10 +78,10 @@ def atomic_write_json(path: Path, payload: dict) -> bool:
     return atomic_write_text(path, json.dumps(payload))
 
 
-class decision_lock:
+class DecisionLock:
     """Non-blocking per-store lock context manager.
 
-    ``with decision_lock(path) as acquired:`` yields True when this holder
+    ``with DecisionLock(path) as acquired:`` yields True when this holder
     won the lock and False when another holder already owns it (contended
     simultaneous decision). Advisory ``flock`` on POSIX, mandatory
     ``msvcrt.locking`` on Windows — same split as ``pipeline_install_lock``

--- a/mcp_server/infrastructure/pg_store.py
+++ b/mcp_server/infrastructure/pg_store.py
@@ -116,7 +116,7 @@ _SUPERSEDE_REBASE_ATTEMPTS = 5
 _CHAIN_HEAD_MAX_DEPTH = 100_000
 
 
-class _SupersedeCasConflict(Exception):
+class _SupersedeCasConflictError(Exception):
     """The chain head moved under our compare-and-set.
 
     Raised inside the supersede_atomic transaction to force a full rollback of
@@ -663,9 +663,9 @@ class PgMemoryStore(
                             (new_id, head_id),
                         ).rowcount
                         if rowcount != 1:
-                            raise _SupersedeCasConflict()
+                            raise _SupersedeCasConflictError()
                         self._transfer_anchor_on(conn, head_id, new_id)
-                except _SupersedeCasConflict:
+                except _SupersedeCasConflictError:
                     continue
                 return new_id, head_id
         return None, last_head

--- a/mcp_server/infrastructure/pipeline_install_lock.py
+++ b/mcp_server/infrastructure/pipeline_install_lock.py
@@ -29,7 +29,7 @@ from mcp_server.shared.platform import home_dir
 _LOCK_FILE = home_dir() / ".claude" / "methodology" / ".install.lock"
 
 
-class InstallLockBusy(RuntimeError):
+class InstallLockBusyError(RuntimeError):
     """Raised when another install_pipeline holder owns the lock."""
 
 
@@ -37,7 +37,7 @@ class InstallLockBusy(RuntimeError):
 def install_lock() -> Iterator[None]:
     """Acquire an exclusive non-blocking lock on the install file.
 
-    Raises ``InstallLockBusy`` immediately on contention so callers can
+    Raises ``InstallLockBusyError`` immediately on contention so callers can
     return a structured ``install_in_progress`` action instead of
     blocking for the duration of someone else's 6-minute build.
 
@@ -69,7 +69,7 @@ if sys.platform == "win32":  # == shared.platform.IS_WINDOWS; literal so the che
             msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
         except OSError as exc:
             os.close(fd)
-            raise InstallLockBusy(str(_LOCK_FILE)) from exc
+            raise InstallLockBusyError(str(_LOCK_FILE)) from exc
 
     def _release(fd: int) -> None:
         try:
@@ -86,7 +86,7 @@ else:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError as exc:
             os.close(fd)
-            raise InstallLockBusy(str(_LOCK_FILE)) from exc
+            raise InstallLockBusyError(str(_LOCK_FILE)) from exc
 
     def _release(fd: int) -> None:
         try:

--- a/mcp_server/infrastructure/pipeline_installer.py
+++ b/mcp_server/infrastructure/pipeline_installer.py
@@ -25,7 +25,7 @@ from mcp_server.infrastructure.pipeline_discovery import (
     _INSTALL_SYMLINK,
 )
 from mcp_server.infrastructure.pipeline_install_lock import (
-    InstallLockBusy,
+    InstallLockBusyError,
     install_lock,
 )
 from mcp_server.infrastructure.pipeline_install_release import try_install_prebuilt
@@ -96,7 +96,7 @@ def install_pipeline(
     try:
         with install_lock():
             return _install_locked(force_rebuild, git_url)
-    except InstallLockBusy as exc:
+    except InstallLockBusyError as exc:
         return {"action": "install_in_progress", "detail": str(exc)}
 
 

--- a/mcp_server/infrastructure/sqlite_schema.py
+++ b/mcp_server/infrastructure/sqlite_schema.py
@@ -423,7 +423,7 @@ def get_all_ddl() -> list[str]:
 
 # ── Migrations ───────────────────────────────────────────────────────────
 # Each migration adds columns that may be missing from older databases.
-# Format: (table, column, type_and_default)
+# Format: (table, column, type_and_default)  # noqa: ERA001 -- format doc, not code
 
 MIGRATIONS: list[tuple[str, str, str]] = [
     ("memories", "is_benchmark", "INTEGER DEFAULT 0"),

--- a/mcp_server/infrastructure/sqlite_store_search.py
+++ b/mcp_server/infrastructure/sqlite_store_search.py
@@ -307,8 +307,9 @@ class SqliteSearchMixin:
         no downstream ranking can demote a superseded or stale hit.
         """
         # NOTE: ``query`` here is an already-built FTS5 expression — callers
-        # (auto_recall._fts_query_from_prompt, recall_helpers.build_expanded_query)
-        # construct their own OR/AND term lists — so it must be passed through
+        # (auto_recall._fts_query_from_prompt,
+        # recall_helpers.build_expanded_query) construct their own OR/AND
+        # term lists — so it must be passed through
         # verbatim, NOT re-expanded (re-wrapping their operators would turn an OR
         # into a literal AND, issue #169 regression). Code-aware matching on this
         # path is carried entirely by index-time augmentation (augment_content),

--- a/mcp_server/infrastructure/sqlite_store_search.py
+++ b/mcp_server/infrastructure/sqlite_store_search.py
@@ -308,8 +308,8 @@ class SqliteSearchMixin:
         """
         # NOTE: ``query`` here is an already-built FTS5 expression — callers
         # (auto_recall._fts_query_from_prompt,
-        # recall_helpers.build_expanded_query) construct their own OR/AND
-        # term lists — so it must be passed through
+        # recall_helpers.build_expanded_query) construct their own OR/AND term
+        # lists — so it must be passed through
         # verbatim, NOT re-expanded (re-wrapping their operators would turn an OR
         # into a literal AND, issue #169 regression). Code-aware matching on this
         # path is carried entirely by index-time augmentation (augment_content),

--- a/mcp_server/infrastructure/wiki_store.py
+++ b/mcp_server/infrastructure/wiki_store.py
@@ -56,11 +56,11 @@ class WriteResult:
     bytes_written: int
 
 
-class WikiExists(Exception):
+class WikiExistsError(Exception):
     """Raised when ``create`` mode finds an existing file."""
 
 
-class WikiMissing(Exception):
+class WikiMissingError(Exception):
     """Raised when ``append`` mode targets a missing file."""
 
 
@@ -109,9 +109,9 @@ def read_page(root: Path | str, rel_path: str) -> str | None:
 
     # CWE-22 sanitization. Structure matches CodeQL's py/path-injection
     # example VERBATIM so the sanitizer is unambiguously recognised:
-    #   base_path = os.path.realpath(root)
-    #   fullpath  = os.path.realpath(os.path.join(base_path, user_input))
-    #   if not fullpath.startswith(base_path): ...
+    #   base_path = os.path.realpath(root)  # noqa: ERA001
+    #   fullpath = os.path.realpath(os.path.join(base_path, user_input))  # noqa: ERA001
+    #   if not fullpath.startswith(base_path): ...  # noqa: ERA001
     # https://codeql.github.com/codeql-query-help/python/py-path-injection/
     if not rel_path or "\x00" in rel_path or os.path.isabs(rel_path):
         return None
@@ -149,10 +149,10 @@ def write_page(
 ) -> WriteResult:
     """Write a page atomically.
 
-    * ``create`` — raises WikiExists if the file already exists.
+    * ``create`` — raises WikiExistsError if the file already exists.
     * ``replace`` — overwrites regardless.
     * ``append`` — appends the content to the existing file (with a
-      separating blank line), raises WikiMissing if the file does not exist.
+      separating blank line), raises WikiMissingError if the file does not exist.
 
     precondition: for ``create``/``replace``, ``content`` is a FULL page
     (frontmatter + body, or plain body with no frontmatter) the caller
@@ -193,13 +193,13 @@ def write_page(
 
     if mode == "create":
         if existed:
-            raise WikiExists(rel_path)
+            raise WikiExistsError(rel_path)
         written = _atomic_write_bytes_str(fullpath, content)
     elif mode == "replace":
         written = _atomic_write_bytes_str(fullpath, content)
     elif mode == "append":
         if not existed:
-            raise WikiMissing(rel_path)
+            raise WikiMissingError(rel_path)
         with open(fullpath, encoding="utf-8") as f:
             current = f.read()
         if current and not current.endswith("\n"):
@@ -244,7 +244,7 @@ def append_section(
     """Append text under a ``## heading`` section, creating it if missing."""
     target = _abs(Path(root), rel_path)
     if not target.exists():
-        raise WikiMissing(rel_path)
+        raise WikiMissingError(rel_path)
     current = target.read_text(encoding="utf-8")
     heading_line = f"## {heading}"
     if heading_line in current:

--- a/mcp_server/infrastructure/workflow_graph_ast_symbols.py
+++ b/mcp_server/infrastructure/workflow_graph_ast_symbols.py
@@ -60,8 +60,8 @@ _SYMBOL_LABELS = (
 # DOES carry) so they still flow into the graph.
 _NON_QUALIFIED_LABELS = {"Import"}
 
-# source: "Cap at 10 tails to keep the WHERE clause tractable"
-# (comment in _symbol_batches_async._where_for_tails)
+# source: "Cap at 10 tails to keep the WHERE clause tractable"  # noqa: ERA001
+# (comment in _symbol_batches_async._where_for_tails)  # noqa: ERA001
 _MAX_WHERE_TAILS = 10
 
 

--- a/mcp_server/shared/redaction.py
+++ b/mcp_server/shared/redaction.py
@@ -87,14 +87,14 @@ def redact_url(url: str) -> str:
 
     # ── (b) query-parameter password (libpq DSN style) ────────────────────
     # Keys matched case-insensitively; order of other params is preserved.
-    _PASSWORD_QUERY_KEYS = frozenset({"password", "pgpassword"})
+    _password_query_keys = frozenset({"password", "pgpassword"})
     query_changed = False
     new_query = parsed.query
     if parsed.query:
         pairs = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
         masked_pairs = []
         for key, value in pairs:
-            if key.lower() in _PASSWORD_QUERY_KEYS and value:
+            if key.lower() in _password_query_keys and value:
                 masked_pairs.append((key, _PASSWORD_MASK))
                 query_changed = True
             else:

--- a/mcp_server/shared/types_features.py
+++ b/mcp_server/shared/types_features.py
@@ -29,7 +29,7 @@ This models the real observed union of shapes, not an approximation.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TopSignal(BaseModel):
@@ -44,35 +44,35 @@ class TopSignal(BaseModel):
 class Feature(BaseModel):
     """A single behavioral-feature atom (seed or learned)."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     index: int
     label: str
     description: str
-    topSignals: list[TopSignal]
+    top_signals: list[TopSignal] = Field(alias="topSignals")
     direction: list[float] | None = None
 
 
 class FeatureDictionary(BaseModel):
     """Sparse-dictionary of behavioral feature atoms (K atoms, D=27 dims)."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     K: int
     D: int
     sparsity: int
-    signalNames: list[str]
+    signal_names: list[str] = Field(alias="signalNames")
     features: list[Feature]
-    learnedFromSessions: int
+    learned_from_sessions: int = Field(alias="learnedFromSessions")
 
 
 class EncodedSession(BaseModel):
     """A single conversation's sparse encoding against a FeatureDictionary."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     weights: dict[str, float]
-    reconstructionError: float
+    reconstruction_error: float = Field(alias="reconstructionError")
 
 
 class PersonaDrift(BaseModel):
@@ -99,13 +99,13 @@ class AttributionNode(BaseModel):
     unset and carry a real float in activation.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     id: str
     label: str
     layer: str
     activation: float
-    categoricalValue: str | None = None
+    categorical_value: str | None = Field(default=None, alias="categoricalValue")
 
 
 class AttributionEdge(BaseModel):

--- a/mcp_server/shared/vader.py
+++ b/mcp_server/shared/vader.py
@@ -28,7 +28,7 @@ _N_SCALAR = -0.74  # negation scalar (H4)
 # engineering text. Valence magnitudes follow VADER's scale convention.
 
 _LEXICON: dict[str, float] = {
-    # Negative [-4, -1]
+    # Negative [-4, -1]  # noqa: ERA001 -- section-header comment, not code
     "error": -2.0,
     "exception": -2.0,
     "traceback": -2.5,
@@ -63,7 +63,7 @@ _LEXICON: dict[str, float] = {
     "blocking": -2.0,
     "outage": -3.0,
     "hotfix": -1.5,
-    # Positive [+1, +4]
+    # Positive [+1, +4]  # noqa: ERA001 -- section-header comment, not code
     "fixed": 2.0,
     "resolved": 2.0,
     "working": 1.5,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,6 +378,66 @@ select = [
     #     `test_sqlite_datetime_adapter_260.py`, where the naive input IS
     #     the test's stated point (round-tripping a tzinfo-less datetime).
     "DTZ",
+    # N (PEP 8 naming) (issue #239, family 4): 26 findings repo-wide across
+    # 7 rule variants, every one fixed or documented, zero per-file-ignore
+    # needed (no tests_py/**-wide carve-out — see below).
+    #   N806/N803 (mostly local-variable/parameter case): renamed to
+    #     lowercase at every mechanical site (_KIND_LABELS, _SENTINEL,
+    #     _PASSWORD_QUERY_KEYS, _TYPE_INTENTS, _EXPLICIT_KNOWLEDGE_TAGS,
+    #     the sparse_dictionary_learning.py Gram-matrix K/D/G/M locals,
+    #     N_THREADS/N_INCREMENTS in a test). Two sites keep the
+    #     capitalization via `# noqa: N803`/`# noqa: N806` instead,
+    #     because the case IS the cited source's notation: Platt (1999)
+    #     logistic-calibration parameters A/B in platt_calibration.py, and
+    #     the Titans paper's memory-matrix symbol M in titans_memory.py —
+    #     renaming would make the code harder to verify against its
+    #     source, the exact case this rule's override exists for.
+    #   N818 (exception name missing Error suffix, 7 sites): every custom
+    #     exception renamed (MalformedArtifactError, InstallLockBusyError,
+    #     WikiExistsError, WikiMissingError, _SupersedeCasConflictError,
+    #     plus two test-local ones) with every raise/except/import site
+    #     updated atomically (blast radius checked via grep before
+    #     renaming, per this program's standing practice).
+    #   N815 (mixed-case attribute in class scope, 5 sites, all in
+    #     shared/types_features.py): NOT a bare rename — these 5 Pydantic
+    #     fields are an external JSON wire contract (the module's own
+    #     docstring: "mirrors the JS-era MCP/profiles.json contract").
+    #     Fixed with `Field(alias="camelCase")` + `populate_by_name=True`,
+    #     mirroring the exact precedent in the sibling module
+    #     shared/types_profiles.py, so the Python attribute is snake_case
+    #     while the wire format is untouched.
+    #   N801 (class name not CapWords, 1 site): decision_lock ->
+    #     DecisionLock.
+    #   N812 (non-lowercase import alias, 1 site): dropped a single-letter
+    #     module alias (`as M`) entirely — the module's own name was
+    #     already short.
+    #   N802 (function name not lowercase, 5 sites): 3 lowercase the
+    #     invariant-ID prefix only (test_I2_* -> test_i2_*, preserving
+    #     traceability to docs/invariants/cortex-invariants.md's I2 row);
+    #     1 moves Tsodyks-Markram (1997) U/u notation out of the test name
+    #     into its docstring rather than collapsing the two letters to the
+    #     same lowercase; 1 is a plain lowercase (HOME env-var reference).
+    #   N999 (invalid module name, 2 sites): test_I2_canonical_writer.py
+    #     and test_I10_pool_capacity.py filenames encode this project's
+    #     OWN invariant-ID scheme, formally cross-referenced by
+    #     docs/invariants/cortex-invariants.md's table (and, for I2,
+    #     ADR-0053 plus two production-code comments citing the filename
+    #     literally) — renaming the file would break that cross-reference
+    #     for zero benefit. Documented with `# noqa: N999` instead.
+    "N",
+    # ERA (commented-out code) (issue #239, family 5): 51 findings
+    # repo-wide, 50 false positives from the eradicate heuristic
+    # misreading documentation as code (quoted-string §8 source
+    # citations, math-formula/SQL/format-by-example documentation, and 3
+    # lines in infrastructure/wiki_store.py that deliberately mirror
+    # CodeQL's py/path-injection sanitizer example verbatim, self-
+    # documented at the site) — each suppressed with a per-site
+    # `# noqa: ERA001 — <reason>`, never a blanket ignore. The one
+    # genuine site (core/pg_recall.py: a literal disabled import + call
+    # for the abandoned v0.1 abstention-gate model) was actually fixed —
+    # the commented invocation deleted, replaced with prose on why the
+    # module stays in the tree unwired.
+    "ERA",
 ]
 # ── Families deliberately NOT selected (issue #197, criterion 1) ────────────
 # Counts measured against mcp_server/ 2026-07-28, ruff 0.15.20 — what
@@ -408,11 +468,12 @@ select = [
 #     contract-lie defect classes this program exists for; each is a
 #     dedicated-PR-sized diff under the fix-with-landing bar.
 #
-# (c) JUDGEMENT families not yet triaged — TRY (163), ARG (53), PTH (91),
-#     N (43), ERA (43), FBT (254), S beyond S110/S608 (34): tracked as
-#     the program's continuation in issue #239 (B, RET, DTZ landed
-#     above). Enabling any of them without the per-finding triage the
-#     landed families received would mean blanket ignores — the exact
+# (c) JUDGEMENT families not yet triaged — TRY (163), ARG (54->667
+#     repo-wide), PTH (91), FBT (258->461 repo-wide), S beyond S110/S608
+#     (34 production + 11078 S101-in-tests): tracked as the program's
+#     continuation in issue #239 (B, RET, DTZ, N, ERA landed above).
+#     Enabling any of them without the per-finding triage the landed
+#     families received would mean blanket ignores — the exact
 #     anti-pattern this explicit select list exists to prevent.
 
 [tool.ruff.lint.per-file-ignores]

--- a/scripts/campaign_guards/i6d5_measure_reheat_ranks.py
+++ b/scripts/campaign_guards/i6d5_measure_reheat_ranks.py
@@ -17,7 +17,7 @@ import psycopg
 from sentence_transformers import SentenceTransformer
 
 # 5 echantillons deliberes, choisis dans le journal du dry-run baseline
-# (docs/campaigns/i6d5_memory_reheat_dry-run_20260710T151019Z.json),
+# (docs/campaigns/i6d5_memory_reheat_dry-run_20260710T151019Z.json),  # noqa: ERA001
 # repartis sur toute la distribution eh_avant (min, p25, median, p75, max
 # parmi les 544 lignes reheated de la mesure de reference).
 SAMPLES = [

--- a/tests_py/benchmarks/benchmark_harness.py
+++ b/tests_py/benchmarks/benchmark_harness.py
@@ -672,7 +672,7 @@ def benchmark_microglial_pruning() -> dict[str, float]:
             "weight": 0.02,
             "last_reinforced": "2026-03-10T12:00:00+00:00",
         },
-        # Stale: old
+        # Stale: old  # noqa: ERA001 -- fixture row label, not code
         {
             "id": 4,
             "source_entity_id": 6,
@@ -809,7 +809,7 @@ def benchmark_decay_with_emotional_resistance() -> dict[str, dict[str, float]]:
             "is_protected": False,
             "store_type": "episodic",
         },
-        # Protected (anchor)
+        # Protected (anchor)  # noqa: ERA001 -- fixture row label, not code
         {
             "id": 5,
             "heat": 0.9,

--- a/tests_py/benchmarks/test_beam_manifest.py
+++ b/tests_py/benchmarks/test_beam_manifest.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from benchmarks.llm_head_to_head import manifest as M
+from benchmarks.llm_head_to_head import manifest
 
 
 @pytest.fixture
@@ -36,16 +36,18 @@ def fake_lockfile(tmp_path: Path) -> Path:
 
 def test_required_fields_present(tmp_path, fake_prompts, fake_lockfile):
     a, b = fake_prompts
-    m = M.build_manifest(
+    m = manifest.build_manifest(
         run_id="testrun-001",
         repo_root=tmp_path,
         generator_models={
-            "haiku_4_5": M.ManifestModelEntry(
+            "haiku_4_5": manifest.ManifestModelEntry(
                 api="anthropic", model_id="claude-haiku-4-5-20251001"
             )
         },
         judge_models={
-            "gpt4o": M.ManifestModelEntry(api="openai", model_id="gpt-4o-2024-11-20")
+            "gpt4o": manifest.ManifestModelEntry(
+                api="openai", model_id="gpt-4o-2024-11-20"
+            )
         },
         judge_mode="cross_vendor",
         item_count=196,
@@ -56,10 +58,10 @@ def test_required_fields_present(tmp_path, fake_prompts, fake_lockfile):
         package_lockfile_path=fake_lockfile,
     )
     out_dir = tmp_path / "results" / "testrun-001"
-    out = M.write_manifest(m, out_dir)
+    out = manifest.write_manifest(m, out_dir)
     blob = json.loads(out.read_text())
 
-    for k in M.REQUIRED_TOP_LEVEL_KEYS:
+    for k in manifest.REQUIRED_TOP_LEVEL_KEYS:
         assert k in blob, f"required §10 field missing: {k}"
 
     # Specific structural checks.
@@ -74,18 +76,18 @@ def test_required_fields_present(tmp_path, fake_prompts, fake_lockfile):
 
 
 def test_audit_flags_anthropic_prefix():
-    findings = M.audit_no_secrets({"key": "sk-ant-1234567890"})
+    findings = manifest.audit_no_secrets({"key": "sk-ant-1234567890"})
     assert findings, "audit must flag sk- prefix"
     assert any("sk-" in f for f in findings)
 
 
 def test_audit_flags_google_prefix():
-    findings = M.audit_no_secrets({"creds": "AIzaSyDeadbeefDeadbeefDeadbeef"})
+    findings = manifest.audit_no_secrets({"creds": "AIzaSyDeadbeefDeadbeefDeadbeef"})
     assert findings
 
 
 def test_audit_clean_for_normal_strings():
-    findings = M.audit_no_secrets(
+    findings = manifest.audit_no_secrets(
         {
             "ok": "claude-haiku-4-5-20251001",
             "model": "gpt-4o-2024-11-20",
@@ -98,7 +100,7 @@ def test_audit_clean_for_normal_strings():
 def test_write_refuses_to_serialize_keys(tmp_path, fake_prompts, fake_lockfile):
     """Defence in depth: even if a key sneaks in, write_manifest aborts."""
     a, b = fake_prompts
-    m = M.build_manifest(
+    m = manifest.build_manifest(
         run_id="testrun-leak",
         repo_root=tmp_path,
         generator_models={},
@@ -115,12 +117,12 @@ def test_write_refuses_to_serialize_keys(tmp_path, fake_prompts, fake_lockfile):
     m.cost_tracking["accidentally_leaked"] = "sk-ant-LEAK_LEAK_LEAK"
     out_dir = tmp_path / "results"
     with pytest.raises(RuntimeError, match="suspected API key"):
-        M.write_manifest(m, out_dir)
+        manifest.write_manifest(m, out_dir)
 
 
 def test_cost_tracking_increment(tmp_path, fake_prompts, fake_lockfile):
     a, b = fake_prompts
-    m = M.build_manifest(
+    m = manifest.build_manifest(
         run_id="testrun-cost",
         repo_root=tmp_path,
         generator_models={},
@@ -134,12 +136,12 @@ def test_cost_tracking_increment(tmp_path, fake_prompts, fake_lockfile):
         package_lockfile_path=fake_lockfile,
     )
     out_dir = tmp_path / "results" / "testrun-cost"
-    path = M.write_manifest(m, out_dir)
+    path = manifest.write_manifest(m, out_dir)
 
-    M.update_cost_tracking(
+    manifest.update_cost_tracking(
         path, add_input_tokens=100, add_output_tokens=20, add_usd=0.01
     )
-    M.update_cost_tracking(
+    manifest.update_cost_tracking(
         path, add_input_tokens=50, add_output_tokens=10, add_usd=0.005
     )
 
@@ -152,7 +154,7 @@ def test_cost_tracking_increment(tmp_path, fake_prompts, fake_lockfile):
 def test_item_result_appends_jsonl(tmp_path):
     out_dir = tmp_path / "items-test"
     out_dir.mkdir()
-    line = M.ItemResultLine(
+    line = manifest.ItemResultLine(
         question_id="q-001",
         ability="information_extraction",
         condition="C",
@@ -165,8 +167,8 @@ def test_item_result_appends_jsonl(tmp_path):
         estimated_usd=0.0046,
         wall_time_s=2.3,
     )
-    M.append_item_result(out_dir, line)
-    M.append_item_result(out_dir, line)
+    manifest.append_item_result(out_dir, line)
+    manifest.append_item_result(out_dir, line)
     contents = (out_dir / "items.jsonl").read_text().strip().splitlines()
     assert len(contents) == 2
     parsed = json.loads(contents[0])

--- a/tests_py/benchmarks/test_beam_standard_rag_live.py
+++ b/tests_py/benchmarks/test_beam_standard_rag_live.py
@@ -86,7 +86,7 @@ def test_standard_rag_issues_cosine_topk_query(patch_embedding) -> None:
     assert len(out) == 3
     assert out[0].memory_id == 1
     assert out[0].content == "memory body 1"
-    # cosine_sim = 1 - cosine_dist
+    # cosine_sim = 1 - cosine_dist  # noqa: ERA001 -- math identity doc, not code
     assert abs(out[0].cosine - 0.90) < 1e-6
 
     sql, params = db.conn._cursor.executed[0]

--- a/tests_py/core/test_sparse_dictionary.py
+++ b/tests_py/core/test_sparse_dictionary.py
@@ -81,7 +81,7 @@ class TestBuildSeedDictionary:
         assert d.K == 8
         assert d.D == 27
         assert d.sparsity == 3
-        assert d.learnedFromSessions == 0
+        assert d.learned_from_sessions == 0
         assert len(d.features) == 8
 
     def test_all_atoms_unit_vectors(self):
@@ -95,7 +95,7 @@ class TestBuildSeedDictionary:
         for f in d.features:
             assert len(f.label) > 0
             assert len(f.description) > 0
-            assert len(f.topSignals) > 0
+            assert len(f.top_signals) > 0
 
 
 class TestOmp:
@@ -132,12 +132,12 @@ class TestLearnDictionary:
     def test_returns_seed_for_few_sessions(self):
         convs = _make_conversations(5)
         d = learn_dictionary(convs)
-        assert d.learnedFromSessions == 0
+        assert d.learned_from_sessions == 0
         assert d.K == 8
 
     def test_returns_seed_for_null(self):
         d = learn_dictionary(None)
-        assert d.learnedFromSessions == 0
+        assert d.learned_from_sessions == 0
 
     def test_learns_for_10_plus_sessions(self):
         convs = _make_conversations(
@@ -149,7 +149,7 @@ class TestLearnDictionary:
             turnCount=15,
         )
         d = learn_dictionary(convs, {"K": 5, "sparsity": 2, "iterations": 2})
-        assert d.learnedFromSessions == 15
+        assert d.learned_from_sessions == 15
         assert d.K <= 5
         assert d.D == 27
         assert d.sparsity == 2
@@ -174,8 +174,8 @@ class TestEncodeSession:
         d = build_seed_dictionary()
         result = encode_session(_make_conv(), d)
         assert isinstance(result.weights, dict)
-        assert isinstance(result.reconstructionError, (int, float))
-        assert result.reconstructionError >= 0
+        assert isinstance(result.reconstruction_error, (int, float))
+        assert result.reconstruction_error >= 0
 
     def test_respects_sparsity(self):
         d = build_seed_dictionary()
@@ -203,7 +203,7 @@ class TestLabelFeature:
         direction[13] = 0.5  # tmp:burst
         result = label_feature(normalize(direction), 0)
         assert len(result.label) > 0
-        assert len(result.topSignals) > 0
+        assert len(result.top_signals) > 0
 
     def test_handles_zero_direction(self):
         result = label_feature([0.0] * 27, 5)

--- a/tests_py/core/test_stochastic_transmission.py
+++ b/tests_py/core/test_stochastic_transmission.py
@@ -114,7 +114,7 @@ class TestEffectiveReleaseProbability:
             full
         ) > compute_effective_release_probability(depleted)
 
-    def test_u_eff_equals_U_plus_u_times_one_minus_U(self):
+    def test_effective_release_probability_matches_exact_formula(self):
         """Exact formula, not just its monotonicity (Tsodyks & Markram 1997).
 
         u_eff = U + u*(1 - U) = 0.2 + 0.5*0.8 = 0.6; x = 1.0, and 0.6 is

--- a/tests_py/core/test_write_gate_autocal.py
+++ b/tests_py/core/test_write_gate_autocal.py
@@ -126,7 +126,7 @@ class TestObserveGateDecision:
         # All-accept for enough samples to pass min_samples and overcome
         # the tolerance band (EMA starts at 0.5, needs to rise above 0.65).
         # With decay 0.95, EMA after k accepts from 0.5 is:
-        #   EMA_k = 1 - 0.5 * 0.95^k
+        #   EMA_k = 1 - 0.5 * 0.95^k  # noqa: ERA001 -- math formula doc, not code
         # 0.65 exceeded when 0.95^k < 0.70 -> k >= 8.
         # But min_samples is 20, so we need at least 20 observations.
         for _ in range(50):

--- a/tests_py/handlers/test_connection_rooted_scoping.py
+++ b/tests_py/handlers/test_connection_rooted_scoping.py
@@ -95,15 +95,15 @@ def test_rooted_remember_forces_root_topic(monkeypatch):
     monkeypatch.setenv(_ENV, _ROOT)
     captured: dict = {}
 
-    class _StopParse(Exception):
+    class _StopParseError(Exception):
         pass
 
     def _fake_parse_args(args):
         captured["agent_topic"] = args.get("agent_topic")
-        raise _StopParse
+        raise _StopParseError
 
     monkeypatch.setattr(remember, "_parse_args", _fake_parse_args)
-    with pytest.raises(_StopParse):
+    with pytest.raises(_StopParseError):
         asyncio.run(
             remember.handler(
                 {"content": "a durable fact", "agent_topic": "some-other-agent"}

--- a/tests_py/handlers/test_ingest_findings_artifacts.py
+++ b/tests_py/handlers/test_ingest_findings_artifacts.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 
 from mcp_server.handlers.ingest_findings_artifacts import (
-    MalformedArtifact,
+    MalformedArtifactError,
     load_finding,
     read_index,
 )
@@ -120,7 +120,7 @@ class TestReadIndex:
         assert "f1" in index["findings"]
 
     def test_missing_index_raises_malformed(self, tmp_path):
-        with pytest.raises(MalformedArtifact):
+        with pytest.raises(MalformedArtifactError):
             read_index(tmp_path / "nope", "run1")
 
     def test_bad_json_raises_malformed(self, tmp_path):
@@ -128,13 +128,13 @@ class TestReadIndex:
         path = output_dir / "runs" / "run1" / "index.json"
         path.parent.mkdir(parents=True)
         path.write_text("{not json", encoding="utf-8")
-        with pytest.raises(MalformedArtifact):
+        with pytest.raises(MalformedArtifactError):
             read_index(output_dir, "run1")
 
     def test_index_without_findings_key_raises_malformed(self, tmp_path):
         output_dir = tmp_path / "ap-output"
         _write_json(output_dir / "runs" / "run1" / "index.json", {"run_id": "run1"})
-        with pytest.raises(MalformedArtifact):
+        with pytest.raises(MalformedArtifactError):
             read_index(output_dir, "run1")
 
 
@@ -183,7 +183,7 @@ class TestLoadFindingHypothesis:
 class TestLoadFindingMalformed:
     def test_missing_refined_raises_malformed(self, tmp_path):
         output_dir = _make_run(tmp_path, "run1")
-        with pytest.raises(MalformedArtifact):
+        with pytest.raises(MalformedArtifactError):
             load_finding(output_dir, "run1", "f1")
 
     def test_corrupt_refined_raises_malformed(self, tmp_path):
@@ -191,7 +191,7 @@ class TestLoadFindingMalformed:
         path = output_dir / "runs" / "run1" / "findings" / "f1" / "stage-1.refined.json"
         path.parent.mkdir(parents=True)
         path.write_text("not json at all", encoding="utf-8")
-        with pytest.raises(MalformedArtifact):
+        with pytest.raises(MalformedArtifactError):
             load_finding(output_dir, "run1", "f1")
 
 

--- a/tests_py/handlers/test_injection_receipts_emitter.py
+++ b/tests_py/handlers/test_injection_receipts_emitter.py
@@ -112,7 +112,7 @@ def test_hook_receipt_records_channel_session_and_ranks() -> None:
     )
     assert rid == 57
     ((_, params),) = conn.calls
-    # (session_id, channel, memory_ids, ranks, scores)
+    # (session_id, channel, memory_ids, ranks, scores)  # noqa: ERA001
     assert params == ("7374abf5-9c12", "session_start", [11, 7], [0, 1], [None, None])
 
 

--- a/tests_py/infrastructure/test_pipeline_discovery.py
+++ b/tests_py/infrastructure/test_pipeline_discovery.py
@@ -389,7 +389,7 @@ class TestInstallPipeline:
 
             @contextmanager
             def busy():
-                raise pipeline_install_lock.InstallLockBusy("test-busy")
+                raise pipeline_install_lock.InstallLockBusyError("test-busy")
                 yield  # pragma: no cover
 
             return busy()

--- a/tests_py/infrastructure/test_pipeline_install_lock.py
+++ b/tests_py/infrastructure/test_pipeline_install_lock.py
@@ -15,7 +15,7 @@ import pytest
 
 from mcp_server.infrastructure import pipeline_install_lock as mod
 from mcp_server.infrastructure.pipeline_install_lock import (
-    InstallLockBusy,
+    InstallLockBusyError,
     install_lock,
 )
 
@@ -40,6 +40,6 @@ def test_acquire_and_release_creates_lock_file(lock_in_tmp):
 )
 def test_contended_acquire_raises_busy(lock_in_tmp):
     with install_lock():
-        with pytest.raises(InstallLockBusy):
+        with pytest.raises(InstallLockBusyError):
             with install_lock():
                 pass

--- a/tests_py/infrastructure/test_wiki_store.py
+++ b/tests_py/infrastructure/test_wiki_store.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import pytest
 
 from mcp_server.infrastructure.wiki_store import (
-    WikiExists,
-    WikiMissing,
+    WikiExistsError,
+    WikiMissingError,
     append_section,
     list_pages,
     next_adr_number,
@@ -25,7 +25,7 @@ def test_create_writes_new_file(tmp_path: Path) -> None:
 
 def test_create_rejects_existing(tmp_path: Path) -> None:
     write_page(tmp_path, "notes/x.md", "body")
-    with pytest.raises(WikiExists):
+    with pytest.raises(WikiExistsError):
         write_page(tmp_path, "notes/x.md", "other")
 
 
@@ -44,7 +44,7 @@ def test_append_adds_content(tmp_path: Path) -> None:
 
 
 def test_append_missing_raises(tmp_path: Path) -> None:
-    with pytest.raises(WikiMissing):
+    with pytest.raises(WikiMissingError):
         write_page(tmp_path, "notes/nope.md", "x", mode="append")
 
 
@@ -66,7 +66,7 @@ def test_append_section_creates_heading(tmp_path: Path) -> None:
 
 
 def test_append_section_missing_page(tmp_path: Path) -> None:
-    with pytest.raises(WikiMissing):
+    with pytest.raises(WikiMissingError):
         append_section(tmp_path, "notes/gone.md", "X", "y")
 
 

--- a/tests_py/invariants/test_I10_pool_capacity.py
+++ b/tests_py/invariants/test_I10_pool_capacity.py
@@ -1,3 +1,6 @@
+# noqa: N999 -- filename encodes the project's own invariant ID (I10, see
+# docs/invariants/cortex-invariants.md); renaming would break the formal
+# invariant-ID cross-reference table.
 """Invariant I10 — pool capacity respects registered cycle workers.
 
 Formal predicate (from docs/invariants/cortex-invariants.md):

--- a/tests_py/invariants/test_I2_canonical_writer.py
+++ b/tests_py/invariants/test_I2_canonical_writer.py
@@ -1,3 +1,6 @@
+# noqa: N999 -- filename encodes the project's own invariant ID (I2, see
+# docs/invariants/cortex-invariants.md and ADR-0053); renaming would break
+# the formal invariant-ID cross-reference table and the ADR's own citation.
 """Invariant I2 — canonical heat_base writer regression guard.
 
 Formal predicate (from docs/invariants/cortex-invariants.md):
@@ -175,7 +178,7 @@ def _scan_heat_writers() -> set[tuple[str, int]]:
 
 
 @pytest.mark.invariants
-def test_I2_no_unauthorized_heat_writes() -> None:
+def test_i2_no_unauthorized_heat_writes() -> None:
     """I2: every UPDATE memories SET heat_base site must be in ALLOWED_WRITERS.
 
     Fails if a new writer is introduced (regression risk: silent drift
@@ -207,7 +210,7 @@ def test_I2_no_unauthorized_heat_writes() -> None:
 
 
 @pytest.mark.invariants
-def test_I2_no_legacy_heat_column_writes() -> None:
+def test_i2_no_legacy_heat_column_writes() -> None:
     """Post-A3: no code should write the legacy ``heat`` column.
 
     The ``heat`` column was renamed to ``heat_base`` in the A3 migration.
@@ -249,7 +252,7 @@ def test_I2_no_legacy_heat_column_writes() -> None:
 
 
 @pytest.mark.invariants
-def test_I2_allow_list_not_empty() -> None:
+def test_i2_allow_list_not_empty() -> None:
     """Sanity: the allow-list must be populated — guards against scanner
     breaking silently."""
     assert len(_ALLOWED_WRITERS) > 0

--- a/tests_py/invariants/test_phase2_parity.py
+++ b/tests_py/invariants/test_phase2_parity.py
@@ -73,8 +73,8 @@ pytestmark = [
 # ── Fixture: synthetic 100 memories × 51 entities with known truth ─────
 
 _FIXTURE_ENTITIES = [
-    # (name, type)
-    # case (a,d,e): canonical 4+ char names, mixed case
+    # (name, type)  # noqa: ERA001 -- fixture shape/case-label comment, not code
+    # case (a,d,e): canonical 4+ char names, mixed case  # noqa: ERA001
     ("Python", "language"),
     ("Postgres", "database"),
     ("pgvector", "extension"),
@@ -106,7 +106,7 @@ _FIXTURE_ENTITIES = [
     ("BEAM", "benchmark"),
     ("MemoryAgentBench", "benchmark"),
     ("EverMemBench", "benchmark"),
-    # case (b): "retroactive orphans" — valid entity names introduced
+    # case (b): "retroactive orphans" — valid entity names introduced  # noqa: ERA001
     # later; appear in older memories but no link at test-setup time
     # until synth_fill_join is called.
     ("retroactive", "concept"),

--- a/tests_py/observability/test_metrics.py
+++ b/tests_py/observability/test_metrics.py
@@ -85,21 +85,21 @@ class TestHistogram:
 
 class TestThreadSafety:
     def test_concurrent_increments(self):
-        N_THREADS = 16
-        N_INCREMENTS = 100
+        n_threads = 16
+        n_increments = 100
 
         def worker():
-            for _ in range(N_INCREMENTS):
+            for _ in range(n_increments):
                 metrics.inc_counter("concurrent")
 
-        threads = [threading.Thread(target=worker) for _ in range(N_THREADS)]
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
         for t in threads:
             t.start()
         for t in threads:
             t.join()
 
         out = metrics.render()
-        expected = N_THREADS * N_INCREMENTS
+        expected = n_threads * n_increments
         assert f"concurrent {expected}" in out
 
 

--- a/tests_py/observability/test_silent_failure.py
+++ b/tests_py/observability/test_silent_failure.py
@@ -63,11 +63,11 @@ class TestNote:
         # A non-string-coercible exception must not turn instrumentation
         # itself into a new failure mode (Move 3: instrumentation must
         # never break the caller).
-        class Explodes(Exception):
+        class ExplodesError(Exception):
             def __str__(self):
                 raise RuntimeError("cannot stringify")
 
-        silent_failure.note("demo.component", Explodes())  # must not raise
+        silent_failure.note("demo.component", ExplodesError())  # must not raise
 
 
 class TestStatus:

--- a/tests_py/shared/test_platform.py
+++ b/tests_py/shared/test_platform.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from mcp_server.shared import platform as plat
 
 
-def test_home_dir_prefers_HOME_override(monkeypatch, tmp_path):
+def test_home_dir_prefers_home_override(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     assert plat.home_dir() == tmp_path
 

--- a/tests_py/test_main.py
+++ b/tests_py/test_main.py
@@ -32,8 +32,9 @@ class TestMain:
 
     def test_main_registers_signal_handlers_and_runs(self):
         # Not mcp.run(transport="stdio"): main() drives stdio via
-        # run_stdio_drained (mcp_server/infrastructure/stdio_transport.py)
-        # instead, so that a request dispatched from the last line of a
+        # run_stdio_drained
+        # (mcp_server/infrastructure/stdio_transport.py) instead, so that
+        # a request dispatched from the last line of a
         # batch is drained before shutdown rather than losing its response
         # to stdin-EOF (see that module's docstring). anyio.run is what
         # main() calls now; assert THAT call, with the drained driver.

--- a/tests_py/validation/test_tags_envelope.py
+++ b/tests_py/validation/test_tags_envelope.py
@@ -42,7 +42,7 @@ class TestTagsArrayEnvelope:
         result = validate_tool_args("remember", _args_with_tags([]))
         assert result["tags"] == []
 
-    # maxItems = 20
+    # maxItems = 20  # noqa: ERA001 -- schema-constant doc, not code
 
     def test_20_tags_passes(self):
         tags = [f"tag{i}" for i in range(20)]


### PR DESCRIPTION
## Summary

Continues the issue #239 maximal-strictness lint program (after #309 landed B/RET/DTZ). This PR lands two more families as blocking gates: **N** (PEP 8 naming, 8 rule variants) and **ERA** (commented-out code). Every finding is fixed or carries a per-site `# noqa: RULE — <reason>` — no blanket ignores, matching the program's established bar.

**Correction on the numbers below vs. earlier drafts of this description:** the true baseline, independently re-measured against a fresh clone of `origin/main` (not the incrementally-tracked worktree state used mid-session, which already had some pre-existing partial fixes baked in before this session's own triage started) is **N: 54 findings, ERA: 54 findings** (108 total) — not the smaller in-progress counts I was tracking turn-by-turn. The end state is unaffected and independently re-verified on a completely fresh clone of the pushed branch: **0 N findings, 0 ERA findings, `ruff check .` and `ruff format --check .` both clean.**

Remaining: TRY (162), ARG (54→667 repo-wide), PTH (91), FBT (258→461 repo-wide), S-rest (34 production + 11078 S101-in-tests). Each is its own follow-up PR per the task's sequencing plan — this PR does **not** close #239.

## What landed

**N family (54 → 0 findings, 8 rule variants — N806, N803, N818, N815, N802, N999, N801, N812):**
- N806/N803 (34 combined): lowercased local variables/parameters at every mechanical site (`decay_cycle.py`, `pg_recall.py`, `sparse_dictionary.py`, `sparse_dictionary_learning.py`'s Gram-matrix helper parameters, `wiki_classifier.py`, `wiki_index.py`, `ap_sync_loop.py`, `shared/redaction.py`, a test's `N_THREADS`/`N_INCREMENTS`). Kept the capitalization via a per-site noqa naming the source for 6 sites where the case *is* the cited notation: Platt (1999) logistic-calibration parameters `A`/`B` in `platt_calibration.py`, and the Titans paper's memory-matrix symbol `M` in `titans_memory.py` — renaming those specific symbols would make the code harder to verify against its citation, not easier.
- N818 (7): added the `Error` suffix to every custom exception class (`MalformedArtifactError`, `InstallLockBusyError`, `WikiExistsError`, `WikiMissingError`, `_SupersedeCasConflictError`, plus two test-local ones), every raise/except/import/test-assertion site updated atomically (blast radius verified via grep before each rename).
- N815 (5, all in `shared/types_features.py`): **not** a bare rename — these Pydantic fields are an external JSON wire contract (the module's own docstring: "mirrors the JS-era MCP/profiles.json contract"). Fixed with `Field(alias="camelCase")` + `populate_by_name=True`, mirroring the exact precedent already in the sibling module `shared/types_profiles.py`, so the Python attribute is snake_case while the wire format is byte-identical.
- N802 (4): 3 lowercase the invariant-ID prefix only (`test_I2_*` → `test_i2_*`, preserving traceability to `docs/invariants/cortex-invariants.md`'s I2 row); 1 moves Tsodyks-Markram (1997) U/u notation out of the test name into its docstring rather than collapsing the two letters to the same lowercase.
- N999 (2): `test_I2_canonical_writer.py` / `test_I10_pool_capacity.py` filenames encode this project's own invariant-ID scheme, formally cross-referenced by `docs/invariants/cortex-invariants.md`'s table (and, for I2, ADR-0053 plus two production-code comments citing the filename literally) — renaming would break that cross-reference for zero benefit. Documented with `# noqa: N999`.
- N801 (1): `decision_lock` → `DecisionLock`.
- N812 (1): dropped a single-letter module import alias (`as M`).

**ERA family (54 → 0 findings):**
- 53 were false positives from ruff's eradicate heuristic misreading documentation as code (quoted §8 source citations, math-formula/SQL/format-by-example documentation, and 3 lines in `infrastructure/wiki_store.py` that *deliberately* mirror CodeQL's sanitizer example verbatim, self-documented at the site). Each suppressed with a per-site noqa naming the specific reason; several rewraps eliminated the trigger outright with no noqa needed.
- 1 was **genuine dead code** in `core/pg_recall.py` — a real disabled import+call for the abandoned v0.1 abstention-gate model — deleted and replaced with prose explaining why the module stays in the tree unwired (verified `abstention_gate.py` and its test file still exist before writing that claim).

## Completion Ledger

| Path introduced by this diff | Asserting evidence |
|---|---|
| N806/N803 renames + 2 documented notation exceptions | `ruff check . --select N806,N803` → 0; full suite unaffected |
| N818 exception renames (7 classes, 16 files) | `ruff check . --select N818` → 0; `pytest tests_py/handlers/test_ingest_findings_artifacts.py tests_py/infrastructure/test_pipeline_install_lock.py tests_py/infrastructure/test_wiki_store.py tests_py/handlers/test_connection_rooted_scoping.py tests_py/observability/test_silent_failure.py` → all pass |
| N815 `Field(alias=...)` rewrite | `ruff check . --select N815` → 0; `pytest tests_py/core/test_sparse_dictionary.py tests_py/core/test_behavioral_crosscoder.py tests_py/core/test_attribution_tracer.py tests_py/handlers/test_explore_features.py tests_py/shared/test_types.py tests_py/core/test_profile_builder.py` → 106 passed; `pyright` → 0 errors |
| N801 `decision_lock`→`DecisionLock` | `ruff check . --select N801` → 0; `pytest tests_py/infrastructure/test_groomer_coordinator.py` → 18 passed |
| N812 drop `as M` alias | `ruff check . --select N812` → 0; `pytest tests_py/benchmarks/test_beam_manifest.py` → 7 passed |
| N802 function renames (3 files) | `ruff check . --select N802` → 0; affected test files pass |
| N999 documented exemptions (2 files) | `ruff check . --select N999` → 0 |
| ERA001 suppressions (26 files, 53 sites) | `ruff check . --select ERA001` → 0; full suite green |
| ERA001 real fix (`core/pg_recall.py`) | `pytest tests_py/core/test_pg_recall_*.py tests_py/infrastructure/test_pg_recall_scoring_debias.py tests_py/core/test_abstention_gate.py` → 50 passed |
| `pyproject.toml` gate enablement | Introduced a throwaway N806+ERA001+RET504 violation in a scratch file, confirmed ruff catches all three, deleted before committing |
| **Independent re-verification** | Fresh `git clone` of this repo (not the working worktree) checked out at this PR's head: `ruff check . --select N` → 0, `ruff check . --select ERA` → 0, `ruff check .` → all checks passed, `ruff format --check .` → all formatted |

**Full suite:** `pytest tests_py/ -q` → 7009 passed, 5 skipped, 121 subtests passed (163.9s) — identical skip count to the pre-PR baseline, 0 regressions, 0 modified test assertions (only mechanical attribute/symbol-name propagation from the renames).

**Gates:** `ruff check .` and `ruff format --check .` both clean repo-wide (verified twice: in-session and via an independent fresh clone). `pyright` on all touched `.py` files: 0/0/0. `scripts/check_doc_claims.py` / `scripts/generate_repo_badges.py --check`: OK. `.bestpractices.json` parses. No conflict markers.

**Size-cap discipline (AST-measured before/after against `origin/main`, per the task's standing waiver):** one already-massively-over-cap file (`infrastructure/sqlite_store_search.py`, 623→624 lines / 123 over the 500 cap before this PR; its `SqliteSearchMixin` class 588→589 / 288 over the 300 cap before this PR) grew by exactly 1 line — the unavoidable cost of a comment rewrap needed to fix a real ERA001 finding without a 2-line split that stays under E501 (tried several, verified each against ruff, none worked). Disclosed, not silently absorbed. A sibling case (`handlers/wiki_migrate.py`) got a genuine zero-growth fix instead.

## Filed en route

Issue #312 — `tests_py/invariants/test_phase2_parity.py` fails hard instead of skipping when a local Postgres is reachable but lacks the `memory_entities` schema (same category as the closed #219). Confirmed pre-existing (reproduces identically on unmodified `main`) and outside this diff's blast radius to fix (a test-isolation bug fix, not a lint refactor) — filed with reproduction and a suggested fix rather than worked around.

## Test plan
- [x] `ruff check .` clean repo-wide (in-session AND independent fresh-clone verification)
- [x] `ruff format --check .` clean repo-wide
- [x] `pyright` on all touched files: 0 errors
- [x] Full suite: 7009 passed, 5 skipped (pre-existing, filed as #312), 0 failed
- [x] `scripts/check_doc_claims.py`, `scripts/generate_repo_badges.py --check`
- [x] AST size-delta measured before/after; one disclosed +1-line exception on an already-over-cap file
- [x] CI: all jobs green on the exact pushed head (`ae35a7a`) — Lint, Type Check, Test ×4 Python versions + SQLite + Windows, Docker Build ×2, Docker Smoke, CodeQL ×3, Build Package, Fuzz (PR batch) ×2

Progresses #239.

Co-Authored-By: Claude <noreply@anthropic.com>