### PR TITLE
fix(core): move auto_curator.py's filesystem I/O behind a WikiPagePort (issue #314)

### DIFF
--- a/mcp_server/core/auto_curator.py
+++ b/mcp_server/core/auto_curator.py
@@ -18,7 +18,13 @@ auto-curator sits in between:
      authors the page and writes it via ``wiki_write``.
 
 Pure business logic — no I/O. The handler composes this with the memory
-store and the wiki writer.
+store and the wiki writer. Wiki-page freshness/content checks needed by
+``is_path_recently_authored`` and ``build_reauthor_jobs`` are declared
+here as the ``WikiPagePort`` protocol (reverse DI, Martin 2017 Ch.11 —
+core declares what it needs, infrastructure implements it, the handler
+composition root wires it); the concrete os/pathlib-backed adapter lives
+in ``infrastructure/wiki_page_fs.py``. This module imports no ``os`` or
+``pathlib`` (issue #314).
 
 References (the user-quoted directives this module exists to satisfy):
   * "ALL ACTIONS SHOULD DOCUMENTED BY OPUS 4.7, IT'S NOT POSSIBLE THE
@@ -38,9 +44,7 @@ from mcp_server.core.wiki_coverage import domain_coverage_missing_scopes
 import re
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
-import os
-import time
-import os as _os
+from typing import Protocol
 
 # 2026-05-17: thresholds tuned to mirror the cluster-quality bar of the
 # hand-authored pages from this session. Below these, a cluster doesn't
@@ -93,25 +97,46 @@ class CurationJob:
 SKIP_IF_AUTHORED_WITHIN_DAYS = 30
 
 
+class WikiPagePort(Protocol):
+    """Wiki-page filesystem access this module needs but must not perform.
+
+    Reverse DI (coding-standards.md §5.1): core declares the shape of the
+    dependency; the concrete os/pathlib-backed adapter lives in
+    ``infrastructure.wiki_page_fs.FsWikiPagePort`` and is constructed by
+    the handler-level composition root (``build_wiki_page_port``). This
+    module never imports that adapter (or ``os``/``pathlib`` itself) —
+    Python Protocols are structurally typed (PEP 544), so the adapter
+    doesn't need to import this Protocol either; that also keeps
+    ``infrastructure/wiki_page_fs.py`` compliant with
+    docs/module-inventory.md's rule that infrastructure/ must not import
+    core/.
+    """
+
+    def is_recently_modified(self, rel_path: str, within_days: int) -> bool:
+        """True if the page at ``rel_path`` (relative to the bound wiki
+        root) exists and was modified within the last ``within_days``."""
+        ...
+
+    def read_text(self, rel_path: str) -> str | None:
+        """Return the page's raw text, or ``None`` if missing/unreadable."""
+        ...
+
+
 def is_path_recently_authored(
     suggested_path: str,
-    wiki_root: str,
+    wiki_page_port: WikiPagePort,
     within_days: int = SKIP_IF_AUTHORED_WITHIN_DAYS,
 ) -> bool:
-    """True if ``<wiki_root>/<suggested_path>`` exists and was modified
+    """True if ``wiki_page_port`` reports ``suggested_path`` was modified
     within the last ``within_days``. Used to skip clusters whose page
     already exists and is fresh.
 
-    The check is filesystem-mtime based — no PG lookup needed. If a
-    user edits a page by hand, the mtime updates and the cluster stays
-    skipped (their edits aren't clobbered).
+    Delegates the filesystem-mtime check to the injected port (issue
+    #314) — this module performs zero I/O itself. If a user edits a page
+    by hand, the mtime updates and the cluster stays skipped (their edits
+    aren't clobbered); the adapter preserves this exact semantics.
     """
-
-    full = os.path.join(wiki_root, suggested_path)
-    if not os.path.isfile(full):
-        return False
-    age_seconds = time.time() - os.path.getmtime(full)
-    return age_seconds < (within_days * 86400)
+    return wiki_page_port.is_recently_modified(suggested_path, within_days)
 
 
 # ── Topic identification ────────────────────────────────────────────────
@@ -239,7 +264,7 @@ def build_clusters(
     domain: str | None = None,
     min_memories: int = MIN_MEMORIES_PER_CLUSTER,
     min_avg_heat: float = MIN_AVG_HEAT_FOR_PAGE,
-    wiki_root: str | None = None,
+    wiki_page_port: WikiPagePort | None = None,
     skip_recently_authored: bool = True,
 ) -> list[CurationCluster]:
     """Group memories into topic clusters via dominant-entity bucketing.
@@ -317,14 +342,14 @@ def build_clusters(
     # 2026-05-17: skip clusters whose suggested page already exists and
     # was authored within ``SKIP_IF_AUTHORED_WITHIN_DAYS``. Without this
     # filter the curator keeps re-suggesting the same topics on every
-    # call, even after a page was just authored. Caller passes the wiki
-    # root path (``WIKI_ROOT``); when omitted we don't filter (useful
+    # call, even after a page was just authored. Caller passes the
+    # injected ``WikiPagePort``; when omitted we don't filter (useful
     # for tests).
-    if skip_recently_authored and wiki_root:
+    if skip_recently_authored and wiki_page_port is not None:
         clusters = [
             c
             for c in clusters
-            if not is_path_recently_authored(c.suggested_path, wiki_root)
+            if not is_path_recently_authored(c.suggested_path, wiki_page_port)
         ]
 
     # Rank by size × avg_heat
@@ -336,15 +361,20 @@ def count_pending_clusters(
     memories: list[dict],
     *,
     domain: str | None = None,
-    wiki_root: str | None = None,
+    wiki_root: WikiPagePort | None = None,
 ) -> int:
     """Count how many clusters would yield a fresh authoring job.
 
     Thin wrapper over the streaming counter (one chunk) so the list and
-    streaming paths can't diverge.
+    streaming paths can't diverge. ``wiki_root`` carries the injected
+    ``WikiPagePort`` (issue #314), not a path string — the parameter name
+    is kept as-is to preserve the existing call-site/test contract
+    (``tests_py/hooks/test_session_start.py`` monkeypatches this function
+    and asserts against a `wiki_root=` keyword call); it is forwarded to
+    ``count_pending_clusters_streamed`` as ``wiki_page_port``.
     """
     return count_pending_clusters_streamed(
-        [memories], domain=domain, wiki_root=wiki_root
+        [memories], domain=domain, wiki_page_port=wiki_root
     )
 
 
@@ -354,7 +384,7 @@ def count_pending_clusters_streamed(
     domain: str | None = None,
     min_memories: int = MIN_MEMORIES_PER_CLUSTER,
     min_avg_heat: float = MIN_AVG_HEAT_FOR_PAGE,
-    wiki_root: str | None = None,
+    wiki_page_port: WikiPagePort | None = None,
     skip_recently_authored: bool = True,
 ) -> int:
     """Count pending cluster jobs in ONE streaming pass — no resident corpus.
@@ -397,10 +427,10 @@ def count_pending_clusters_streamed(
             continue
         if b["heat_sum"] / b["count"] < min_avg_heat:
             continue
-        if skip_recently_authored and wiki_root:
+        if skip_recently_authored and wiki_page_port is not None:
             kind = _infer_kind_from_tags(b["tags"])
             path = f"{_kind_dir(kind)}/{b['domain']}/{_slugify(entity)}.md"
-            if is_path_recently_authored(path, wiki_root):
+            if is_path_recently_authored(path, wiki_page_port):
                 continue
         count += 1
     return count
@@ -913,7 +943,7 @@ def build_reauthor_prompt(
 
 def build_reauthor_jobs(
     drifts: list,
-    wiki_root: str,
+    wiki_page_port: WikiPagePort,
     source_root_resolver,
     today: str = "",
 ) -> list[ReauthorJob]:
@@ -922,15 +952,17 @@ def build_reauthor_jobs(
     ``source_root_resolver`` is a callable ``domain -> str | None``
     (matches ``wiki_coverage._project_source_root``). Returns jobs in
     input order — callers can sort by reason severity if desired.
+
+    Reads each drifted page's current text via the injected
+    ``wiki_page_port`` (issue #314) — this module performs zero I/O
+    itself. A page that can't be read (missing file, permission error)
+    is silently skipped, matching the pre-refactor behaviour.
     """
 
     jobs: list[ReauthorJob] = []
     for d in drifts:
-        full = _os.path.join(wiki_root, d.wiki_path)
-        try:
-            with open(full, encoding="utf-8", errors="ignore") as fp:
-                text = fp.read()
-        except OSError:
+        text = wiki_page_port.read_text(d.wiki_path)
+        if text is None:
             continue
         src_root = source_root_resolver(d.domain) if d.domain else None
         prompt = build_reauthor_prompt(d, text, src_root, today=today)

--- a/mcp_server/handlers/consolidation/wiki_backlog_pass.py
+++ b/mcp_server/handlers/consolidation/wiki_backlog_pass.py
@@ -41,6 +41,7 @@ from mcp_server.core.wiki_coverage import (
 )
 from mcp_server.core.wiki_drift import audit_wiki_drift
 from mcp_server.infrastructure.config import WIKI_ROOT
+from mcp_server.infrastructure.wiki_page_fs import build_wiki_page_port
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,7 @@ async def run_backlog_pass(store: Any) -> dict[str, Any]:
         else [store.get_all_memories_for_decay()]
     )
     out["cluster_jobs"] = count_pending_clusters_streamed(
-        chunks, wiki_root=str(WIKI_ROOT)
+        chunks, wiki_page_port=build_wiki_page_port(str(WIKI_ROOT))
     )
 
     coverages = audit_all_domains(str(WIKI_ROOT))

--- a/mcp_server/handlers/curate_wiki.py
+++ b/mcp_server/handlers/curate_wiki.py
@@ -68,6 +68,7 @@ from mcp_server.handlers.curate_wiki_serialize import (
 from mcp_server.handlers.curate_wiki_uncited import report_uncited_deliberate
 from mcp_server.infrastructure.config import WIKI_ROOT
 from mcp_server.infrastructure.memory_store import get_shared_store
+from mcp_server.infrastructure.wiki_page_fs import build_wiki_page_port
 
 
 schema = {
@@ -307,6 +308,9 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
 
     existing_pages = _scan_existing_pages(Path(WIKI_ROOT))
     today = _today()
+    # Composition-root wiring (§5.2): core declares WikiPagePort, this
+    # handler builds the concrete os/pathlib-backed adapter (issue #314).
+    wiki_page_port = build_wiki_page_port(str(WIKI_ROOT))
 
     # 1. Coverage jobs — top-down structural scopes.
     coverage_payload: list[dict[str, Any]] = []
@@ -357,7 +361,7 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
         )
         reauthor_jobs = build_reauthor_jobs(
             drifts,
-            wiki_root=str(WIKI_ROOT),
+            wiki_page_port=wiki_page_port,
             source_root_resolver=_project_source_root,
             today=today,
         )
@@ -372,7 +376,7 @@ async def handler(args: dict[str, Any] | None = None) -> dict[str, Any]:
             domain=domain,
             min_memories=min_memories,
             min_avg_heat=min_avg_heat,
-            wiki_root=str(WIKI_ROOT),
+            wiki_page_port=wiki_page_port,
             skip_recently_authored=True,
         )
         total_clusters_eligible = len(clusters)

--- a/mcp_server/hooks/session_start.py
+++ b/mcp_server/hooks/session_start.py
@@ -323,14 +323,19 @@ def _count_pending_curations(conn) -> int:
         if not memories:
             return 0
         # WIKI_ROOT lookup so the curator can skip already-authored
-        # clusters by filesystem mtime.
+        # clusters by filesystem mtime. The port is built here
+        # (composition root, §5.2) — core only declares the WikiPagePort
+        # shape it needs (issue #314).
         try:
             from mcp_server.infrastructure.config import WIKI_ROOT  # noqa: PLC0415 — optional-feature probe: ImportError here is a handled degraded mode
+            from mcp_server.infrastructure.wiki_page_fs import (  # noqa: PLC0415 — same optional-feature probe boundary
+                build_wiki_page_port,
+            )
 
-            wiki_root = str(WIKI_ROOT)
+            wiki_page_port = build_wiki_page_port(str(WIKI_ROOT))
         except ImportError:
-            wiki_root = None
-        return count_pending_clusters(memories, wiki_root=wiki_root)
+            wiki_page_port = None
+        return count_pending_clusters(memories, wiki_root=wiki_page_port)
     except Exception as exc:  # noqa: BLE001 — hook boundary; failure is logged to the hook log, the banner degrades
         _log(f"pending-cluster count failed (non-fatal): {exc}")
         return 0

--- a/mcp_server/infrastructure/wiki_page_fs.py
+++ b/mcp_server/infrastructure/wiki_page_fs.py
@@ -1,0 +1,84 @@
+"""Filesystem adapter for ``core.auto_curator``'s ``WikiPagePort`` (issue #314).
+
+``core/auto_curator.py``'s module docstring states "Pure business logic —
+no I/O", but it used to perform direct ``os``/``pathlib`` filesystem
+calls (mtime freshness check + page-content read) — a layer violation of
+docs/module-inventory.md's dependency rule ("core/ ... Must NOT Import:
+... os/pathlib"). This module is where that concrete I/O now lives,
+behind the ``WikiPagePort`` protocol core declares. Reverse DI
+(coding-standards.md §5.1/§5.2): core declares the shape of the
+dependency it needs; this adapter implements it; the handler-level
+composition roots (``handlers/curate_wiki.py``,
+``handlers/consolidation/wiki_backlog_pass.py``,
+``hooks/session_start.py``) construct it via ``build_wiki_page_port`` and
+inject the instance.
+
+This module intentionally does NOT import ``core.auto_curator`` — Python
+Protocols are structurally typed (PEP 544): a class satisfies a Protocol
+by matching its method shapes, no inheritance or import required. That
+also keeps this file compliant with docs/module-inventory.md's
+infrastructure/ dependency rule, which forbids infrastructure/ importing
+core/.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+
+class FsWikiPagePort:
+    """os/pathlib-backed ``WikiPagePort``, bound to one wiki root.
+
+    Preserves the exact pre-refactor semantics of the two call sites this
+    replaces in ``core/auto_curator.py`` (behaviour-preserving move, issue
+    #314): ``is_recently_modified`` is the same
+    ``os.path.isfile`` + ``time.time() - os.path.getmtime`` check that
+    used to live in ``is_path_recently_authored``; ``read_text`` is the
+    same naive ``os.path.join`` + ``open(..., errors="ignore")`` +
+    catch-``OSError``-and-skip read that used to live in
+    ``build_reauthor_jobs``. Both call sites' inputs come from the
+    system's own suggested/drift paths, not untrusted external input, so
+    no additional path-traversal hardening was added here — that would be
+    a behaviour change, out of scope for this refactor (see
+    ``infrastructure/wiki_store.py::read_page`` for the CWE-22-hardened
+    variant used where the input is untrusted).
+    """
+
+    def __init__(self, wiki_root: str) -> None:
+        self._wiki_root = wiki_root
+
+    def is_recently_modified(self, rel_path: str, within_days: int) -> bool:
+        """True if ``<wiki_root>/<rel_path>`` exists and was modified
+        within the last ``within_days`` days."""
+        full = os.path.join(self._wiki_root, rel_path)
+        if not os.path.isfile(full):
+            return False
+        age_seconds = time.time() - os.path.getmtime(full)
+        return age_seconds < (within_days * 86400)
+
+    def read_text(self, rel_path: str) -> str | None:
+        """Return ``<wiki_root>/<rel_path>``'s raw text, or ``None`` if
+        the file is missing or can't be read."""
+        full = os.path.join(self._wiki_root, rel_path)
+        try:
+            # source: mutation run 2026-07-31 (scripts/mutation_check.sh),
+            # tests_py/infrastructure/test_wiki_page_fs.py — 28/31 mutants
+            # killed. 3 accepted-equivalent survivors on `encoding="utf-8"`:
+            # dropping it or passing `encoding=None` is unkillable in this
+            # repo's supported environments (every CI runner and documented
+            # dev setup runs a UTF-8 locale, verified empirically —
+            # monkeypatching `locale.getencoding`/`getpreferredencoding`
+            # does not change what a bare `open()` resolves to on this
+            # platform, so the explicit arg is redundant-but-harmless
+            # here); `encoding="UTF-8"` is a true equivalent always (codec
+            # names are case/dash-insensitive in Python's codec registry).
+            with open(full, encoding="utf-8", errors="ignore") as fp:
+                return fp.read()
+        except OSError:
+            return None
+
+
+def build_wiki_page_port(wiki_root: str) -> FsWikiPagePort:
+    """Factory — composition roots call this to wire the port (§5.2)."""
+    return FsWikiPagePort(wiki_root)

--- a/tests_py/core/test_auto_curator.py
+++ b/tests_py/core/test_auto_curator.py
@@ -7,8 +7,12 @@ from mcp_server.core.auto_curator import (
     _ADR_TASK_RECORD_SECTIONS,
     _GENERIC_STRUCTURE_SECTIONS,
     build_authoring_prompt,
+    build_clusters,
     build_coverage_jobs,
     build_coverage_prompt,
+    build_reauthor_jobs,
+    count_pending_clusters_streamed,
+    is_path_recently_authored,
     sort_coverage_jobs,
 )
 from mcp_server.core.wiki_coverage import DomainCoverage, ScopeCoverage, SCOPES
@@ -140,3 +144,135 @@ class TestCoverageJobBuilder:
         jobs = sort_coverage_jobs(build_coverage_jobs(covs))
         names = [j.scope_name for j in jobs]
         assert names == ["architecture", "api", "data-flow"]
+
+
+class _FakeWikiPagePort:
+    """Records every call — proves core delegates through the injected
+    ``WikiPagePort`` and never performs filesystem I/O itself (issue
+    #314). No ``tmp_path``/real file appears anywhere in this class or
+    its callers below; a real ``FsWikiPagePort`` is exercised separately
+    in ``tests_py/infrastructure/test_wiki_page_fs.py``.
+    """
+
+    def __init__(
+        self,
+        *,
+        fresh: frozenset[str] = frozenset(),
+        texts: dict[str, str] | None = None,
+    ) -> None:
+        self._fresh = fresh
+        self._texts = texts or {}
+        self.is_recently_modified_calls: list[tuple[str, int]] = []
+        self.read_text_calls: list[str] = []
+
+    def is_recently_modified(self, rel_path: str, within_days: int) -> bool:
+        self.is_recently_modified_calls.append((rel_path, within_days))
+        return rel_path in self._fresh
+
+    def read_text(self, rel_path: str) -> str | None:
+        self.read_text_calls.append(rel_path)
+        return self._texts.get(rel_path)
+
+
+class _Drift:
+    """Minimal stand-in for ``wiki_drift.PageDrift`` — only the fields
+    ``build_reauthor_jobs``/``build_reauthor_prompt`` read."""
+
+    def __init__(
+        self, wiki_path: str, domain: str = "cortex", kind: str = "reference"
+    ) -> None:
+        self.wiki_path = wiki_path
+        self.domain = domain
+        self.kind = kind
+        self.reasons: list[str] = ["stale_content"]
+        self.missing_source_files: list[str] = []
+        self.cited_source_files: list[str] = []
+        self.last_updated = ""
+        self.age_days = 40.0
+
+
+def _memory(mid: int, content: str, heat: float = 0.5) -> dict:
+    return {
+        "id": mid,
+        "content": content,
+        "tags": [],
+        "effective_heat": heat,
+        "domain": "cortex",
+        "created_at": "2026-05-01",
+    }
+
+
+_ENTITY_MEMORIES = [
+    _memory(i, f"predictive_coding_gate detail {i} predictive_coding_gate")
+    for i in range(5)
+]
+_ENTITY_SUGGESTED_PATH = "reference/cortex/predictive-coding-gate.md"
+
+
+class TestWikiPagePortDIP:
+    """core/auto_curator.py declares ``WikiPagePort`` and delegates every
+    filesystem-shaped decision to the injected instance (issue #314) —
+    it performs zero I/O itself."""
+
+    def test_is_path_recently_authored_delegates_to_port(self):
+        port = _FakeWikiPagePort(fresh=frozenset({"reference/cortex/x.md"}))
+        assert is_path_recently_authored("reference/cortex/x.md", port) is True
+        assert is_path_recently_authored("reference/cortex/y.md", port) is False
+        assert port.is_recently_modified_calls == [
+            ("reference/cortex/x.md", 30),
+            ("reference/cortex/y.md", 30),
+        ]
+
+    def test_build_clusters_skips_fresh_pages_via_port(self):
+        fresh_port = _FakeWikiPagePort(fresh=frozenset({_ENTITY_SUGGESTED_PATH}))
+        clusters = build_clusters(_ENTITY_MEMORIES, wiki_page_port=fresh_port)
+        assert clusters == []
+        assert fresh_port.is_recently_modified_calls  # the port was consulted
+
+    def test_build_clusters_keeps_stale_pages_via_port(self):
+        stale_port = _FakeWikiPagePort()
+        clusters = build_clusters(_ENTITY_MEMORIES, wiki_page_port=stale_port)
+        assert len(clusters) == 1
+        assert stale_port.is_recently_modified_calls == [(_ENTITY_SUGGESTED_PATH, 30)]
+
+    def test_build_clusters_skips_no_filtering_without_a_port(self):
+        # No port injected → freshness filter is skipped entirely, same
+        # as the pre-refactor `if skip_recently_authored and wiki_root:`
+        # guard when wiki_root was falsy.
+        clusters = build_clusters(_ENTITY_MEMORIES)
+        assert len(clusters) == 1
+
+    def test_count_pending_clusters_streamed_uses_injected_port(self):
+        port = _FakeWikiPagePort(fresh=frozenset({_ENTITY_SUGGESTED_PATH}))
+        assert (
+            count_pending_clusters_streamed([_ENTITY_MEMORIES], wiki_page_port=port)
+            == 0
+        )
+        assert port.is_recently_modified_calls
+
+    def test_build_reauthor_jobs_reads_via_port_not_filesystem(self):
+        port = _FakeWikiPagePort(texts={"reference/cortex/a.md": "# A\n\nold body"})
+        drifts = [
+            _Drift("reference/cortex/a.md"),
+            _Drift("reference/cortex/missing.md"),
+        ]
+        jobs = build_reauthor_jobs(
+            drifts, wiki_page_port=port, source_root_resolver=lambda _d: None
+        )
+        # Only the drift whose text the port returns becomes a job — the
+        # missing one is silently skipped, matching pre-refactor semantics
+        # (the old code caught OSError from `open()` and did `continue`).
+        assert [j.wiki_path for j in jobs] == ["reference/cortex/a.md"]
+        assert port.read_text_calls == [
+            "reference/cortex/a.md",
+            "reference/cortex/missing.md",
+        ]
+
+    def test_count_pending_clusters_streamed_skips_filter_without_a_port(self):
+        # Mutation-driven (§12): `skip_recently_authored and wiki_page_port
+        # is not None` mutated to `or` would call
+        # `is_path_recently_authored(path, None)` here — an
+        # AttributeError on `None.is_recently_modified(...)`, not a
+        # silent skip. No port injected → the guard must short-circuit
+        # before ever touching the port.
+        assert count_pending_clusters_streamed([_ENTITY_MEMORIES]) == 1

--- a/tests_py/infrastructure/test_wiki_page_fs.py
+++ b/tests_py/infrastructure/test_wiki_page_fs.py
@@ -1,0 +1,109 @@
+"""Tests for infrastructure.wiki_page_fs — the WikiPagePort adapter
+core/auto_curator.py's freshness check and drift re-author read used to
+perform inline (issue #314). Exercises the real filesystem via
+``tmp_path`` — the counterpart to test_auto_curator.py's fake-port DIP
+tests, which never touch a real file.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from mcp_server.infrastructure.wiki_page_fs import build_wiki_page_port
+
+
+def test_is_recently_modified_true_for_a_fresh_file(tmp_path: Path) -> None:
+    (tmp_path / "reference" / "cortex").mkdir(parents=True)
+    page = tmp_path / "reference" / "cortex" / "x.md"
+    page.write_text("body")
+
+    port = build_wiki_page_port(str(tmp_path))
+    assert port.is_recently_modified("reference/cortex/x.md", within_days=30) is True
+
+
+def test_is_recently_modified_false_for_a_stale_file(tmp_path: Path) -> None:
+    (tmp_path / "reference" / "cortex").mkdir(parents=True)
+    page = tmp_path / "reference" / "cortex" / "x.md"
+    page.write_text("body")
+    old = time.time() - (31 * 86400)
+    os.utime(page, (old, old))
+
+    port = build_wiki_page_port(str(tmp_path))
+    assert port.is_recently_modified("reference/cortex/x.md", within_days=30) is False
+
+
+def test_is_recently_modified_false_for_a_missing_file(tmp_path: Path) -> None:
+    port = build_wiki_page_port(str(tmp_path))
+    result = port.is_recently_modified("reference/cortex/absent.md", within_days=30)
+    assert result is False
+
+
+def test_is_recently_modified_boundary_is_strictly_less_than(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Mutation-driven (§12): an mtime EXACTLY ``within_days * 86400``
+    seconds old must read as stale (``<``, not ``<=``) — pins the
+    threshold arithmetic itself, not just the multiplier's sign, since a
+    wrong multiplier (``86401`` or ``/`` instead of ``*``) also flips
+    this exact boundary. ``time.time()`` is monkeypatched to a fixed
+    value so the boundary lands exactly — measuring wall-clock elapsed
+    time between ``os.utime`` and the assertion is inherently racy
+    (a few microseconds pushes ``age_seconds`` just past the boundary,
+    making ``<`` and ``<=`` agree and the mutant invisible)."""
+    (tmp_path / "reference" / "cortex").mkdir(parents=True)
+    page = tmp_path / "reference" / "cortex" / "x.md"
+    page.write_text("body")
+    fixed_mtime = 1_700_000_000.0
+    os.utime(page, (fixed_mtime, fixed_mtime))
+    monkeypatch.setattr(
+        "mcp_server.infrastructure.wiki_page_fs.time.time",
+        lambda: fixed_mtime + 86400,  # exactly the within_days=1 threshold
+    )
+
+    port = build_wiki_page_port(str(tmp_path))
+    assert port.is_recently_modified("reference/cortex/x.md", within_days=1) is False
+
+
+def test_is_recently_modified_scales_with_days_not_a_fixed_constant(
+    tmp_path: Path,
+) -> None:
+    """A file aged 20 seconds is fresh under ``within_days=1`` (threshold
+    86400s) but would read as stale under a mutant that divides instead
+    of multiplies (``1 / 86400`` ≈ 0.0000116s threshold)."""
+    (tmp_path / "reference" / "cortex").mkdir(parents=True)
+    page = tmp_path / "reference" / "cortex" / "x.md"
+    page.write_text("body")
+    twenty_seconds_old = time.time() - 20
+    os.utime(page, (twenty_seconds_old, twenty_seconds_old))
+
+    port = build_wiki_page_port(str(tmp_path))
+    assert port.is_recently_modified("reference/cortex/x.md", within_days=1) is True
+
+
+def test_read_text_returns_file_content(tmp_path: Path) -> None:
+    (tmp_path / "reference" / "cortex").mkdir(parents=True)
+    (tmp_path / "reference" / "cortex" / "a.md").write_text("# A\n\nbody")
+
+    port = build_wiki_page_port(str(tmp_path))
+    assert port.read_text("reference/cortex/a.md") == "# A\n\nbody"
+
+
+def test_read_text_returns_none_for_a_missing_file(tmp_path: Path) -> None:
+    port = build_wiki_page_port(str(tmp_path))
+    assert port.read_text("reference/cortex/absent.md") is None
+
+
+def test_read_text_ignores_undecodable_bytes(tmp_path: Path) -> None:
+    """Mutation-driven (§12): pins ``errors="ignore"`` — an invalid or
+    misspelled error-handler name (e.g. ``"IGNORE"``, unregistered — codec
+    error-handler names are case-sensitive, unlike encoding names) raises
+    ``LookupError``/``UnicodeDecodeError`` on this invalid byte instead of
+    silently dropping it, and neither is caught by ``except OSError``."""
+    (tmp_path / "reference" / "cortex").mkdir(parents=True)
+    page = tmp_path / "reference" / "cortex" / "bad.md"
+    page.write_bytes(b"ok \xffend")
+
+    port = build_wiki_page_port(str(tmp_path))
+    assert port.read_text("reference/cortex/bad.md") == "ok end"


### PR DESCRIPTION
Closes #314

## Summary

`mcp_server/core/auto_curator.py`'s module docstring claimed "Pure business logic — no I/O", but the module imported `os` / `os as _os` / `time` and performed direct filesystem I/O in two spots — a Clean Architecture layer violation (coding-standards.md §2.2/DIP, docs/module-inventory.md's "core/ must not import os/pathlib" rule).

**Fix (reverse DI, §5.1/§5.2):** core declares a `WikiPagePort` Protocol (`is_recently_modified`, `read_text`); the concrete os/pathlib-backed adapter (`FsWikiPagePort` + `build_wiki_page_port` factory) lives in the new `mcp_server/infrastructure/wiki_page_fs.py`, which does **not** import core — Python Protocols are structurally typed (PEP 544), so no inheritance/import is needed, keeping infrastructure/'s documented "must not import core" rule intact. The three composition roots (`handlers/curate_wiki.py`, `handlers/consolidation/wiki_backlog_pass.py`, `hooks/session_start.py`) construct the port and inject it.

Behaviour-preserving: `FsWikiPagePort`'s methods are the exact pre-refactor logic verbatim (same `os.path.join`/`isfile`/`getmtime` math, same `open(errors="ignore")`/`except OSError` read) — no CWE-22 hardening added (that's `wiki_store.py::read_page`'s job for untrusted input; these call sites' paths are the system's own suggested/drift paths, not adversarial).

`count_pending_clusters`'s `wiki_root` keyword name is deliberately kept (now typed `WikiPagePort`, not `str`) because `tests_py/hooks/test_session_start.py` monkeypatches it with a fake whose signature is `wiki_root=None` — renaming would require a test-file edit, which a refactor must never do. Documented in the function's docstring.

## Acceptance criteria (from #314)

- [x] `mcp_server/core/auto_curator.py` contains no `import os` / `import pathlib` / direct filesystem calls — grep-verified (`grep -n "^import os\|^import pathlib\|os\.path\|open(" mcp_server/core/auto_curator.py` → no matches).
- [x] The functions doing I/O are unit-testable without a real filesystem — `tests_py/core/test_auto_curator.py::TestWikiPagePortDIP` (7 tests) uses a fake port, zero `tmp_path`/real files.
- [x] Existing tests pass unchanged in behavior — verified via `git stash` paired comparison: 7012 passed/5 skipped before, 7012 passed/5 skipped after the refactor commit alone (zero test files touched in that commit).
- [x] Docstring "Pure business logic — no I/O" is true again — and now explains the port pattern.

## Completion Ledger

| # | Path introduced by the diff | Asserting test |
|---|---|---|
| 1 | `WikiPagePort.is_recently_modified` delegation (`is_path_recently_authored`) | `test_is_path_recently_authored_delegates_to_port` |
| 2 | `build_clusters` filters via port when injected | `test_build_clusters_skips_fresh_pages_via_port`, `test_build_clusters_keeps_stale_pages_via_port` |
| 3 | `build_clusters` skips filtering with no port (guard false-branch) | `test_build_clusters_skips_no_filtering_without_a_port` |
| 4 | `count_pending_clusters_streamed` filters via port when injected | `test_count_pending_clusters_streamed_uses_injected_port` |
| 5 | `count_pending_clusters_streamed` guard short-circuits with no port (mutation-driven: `and`→`or` survivor) | `test_count_pending_clusters_streamed_skips_filter_without_a_port` |
| 6 | `build_reauthor_jobs` reads via port; missing page silently skipped | `test_build_reauthor_jobs_reads_via_port_not_filesystem` |
| 7 | `FsWikiPagePort.is_recently_modified` — fresh/stale/missing + exact boundary (`<` not `<=`, mutation-driven) | `test_is_recently_modified_true_for_a_fresh_file`, `..._false_for_a_stale_file`, `..._false_for_a_missing_file`, `..._boundary_is_strictly_less_than`, `..._scales_with_days_not_a_fixed_constant` |
| 8 | `FsWikiPagePort.read_text` — content/missing/undecodable-bytes (mutation-driven: `errors="ignore"` survivors) | `test_read_text_returns_file_content`, `..._returns_none_for_a_missing_file`, `..._ignores_undecodable_bytes` |
| 9 | Composition-root wiring in `curate_wiki.py`/`wiki_backlog_pass.py`/`session_start.py` | Existing handler/hook tests (`test_curate_wiki_uncited.py`, `test_wiki_backlog_pass.py`, `test_session_start.py`) pass unchanged post-refactor — proves the wiring didn't break the call sites |

## Test plan

- Full suite: `7012 passed, 5 skipped` (baseline, `git stash` paired comparison) → `7027 passed, 5 skipped` (this PR, +15 new tests, 0 removed, 0 modified, 0 regressions).
- `ruff check .` / `ruff format --check` on touched files: clean.
- `pyright` (0-diagnostic gate) on touched files: 0 errors/warnings.
- Mutation testing (`scripts/mutation_check.sh`-style scoped run, coding-standards.md §12): `infrastructure/wiki_page_fs.py` 28/31 killed (3 documented equivalents, see commit message + in-code comment); `core/auto_curator.py` — every mutant precisely on this diff's changed lines killed (verified by diffing each survivor against the unmutated original; ~700 other survivors are pre-existing, in unrelated untouched functions, out of scope per the standing §4/§12 waiver).
- `scripts/check_doc_claims.py --test-count 7027`: OK.
- `scripts/generate_repo_badges.py --check`: OK (badges are a floor, no update needed).
- AST size check: no new/grown function exceeds the 40-line local cap; no touched file's *added* code exceeds it (pre-existing over-cap functions in `curate_wiki.py::handler` and `session_start.py::_count_pending_curations` grew by 3 and 5 lines respectively for the port-wiring line — measured, not asserted; not my obligation to shrink per the standing waiver, noted for transparency).

Co-Authored-By: Claude <noreply@anthropic.com>