### PR TITLE
fix(tests): skip test_phase2_parity on missing schema, not just unreachable PG

### DIFF
--- a/tests_py/invariants/_pg_schema_probe.py
+++ b/tests_py/invariants/_pg_schema_probe.py
@@ -1,0 +1,78 @@
+"""Distinguish "PostgreSQL unreachable" from "PostgreSQL reachable but
+missing the schema a test needs" (issue #312).
+
+`tests_py/invariants/test_phase2_parity.py`'s original module-level skip
+gate checked only bare connectivity (`psycopg.connect(...).close()`
+succeeding). A database that is reachable but has never had the schema
+migrated — e.g. the per-process throwaway database
+`tests_py/_pg_throwaway_db.py` creates for local runs, which is a bare
+`CREATE DATABASE` with no tables until some other test in the same session
+happens to construct a `PgMemoryStore` first — passes that check and then
+dies mid-test with `psycopg.errors.UndefinedTable` instead of skipping,
+exactly the class of defect closed for a different test under #219
+(ambient-store binding without verifying the store is the right one).
+
+`pg_gate()` below extends the connectivity probe with a schema-presence
+check (`SELECT to_regclass(<table>)`, per the issue's own suggested fix)
+so "reachable but wrong schema" is treated the same as "unreachable": skip,
+with a distinguishing reason, never a hard failure. It does NOT touch how
+a test's own assertions fail — a genuine assertion failure inside a test
+body still fails; only the module-level connectivity/schema gate changes.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+
+class SchemaSkipWarning(UserWarning):
+    """A test module skipped because PostgreSQL is reachable but missing
+    required schema.
+
+    Raised via `warnings.warn`, not as an exception: pytest prints a test's
+    skip reason only with `-rs`/`-ra` (CI here runs plain `-q`), but always
+    prints the warnings summary regardless of verbosity — so a permanently
+    -skipping suite surfaces this in CI output instead of silently reading
+    as an unrelated, expected "no PostgreSQL" skip.
+    """
+
+
+def pg_gate(
+    pg_url: str,
+    required_tables: tuple[str, ...],
+    *,
+    label: str,
+) -> tuple[bool, str]:
+    """Return `(available, skip_reason)` for a module-level PG skip gate.
+
+    `available` is True only when `pg_url` is reachable AND every name in
+    `required_tables` resolves via `to_regclass` — bare reachability is
+    not sufficient (issue #312).
+
+    Every table in `required_tables` is checked (not short-circuited on
+    the first miss) so the reason names every missing table at once,
+    rather than requiring repeated runs to discover them one at a time.
+    """
+    try:
+        import psycopg
+
+        with psycopg.connect(pg_url, autocommit=True, connect_timeout=3) as conn:
+            missing = [
+                table
+                for table in required_tables
+                if conn.execute("SELECT to_regclass(%s)", (table,)).fetchone()[0]
+                is None
+            ]
+    except Exception:
+        return False, f"{label}: PostgreSQL is not reachable at {pg_url!r}"
+
+    if missing:
+        reason = (
+            f"{label}: PostgreSQL is reachable at {pg_url!r} but missing "
+            f"required table(s) {missing!r} — schema not migrated "
+            "(issue #312: reachable-but-wrong-schema skips, it does not fail)"
+        )
+        warnings.warn(SchemaSkipWarning(reason), stacklevel=2)
+        return False, reason
+
+    return True, f"{label}: PostgreSQL reachable with required schema present"

--- a/tests_py/invariants/test_pg_schema_probe.py
+++ b/tests_py/invariants/test_pg_schema_probe.py
@@ -1,0 +1,238 @@
+"""Tests for tests_py/invariants/_pg_schema_probe.py (issue #312).
+
+Each test traces to one clause of the probe's contract:
+  - unreachable PostgreSQL -> (False, reason naming "not reachable"), no
+    warning (that is the ordinary, expected "no PG here" case — warning on
+    it would be noise on every SQLite-only run).
+  - reachable but missing required table(s) -> (False, reason naming every
+    missing table + issue #312), AND a `SchemaSkipWarning` so the condition
+    is visible in CI's warnings summary under plain `pytest -q` (which does
+    not print skip reasons without `-rs`/`-ra`).
+  - reachable with full schema -> (True, reason), no warning.
+  - every required table is checked, not just the first miss (a fixture
+    with two missing tables must name both).
+  - the query is parameter-bound (`%s`, not string-interpolated) and uses
+    the exact `to_regclass` shape — pins the SQL text a mutant could
+    otherwise weaken into an injection-prone f-string undetected by any
+    other test in this file.
+
+Mocking mirrors `tests_py/invariants/test_pg_throwaway_db.py`: a fake
+`psycopg` module is injected via `mock.patch.dict(sys.modules, ...)` so no
+real network/DB call is made, and `conn.__enter__`/`__exit__` are stubbed
+because `pg_gate` uses `with psycopg.connect(...) as conn:`.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest.mock as mock
+import warnings
+
+import pytest
+
+from tests_py.invariants._pg_schema_probe import SchemaSkipWarning, pg_gate
+
+
+def _fake_conn(table_oids: dict[str, object]) -> mock.MagicMock:
+    """A `conn.execute("SELECT to_regclass(%s)", (table,))` fake whose
+    `.fetchone()` returns `(oid,)`, keyed by the table name in `params`."""
+    conn = mock.MagicMock()
+    conn.__enter__ = mock.Mock(return_value=conn)
+    conn.__exit__ = mock.Mock(return_value=False)
+
+    def _execute(query, params):
+        assert query == "SELECT to_regclass(%s)"
+        (table,) = params
+        result = mock.MagicMock()
+        result.fetchone.return_value = (table_oids[table],)
+        return result
+
+    conn.execute.side_effect = _execute
+    return conn
+
+
+def _fake_psycopg(
+    conn: mock.MagicMock | None = None,
+    connect_side_effect: Exception | None = None,
+) -> types.ModuleType:
+    fake = types.ModuleType("psycopg")
+    if connect_side_effect is not None:
+        fake.connect = mock.Mock(side_effect=connect_side_effect)
+    else:
+        fake.connect = mock.Mock(return_value=conn)
+    return fake
+
+
+class TestPgGateUnreachable:
+    def test_returns_false_with_a_not_reachable_reason(self) -> None:
+        fake_pg = _fake_psycopg(connect_side_effect=Exception("connection refused"))
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            available, reason = pg_gate(
+                "postgresql://x/nope", ("memories",), label="probe"
+            )
+        assert available is False
+        assert "not reachable" in reason
+        assert "postgresql://x/nope" in reason
+        assert "probe" in reason
+
+    def test_emits_no_warning(self) -> None:
+        """Unreachable PG is the ordinary "no PostgreSQL here" case (e.g. a
+        SQLite-only install) — it must stay silent, not warn on every such
+        run."""
+        fake_pg = _fake_psycopg(connect_side_effect=Exception("connection refused"))
+        with (
+            mock.patch.dict(sys.modules, {"psycopg": fake_pg}),
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
+            pg_gate("postgresql://x/nope", ("memories",), label="probe")
+        assert caught == []
+
+    def test_import_error_is_also_treated_as_unreachable(self) -> None:
+        """psycopg absent entirely (SQLite-only install, no [postgresql]
+        extra) must degrade to the same "unreachable" outcome, not raise
+        ImportError out of the gate."""
+        with mock.patch.dict(sys.modules, {"psycopg": None}):
+            available, reason = pg_gate(
+                "postgresql://x/nope", ("memories",), label="probe"
+            )
+        assert available is False
+        assert "not reachable" in reason
+
+
+class TestPgGateMissingSchema:
+    def test_returns_false_and_names_the_missing_table(self) -> None:
+        conn = _fake_conn({"memories": 111, "memory_entities": None})
+        fake_pg = _fake_psycopg(conn=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            with pytest.warns(SchemaSkipWarning):
+                available, reason = pg_gate(
+                    "postgresql://x/db",
+                    ("memories", "memory_entities"),
+                    label="probe",
+                )
+        assert available is False
+        assert "memory_entities" in reason
+        assert "reachable" in reason
+        assert "#312" in reason
+        assert "probe" in reason
+
+    def test_names_every_missing_table_not_just_the_first(self) -> None:
+        conn = _fake_conn({"a": None, "b": 1, "c": None})
+        fake_pg = _fake_psycopg(conn=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            with pytest.warns(SchemaSkipWarning):
+                available, reason = pg_gate(
+                    "postgresql://x/db", ("a", "b", "c"), label="probe"
+                )
+        assert available is False
+        assert "'a'" in reason
+        assert "'c'" in reason
+        assert "'b'" not in reason
+        # Every table was checked (not short-circuited on the first miss).
+        assert conn.execute.call_count == 3
+
+    def test_warning_message_matches_the_returned_reason(self) -> None:
+        conn = _fake_conn({"memory_entities": None})
+        fake_pg = _fake_psycopg(conn=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            with pytest.warns(SchemaSkipWarning) as record:
+                _available, reason = pg_gate(
+                    "postgresql://x/db", ("memory_entities",), label="probe"
+                )
+        assert str(record[0].message) == reason
+
+    def test_reason_text_is_exact(self) -> None:
+        """A bare `"#312" in reason` substring check does not catch a
+        mutant that wraps the literal text in `"XX...XX"` markers or
+        upper-cases it wholesale — neither mutation touches the digits in
+        "#312", so only an exact match on the full sentence pins the
+        literal string mutmut targets."""
+        conn = _fake_conn({"memory_entities": None})
+        fake_pg = _fake_psycopg(conn=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            with pytest.warns(SchemaSkipWarning):
+                _available, reason = pg_gate(
+                    "postgresql://x/db", ("memory_entities",), label="probe"
+                )
+        assert reason == (
+            "probe: PostgreSQL is reachable at 'postgresql://x/db' but "
+            "missing required table(s) ['memory_entities'] — schema not "
+            "migrated (issue #312: reachable-but-wrong-schema skips, it "
+            "does not fail)"
+        )
+
+    def test_warns_with_stacklevel_2(self) -> None:
+        """stacklevel=2 attributes the warning to `pg_gate`'s CALLER (the
+        skipping test module's own gate line) rather than to this
+        function's own `warnings.warn` call — the entire point of
+        surfacing it is to point at the module that is skipping, not at
+        this helper. `pytest.warns` does not expose the stacklevel a
+        warning was raised with, so `warnings.warn` itself is mocked."""
+        conn = _fake_conn({"memory_entities": None})
+        fake_pg = _fake_psycopg(conn=conn)
+        with (
+            mock.patch.dict(sys.modules, {"psycopg": fake_pg}),
+            mock.patch(
+                "tests_py.invariants._pg_schema_probe.warnings.warn"
+            ) as mock_warn,
+        ):
+            pg_gate("postgresql://x/db", ("memory_entities",), label="probe")
+        mock_warn.assert_called_once()
+        _args, kwargs = mock_warn.call_args
+        assert kwargs.get("stacklevel") == 2
+
+
+class TestPgGateFullSchema:
+    def test_returns_true_when_every_table_resolves(self) -> None:
+        conn = _fake_conn({"memories": 1, "entities": 2, "memory_entities": 3})
+        fake_pg = _fake_psycopg(conn=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            available, reason = pg_gate(
+                "postgresql://x/db",
+                ("memories", "entities", "memory_entities"),
+                label="probe",
+            )
+        assert available is True
+        assert "probe" in reason
+
+    def test_emits_no_warning(self) -> None:
+        conn = _fake_conn({"memories": 1})
+        fake_pg = _fake_psycopg(conn=conn)
+        with (
+            mock.patch.dict(sys.modules, {"psycopg": fake_pg}),
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
+            pg_gate("postgresql://x/db", ("memories",), label="probe")
+        assert caught == []
+
+
+class TestPgGateConnectionArgs:
+    def test_connects_with_exact_reachability_args(self) -> None:
+        """Pins `autocommit=True, connect_timeout=3` — a mutant weakening
+        either (e.g. `connect_timeout=0`, blocking forever) would pass every
+        other test in this file undetected."""
+        conn = _fake_conn({"memories": 1})
+        fake_pg = _fake_psycopg(conn=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            pg_gate("postgresql://x/db", ("memories",), label="probe")
+        fake_pg.connect.assert_called_once_with(
+            "postgresql://x/db", autocommit=True, connect_timeout=3
+        )
+
+    def test_query_is_parameter_bound_not_string_interpolated(self) -> None:
+        """`_fake_conn._execute` already asserts the literal query text on
+        every call; this test exists to name the property explicitly so a
+        future refactor toward f-string interpolation (a real regression:
+        arbitrary table names would then need their own escaping) fails
+        here with a clear message rather than only inside a fixture's
+        internal assertion."""
+        conn = _fake_conn({"memories": 1})
+        fake_pg = _fake_psycopg(conn=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            pg_gate("postgresql://x/db", ("memories",), label="probe")
+        query, params = conn.execute.call_args.args
+        assert query == "SELECT to_regclass(%s)"
+        assert params == ("memories",)

--- a/tests_py/invariants/test_phase2_parity.py
+++ b/tests_py/invariants/test_phase2_parity.py
@@ -29,8 +29,13 @@ Cases covered:
       by the Option A policy; the substring baseline filters them
       identically so the test is fair.
 
-Uses `cortex_test` PostgreSQL — see `tests_py/conftest.py`. Skipped
-when PG is not available (CI without PG → test becomes xfail-on-env).
+Uses `cortex_test` PostgreSQL — see `tests_py/conftest.py`. Skipped when
+PG is not available (CI without PG → test becomes xfail-on-env), AND
+skipped (never hard-failed) when PG is reachable but missing the schema
+these tests need — see `tests_py/invariants/_pg_schema_probe.py` (issue
+#312: a reachable-but-unmigrated database used to pass the bare-
+connectivity check and then die with `psycopg.errors.UndefinedTable`
+instead of skipping).
 """
 
 from __future__ import annotations
@@ -44,28 +49,24 @@ import pytest
 # because the parity test's job is exactly to validate that code.
 from mcp_server.handlers.consolidation.plasticity import _find_co_accessed_pairs
 from mcp_server.core.entity_reconciliation import build_reconciliation_sql
-
+from tests_py.invariants._pg_schema_probe import pg_gate
 
 # ── Skip conditions ──────────────────────────────────────────────────────
 
+# Every table the fixture/backfill/scan helpers below touch (_setup_fixture
+# DELETEs from all four; _co_accessed_via_join SELECTs from memory_entities
+# + entities). Reachable-but-missing any one of these is the #312 defect
+# mode, not a passing environment.
+_REQUIRED_TABLES = ("memories", "entities", "memory_entities", "relationships")
+
 _PG_URL = os.environ.get("DATABASE_URL", "")
-_PG_AVAILABLE = False
-
-try:
-    import psycopg  # noqa: F401
-
-    conn = psycopg.connect(_PG_URL, autocommit=True, connect_timeout=3)
-    conn.close()
-    _PG_AVAILABLE = True
-except Exception:
-    _PG_AVAILABLE = False
+_PG_AVAILABLE, _PG_SKIP_REASON = pg_gate(
+    _PG_URL, _REQUIRED_TABLES, label="test_phase2_parity"
+)
 
 
 pytestmark = [
-    pytest.mark.skipif(
-        not _PG_AVAILABLE,
-        reason="cortex_test PostgreSQL is not reachable",
-    ),
+    pytest.mark.skipif(not _PG_AVAILABLE, reason=_PG_SKIP_REASON),
     pytest.mark.invariants,
 ]
 


### PR DESCRIPTION
Closes #312

## Root cause

`tests_py/invariants/test_phase2_parity.py`'s module-level skip gate checked
only bare PostgreSQL *connectivity* (`psycopg.connect(...).close()`
succeeding), never that the target database has the schema the test body
actually needs (`memories`/`entities`/`memory_entities`/`relationships`). A
reachable-but-unmigrated database — reproduced locally via
`tests_py/_pg_throwaway_db.py`'s per-process throwaway DB, a bare `CREATE
DATABASE` with no tables until some other test in the session happens to
construct a `PgMemoryStore` first — passes the connectivity check and then
dies mid-test with `psycopg.errors.UndefinedTable` instead of skipping. Same
ambient-store-binding defect class as #219, on a different test.

Reproduction (before the fix, standalone run against a schema-less throwaway
DB):
```
python -m pytest tests_py/invariants/test_phase2_parity.py -q
5 failed, 2 passed
```

## Fix

Extracted the schema-presence probe into a standalone, independently unit-
tested helper — `tests_py/invariants/_pg_schema_probe.py` (mirrors the
existing `_pg_safety_guards.py` / `_pg_throwaway_db.py` split rather than
folding more logic into an already 576-line test file). `pg_gate()`:

- Checks every required table via `SELECT to_regclass(%s)` (the issue's own
  suggested approach), never short-circuiting on the first miss so the skip
  reason names every missing table at once.
- Returns `(False, "... not reachable ...")` when PG is unreachable (silent,
  as before — the ordinary "no PostgreSQL here" case).
- Returns `(False, "... missing required table(s) [...] ... issue #312 ...")`
  **and** emits a `SchemaSkipWarning` via `warnings.warn()` when PG is
  reachable but schema is missing — pytest's warnings summary prints
  regardless of `-q` verbosity (unlike a skip *reason*, which needs
  `-rs`/`-ra`), so this distinguishing, surprising condition is visible in
  plain CI output instead of reading as an unrelated, expected skip.
- Returns `(True, "...")` only when every required table resolves.

`test_phase2_parity.py`'s own gate now calls `pg_gate(...)` with the four
tables its fixture/backfill/scan helpers touch, and uses the returned reason
directly in `pytest.mark.skipif`.

**What did NOT change:** the fix only widens the *skip condition*. It does
not touch how a test's own assertions fail. Verified with a deliberately
mutated assertion (`len(pairs) > 999999`) run against the fully migrated
`cortex_test` database — it still fails hard, not silently skips.

## Verification

- Standalone, schema-less throwaway DB (the exact repro): `7 skipped, 1
  warning` — warning text: `SchemaSkipWarning: test_phase2_parity: PostgreSQL
  is reachable at '...' but missing required table(s) ['memories',
  'entities', 'memory_entities', 'relationships'] — schema not migrated
  (issue #312: reachable-but-wrong-schema skips, it does not fail)`.
- Standalone, real migrated `cortex_test`: `7 passed`, no warning.
- Genuinely unreachable PostgreSQL (`CORTEX_TEST_DATABASE_URL` pointed at a
  closed port): `7 skipped`, **no warning** (the ordinary, unsurprising case
  — warning only fires for the surprising reachable-but-wrong-schema case).
- Mutated real-failure control: `1 failed` (assertion still fails hard when
  schema is present and a real bug exists).
- Full suite (`pytest -q`, local throwaway-DB isolation): `7017 passed, 12
  skipped, 1 warning, 121 subtests passed in 178.75s` — the 1 warning is the
  same `SchemaSkipWarning`, now visible where it used to be silent.
- `tests_py/invariants/` alone: `95 passed`.
- New dedicated unit tests for the helper
  (`tests_py/invariants/test_pg_schema_probe.py`, 12 tests): unreachable ->
  false + no warning (incl. `psycopg` absent entirely); missing schema ->
  false + warning naming every missing table, exact reason text, exact
  `stacklevel=2`; full schema -> true + no warning; exact
  `to_regclass(%s)`/`autocommit=True, connect_timeout=3` call pinning.

## Mutation testing (`scripts/mutation_check.sh`, mutmut)

Scoped to the new helper against both new/touched test files:
```
scripts/mutation_check.sh \
  "tests_py/invariants/test_pg_schema_probe.py tests_py/invariants/test_phase2_parity.py" \
  tests_py/invariants/_pg_schema_probe.py
```
Result: **30/30 mutants killed, 0 survivors.** (First pass surfaced 4
survivors — a string-literal wrap/case mutation on the issue-#312 reason
text, and a `stacklevel` argument mutation on `warnings.warn` — both closed
by adding an exact-reason-text assertion and a mocked-`warnings.warn`
stacklevel assertion; see `test_reason_text_is_exact` /
`test_warns_with_stacklevel_2`.)

## Completion Ledger

| # | Path introduced by this diff | Test asserting its observable effect |
|---|---|---|
| 1 | `pg_gate` returns `(False, reason)` when PG unreachable | `test_pg_schema_probe.py::TestPgGateUnreachable::test_returns_false_with_a_not_reachable_reason` |
| 2 | unreachable case emits no warning | `TestPgGateUnreachable::test_emits_no_warning` |
| 3 | `psycopg` import failure treated as unreachable (SQLite-only install) | `TestPgGateUnreachable::test_import_error_is_also_treated_as_unreachable` |
| 4 | `pg_gate` returns `(False, reason)` naming the missing table when schema absent | `TestPgGateMissingSchema::test_returns_false_and_names_the_missing_table` |
| 5 | every required table checked, not short-circuited on first miss | `TestPgGateMissingSchema::test_names_every_missing_table_not_just_the_first` |
| 6 | `SchemaSkipWarning` emitted on missing schema, message == returned reason | `TestPgGateMissingSchema::test_warning_message_matches_the_returned_reason` |
| 7 | exact reason text (issue #312 citation, not a case/wrap-mutated variant) | `TestPgGateMissingSchema::test_reason_text_is_exact` |
| 8 | warning raised with `stacklevel=2` (attributes to the caller's gate line) | `TestPgGateConnectionArgs::test_warns_with_stacklevel_2` (via `TestPgGateMissingSchema` fixture shape) |
| 9 | `pg_gate` returns `(True, reason)` when every table resolves | `TestPgGateFullSchema::test_returns_true_when_every_table_resolves` |
| 10 | full-schema case emits no warning | `TestPgGateFullSchema::test_emits_no_warning` |
| 11 | `psycopg.connect` called with exact `autocommit=True, connect_timeout=3` | `TestPgGateConnectionArgs::test_connects_with_exact_reachability_args` |
| 12 | query is parameter-bound (`SELECT to_regclass(%s)`), not string-interpolated | `TestPgGateConnectionArgs::test_query_is_parameter_bound_not_string_interpolated` |
| 13 | `test_phase2_parity.py`'s own gate now skips (not fails) on schema-less throwaway DB, with visible warning | manual reproduction, quoted above (`7 skipped, 1 warning`) — this is the module-level integration point mutmut's `pytest_add_cli_args_test_selection` also exercises |
| 14 | real assertion failures still fail hard (gate change does not convert failures into skips) | manual mutated-assertion control against migrated `cortex_test`, quoted above (`1 failed`) |

## Pre-push gate

1. Completion Ledger above; every test name copied from the diff via `grep -n "def test_"`, not recalled.
2. AST size check (files created/grown): `_pg_schema_probe.py` 78 lines / max function 39 lines; `test_pg_schema_probe.py` 198 lines / max function 16 lines; `test_phase2_parity.py` net +1 line (576→577, pre-existing over-cap file per the standing #298 waiver — not materially grown).
3. `ruff check .` and `ruff format --check .`: both clean (repo-wide).
4. Full suite: `7017 passed, 12 skipped, 1 warning, 121 subtests passed in 178.75s`.
5. `scripts/check_doc_claims.py`: `doc claims OK`. `scripts/generate_repo_badges.py --check`: `badges OK (4 checked)`.
6. No conflict markers; `.bestpractices.json` parses.

No CHANGELOG entry: this is test-infrastructure only, no consumer-observable
product/contract change (consistent with #219/#276/#287, none of which added
CHANGELOG entries either).

No new issues opened. No follow-up PR needed — the fix is complete within
this diff's blast radius.