### PR TITLE
fix(launcher): strip extras from the pip constraints file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The ML stack never installed on current pip, silently degrading recall to
+  first-stage scores** — `scripts/launcher_deps_install.py`. `ensure_all_deps`
+  passes `BASE_PACKAGES` verbatim as the `-c` constraints file
+  (`launcher_deps.py:318`), and one entry carries an extra —
+  `psycopg[binary]==3.3.4` (`launcher_pins.py:89`). pip has always documented
+  constraints files as version-only and now rejects extras outright, so the
+  whole ML resolve aborted with `ERROR: Constraints cannot have extras`:
+  `sentence-transformers` and `flashrank` never landed. Nothing surfaced the
+  failure — only the ML install passes constraints, so the base stack
+  installed clean and the FlashRank re-ranker was simply absent, the same
+  observable shape as the 2026-07-10 FlashRank incident. `pip_install` now
+  normalizes every constraint through the new `constraint_without_extras`
+  before writing the file, which restores the parameter's own documented
+  contract (its docstring already promised `name==ver`) rather than changing
+  it: a constraint pins the VERSION a shared transitive resolves to, and pip
+  applies it to the distribution however its extras were requested — the
+  install target still carries `[binary]`. Measured 2026-08-02 on pip
+  26.0.1 / Python 3.14.4 and reproduced on pip 25.2 / Python 3.13, so the
+  affected range is not pip-26-only; both accept the stripped file
+  (`pip install --dry-run --no-index -c <BASE_PACKAGES>`).
+
 ## [4.17.1] - 2026-08-02
 
 ### Fixed

--- a/scripts/launcher_deps_install.py
+++ b/scripts/launcher_deps_install.py
@@ -29,6 +29,38 @@ if _SCRIPTS_DIR not in sys.path:
 import launcher_deps_fs as _fs  # noqa: E402
 
 
