### PR TITLE
Bump cortex-viz marketplace pin to 2.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,7 +64,7 @@
         "repo": "cdeust/cortex-viz"
       },
       "description": "Standalone visualization MCP for Cortex — a live neural-graph galaxy of every project, file, symbol, memory, discussion and wiki page, plus a per-session execution trace, a consolidation kanban, and a curated knowledge/wiki browser. Read-only bridge over Cortex's shared PostgreSQL store and the ~/.claude artifacts; it renders, it never remembers. Restores the open_visualization / get_methodology_graph / query_workflow_graph tools removed from Cortex 3.21.0; launch with /cortex-visualize.",
-      "version": "2.7.1",
+      "version": "2.8.0",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"


### PR DESCRIPTION
## What changed

Updates the `cortex-viz` entry in `.claude-plugin/marketplace.json` from `2.7.1` to `2.8.0`.

## Why

Cortex Viz 2.8.0 uses the canonical PyPI and MCP Registry distribution identity `hypermnesia-mcp-viz` while retaining the `cortex-viz` Claude Code plugin identity. The Cortex marketplace pin must move with the release so Claude Code installations resolve the new plugin version.

## Validation

- parsed `.claude-plugin/marketplace.json` with `python3 -m json.tool`
- `git diff --check`
- scoped one-line manifest change only

## Release dependency

The `v2.8.0` tag exists. The first cortex-viz release workflow is awaiting correction of the PyPI Trusted Publisher claim before it can be rerun; merge this pin after that release succeeds.
