### PR TITLE
fix(registry): align server.json with the published registry entry, and gate its description

### DIFF
--- a/scripts/check_doc_claims.py
+++ b/scripts/check_doc_claims.py
@@ -102,13 +102,25 @@ SCANNED_FILES = (
     # published to the badge. Three of its test counts had drifted two
     # corrections behind the repository before it was scanned (2026-07-27).
     ".bestpractices.json",
+    # The MCP registry serves server.json's description verbatim, so a stale
+    # number here is published to every registry client. Only its `version`
+    # was asserted (check_versions) until its description was found still
+    # advertising "72 references" — two corrections behind the 97-reference
+    # bibliography — and shipped that way to the registry (2026-08-02).
+    "server.json",
 )
 
 TOOL_CLAIM = re.compile(r"(\d+)\s+(?:memory|standalone|MCP)\s+tools\b")
 TOOL_TOTAL_CLAIM = re.compile(r"\((\d+)\s+(?:total\s+)?with\b[^)]*\)")
 REFERENCE_CLAIM = re.compile(r"(\d+)[-\s]reference\b")
+# `cited` is optional because the claim is written both ways ("36
+# neuroscience-grounded mechanisms" in CONTRIBUTING, "36 cited brain
+# mechanisms" in the README lede and "36 cited neuroscience mechanisms" in
+# server.json). Without it the qualified phrasings parsed as no claim at
+# all, so the README lede and the registry description were never asserted
+# against the canonical count (found 2026-08-02).
 MECHANISM_CLAIM = re.compile(
-    r"(\d+)\s+(?:neuroscience[- ]grounded|neuroscience|biological|brain)?"
+    r"(\d+)\s+(?:cited\s+)?(?:neuroscience[- ]grounded|neuroscience|biological|brain)?"
     r"\s*mechanisms\b"
 )
 # Both the "N tests" and the "N-test suite" phrasings state the count. No

--- a/server.json
+++ b/server.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cdeust/hypermnesia-mcp",
-  "description": "Scientifically-grounded persistent memory for Claude — local-first, hybrid retrieval, 72 references.",
+  "description": "Persistent memory for Claude — 36 cited neuroscience mechanisms, local-first, hybrid retrieval.",
   "repository": {
     "url": "https://github.com/cdeust/Cortex",
     "source": "github"
   },
   "version": "4.17.1",
+  "websiteUrl": "https://ai-architect.tools",
   "packages": [
     {
       "registryType": "pypi",


### PR DESCRIPTION
## Contexte

L'entrée `hypermnesia-mcp` du registre MCP officiel a été republiée en 4.17.1 le 2026-08-02. Deux écarts constatés entre le `server.json` du dépôt et ce qui est publié / ce que le schéma autorise :

1. `description` non conforme — le schéma du registre plafonne le champ à **100 caractères**, la description GitHub (290-380 car.) n'est donc pas copiable telle quelle ; la version courte publiée n'était pas reflétée dans le dépôt.
2. `websiteUrl` absent — l'entrée publiée pointe vers `https://ai-architect.tools`.

Sans ce commit, le dépôt et le registre divergent silencieusement : rien ne le détecte.

## Changements

- `server.json` : description alignée sur l'entrée publiée (≤ 100 car.) + ajout de `websiteUrl`.
- `scripts/check_doc_claims.py` : la gate n'assertait que la *version* de `server.json`. Elle asserte désormais aussi sa **description**, de sorte qu'une dérive du claim mécanisme dans ce fichier échoue en CI comme dans les autres documents scannés.
  - `MECHANISM_CLAIM` ne matchait pas « 36 **cited** neuroscience mechanisms » ni le chapô README « 36 cited brain mechanisms » — le qualificatif `cited` est rendu optionnel.

## Vérification

- `scripts/check_doc_claims.py` → exit 0.
- **Vérifié par falsification** : en passant le compte à 35, la gate sort en exit 1. Le test n'est donc pas vacuous.
- `ruff check` + `ruff format --check` propres.
- Entrée du registre revérifiée par API après publication : `active`, sha256 juste.

## Note

Ces deux commits étaient sur `fix/release-workflow-network-hardening`, dont la PR #335 a été mergée en squash avant qu'ils ne soient inclus. Ils sont ici rebasés proprement sur `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)