+def constraint_without_extras(spec: str) -> str:
+    """Drop the ``[extra]`` clause from a pip spec, keeping the version.
+
+    Precondition: ``spec`` is a pip requirement string. Postcondition: the
+    return value carries no extras clause; everything else is unchanged.
+
+    pip documents constraints files as version-only and now rejects extras
+    outright, so ``psycopg[binary]==3.3.4`` (BASE_PACKAGES) failed the whole
+    ML install — silently, since only that install passes constraints:
+    FlashRank never landed and recall degraded to first-stage scores.
+
+    Stripping preserves the intent rather than changing it — a constraint
+    pins the VERSION a shared transitive resolves to, and pip applies it to
+    the distribution however its extras were requested; extras belong on the
+    install target (which still carries them), not on the constraint.
+
+    # source: https://pip.pypa.io/en/stable/user_guide/#constraints-files
+    #   ("only control which version of a requirement is installed")
+    # source: measured 2026-08-02 — pip 26.0.1/py3.14 aborted the plugin's
+    #   ML install with "ERROR: Constraints cannot have extras"; reproduced
+    #   on pip 25.2/py3.13 (`--dry-run --no-index -c <BASE_PACKAGES>`), so
+    #   the range is not pip-26-only. Both accept the stripped file.
+    """
+    head, bracket, rest = spec.partition("[")
+    if not bracket:
+        return spec
+    _dropped, closing, tail = rest.partition("]")
+    if not closing:
+        return spec  # unbalanced — not ours to rewrite; hand it to pip as-is
+    return head + tail
+
+
 def _remove_path(path: str, *, best_effort: bool = False) -> None:
     """Remove a file or directory at ``path``, whichever it is.
 
@@ -169,8 +201,10 @@ def pip_install(
     PIP_EXTRA_INDEX_URL / PIP_CONFIG_FILE so a caller can't reopen the
     dependency-confusion vector this closes.
 
-    ``constraints``, when given, is a list of pip specs (``name==ver``)
-    written to a ``-c`` constraints file for this install only (issue
+    ``constraints``, when given, is a list of pip specs written to a ``-c``
+    constraints file for this install only — each one normalized through
+    ``constraint_without_extras`` first, because a constraints file may not
+    carry an ``[extra]`` clause (issue
     #97 residue 3, reporter mbe14, "the substantial one"): without it, a
     package pip pulls in as a TRANSITIVE (e.g. numpy via
     sentence-transformers for the ML install) resolves freely and can
@@ -203,7 +237,7 @@ def pip_install(
     if constraints:
         constraints_file = f"{deps_dir}.constraints-{os.getpid()}.txt"
         with open(constraints_file, "w", encoding="utf-8") as fh:
-            fh.write("\n".join(constraints) + "\n")
+            fh.write("\n".join(map(constraint_without_extras, constraints)) + "\n")
     base = [
         sys.executable,
         "-m",

--- a/tests_py/scripts/test_launcher_constraints_extras.py
+++ b/tests_py/scripts/test_launcher_constraints_extras.py
@@ -1,0 +1,127 @@
+"""Tests for the constraints-file extras strip in scripts/launcher_deps_install.py.
+
+Source: measured 2026-08-02 on macOS, Python 3.14.4 / pip 26.0.1. A plugin
+install of the ML stack aborted with ``ERROR: Constraints cannot have
+extras``. ``launcher_deps.ensure_all_deps`` passes ``BASE_PACKAGES``
+verbatim as the ``-c`` constraints file, and one of its entries carries an
+extra (``psycopg[binary]==3.3.4``). pip has always documented constraints
+files as version-only; it now rejects extras outright. Reproduced the same
+day on pip 25.2 / Python 3.13, so this is not a pip-26-only regression.
+
+The damage was silent: only the ML install passes constraints, so the base
+stack installed fine while sentence-transformers and flashrank never landed
+— leaving recall on first-stage scores with no failed check to notice, the
+same failure shape as the 2026-07-10 FlashRank incident.
+
+The first test is the regression proper: it asserts the bytes written to the
+constraints file, which is what pip actually parses. The last is the
+end-to-end guard against the real pin list drifting back into a spec pip
+rejects.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _load(module_name: str):
+    """Import a launcher module by path — they live outside the package."""
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location(
+        module_name, SCRIPTS_DIR / f"{module_name}.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+install = _load("launcher_deps_install")
+pins = _load("launcher_pins")
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("psycopg[binary]==3.3.4", "psycopg==3.3.4"),
+        ("pkg[a,b]==1.0", "pkg==1.0"),
+        ("pkg[extra]>=1.0,<2.0", "pkg>=1.0,<2.0"),
+        # No extras clause — must pass through byte-identical.
+        ("numpy==2.5.1", "numpy==2.5.1"),
+        ("pgvector==0.5.0", "pgvector==0.5.0"),
+        # Unbalanced bracket: not ours to rewrite, hand it to pip untouched
+        # so pip's own error names the malformed spec.
+        ("pkg[broken==1.0", "pkg[broken==1.0"),
+    ],
+)
+def test_constraint_without_extras(spec: str, expected: str) -> None:
+    assert install.constraint_without_extras(spec) == expected
+
+
+def test_written_constraints_file_carries_no_extras(monkeypatch, tmp_path) -> None:
+    """The regression: assert the file pip parses, not just the helper.
+
+    A correct helper wired in at the wrong place would still ship the bug.
+    """
+    written: dict[str, str] = {}
+    real_open = open
+
+    def spy_open(path, mode="r", *args, **kwargs):
+        handle = real_open(path, mode, *args, **kwargs)
+        if "w" in mode and str(path).endswith(".txt"):
+
+            class _Spy:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *exc):
+                    handle.close()
+                    return False
+
+                def write(self, data):
+                    written[str(path)] = written.get(str(path), "") + data
+                    return handle.write(data)
+
+            return _Spy()
+        return handle
+
+    monkeypatch.setattr("builtins.open", spy_open)
+
+    class _PipReachedError(Exception):
+        """Raised in place of spawning pip — the file is written by then."""
+
+    def no_pip(*_args, **_kwargs):
+        raise _PipReachedError
+
+    monkeypatch.setattr(install.subprocess, "run", no_pip)
+
+    deps_dir = str(tmp_path / "deps")
+    with pytest.raises(_PipReachedError):
+        install.pip_install(
+            deps_dir, ["flashrank==0.2.10"], constraints=["psycopg[binary]==3.3.4"]
+        )
+
+    assert written, "no constraints file was written"
+    body = next(iter(written.values()))
+    assert "[binary]" not in body
+    assert "psycopg==3.3.4" in body
+
+
+def test_real_base_pins_survive_the_strip() -> None:
+    """Guard the actual pin list, so a future extra can't reintroduce this."""
+    stripped = [
+        install.constraint_without_extras(spec) for _name, spec in pins.BASE_PACKAGES
+    ]
+    assert not any("[" in spec for spec in stripped)
+    # The strip must not silently drop a pin or its version.
+    assert len(stripped) == len(pins.BASE_PACKAGES)
+    assert all("==" in spec for spec in stripped)


