### PR TITLE
ci(dependabot): ignore caio >= 0.10, document the pip resync step

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,20 @@ updates:
       prefix: "build"
 
   # Python dependencies are declared in pyproject.toml and locked in uv.lock.
+  #
+  # Note on what these PRs still require by hand: Dependabot rewrites a version
+  # specifier — in pyproject.toml, or directly in one of the generated
+  # requirements/*.txt exports it reads as a manifest — and never runs `uv lock`
+  # or scripts/generate_pip_constraints.py. Every `deps` PR therefore arrives
+  # failing the two Lint steps that guard exactly that chain (`uv lock --check`,
+  # `generate_pip_constraints.py --check`). Resync before merging:
+  #
+  #   uv lock --upgrade-package <name>      # uv 0.11.3, the version ci.yml pins
+  #   python scripts/generate_pip_constraints.py
+  #
+  # Pushing that commit to the dependabot/** branch disables Dependabot's
+  # auto-rebase for the PR — do not comment `@dependabot rebase` afterwards, it
+  # would drop the resync.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -55,3 +69,17 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "deps"
+    ignore:
+      # caio is transitive, not declared: hypermnesia-mcp -> fastmcp ->
+      # fastmcp-slim -> py-key-value-aio -> aiofile -> caio. Every published
+      # aiofile pins caio below 0.10 — 3.9.0 `caio<0.10.0,>=0.9.0`, and 3.10.0
+      # through 3.11.1 (latest, 2026-05-16) `caio~=0.9.0` — while caio 0.10.2
+      # shipped 2026-07-05, after it. No version set satisfies both, so the bump
+      # is unresolvable rather than merely unresynced: PR #322 failed every job,
+      # not just Lint, and was closed for this reason.
+      # No advisory affects caio (`gh api "/advisories?ecosystem=pip&affects=caio"`
+      # returned none on 2026-08-01), so 0.9.25 is not a security hold.
+      # Remove this entry as soon as aiofile widens its bound.
+      # source: PyPI JSON API, verified 2026-08-01.
+      - dependency-name: "caio"
+        versions: [">=0.10.0"]


### PR DESCRIPTION
## Why

Two distinct problems showed up in this week's Dependabot batch. This PR closes the one that is a config bug and documents the one that is a workflow gap.

### 1. `caio` is unresolvable, not merely unresynced — `ignore` it

`caio` is transitive, not declared:

```
hypermnesia-mcp -> fastmcp -> fastmcp-slim -> py-key-value-aio -> aiofile -> caio
```

Every published `aiofile` pins `caio` below 0.10 (PyPI JSON API, verified 2026-08-01):

| aiofile | caio constraint |
|---|---|
| 3.9.0 | `caio<0.10.0,>=0.9.0` |
| 3.10.0 | `caio~=0.9.0` |
| 3.11.0 | `caio~=0.9.0` |
| 3.11.1 (latest, 2026-05-16) | `caio~=0.9.0` |

`caio` 0.10.2 shipped 2026-07-05, after the latest `aiofile`. No version set satisfies both, which is why #322 failed *every* job rather than just Lint — pip reported `ResolutionImpossible`. #322 is closed; this rule stops it being reopened weekly. It should be removed as soon as `aiofile` widens its bound.

No advisory affects `caio` (`gh api "/advisories?ecosystem=pip&affects=caio"` returned none on 2026-08-01), so holding at 0.9.25 is not a security trade-off.

### 2. The resolvable `deps` PRs still arrive red — document the fix

Dependabot rewrites a version specifier and never runs `uv lock` or `scripts/generate_pip_constraints.py`. The Lint job guards exactly that chain (`uv lock --check`, `generate_pip_constraints.py --check`, added for #251), so every pip PR fails on arrival. The two-command resync now sits in a comment directly above the pip entry, along with the warning that pushing to a `dependabot/**` branch disables auto-rebase.

## Scope

`.github/dependabot.yml` only — comments plus one `ignore` entry. No workflow, no dependency, no code.

## Verification

- YAML parses; the pip entry gains only `ignore`, with `[{'dependency-name': 'caio', 'versions': ['>=0.10.0']}]`
- CI is expected green: nothing this PR touches is read by any job