### PR TITLE
fix(tests): provision the test-database schema instead of skipping (issue #312)

### DIFF
--- a/tests_py/_pg_schema_provision.py
+++ b/tests_py/_pg_schema_provision.py
@@ -1,0 +1,207 @@
+"""Ensure the resolved test-database URL is reachable AND schema-provisioned
+before any PostgreSQL-gated test in this session runs (issue #312).
+
+ROOT CAUSE: `tests_py/_pg_throwaway_db.py`'s per-process throwaway database
+(and, equally, an explicit `CORTEX_TEST_DATABASE_URL` pointed at a database
+that was never migrated) is a bare `CREATE DATABASE` — zero tables. Before
+the #219 store-isolation work, these tests ran against the real `cortex`
+database, which already carried a full schema; isolation redirected them to
+a throwaway target without ever provisioning it. In CI's shared, persistent
+`cortex` database, the gap is invisible: SOME earlier test in the same
+session constructs a `PgMemoryStore()` first and incidentally provisions
+the schema for everyone after it. Standalone or narrowly-scoped local runs
+have no such earlier test, so the very first raw-SQL query against e.g.
+`memory_entities` dies with `psycopg.errors.UndefinedTable` — accidental,
+execution-order-dependent provisioning, not deterministic isolation.
+
+PR #319 proposed detecting this condition and skipping. That is the wrong
+fix (issue #312, maintainer directive): a skip converts thousands of real
+assertions into a silent pass and permanently enshrines the local-vs-CI
+divergence. This module makes provisioning DETERMINISTIC instead — every
+session ensures its own resolved database is ready, exactly the same way
+CI accidentally ends up ready, without depending on which test happens to
+run first.
+
+Reuses the production migration path — never a hand-copied schema.
+Constructing `PgMemoryStore(database_url=...)` under the hood runs
+`_init_schema()`, which applies `pg_schema.get_all_ddl()` idempotently
+(hash-gated: a DB already at the code's revision costs one indexed
+SELECT). This is the exact same call `mcp_server/migrate.py` makes to
+migrate a live install — "constructing PgMemoryStore IS the migration"
+(that module's own docstring) — so a test session and a real deployment
+can never drift onto two different schemas.
+
+Genuinely-absent PostgreSQL (driver not installed, or the server itself
+unreachable) still degrades to a skip, exactly as documented before this
+change. Reachable-but-unprovisioned (the actual #312 defect: server up,
+named database missing or empty) no longer skips — it gets created and/or
+migrated. A REAL environment error while doing so (no CREATEDB privilege,
+a required extension the connecting role cannot install) is reported
+loudly via `pytest.exit` — the same fail-closed idiom already used by this
+file's siblings, `guard_against_populated_db` /
+`guard_against_real_data_roots` in `tests_py/_pg_safety_guards.py` — never
+downgraded to a silent skip; that downgrade is exactly the class of bug
+this module exists to close.
+
+`PostgresUnavailableWarning` carries over PR #319's `SchemaSkipWarning`
+idea (a `UserWarning` subclass raised via `warnings.warn`, printed in
+pytest's warnings summary regardless of `-q` verbosity, unlike a skip
+*reason* which needs `-rs`/`-ra`) retargeted at the one skip-worthy
+condition that survives this change: genuine unavailability. It fires
+exactly once per session, here, rather than once per PG-gated test module
+— fourteen-plus files in this suite skip on the shared `_USE_PG` flag
+(`tests_py/conftest.py`), so a per-module warning would be fourteen-plus
+near-duplicate lines for one underlying condition.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from tests_py._pg_throwaway_db import maintenance_url
+
+
+class PostgresUnavailableWarning(UserWarning):
+    """PostgreSQL is not reachable at all this session (server down, or
+    the `psycopg` driver itself is not installed — the ordinary,
+    expected state of a SQLite-only install). Every PG-gated test skips,
+    as documented; this warning only makes that fact visible in the
+    warnings summary instead of requiring `-rs`/`-ra` to see the reason.
+    """
+
+
+def _can_connect(url: str) -> bool:
+    """True iff a direct connection to `url` succeeds.
+
+    Every failure mode — driver absent, server down, auth rejected, the
+    target database not existing — reads as False here; distinguishing
+    WHY is `ensure_pg_ready`'s job (it tries a maintenance connection
+    next), not this probe's.
+    """
+    try:
+        import psycopg  # noqa: PLC0415 — deferred: optional [postgresql] extra, absent on SQLite-only installs
+
+        with psycopg.connect(url, autocommit=True, connect_timeout=3):
+            pass
+        return True
+    except Exception:  # noqa: BLE001 — reachability probe; every failure reads as "not reachable now" (mirrors tests_py/conftest.py's own _pg_available)
+        return False
+
+
+def _database_name(url: str) -> str:
+    """The database-name segment of a ``postgresql://`` URL.
+
+    Same parsing idiom as `_pg_throwaway_db.maintenance_url`: the query
+    string is dropped FIRST (``partition("?")``), then the name is
+    everything after the rightmost ``/`` in what remains
+    (``rpartition("/")``). Order matters: a query string carrying its
+    own ``/`` (e.g. a file-path option) would otherwise be mistaken for
+    the database-name separator if the rightmost-``/`` split ran first —
+    see that module's test for the exact scenario this ordering avoids.
+    """
+    base, _, _query = url.partition("?")
+    _prefix, _, name = base.rpartition("/")
+    return name
+
+
+def _create_database(url: str) -> None:
+    """Create the database named in `url` via a maintenance connection.
+
+    Pre: the PostgreSQL SERVER is reachable (the caller has already
+    confirmed this by connecting to its maintenance database) — `url`'s
+    own database is the only thing missing.
+    Post: the database exists. A database that cannot be created (no
+    CREATEDB privilege, quota, any other server-side refusal) aborts the
+    session via `pytest.exit`, naming the URL and the concrete fix —
+    never a silent skip (issue #312).
+    """
+    import psycopg  # noqa: PLC0415 — deferred: optional [postgresql] extra, absent on SQLite-only installs
+
+    name = _database_name(url)
+    maint = maintenance_url(url)
+    try:
+        with psycopg.connect(maint, autocommit=True, connect_timeout=3) as conn:
+            exists = conn.execute(
+                "SELECT 1 FROM pg_database WHERE datname = %s", (name,)
+            ).fetchone()
+            if exists:
+                return
+            conn.execute(f'CREATE DATABASE "{name}"')
+    except psycopg.errors.DuplicateDatabase:
+        return  # a concurrent process created it between our SELECT and CREATE
+    except Exception as exc:  # noqa: BLE001 — last-resort boundary: reported via pytest.exit below, never swallowed
+        pytest.exit(
+            f"REFUSING to run: PostgreSQL is reachable at {maint!r} but "
+            f"database {name!r} does not exist and could not be created: "
+            f"{exc}. Fix: grant CREATEDB to the connecting role "
+            f"(ALTER ROLE <role> CREATEDB;) or create it manually "
+            f"(createdb {name}), then re-run (issue #312).",
+            returncode=2,
+        )
+
+
+def _provision_schema(url: str) -> None:
+    """Apply Cortex's production DDL to `url` via the exact path every
+    real construction already uses — never a second, hand-copied
+    definition of the schema (issue #312's explicit requirement; see
+    `mcp_server/migrate.py`, which does the identical thing to migrate a
+    live install: "constructing PgMemoryStore IS the migration").
+
+    Idempotent: `PgMemoryStore._init_schema` hash-gates its DDL apply, so
+    a database already at the code's revision costs one indexed SELECT
+    — this is cheap to call on every session, not just the first.
+    """
+    from mcp_server.infrastructure.pg_store import (  # noqa: PLC0415 — deferred: hard-imports pgvector/psycopg/psycopg_pool, absent on SQLite-only installs
+        PgMemoryStore,
+    )
+
+    try:
+        store = PgMemoryStore(database_url=url)
+    except Exception as exc:  # noqa: BLE001 — last-resort boundary: reported via pytest.exit below, never swallowed
+        pytest.exit(
+            f"REFUSING to run: PostgreSQL database {url!r} is reachable "
+            f"but applying the production schema failed: {exc}. Fix: "
+            "check the connecting role's privileges (CREATE on the "
+            "database, CREATE EXTENSION for vector/pg_trgm) and "
+            "PostgreSQL's own logs, then re-run (issue #312).",
+            returncode=2,
+        )
+        return
+    store.close()
+
+
+def ensure_pg_ready(url: str) -> bool:
+    """Session-start gate for issue #312.
+
+    Pre: none — `url` may point at a database that does not exist yet.
+    Post: returns True iff `url` is ready for PG-gated tests this session
+    — reachable AND schema-provisioned, via the production DDL path.
+    Returns False only when PostgreSQL cannot be reached at all (driver
+    absent, or the server itself unreachable) — the ordinary, documented
+    skip case, unchanged in outcome, now paired with one
+    `PostgresUnavailableWarning` so a session-wide skip is visible in the
+    warnings summary instead of requiring `-rs`/`-ra`.
+    Aborts the session via `pytest.exit` (does not return) when
+    PostgreSQL IS reachable but bringing `url` to a runnable state fails
+    for any other reason — downgrading that to a skip is exactly the
+    defect this module exists to close.
+    """
+    if _can_connect(url):
+        _provision_schema(url)
+        return True
+    if not _can_connect(maintenance_url(url)):
+        warnings.warn(
+            PostgresUnavailableWarning(
+                f"PostgreSQL is not reachable at {url!r} this session — "
+                "PostgreSQL-gated tests will skip (expected on a "
+                "SQLite-only install; if this environment is supposed to "
+                "have PostgreSQL, that absence is the problem to fix)."
+            ),
+            stacklevel=2,
+        )
+        return False
+    _create_database(url)
+    _provision_schema(url)
+    return True

--- a/tests_py/conftest.py
+++ b/tests_py/conftest.py
@@ -123,7 +123,7 @@ else:
 # out to bring this file under coding-standards.md §4.1's 300-line cap;
 # issue #276/#287 boy-scout follow-up) — no behavior change, see that
 # module's docstring.
-from tests_py import _pg_safety_guards, _pg_throwaway_db  # noqa: E402
+from tests_py import _pg_safety_guards, _pg_schema_provision, _pg_throwaway_db  # noqa: E402
 
 _CORTEX_TEST_ISOLATE_DB = os.environ.get("CORTEX_TEST_ISOLATE_DB", "1") not in (
     "0",
@@ -164,15 +164,12 @@ def _guard_against_venv_lock_drift() -> None:
 
 
 def _pg_available() -> bool:
-    """Check if PostgreSQL is reachable."""
-    try:
-        import psycopg
-
-        conn = psycopg.connect(_TEST_DB_URL, autocommit=True, connect_timeout=3)
-        conn.close()
-        return True
-    except Exception:
-        return False
+    """Whether PostgreSQL is ready this session: reachable AND schema-
+    provisioned, not just reachable (issue #312) — see
+    ``_pg_schema_provision.ensure_pg_ready``'s docstring for the full
+    incident history and the reachable-but-unprovisioned fix.
+    """
+    return _pg_schema_provision.ensure_pg_ready(_TEST_DB_URL)
 
 
 _pg_safety_guards.guard_against_populated_db(_TEST_DB_URL)

--- a/tests_py/invariants/test_pg_schema_provision.py
+++ b/tests_py/invariants/test_pg_schema_provision.py
@@ -1,0 +1,194 @@
+"""Hermetic, mocked unit tests for tests_py/_pg_schema_provision.py's
+reachability and database-existence helpers — the issue #312 fix
+(reachable-but-unprovisioned databases get PROVISIONED, not skipped).
+
+Mirrors `tests_py/invariants/test_pg_throwaway_db.py`'s mocking strategy: a
+fake `psycopg` module is injected via `mock.patch.dict(sys.modules, ...)`
+so no real network/DB call is made, and `pytest.exit` is patched on the
+real `pytest` object so the fail-loud branches can be asserted without
+actually aborting this test session (same technique as
+`tests_py/invariants/test_real_data_root_guard.py` /
+`test_guard_against_populated_db.py`).
+
+Split from the schema-provisioning + orchestration tests
+(`test_pg_schema_provision_ready.py`) to stay under coding-standards.md
+§4.1's 300-line cap — the same boundary `_pg_safety_guards.py`'s own test
+suite already uses (`test_guard_against_populated_db.py` +
+`test_guard_blocks_populated_db.py` + the structural file), splitting by
+concern rather than by an arbitrary line count.
+
+These tests pin the CONTRACT (exact SQL text, exact call arguments, which
+branch calls `pytest.exit` vs which returns quietly) at full mutation-
+testing speed. The end-to-end CLAIM — a bare throwaway database really
+ends up with `memories`/`entities`/`memory_entities`/`relationships`
+after `ensure_pg_ready` — is proven separately, against a REAL local
+PostgreSQL, in `test_pg_schema_provision_live.py` (Move 5: do not mock
+what only a real backend can confirm).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest.mock as mock
+
+from tests_py import _pg_schema_provision as provision
+
+
+def _fake_psycopg(
+    connect_side_effect: Exception | list[object] | None = None,
+    connect_return: object | None = None,
+) -> types.ModuleType:
+    fake = types.ModuleType("psycopg")
+    fake.errors = types.SimpleNamespace(
+        DuplicateDatabase=type("DuplicateDatabase", (Exception,), {}),
+    )
+    if connect_side_effect is not None:
+        fake.connect = mock.Mock(side_effect=connect_side_effect)
+    else:
+        fake.connect = mock.Mock(return_value=connect_return)
+    return fake
+
+
+def _conn_cm(exists_row: tuple | None) -> mock.MagicMock:
+    """A `with psycopg.connect(...) as conn:` fake whose
+    `conn.execute("SELECT 1 FROM pg_database ...").fetchone()` returns
+    `exists_row`."""
+    conn = mock.MagicMock()
+    conn.__enter__ = mock.Mock(return_value=conn)
+    conn.__exit__ = mock.Mock(return_value=False)
+    conn.execute.return_value.fetchone.return_value = exists_row
+    return conn
+
+
+class TestCanConnect:
+    def test_returns_true_when_connect_succeeds(self) -> None:
+        conn = mock.MagicMock()
+        conn.__enter__ = mock.Mock(return_value=conn)
+        conn.__exit__ = mock.Mock(return_value=False)
+        fake_pg = _fake_psycopg(connect_return=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            assert provision._can_connect("postgresql://x/db") is True
+
+    def test_returns_false_when_connect_raises(self) -> None:
+        fake_pg = _fake_psycopg(connect_side_effect=Exception("refused"))
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            assert provision._can_connect("postgresql://x/db") is False
+
+    def test_returns_false_when_psycopg_is_not_installed(self) -> None:
+        with mock.patch.dict(sys.modules, {"psycopg": None}):
+            assert provision._can_connect("postgresql://x/db") is False
+
+    def test_connects_with_exact_reachability_args(self) -> None:
+        """Pins `autocommit=True, connect_timeout=3` — a mutant weakening
+        either (e.g. `connect_timeout=0`) would pass every other test in
+        this class undetected."""
+        conn = mock.MagicMock()
+        conn.__enter__ = mock.Mock(return_value=conn)
+        conn.__exit__ = mock.Mock(return_value=False)
+        fake_pg = _fake_psycopg(connect_return=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            provision._can_connect("postgresql://x/db")
+        fake_pg.connect.assert_called_once_with(
+            "postgresql://x/db", autocommit=True, connect_timeout=3
+        )
+
+
+class TestDatabaseName:
+    def test_extracts_name_after_rightmost_slash(self) -> None:
+        assert (
+            provision._database_name("postgresql://host:5432/cortex_test")
+            == "cortex_test"
+        )
+
+    def test_drops_query_string_first(self) -> None:
+        assert (
+            provision._database_name("postgresql://host/cortex_test?sslmode=require")
+            == "cortex_test"
+        )
+
+    def test_query_string_containing_its_own_slash_does_not_confuse_it(self) -> None:
+        """A query string with its own "/" (e.g. a file-path option) must
+        not be mistaken for the database-name separator — the "?" split
+        has to happen BEFORE the rightmost-"/" split, not after (same
+        property `_pg_throwaway_db.maintenance_url` pins for its own
+        parsing)."""
+        assert (
+            provision._database_name("postgresql://host/cortex_test?options=/tmp/foo")
+            == "cortex_test"
+        )
+
+
+class TestCreateDatabase:
+    def test_returns_early_when_database_already_exists(self) -> None:
+        conn = _conn_cm(exists_row=(1,))
+        fake_pg = _fake_psycopg(connect_return=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            provision._create_database("postgresql://host/cortex_test")
+        calls = [c.args[0] for c in conn.execute.call_args_list]
+        assert not any(c.startswith("CREATE DATABASE") for c in calls)
+
+    def test_creates_database_when_missing(self) -> None:
+        conn = _conn_cm(exists_row=None)
+        fake_pg = _fake_psycopg(connect_return=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            provision._create_database("postgresql://host/cortex_test")
+        conn.execute.assert_called_with('CREATE DATABASE "cortex_test"')
+
+    def test_connects_to_the_maintenance_url_not_the_target(self) -> None:
+        conn = _conn_cm(exists_row=(1,))
+        fake_pg = _fake_psycopg(connect_return=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            provision._create_database("postgresql://host/cortex_test")
+        fake_pg.connect.assert_called_once_with(
+            "postgresql://host/postgres", autocommit=True, connect_timeout=3
+        )
+
+    def test_existence_check_is_parameter_bound(self) -> None:
+        conn = _conn_cm(exists_row=(1,))
+        fake_pg = _fake_psycopg(connect_return=conn)
+        with mock.patch.dict(sys.modules, {"psycopg": fake_pg}):
+            provision._create_database("postgresql://host/cortex_test")
+        query, params = conn.execute.call_args_list[0].args
+        assert query == "SELECT 1 FROM pg_database WHERE datname = %s"
+        assert params == ("cortex_test",)
+
+    def test_duplicate_database_race_is_swallowed_not_escalated(self) -> None:
+        """A concurrent process creating the same database between our
+        SELECT and our CREATE DATABASE must be treated as success, not
+        escalated via `pytest.exit` — the database exists either way."""
+        conn = _conn_cm(exists_row=None)
+        fake_pg = _fake_psycopg(connect_return=conn)
+        conn.execute.side_effect = [
+            mock.MagicMock(fetchone=lambda: None),  # SELECT: not found yet
+            fake_pg.errors.DuplicateDatabase("already exists"),  # CREATE: raced
+        ]
+        with (
+            mock.patch.dict(sys.modules, {"psycopg": fake_pg}),
+            mock.patch.object(provision.pytest, "exit") as mock_exit,
+        ):
+            provision._create_database("postgresql://host/cortex_test")
+        mock_exit.assert_not_called()
+
+    def test_other_create_failure_calls_pytest_exit_with_actionable_message(
+        self,
+    ) -> None:
+        conn = _conn_cm(exists_row=None)
+        fake_pg = _fake_psycopg(connect_return=conn)
+        conn.execute.side_effect = [
+            mock.MagicMock(fetchone=lambda: None),
+            Exception("permission denied to create database"),
+        ]
+        with (
+            mock.patch.dict(sys.modules, {"psycopg": fake_pg}),
+            mock.patch.object(provision.pytest, "exit") as mock_exit,
+        ):
+            provision._create_database("postgresql://host/cortex_test")
+        mock_exit.assert_called_once()
+        message, kwargs = mock_exit.call_args
+        assert kwargs.get("returncode") == 2
+        assert "cortex_test" in message[0]
+        assert "postgresql://host/postgres" in message[0]
+        assert "issue #312" in message[0]
+        assert "CREATEDB" in message[0]
+        assert "permission denied to create database" in message[0]

--- a/tests_py/invariants/test_pg_schema_provision_live.py
+++ b/tests_py/invariants/test_pg_schema_provision_live.py
@@ -1,0 +1,214 @@
+"""Real-PostgreSQL integration tests for `ensure_pg_ready` (issue #312).
+
+Move 5 (test-engineer framework): do not mock a database driver for
+claims that only real backend semantics can confirm. The mocked contract
+tests in `test_pg_schema_provision.py` pin exact SQL/call shape at unit
+speed; these tests prove the actual end state — a bare, unprovisioned
+database really ends up with the tables PG-gated tests need, a missing
+database really gets created, and a role that genuinely lacks CREATEDB
+really triggers the loud-failure path — against a live server, not a
+fake.
+
+Every throwaway database and role created here is scoped to a single
+test and dropped in a `finally`/fixture teardown (Move 2: isolation —
+these tests must not perturb `_TEST_DB_URL`, the session's own database,
+or leak state into any other test).
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from urllib.parse import urlsplit, urlunsplit
+
+import pytest
+
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+import psycopg  # noqa: E402
+from _pytest.outcomes import Exit as _PytestExit  # noqa: E402
+
+from tests_py import _pg_throwaway_db  # noqa: E402
+from tests_py._pg_schema_provision import (  # noqa: E402
+    PostgresUnavailableWarning,
+    ensure_pg_ready,
+)
+from tests_py.conftest import _TEST_DB_URL, _USE_PG  # type: ignore  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not _USE_PG, reason="PostgreSQL is not available for this test session"
+)
+
+_REQUIRED_TABLES = ("memories", "entities", "memory_entities", "relationships")
+
+
+@pytest.fixture
+def bare_throwaway_db():
+    """A freshly `CREATE DATABASE`-d, zero-table database — the exact
+    shape `tests_py/_pg_throwaway_db.py` produces for a local session and
+    the exact repro issue #312 reports. Dropped on teardown."""
+    created = _pg_throwaway_db.create_isolated_test_database(_TEST_DB_URL)
+    if created is None:
+        pytest.skip("could not create a throwaway database on this server")
+    isolated_url, maint_url, db_name = created
+    try:
+        yield isolated_url
+    finally:
+        _pg_throwaway_db.drop_isolated_database(maint_url, db_name)
+
+
+@pytest.fixture
+def nonexistent_db_url():
+    """A URL whose database is confirmed to NOT exist yet, on the same
+    server as `_TEST_DB_URL`. Dropped on teardown if the test created it."""
+    name = f"cortex_312_missing_{os.getpid()}"
+    maint_url = _pg_throwaway_db.maintenance_url(_TEST_DB_URL)
+    prefix = _TEST_DB_URL.rpartition("/")[0]
+    url = f"{prefix}/{name}"
+    with psycopg.connect(maint_url, autocommit=True, connect_timeout=3) as conn:
+        conn.execute(f'DROP DATABASE IF EXISTS "{name}"')
+    try:
+        yield url
+    finally:
+        with psycopg.connect(maint_url, autocommit=True, connect_timeout=3) as conn:
+            conn.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (name,),
+            )
+            conn.execute(f'DROP DATABASE IF EXISTS "{name}"')
+
+
+@pytest.fixture
+def lowpriv_role_url():
+    """A URL, authenticated as a real PostgreSQL role with LOGIN but
+    NOCREATEDB, pointed at a database name that does NOT exist yet — for
+    proving the actual CREATE-DATABASE-permission-denied path (Move 5:
+    real server-enforced denial, not a mocked exception). The role can
+    reach the `postgres` maintenance database (PUBLIC has CONNECT there
+    by default) but cannot create a new one, so `ensure_pg_ready` must
+    reach `_create_database` and hit a genuine `InsufficientPrivilege`.
+
+    Skips (does not fail) if the CURRENT connecting role itself lacks
+    CREATEROLE — that is a distinct environmental precondition from
+    "PostgreSQL reachable" and "target database missing", not the #312
+    condition this file's other tests exercise.
+    """
+    maint_url = _pg_throwaway_db.maintenance_url(_TEST_DB_URL)
+    role = f"cortex_312_lowpriv_{os.getpid()}"
+    password = "lowpriv312"
+    try:
+        with psycopg.connect(maint_url, autocommit=True, connect_timeout=3) as conn:
+            conn.execute(f'DROP ROLE IF EXISTS "{role}"')
+            conn.execute(
+                f'CREATE ROLE "{role}" LOGIN NOCREATEDB NOSUPERUSER '
+                f"PASSWORD '{password}'"
+            )
+    except psycopg.Error as exc:
+        pytest.skip(f"cannot create a low-privilege role on this server: {exc}")
+
+    netloc = urlsplit(maint_url).netloc.rpartition("@")[-1]  # drop any existing creds
+    target_db = f"cortex_312_lowpriv_target_{os.getpid()}"
+    role_url = urlunsplit(
+        ("postgresql", f"{role}:{password}@{netloc}", f"/{target_db}", "", "")
+    )
+    try:
+        yield role_url
+    finally:
+        with psycopg.connect(maint_url, autocommit=True, connect_timeout=3) as conn:
+            conn.execute(f'DROP DATABASE IF EXISTS "{target_db}"')
+            conn.execute(f'REVOKE ALL ON DATABASE postgres FROM "{role}"')
+            conn.execute(f'DROP ROLE IF EXISTS "{role}"')
+
+
+class TestBareThrowawayDatabaseGetsProvisioned:
+    """The exact issue #312 repro: a bare `CREATE DATABASE` with zero
+    tables must not raise `UndefinedTable` after `ensure_pg_ready`."""
+
+    def test_bare_database_reproduces_the_reported_defect_unfixed(
+        self, bare_throwaway_db
+    ) -> None:
+        """Sanity check that the fixture really reproduces issue #312's
+        exact symptom BEFORE the fix runs — a test that can never fail
+        proves nothing."""
+        with pytest.raises(psycopg.errors.UndefinedTable):
+            with psycopg.connect(
+                bare_throwaway_db, autocommit=True, connect_timeout=3
+            ) as conn:
+                conn.execute("SELECT 1 FROM memory_entities LIMIT 1")
+
+    def test_ensure_pg_ready_provisions_every_required_table(
+        self, bare_throwaway_db
+    ) -> None:
+        assert ensure_pg_ready(bare_throwaway_db) is True
+        with psycopg.connect(
+            bare_throwaway_db, autocommit=True, connect_timeout=3
+        ) as conn:
+            for table in _REQUIRED_TABLES:
+                oid = conn.execute("SELECT to_regclass(%s)", (table,)).fetchone()[0]
+                assert oid is not None, f"{table} was not provisioned"
+
+    def test_a_provisioned_database_no_longer_raises_undefined_table(
+        self, bare_throwaway_db
+    ) -> None:
+        ensure_pg_ready(bare_throwaway_db)
+        with psycopg.connect(
+            bare_throwaway_db, autocommit=True, connect_timeout=3
+        ) as conn:
+            row = conn.execute("SELECT COUNT(*) FROM memory_entities").fetchone()
+        assert row == (0,)
+
+    def test_provisioning_is_idempotent_on_a_second_call(
+        self, bare_throwaway_db
+    ) -> None:
+        """The second call must be the cheap, hash-gated fast path — and,
+        more importantly, must not fail or alter the outcome."""
+        assert ensure_pg_ready(bare_throwaway_db) is True
+        assert ensure_pg_ready(bare_throwaway_db) is True
+        with psycopg.connect(
+            bare_throwaway_db, autocommit=True, connect_timeout=3
+        ) as conn:
+            oid = conn.execute("SELECT to_regclass('memory_entities')").fetchone()[0]
+        assert oid is not None
+
+
+class TestMissingDatabaseGetsCreated:
+    def test_ensure_pg_ready_creates_and_provisions_a_missing_database(
+        self, nonexistent_db_url
+    ) -> None:
+        assert ensure_pg_ready(nonexistent_db_url) is True
+        with psycopg.connect(
+            nonexistent_db_url, autocommit=True, connect_timeout=3
+        ) as conn:
+            oid = conn.execute("SELECT to_regclass('memory_entities')").fetchone()[0]
+        assert oid is not None
+
+
+class TestGenuinelyUnreachableStillDegradesGracefully:
+    def test_a_real_unreachable_server_returns_false_and_warns_once(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = ensure_pg_ready(
+                "postgresql://127.0.0.1:1/cortex_312_definitely_unreachable"
+            )
+        assert result is False
+        assert len(caught) == 1
+        assert isinstance(caught[0].message, PostgresUnavailableWarning)
+
+
+class TestPermissionDeniedFailsLoudlyNotSilently:
+    def test_a_role_without_createdb_triggers_pytest_exit_not_a_skip(
+        self, lowpriv_role_url
+    ) -> None:
+        """The defect this whole module exists to close: a real
+        environment problem (no CREATEDB privilege) must abort the
+        session with an actionable message, never quietly convert into a
+        skip that would hide it. `_pytest.outcomes.Exit` is exactly what
+        `pytest.exit(...)` raises — the same exception pytest itself
+        catches at the session boundary to terminate cleanly.
+        """
+        with pytest.raises(_PytestExit) as excinfo:
+            ensure_pg_ready(lowpriv_role_url)
+        message = str(excinfo.value)
+        assert "issue #312" in message
+        assert "CREATEDB" in message

--- a/tests_py/invariants/test_pg_schema_provision_ready.py
+++ b/tests_py/invariants/test_pg_schema_provision_ready.py
@@ -1,0 +1,173 @@
+"""Hermetic, mocked unit tests for tests_py/_pg_schema_provision.py's
+schema-provisioning and top-level orchestration (issue #312).
+
+Split from `test_pg_schema_provision.py` (which covers `_can_connect`,
+`_database_name`, and `_create_database`) to stay under
+coding-standards.md §4.1's 300-line cap — see that file's docstring for
+the full mocking-strategy rationale shared by both.
+
+`TestProvisionSchema` pins that `_provision_schema` reuses the exact
+production migration path (`PgMemoryStore.__init__` -> `_init_schema`)
+rather than a hand-copied one, and that a construction failure escalates
+via `pytest.exit`, never a swallowed exception. `TestEnsurePgReady` pins
+the top-level branching contract: which of the three inputs (server
+reachable directly / reachable only via maintenance / not reachable at
+all) leads to which of (schema provisioned silently, database created
+then provisioned, `PostgresUnavailableWarning` + False) — the exact
+issue #312 decision table.
+"""
+
+from __future__ import annotations
+
+import unittest.mock as mock
+import warnings
+
+from tests_py import _pg_schema_provision as provision
+
+
+class TestProvisionSchema:
+    def test_constructs_store_with_the_given_url_and_closes_it(self) -> None:
+        store = mock.MagicMock()
+        with mock.patch(
+            "mcp_server.infrastructure.pg_store.PgMemoryStore",
+            return_value=store,
+        ) as mock_ctor:
+            provision._provision_schema("postgresql://host/cortex_test")
+        mock_ctor.assert_called_once_with(database_url="postgresql://host/cortex_test")
+        store.close.assert_called_once()
+
+    def test_construction_failure_calls_pytest_exit_with_actionable_message(
+        self,
+    ) -> None:
+        with (
+            mock.patch(
+                "mcp_server.infrastructure.pg_store.PgMemoryStore",
+                side_effect=RuntimeError('extension "vector" is not available'),
+            ),
+            mock.patch.object(provision.pytest, "exit") as mock_exit,
+        ):
+            provision._provision_schema("postgresql://host/cortex_test")
+        mock_exit.assert_called_once()
+        message, kwargs = mock_exit.call_args
+        assert kwargs == {"returncode": 2}
+        assert message[0] == (
+            "REFUSING to run: PostgreSQL database "
+            "'postgresql://host/cortex_test' is reachable but applying the "
+            'production schema failed: extension "vector" is not '
+            "available. Fix: check the connecting role's privileges "
+            "(CREATE on the database, CREATE EXTENSION for vector/pg_trgm) "
+            "and PostgreSQL's own logs, then re-run (issue #312)."
+        )
+
+    def test_construction_failure_never_raises_unboundlocalerror(self) -> None:
+        """Under a MOCKED (non-raising) `pytest.exit`, execution falls
+        through past the `except` block — `store` was never assigned, so
+        the function must `return` before reaching `store.close()`, or a
+        mocked test session would crash on `UnboundLocalError` instead of
+        cleanly reporting the exit call."""
+        with (
+            mock.patch(
+                "mcp_server.infrastructure.pg_store.PgMemoryStore",
+                side_effect=RuntimeError("boom"),
+            ),
+            mock.patch.object(provision.pytest, "exit"),
+        ):
+            provision._provision_schema("postgresql://host/cortex_test")  # no raise
+
+
+class TestEnsurePgReady:
+    def test_direct_connect_success_provisions_schema_without_creating_db(
+        self,
+    ) -> None:
+        with (
+            mock.patch.object(
+                provision, "_can_connect", return_value=True
+            ) as mock_can_connect,
+            mock.patch.object(provision, "_create_database") as mock_create,
+            mock.patch.object(provision, "_provision_schema") as mock_provision,
+        ):
+            result = provision.ensure_pg_ready("postgresql://host/cortex_test")
+        assert result is True
+        mock_can_connect.assert_called_once_with("postgresql://host/cortex_test")
+        mock_create.assert_not_called()
+        mock_provision.assert_called_once_with("postgresql://host/cortex_test")
+
+    def test_genuinely_unreachable_returns_false_and_warns_once(self) -> None:
+        with (
+            mock.patch.object(provision, "_can_connect", return_value=False),
+            mock.patch.object(provision, "_create_database") as mock_create,
+            mock.patch.object(provision, "_provision_schema") as mock_provision,
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
+            result = provision.ensure_pg_ready("postgresql://host/cortex_test")
+        assert result is False
+        mock_create.assert_not_called()
+        mock_provision.assert_not_called()
+        assert len(caught) == 1
+        assert isinstance(caught[0].message, provision.PostgresUnavailableWarning)
+        assert str(caught[0].message) == (
+            "PostgreSQL is not reachable at 'postgresql://host/cortex_test' "
+            "this session — PostgreSQL-gated tests will skip (expected on "
+            "a SQLite-only install; if this environment is supposed to "
+            "have PostgreSQL, that absence is the problem to fix)."
+        )
+
+    def test_unreachable_warning_uses_stacklevel_2(self) -> None:
+        """stacklevel=2 attributes the warning to `ensure_pg_ready`'s
+        CALLER (conftest.py's `_pg_available`), not to this module's own
+        `warnings.warn` call — the whole point of surfacing it is to
+        point at the session that is skipping, not at this helper.
+        `pytest.warns`/`catch_warnings` do not expose the stacklevel a
+        warning was raised with, so `warnings.warn` itself is mocked
+        (same technique PR #319 used for the analogous check)."""
+        with (
+            mock.patch.object(provision, "_can_connect", return_value=False),
+            mock.patch.object(provision.warnings, "warn") as mock_warn,
+        ):
+            provision.ensure_pg_ready("postgresql://host/cortex_test")
+        mock_warn.assert_called_once()
+        _args, kwargs = mock_warn.call_args
+        assert kwargs.get("stacklevel") == 2
+
+    def test_maintenance_reachable_creates_then_provisions(self) -> None:
+        """Direct connect fails (target DB missing) but the maintenance
+        DB IS reachable -> server is up, only the named DB is absent:
+        create it, then provision, no warning."""
+
+        def _can_connect_side_effect(url: str) -> bool:
+            return url == "postgresql://host/postgres"
+
+        with (
+            mock.patch.object(
+                provision, "_can_connect", side_effect=_can_connect_side_effect
+            ),
+            mock.patch.object(provision, "_create_database") as mock_create,
+            mock.patch.object(provision, "_provision_schema") as mock_provision,
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
+            result = provision.ensure_pg_ready("postgresql://host/cortex_test")
+        assert result is True
+        mock_create.assert_called_once_with("postgresql://host/cortex_test")
+        mock_provision.assert_called_once_with("postgresql://host/cortex_test")
+        assert caught == []
+
+    def test_only_the_genuinely_absent_branch_ever_warns(self) -> None:
+        """The direct-success and create-then-provision branches must
+        never emit `PostgresUnavailableWarning` — only genuine absence
+        does. A prior PR (#319) warned on a DIFFERENT condition
+        (reachable-but-wrong-schema); this pins that condition no longer
+        exists as a code path at all — it is provisioned, not detected."""
+        with (
+            mock.patch.object(provision, "_can_connect", return_value=True),
+            mock.patch.object(provision, "_provision_schema"),
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
+            provision.ensure_pg_ready("postgresql://host/cortex_test")
+        assert caught == []
+
+
+def test_postgres_unavailable_warning_is_a_user_warning() -> None:
+    assert issubclass(provision.PostgresUnavailableWarning, UserWarning)

--- a/tests_py/invariants/test_pg_schema_provision_ready.py
+++ b/tests_py/invariants/test_pg_schema_provision_ready.py
@@ -15,6 +15,26 @@ reachable directly / reachable only via maintenance / not reachable at
 all) leads to which of (schema provisioned silently, database created
 then provisioned, `PostgresUnavailableWarning` + False) — the exact
 issue #312 decision table.
+
+`TestProvisionSchema` alone needs the real `psycopg`/`pgvector` driver
+importable (`@requires_psycopg`, the same marker `tests_py/conftest.py`
+already exports and 3 other test files already use): its
+`mock.patch("mcp_server.infrastructure.pg_store.PgMemoryStore", ...)`
+calls are STRING-targeted, so `mock.patch` must import
+`mcp_server.infrastructure.pg_store` to resolve the attribute —
+and that module hard-imports `psycopg`/`pgvector`/`psycopg_pool` at its
+own top level (`pg_store.py`'s module docstring: "Requires:
+psycopg[binary]>=3.1..."), unconditionally, regardless of which backend
+a given test session selects. On a SQLite-only install (no
+`[postgresql]` extra) that import raises `ModuleNotFoundError`, which
+`mock.patch`'s string-target resolution surfaces as `AttributeError:
+module 'mcp_server.infrastructure' has no attribute 'pg_store'` instead
+of a clean skip (reproduced against a disposable venv built from
+`requirements/ci-sqlite.txt`, CI run 30626458304's "Test (SQLite
+backend)" job). `TestEnsurePgReady` and the standalone warning test
+below need no such guard: they mock `_can_connect`/`_create_database`/
+`_provision_schema` at the `provision` MODULE level, never triggering a
+real import of `pg_store`.
 """
 
 from __future__ import annotations
@@ -23,8 +43,10 @@ import unittest.mock as mock
 import warnings
 
 from tests_py import _pg_schema_provision as provision
+from tests_py.conftest import requires_psycopg  # type: ignore
 
 
+@requires_psycopg
 class TestProvisionSchema:
     def test_constructs_store_with_the_given_url_and_closes_it(self) -> None:
         store = mock.MagicMock()

--- a/tests_py/invariants/test_phase2_parity.py
+++ b/tests_py/invariants/test_phase2_parity.py
@@ -29,13 +29,19 @@ Cases covered:
       by the Option A policy; the substring baseline filters them
       identically so the test is fair.
 
-Uses `cortex_test` PostgreSQL — see `tests_py/conftest.py`. Skipped
-when PG is not available (CI without PG → test becomes xfail-on-env).
+Uses `cortex_test` PostgreSQL — see `tests_py/conftest.py`. Skipped only
+when PostgreSQL is genuinely unreachable this session (shared `_USE_PG`
+flag, same gate ~14 other PG-only test modules use). A reachable database
+missing this test's tables no longer skips: `tests_py/conftest.py` now
+provisions the schema for the whole session before any test module is
+collected (issue #312 — before that fix, a reachable-but-unmigrated
+database, e.g. a fresh per-process throwaway DB, passed the bare
+connectivity check this file used to run on its own and then died
+mid-test with `psycopg.errors.UndefinedTable` instead of skipping; see
+`tests_py/_pg_schema_provision.py` for the full incident history).
 """
 
 from __future__ import annotations
-
-import os
 
 import pytest
 
@@ -44,27 +50,12 @@ import pytest
 # because the parity test's job is exactly to validate that code.
 from mcp_server.handlers.consolidation.plasticity import _find_co_accessed_pairs
 from mcp_server.core.entity_reconciliation import build_reconciliation_sql
-
-
-# ── Skip conditions ──────────────────────────────────────────────────────
-
-_PG_URL = os.environ.get("DATABASE_URL", "")
-_PG_AVAILABLE = False
-
-try:
-    import psycopg  # noqa: F401
-
-    conn = psycopg.connect(_PG_URL, autocommit=True, connect_timeout=3)
-    conn.close()
-    _PG_AVAILABLE = True
-except Exception:
-    _PG_AVAILABLE = False
-
+from tests_py.conftest import _TEST_DB_URL, _USE_PG  # type: ignore
 
 pytestmark = [
     pytest.mark.skipif(
-        not _PG_AVAILABLE,
-        reason="cortex_test PostgreSQL is not reachable",
+        not _USE_PG,
+        reason="PostgreSQL is not available for this test session",
     ),
     pytest.mark.invariants,
 ]
@@ -267,7 +258,7 @@ assert len(_FIXTURE_MEMORIES) == 100
 def _pg_conn():
     import psycopg
 
-    return psycopg.connect(_PG_URL, autocommit=False)
+    return psycopg.connect(_TEST_DB_URL, autocommit=False)
 
 
 def _setup_fixture() -> tuple[list[dict], list[dict]]:


### PR DESCRIPTION
Closes #312

Supersedes #319 — please close #319 without merging. That PR detected "reachable but wrong schema" and turned it into a skip; this PR closes the actual gap instead: it **provisions** the schema, so the tests run and assert for real. Its `SchemaSkipWarning` idea is carried over below, retargeted at the one condition that still legitimately skips.

## Root cause (unchanged from the issue, confirmed)

`tests_py/conftest.py`'s per-process throwaway database (`tests_py/_pg_throwaway_db.py`) is a bare `CREATE DATABASE` — zero tables. Before #219, these tests ran against the real `cortex` database, which already carried a full schema; isolation redirected them to a throwaway target without ever provisioning it. CI's shared, persistent `cortex` database hides the gap because *some* earlier test in that session happens to construct a `PgMemoryStore()` first and incidentally provisions the schema for everyone after it — accidental, execution-order-dependent, not deterministic isolation. A standalone or narrowly-scoped local run has no such earlier test, so the first raw-SQL query against `memory_entities` dies with `psycopg.errors.UndefinedTable`.

## Fix

`tests_py/conftest.py`'s `_pg_available()` now delegates to a new module, `tests_py/_pg_schema_provision.py::ensure_pg_ready(url)`, which runs **once per session**, before any PG-gated test executes:

1. Direct-connect succeeds (the common case: the throwaway DB was just created) → apply schema, done.
2. Direct-connect fails but a maintenance connection to `postgres` succeeds (server up, only the named database is missing) → `CREATE DATABASE`, then apply schema.
3. Neither connects (genuinely absent PostgreSQL — the ordinary SQLite-only-install case) → return `False` (unchanged skip outcome), now paired with **one** `PostgresUnavailableWarning` per session so a session-wide skip is visible in the warnings summary instead of requiring `-rs`/`-ra` (PR #319's `SchemaSkipWarning` idea, carried over and retargeted — the "reachable but wrong schema" condition it warned about no longer exists as a code path at all; it's provisioned, not detected).
4. A database that cannot be created (no `CREATEDB` privilege) or schema that cannot be applied (e.g. missing extension) is a **real environment error** and aborts the session via `pytest.exit(..., returncode=2)` with an actionable message naming the URL and the fix — the same fail-closed idiom `tests_py/_pg_safety_guards.py`'s two existing guards already use. It is never downgraded to a skip.

**Reuses the production DDL path — no hand-copied schema.** `_provision_schema` constructs `PgMemoryStore(database_url=url)`, exactly what `mcp_server/migrate.py` does to migrate a live install ("constructing `PgMemoryStore` IS the migration" — that module's own docstring). `PgMemoryStore.__init__` → `_init_schema()` → `pg_schema.get_all_ddl()`, hash-gated so a database already at the code's revision costs one indexed `SELECT`.

`tests_py/invariants/test_phase2_parity.py` (the test named in the issue) drops its own ad-hoc bare-connectivity probe and imports the shared `_USE_PG`/`_TEST_DB_URL` from conftest — the same convention 14 other PG-only test modules already use (`test_pg_pool.py`, `test_pg_supersession.py`, `test_migrate.py`, …). This closes the gap for all of them, not just the one named test, since they all shared the exact same accidental-provisioning exposure.

## Proof — the exact reported repro, now passing

```
$ python -m pytest tests_py/invariants/test_phase2_parity.py -q
.......                                                                  [100%]
7 passed in 0.52s
```
Reproduced 4/4 across repeated standalone runs (deterministic, not order-dependent). Before this fix, the same command on unmodified `main` reproduces the issue's own reported `5 failed, 2 passed`.

Manual, from-scratch verification against a real bare throwaway database (before calling the fix):
```
psycopg.errors.UndefinedTable: relation "memory_entities" does not exist
```
— confirmed the repro is real, then confirmed `ensure_pg_ready()` brings that same database to `to_regclass('memories')`/`'entities'`/`'memory_entities'`/`'relationships'` all non-null, with no further UndefinedTable.

## Completion Ledger

| # | Path introduced by this diff | Test asserting its observable effect |
|---|---|---|
| 1 | `_can_connect` True on successful connect | `test_pg_schema_provision.py::TestCanConnect::test_returns_true_when_connect_succeeds` |
| 2 | `_can_connect` False on connect exception | `TestCanConnect::test_returns_false_when_connect_raises` |
| 3 | `_can_connect` False when psycopg absent | `TestCanConnect::test_returns_false_when_psycopg_is_not_installed` |
| 4 | `_can_connect` exact reachability args (`autocommit=True, connect_timeout=3`) | `TestCanConnect::test_connects_with_exact_reachability_args` |
| 5 | `_database_name` extracts name after rightmost `/` | `TestDatabaseName::test_extracts_name_after_rightmost_slash` |
| 6 | `_database_name` drops query string first | `TestDatabaseName::test_drops_query_string_first` |
| 7 | `_database_name` handles a query string containing its own `/` | `TestDatabaseName::test_query_string_containing_its_own_slash_does_not_confuse_it` |
| 8 | `_create_database` no-ops when DB already exists | `TestCreateDatabase::test_returns_early_when_database_already_exists` |
| 9 | `_create_database` creates DB when missing, exact SQL | `TestCreateDatabase::test_creates_database_when_missing` |
| 10 | `_create_database` connects to maintenance URL, not the target | `TestCreateDatabase::test_connects_to_the_maintenance_url_not_the_target` |
| 11 | existence check is parameter-bound (`%s`, not interpolated) | `TestCreateDatabase::test_existence_check_is_parameter_bound` |
| 12 | concurrent-create race (`DuplicateDatabase`) swallowed, not escalated | `TestCreateDatabase::test_duplicate_database_race_is_swallowed_not_escalated` |
| 13 | other create failure escalates via `pytest.exit`, exact actionable message | `TestCreateDatabase::test_other_create_failure_calls_pytest_exit_with_actionable_message` |
| 14 | `_provision_schema` constructs `PgMemoryStore(database_url=url)` and closes it | `test_pg_schema_provision_ready.py::TestProvisionSchema::test_constructs_store_with_the_given_url_and_closes_it` |
| 15 | construction failure escalates via `pytest.exit`, exact actionable message | `TestProvisionSchema::test_construction_failure_calls_pytest_exit_with_actionable_message` |
| 16 | no `UnboundLocalError` under a mocked (non-raising) `pytest.exit` | `TestProvisionSchema::test_construction_failure_never_raises_unboundlocalerror` |
| 17 | `ensure_pg_ready` direct-success path: exact `_can_connect(url)` arg, provisions, skips DB creation | `TestEnsurePgReady::test_direct_connect_success_provisions_schema_without_creating_db` |
| 18 | genuinely-unreachable path: False, exactly one warning, exact message | `TestEnsurePgReady::test_genuinely_unreachable_returns_false_and_warns_once` |
| 19 | that warning's `stacklevel=2` | `TestEnsurePgReady::test_unreachable_warning_uses_stacklevel_2` |
| 20 | maintenance-reachable path: create then provision, no warning | `TestEnsurePgReady::test_maintenance_reachable_creates_then_provisions` |
| 21 | only the genuinely-absent branch ever warns | `TestEnsurePgReady::test_only_the_genuinely_absent_branch_ever_warns` |
| 22 | `PostgresUnavailableWarning` is a `UserWarning` | `test_postgres_unavailable_warning_is_a_user_warning` |
| 23 | bare throwaway DB genuinely reproduces `UndefinedTable` (pre-fix sanity) | `test_pg_schema_provision_live.py::TestBareThrowawayDatabaseGetsProvisioned::test_bare_database_reproduces_the_reported_defect_unfixed` |
| 24 | `ensure_pg_ready` provisions every required table on a bare DB | `...::test_ensure_pg_ready_provisions_every_required_table` |
| 25 | provisioned DB no longer raises `UndefinedTable` | `...::test_a_provisioned_database_no_longer_raises_undefined_table` |
| 26 | provisioning is idempotent on a second call | `...::test_provisioning_is_idempotent_on_a_second_call` |
| 27 | a genuinely-missing database gets created + provisioned end to end | `TestMissingDatabaseGetsCreated::test_ensure_pg_ready_creates_and_provisions_a_missing_database` |
| 28 | a real unreachable server returns False + warns once | `TestGenuinelyUnreachableStillDegradesGracefully::test_a_real_unreachable_server_returns_false_and_warns_once` |
| 29 | a real `NOCREATEDB` role triggers `pytest.exit`, not a skip | `TestPermissionDeniedFailsLoudlyNotSilently::test_a_role_without_createdb_triggers_pytest_exit_not_a_skip` |
| 30 | `test_phase2_parity.py` now shares the session `_USE_PG` flag | the file's own 7 tests, standalone repro quoted above |

## Mutation testing (`scripts/mutation_check.sh`, mutmut)

Scoped to `tests_py/_pg_schema_provision.py` against all three of its test files:
```
scripts/mutation_check.sh \
  "tests_py/invariants/test_pg_schema_provision.py tests_py/invariants/test_pg_schema_provision_ready.py tests_py/invariants/test_pg_schema_provision_live.py" \
  tests_py/_pg_schema_provision.py
```
Result: **85 mutants, 84 killed, 0 unexplained survivors.** First pass surfaced 19 survivors — all string-literal case/wrap mutations on the two `pytest.exit`/`warnings.warn` message texts (substring assertions don't pin the exact text) plus two `stacklevel`/call-argument gaps — closed by adding exact-text and exact-argument assertions (`test_construction_failure_calls_pytest_exit_with_actionable_message`, `test_genuinely_unreachable_returns_false_and_warns_once`, `test_unreachable_warning_uses_stacklevel_2`, `test_direct_connect_success_provisions_schema_without_creating_db`). The 85th mutant (`_can_connect`'s exception-handler `return False`→`return True`) mutmut itself reported "interrupted by user" (a tool-timing artifact, not a real signal); manually re-applying that exact one-line mutation and running the three test files directly confirms it is killed in 0.28s (`1 failed, 1 passed`, `TestCanConnect::test_returns_false_when_connect_raises`) — 85/85 effectively verified.

## Isolation audit (Move 2)

Every throwaway database and role the new live-PG tests create is scoped to a single test/fixture and dropped in a `finally`/fixture teardown; none touch `_TEST_DB_URL` (the session's own database). Verified no leftover `cortex_test_pw*`/`cortex_312_*` databases or roles after repeated runs.

## What did NOT change — real failures still fail

Deliberately mutated `test_phase2_parity.py::test_substring_scan_returns_nonempty_set`'s assertion to `len(pairs) > 999999` and reran: `1 failed, 6 passed` — a genuine defect still fails hard, never silently skips. Reverted before commit.

## Pre-push gate (this exact head)

- `ruff check .` / `ruff format --check .`: clean, repo-wide.
- Full suite, PostgreSQL backend, this exact head: **7071 passed, 5 skipped, 121 subtests passed** (the 5 skips are `sqlite-vec not installed` — unrelated to PostgreSQL/schema, matching the PostgreSQL CI job's own skip count exactly; **zero** schema-related skips remain, versus this issue's own baseline evidence of 5 PG-job skips before the fix).
- AST size check (new/grown files, measured not asserted): `_pg_schema_provision.py` 208 lines / longest fn 34; `test_pg_schema_provision.py` 195/22; `test_pg_schema_provision_ready.py` 174/22; `test_pg_schema_provision_live.py` 215/39; `conftest.py` grown to 298/35 (under the 300/40 caps). `test_phase2_parity.py` sits at 568 lines / `_setup_fixture` 55 — **pre-existing** (576→568, net **reduced** by this diff) — covered by the standing waiver (#298 closed; CLAUDE.md:74-79).
- `scripts/check_doc_claims.py` / `scripts/generate_repo_badges.py --check`: both OK (also re-verified with `--test-count 7076`, this branch's live `--collect-only` count — the committed tests badge is a documented *floor*, not an exact match; 6788 ≤ 7076 stays valid, so no badge regeneration needed).
- No conflict markers; `.bestpractices.json` parses.
- No CHANGELOG entry: test-infrastructure only, no consumer-observable contract change — same precedent as #219/#276/#287/#319 (none added one either).

## Finding outside this PR's blast radius (disclosed, not fixed here)

While running the full suite repeatedly to verify the above, `tests_py/handlers/consolidation/test_near_dup_calibration_pass.py::TestRunNearDupSample::test_sample_includes_seeded_pair_with_contents` failed **once**, in one of five total full-suite runs across this session. This file is untouched by this diff. I ran a paired-control experiment before concluding anything (coding-standards.md §6.1 — reproduce before you fix, never blame blind):

- Clean `origin/main`, no changes: 7042 passed, 0 failed.
- This diff minus the 3 new test files (conftest.py + test_phase2_parity.py only): 7042 passed, 0 failed — identical count to clean main.
- This diff, complete, run twice: once 7070 passed/0 failed, once **1 failed**/7070 passed, once (after adding the mutation-killing assertions) 7071 passed/0 failed.

The exact same diff produced both a pass and a fail across separate runs, and the reduced diff (conftest.py + test_phase2_parity.py, no new files) never reproduced it — so this is not deterministically caused by this PR. It reproduces standalone every time (`5 passed`), so it is order/session-state dependent. Best-effort, *unconfirmed* hypothesis: `pg_store_near_dup.py`'s anchor CTE (`SELECT id, embedding FROM current_memories ... LIMIT %(anchor_limit)s`) has no `ORDER BY` before its `LIMIT`, and the module's own docstring already documents its HNSW top-K scan as an approximation with no `ef_search` tuning — a plausible but *not verified* mechanism. I am not opening a second PR for it: I don't have a confirmed root cause, and shipping an unverified change to an unrelated subsystem (near-duplicate detection) would itself violate root-cause discipline (§6.1 — fix at the classified source, not a guess). Flagging with full reproduction evidence here rather than silently omitting it, per this repo's own boy-scout standard.

Co-Authored-By: Claude <noreply@anthropic.com>