### PR DESCRIPTION
## The bug

`ensure_all_deps` passes `BASE_PACKAGES` verbatim as the `-c` constraints file (`launcher_deps.py:318`), and one entry carries an extra — `psycopg[binary]==3.3.4` (`launcher_pins.py:89`). pip has always documented constraints files as version-only and now rejects extras outright, so the **entire ML resolve aborts**:

```
ERROR: Constraints cannot have extras
[cortex-launcher] dependency install failed for sentence-transformers==5.6.1, flashrank==0.2.10
```

`sentence-transformers` and `flashrank` never install.

## Why it went unnoticed

Only the ML install passes constraints. The base stack installs clean, so nothing fails visibly — the FlashRank re-ranker is simply **absent**, and `recall` silently degrades to first-stage-only scores. Same observable shape as the 2026-07-10 FlashRank incident.

Hit on a real plugin install (fresh `hypermnesia-mcp@cortex-plugins` 4.17.1, macOS).

## The fix

`pip_install` normalizes each constraint through the new `constraint_without_extras` before writing the file.

This **restores** the parameter's own documented contract rather than changing it — its docstring already promised `name==ver`. A constraint pins the VERSION a shared transitive resolves to (numpy, via sentence-transformers), and pip applies it to the distribution however its extras were requested. Extras belong on the install target, which still carries `[binary]`.

## Version range — not pip-26-only

I first attributed this to pip 26. That was wrong: **pip 25.2 rejects it too**, found while validating against the project venv. The affected population is considerably wider than the pip-26 leading edge. Both measurements are now in the source comment and CHANGELOG.

## Verification — external signals

pip itself judges the generated file:

| | verdict |
|---|---|
| before | `ERROR: Constraints cannot have extras` |
| after | **0 occurrences** |

Command: `pip install --dry-run --no-index -c <BASE_PACKAGES> flashrank==0.2.10`, run on pip 26.0.1/py3.14 and pip 25.2/py3.13.

- Regression test **fails without the fix**, passes with it — it asserts the bytes written to the constraints file (what pip actually parses), not the helper: a correct helper wired in at the wrong place would still ship the bug.
- A third test locks the real `BASE_PACKAGES` list so a future extra cannot reintroduce this.
- `tests_py/scripts/`: 578 passed, 121 subtests.
- `ruff check` + `ruff format --check`: clean.
- `launcher_deps_install.py` stays within the repo's 300-line cap (300/300).

## Note for release

Per CLAUDE.md, this delivers nothing to installs until the marketplace pins move — the fix needs a release + `.claude-plugin/marketplace.json` bump with `scripts/check_marketplace_pins.py` exiting 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)