### PR TITLE
docs: present Cortex as a cross-platform memory MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- mcp-name: io.github.cdeust/hypermnesia-mcp -->
 
 <p align="center">
-  <img src="assets/banner.svg" alt="Cortex — persistent memory for Claude Code" width="820">
+  <img src="assets/banner.svg" alt="Cortex — cross-platform persistent memory for AI coding agents" width="820">
 </p>
 
 <p align="center">
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <strong>Persistent memory for Claude Code built on computational neuroscience — not just retrieval.</strong> 36 cited brain mechanisms consolidate what matters, keep it current as your project evolves, and reconstruct the right context at the right time — a living memory, not a flat RAG. Says "I don't know" when unsure, flags its own contradictions. Local-first, single-click MCP install.
+  <strong>Cross-platform persistent memory for Codex, Gemini CLI, Claude Code, and other local MCP hosts — built on computational neuroscience, not just retrieval.</strong> 36 cited brain mechanisms consolidate what matters, keep it current as your project evolves, and reconstruct the right context at the right time. The MCP server is host-agnostic; Claude Code adds optional automatic lifecycle hooks.
 </p>
 
 <p align="center">
@@ -36,9 +36,9 @@
 
 ---
 
-Claude forgets you every time you close the tab. Every architecture decision you explained. Every debugging session where you traced a bug through four layers of abstraction. Every "remember, we decided to use event sourcing, not CRUD" correction. Gone. Next session, you're a stranger to your own tools.
+Your coding agent forgets you every time you close the session. Every architecture decision you explained. Every debugging session where you traced a bug through four layers of abstraction. Every "remember, we decided to use event sourcing, not CRUD" correction. Gone. Next session, your agent is a stranger to its own tools.
 
-Cortex is a persistent memory engine for Claude built on computational neuroscience. It remembers what you worked on, how you think, what you decided and why — not as a text dump shoved into context, but as a living memory system that consolidates, forgets intelligently, and reconstructs the right context at the right time.
+Cortex is a cross-platform persistent memory engine for AI coding agents, built on computational neuroscience. Codex, Gemini CLI, Claude Code, and any local stdio MCP host can use the same remember/recall, knowledge-graph, consolidation, and wiki tools. Claude Code's plugin adds automatic capture and injection hooks; other hosts use the same memory through explicit tool calls.
 
 It runs **entirely on your machine** — a local SQLite database by default (zero setup, no services to install), or PostgreSQL + pgvector when you want it. A 22 MB embedding model, no LLM in the retrieval loop, no data leaving localhost.
 

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
       "python": ">=3.10"
     }
   },
-  "description": "Persistent memory and cognitive profiling for Claude \u2014 remembers across sessions automatically. Scientific retrieval backed by 72 published references.",
+  "description": "Cross-platform persistent memory and cognitive profiling for AI agents. Scientific retrieval backed by 97 published references; optional automatic lifecycle hooks on Claude Code.",
   "display_name": "Cortex \u2014 Persistent Memory",
   "documentation": "https://github.com/cdeust/Cortex#readme",
   "homepage": "https://github.com/cdeust/Cortex",
@@ -22,20 +22,22 @@
   "keywords": [
     "persistent memory",
     "long-term memory",
-    "memory for claude",
+    "memory for ai agents",
     "agent recall",
     "agent memory",
     "hypermnesia",
     "memory",
     "persistent",
     "mcp",
-    "claude",
+    "codex",
+    "gemini-cli",
+    "claude-code",
     "neuroscience",
     "cognitive-profiling",
     "agents"
   ],
   "license": "MIT",
-  "long_description": "Cortex gives Claude a durable, scientifically-grounded memory. It stores decisions, lessons, and context across sessions and retrieves them with a hybrid WRRF fusion (vector + full-text + trigram + heat + recency) reranked by a cross-encoder. Its 36 neuroscience-grounded mechanisms are drawn from a 97-reference bibliography (spreading activation, synaptic tagging, neuromodulation, LTP/LTD, predictive-coding write gates). This connector exposes 52 memory tools standalone (55 with upstream integrations available) and runs fully local with zero external services using the built-in SQLite backend; advanced users can point it at PostgreSQL + pgvector. For the automatic session-lifecycle memory (injection at session start, auto-capture, compaction checkpointing), install the companion Claude Code plugin \u2014 its hooks drive that automation, which the MCP bundle format does not carry.",
+  "long_description": "Cortex gives Codex, Gemini CLI, Claude Code, and other local MCP hosts a durable, scientifically-grounded memory. It stores decisions, lessons, and context across sessions and retrieves them with a hybrid WRRF fusion (vector + full-text + trigram + heat + recency) reranked by a cross-encoder. Its 36 neuroscience-grounded mechanisms are drawn from a 97-reference bibliography (spreading activation, synaptic tagging, neuromodulation, LTP/LTD, predictive-coding write gates). This connector exposes 52 memory tools standalone (55 with upstream integrations available) and runs fully local with zero external services using the built-in SQLite backend; advanced users can point it at PostgreSQL + pgvector. For automatic session-lifecycle memory (injection at session start, auto-capture, compaction checkpointing), install the companion Claude Code plugin; other hosts use the same memory through explicit MCP tool calls.",
   "manifest_version": "0.4",
   "name": "hypermnesia-mcp",
   "privacy_policies": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hypermnesia-mcp",
   "version": "4.17.2",
-  "description": "Persistent memory and cognitive profiling for Claude Code",
+  "description": "Cross-platform persistent memory and cognitive profiling for AI coding agents",
   "repository": {
     "type": "git",
     "url": "https://github.com/cdeust/Cortex"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 authors = [
     { name = "Clement Deust", email = "admin@ai-architect.tools" },
 ]
-keywords = ["mcp", "claude-code", "memory", "cognitive-profiling"]
+keywords = ["mcp", "codex", "gemini-cli", "claude-code", "memory", "cognitive-profiling"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cdeust/hypermnesia-mcp",
-  "description": "Persistent memory for Claude — 36 cited neuroscience mechanisms, local-first, hybrid retrieval.",
+  "description": "Cross-platform persistent memory for AI agents — 36 cited neuroscience mechanisms, local-first, hybrid retrieval.",
   "repository": {
     "url": "https://github.com/cdeust/Cortex",
     "source": "github"


### PR DESCRIPTION
## Summary

- lead with Cortex as a cross-platform memory MCP for Codex, Gemini CLI, Claude Code, and other local stdio MCP hosts
- align README, MCPB, npm, PyPI, and MCP Registry descriptions and keywords
- keep the boundary explicit: the 52-tool server is host-agnostic, while automatic lifecycle capture and injection remain Claude Code plugin hooks

The GitHub repository description and topics were updated separately so the same positioning is visible in search and discovery.

## Validation

- `python scripts/check_doc_claims.py`
- `pytest --confcutdir=tests_py/scripts -q tests_py/scripts/test_cross_host_manifests.py tests_py/scripts/test_codex_plugin_contract.py tests_py/scripts/test_check_doc_claims.py` — 116 passed
- `git diff --check`
