### PR TITLE
fix(docker): retry the HuggingFace prewarm fetch instead of failing the build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -78,9 +78,27 @@ ENV HF_HOME=/opt/model-cache/huggingface \
     XDG_CACHE_HOME=/opt/model-cache \
     CORTEX_RUNTIME=cowork
 
+# Both prewarms retry with backoff before failing the build: a transient
+# huggingface.co blip must not decide whether the image builds. The bare
+# single-shot form of this fetch failed the sibling docker/Dockerfile build on
+# PR #337 (CI run 30749502167, 2026-08-02) with "We couldn't connect to
+# 'https://huggingface.co'" after 73s. Failing loudly after the retries is
+# deliberate — a silently unprewarmed image is the 2026-07-11 FlashRank
+# incident again, one layer up.
+# source: .github/workflows/ci.yml:131-155 (5 attempts, attempt*10s backoff)
 RUN mkdir -p /opt/model-cache && \
-    python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')" && \
-    python -c "from mcp_server.core.reranker import _ensure_reranker; assert _ensure_reranker() is not None, 'FlashRank prewarm failed at build time'" && \
+    retry() { \
+        label="$1"; shift; \
+        for attempt in 1 2 3 4 5; do \
+            "$@" && return 0; \
+            echo "${label} prewarm attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2; \
+            sleep $((attempt * 10)); \
+        done; \
+        echo "${label} prewarm failed after 5 attempts" >&2; \
+        return 1; \
+    }; \
+    retry HF python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')" && \
+    retry FlashRank python -c "from mcp_server.core.reranker import _ensure_reranker; assert _ensure_reranker() is not None, 'FlashRank prewarm failed at build time'" && \
     chown -R cortex:cortex /opt/model-cache /workspace
 
 USER cortex

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,9 +93,24 @@ RUN pip install --no-cache-dir --require-hashes -r /tmp/requirements.txt
 COPY . /opt/cortex
 RUN pip install --no-cache-dir --no-deps -e /opt/cortex
 
-# Pre-cache embedding model
-RUN python3 -c "from sentence_transformers import SentenceTransformer; \
-    SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')"
+# Pre-cache embedding model. Retry-with-backoff, fail-loudly: same shape and
+# same attempt/backoff constants as ci.yml's "Pre-download embedding model"
+# step, for the same reason — a transient huggingface.co blip must not decide
+# whether the image builds. The bare single-shot form failed this build on PR
+# #337 (CI run 30749502167, 2026-08-02) with "We couldn't connect to
+# 'https://huggingface.co'" after 73s, on a commit touching neither this file
+# nor anything it depends on; the same job had passed on its parent commit.
+# No BuildKit cache mount here on purpose: the runtime stage COPYs this cache
+# out of the builder layer, and a cache mount is not part of the layer.
+# source: .github/workflows/ci.yml:131-139 (5 attempts, attempt*10s backoff)
+RUN for attempt in 1 2 3 4 5; do \
+        python3 -c "from sentence_transformers import SentenceTransformer; \
+            SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')" && exit 0; \
+        echo "HF pre-download attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2; \
+        sleep $((attempt * 10)); \
+    done; \
+    echo "HF pre-download failed after 5 attempts" >&2; \
+    exit 1
 
 # ── Runtime ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Le défaut

`docker/Dockerfile` et `.devcontainer/Dockerfile` pré-cachent le modèle d'embedding avec un fetch réseau **single-shot**. Un blip transitoire de `huggingface.co` fait donc échouer le build entier.

Ce n'est pas hypothétique — c'est arrivé aujourd'hui :

```
#17 73.06 OSError: We couldn't connect to 'https://huggingface.co' to load the files,
          and couldn't find them in the cached files.
ERROR: failed to build: ... docker/Dockerfile:97
```

CI run `30749502167`, sur la PR #337, dont la diff ne touchait **ni** ce Dockerfile **ni** aucune de ses dépendances. Le même job passait sur le commit parent, et un re-run sans changement de code est repassé vert. C'est le fetch qui décidait de l'issue du build, pas le contenu de la PR.

## Le correctif

`ci.yml` avait déjà résolu ce problème à **quatre endroits** (5 tentatives, backoff `attempt*10`s, échec bruyant). Les Dockerfiles sont les seuls chemins qui ne l'avaient jamais reçu. Ce commit y porte l'idiome à l'identique, constantes comprises, avec `# source:` pointant vers `ci.yml`.

Le prewarm FlashRank du devcontainer reçoit le même traitement. L'échec bruyant après épuisement des tentatives y est délibéré : une image silencieusement non-préchauffée, c'est l'incident du 2026-07-11 (re-ranker absent en silence, 6 benchmarks invalidés) reproduit une couche plus haut.

## Choix explicites

- **Pas de cache mount BuildKit.** Le stage runtime fait `COPY --from=builder /root/.cache/huggingface` — un cache mount ne fait pas partie du layer, l'image sortirait sans modèle.
- **`scripts/setup.sh` volontairement non modifié.** Il fait le même fetch, mais dégrade déjà en « will download on first use » au lieu d'échouer. Y ajouter des retries n'achèterait aucune correction et coûterait jusqu'à 100 s d'attente silencieuse dans un installeur interactif.

## Vérification

- Les corps de `RUN`, joints comme Docker joint les continuations (sans newline), passent `sh -n`.
- Les trois charges `python -c` compilent (`compile(..., "exec")`).
- Le helper `retry` retourne 0 sur le chemin succès et propage un code non nul après épuisement — les deux chemins exécutés.
- Flake confirmé empiriquement : re-run du job en échec, sans changement de code → vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)