### PR TITLE
fix(ast): bound extractor traversal by heap, not the interpreter stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,17 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A deeply nested source file no longer fails the whole indexing run.** Every
+  full-tree AST walker in the extractor layer recursed once per AST level and
+  raised an uncaught `RecursionError` past a depth of ~1003 (default recursion
+  limit 1000) — reachable on the minified and generated sources found in
+  third-party repositories, and fatal for the entire repository rather than the
+  one file, since nothing in `mcp_server/` catches it. Seven walkers now use an
+  explicit stack: `_walk_type` and `_walk_for_calls` (Python/JS/shared),
+  `_walk_java`, `_walk_kotlin`, `_walk_csharp`, `_walk_ruby`, `_walk_php` and
+  `_extract_swift_node`. Traversal order is unchanged, verified differentially
+  against the previous implementation over 2229 real and synthetic sources with
+  zero output differences, including dictionary key order.
 - FastMCP's banner-time network update probe can no longer abort stdio startup
   before MCP `initialize` when a SOCKS proxy is configured without optional
   HTTP SOCKS support. The diagnostic banner and its existing user setting are

--- a/mcp_server/core/ast_extractors.py
+++ b/mcp_server/core/ast_extractors.py
@@ -30,12 +30,23 @@ def _find_children(node: Node, *types: str) -> list[Node]:
 
 
 def _walk_type(node: Node, node_type: str) -> list[Node]:
-    """Recursively find all descendants of a given type."""
+    """Find `node` and all its descendants of a given type, in document order.
+
+    Iterative on purpose. The recursive form consumed one Python frame per AST
+    level and raised RecursionError at an AST depth of ~1003 under the default
+    limit of 1000 — reachable on minified or generated sources in third-party
+    repositories, and unhandled (no caller catches RecursionError). Heap depth
+    replaces stack depth; the traversal order is unchanged.
+    """
     results: list[Node] = []
-    if node.type == node_type:
-        results.append(node)
-    for child in node.children:
-        results.extend(_walk_type(child, node_type))
+    stack: list[Node] = [node]
+    while stack:
+        current = stack.pop()
+        if current.type == node_type:
+            results.append(current)
+        # Reversed, so siblings pop left-to-right and the result stays
+        # pre-order document order — identical to the recursive form.
+        stack.extend(reversed(current.children))
     return results
 
 
@@ -287,34 +298,44 @@ def _walk_for_calls(
     source: bytes,
     out: dict[str, list[str]],
 ) -> None:
-    """Recurse through ``node``'s children, tracking the enclosing class.
+    """Walk ``node``'s descendants, tracking the enclosing class.
 
     Precondition: `out` is the accumulator `extract_calls_per_function`
     returns; this function only adds keys, it does not read existing ones.
     Postcondition: every named function/method reachable from `node` has
     its qualified name mapped to its deduped callee-basename list in `out`.
+
+    Iterative for the same reason as `_walk_type`: one Python frame per AST
+    level raised RecursionError on deeply nested sources, and no caller
+    catches it. The explicit stack carries the enclosing class scope with
+    each node, and descendants are pushed reversed so they pop before the
+    remaining siblings — preserving the depth-first pre-order the recursive
+    form had, and with it the insertion order of `out`.
     """
-    for child in node.children:
+    stack: list[tuple[Node, str]] = [(c, class_scope) for c in reversed(node.children)]
+    while stack:
+        child, scope = stack.pop()
         ntype = child.type
         if ntype in _CLASS_NODE_TYPES:
             name_node = child.child_by_field_name("name")
-            cls = _text(name_node, source) if name_node else class_scope
+            cls = _text(name_node, source) if name_node else scope
             body = child.child_by_field_name("body") or child
-            _walk_for_calls(body, cls or class_scope, source, out)
+            inner = cls or scope
+            stack.extend((c, inner) for c in reversed(body.children))
         elif ntype == "decorated_definition":
-            _walk_for_calls(child, class_scope, source, out)
+            stack.extend((c, scope) for c in reversed(child.children))
         elif ntype in _FUNCTION_NODE_TYPES:
             name_node = child.child_by_field_name("name")
             fn_name = _text(name_node, source) if name_node else ""
             body = child.child_by_field_name("body") or child
             if fn_name:
-                qname = f"{class_scope}.{fn_name}" if class_scope else fn_name
+                qname = f"{scope}.{fn_name}" if scope else fn_name
                 out[qname] = _collect_call_basenames(body, source)
-            # Recurse into body for nested definitions (inner
+            # Descend into the body for nested definitions (inner
             # functions, closures that define named functions).
-            _walk_for_calls(body, class_scope, source, out)
+            stack.extend((c, scope) for c in reversed(body.children))
         else:
-            _walk_for_calls(child, class_scope, source, out)
+            stack.extend((c, scope) for c in reversed(child.children))
 
 
 def _collect_call_basenames(body: Node, source: bytes) -> list[str]:

--- a/mcp_server/core/ast_extractors_clike.py
+++ b/mcp_server/core/ast_extractors_clike.py
@@ -114,22 +114,35 @@ def extract_csharp_definitions(root: Node, source: bytes) -> list[SymbolDef]:
 
 
 def _walk_csharp(node: Node, source: bytes, defs: list[SymbolDef], parent: str) -> None:
-    """Recursively extract C# definitions, qualifying methods by type."""
-    if node.type in _CSHARP_TYPE_KINDS:
-        name = node.child_by_field_name("name")
-        if name:
-            n = _text(name, source)
-            defs.append(SymbolDef(name=n, kind=_CSHARP_TYPE_KINDS[node.type]))
-            for child in _find_children(node, "declaration_list"):
-                for member in child.children:
-                    _walk_csharp(member, source, defs, n)
-            return
-    if node.type == "method_declaration":
-        name = node.child_by_field_name("name")
-        if name:
-            n = _text(name, source)
-            full = f"{parent}.{n}" if parent else n
-            defs.append(SymbolDef(name=full, kind="method" if parent else "function"))
-        return
-    for child in node.children:
-        _walk_csharp(child, source, defs, parent)
+    """Extract C# definitions, qualifying methods by type.
+
+    Iterative (see `ast_extractors._walk_type`): one Python frame per AST level
+    raised an uncaught RecursionError on deeply nested sources. Descendants are
+    pushed reversed, so `defs` keeps its depth-first pre-order.
+    """
+    stack: list[tuple[Node, str]] = [(node, parent)]
+    while stack:
+        current, scope = stack.pop()
+        if current.type in _CSHARP_TYPE_KINDS:
+            name = current.child_by_field_name("name")
+            if name:
+                n = _text(name, source)
+                defs.append(SymbolDef(name=n, kind=_CSHARP_TYPE_KINDS[current.type]))
+                members = [
+                    (member, n)
+                    for child in _find_children(current, "declaration_list")
+                    for member in child.children
+                ]
+                stack.extend(reversed(members))
+                continue
+            # Unnamed: fall through, as the recursive form did.
+        if current.type == "method_declaration":
+            name = current.child_by_field_name("name")
+            if name:
+                n = _text(name, source)
+                full = f"{scope}.{n}" if scope else n
+                defs.append(
+                    SymbolDef(name=full, kind="method" if scope else "function")
+                )
+            continue
+        stack.extend((c, scope) for c in reversed(current.children))

--- a/mcp_server/core/ast_extractors_extra.py
+++ b/mcp_server/core/ast_extractors_extra.py
@@ -111,25 +111,35 @@ def _extract_swift_node(
     defs: list[SymbolDef],
     parent: str,
 ) -> None:
-    """Recursively extract Swift definitions."""
-    if node.type == "function_declaration":
-        name = node.child_by_field_name("name")
-        if name:
-            n = _text(name, source)
-            full = f"{parent}.{n}" if parent else n
-            defs.append(SymbolDef(name=full, kind="method" if parent else "function"))
-    elif node.type in _SWIFT_KIND_MAP:
-        name = node.child_by_field_name("name")
-        if name:
-            n = _text(name, source)
-            defs.append(SymbolDef(name=n, kind=_SWIFT_KIND_MAP[node.type]))
-            body = node.child_by_field_name("body")
-            if body:
-                for child in body.children:
-                    _extract_swift_node(child, source, defs, n)
-    else:
-        for child in node.children:
-            _extract_swift_node(child, source, defs, parent)
+    """Extract Swift definitions.
+
+    Iterative (see `ast_extractors._walk_type`): one Python frame per AST level
+    raised an uncaught RecursionError on deeply nested sources. Descendants are
+    pushed reversed, so `defs` keeps its depth-first pre-order. The branch
+    structure is the original if/elif/else: a `_SWIFT_KIND_MAP` node never
+    reaches the catch-all descent, and an unnamed one descends nowhere.
+    """
+    stack: list[tuple[Node, str]] = [(node, parent)]
+    while stack:
+        current, scope = stack.pop()
+        if current.type == "function_declaration":
+            name = current.child_by_field_name("name")
+            if name:
+                n = _text(name, source)
+                full = f"{scope}.{n}" if scope else n
+                defs.append(
+                    SymbolDef(name=full, kind="method" if scope else "function")
+                )
+        elif current.type in _SWIFT_KIND_MAP:
+            name = current.child_by_field_name("name")
+            if name:
+                n = _text(name, source)
+                defs.append(SymbolDef(name=n, kind=_SWIFT_KIND_MAP[current.type]))
+                body = current.child_by_field_name("body")
+                if body:
+                    stack.extend((c, n) for c in reversed(body.children))
+        else:
+            stack.extend((c, scope) for c in reversed(current.children))
 
 
 # ── Rust ──────────────────────────────────────────────────────────────────

--- a/mcp_server/core/ast_extractors_jvm.py
+++ b/mcp_server/core/ast_extractors_jvm.py
@@ -44,26 +44,37 @@ def extract_java_definitions(root: Node, source: bytes) -> list[SymbolDef]:
 
 
 def _walk_java(node: Node, source: bytes, defs: list[SymbolDef], parent: str) -> None:
-    """Recursively extract Java definitions, qualifying methods by class."""
-    if node.type in _JAVA_TYPE_KINDS:
-        name = node.child_by_field_name("name")
-        if name:
-            n = _text(name, source)
-            defs.append(SymbolDef(name=n, kind=_JAVA_TYPE_KINDS[node.type]))
-            body = node.child_by_field_name("body")
-            if body:
-                for child in body.children:
-                    _walk_java(child, source, defs, n)
-            return
-    if node.type in ("method_declaration", "constructor_declaration"):
-        name = node.child_by_field_name("name")
-        if name:
-            n = _text(name, source)
-            full = f"{parent}.{n}" if parent else n
-            defs.append(SymbolDef(name=full, kind="method" if parent else "function"))
-        return
-    for child in node.children:
-        _walk_java(child, source, defs, parent)
+    """Extract Java definitions, qualifying methods by class.
+
+    Iterative (see `ast_extractors._walk_type`): the recursive form spent one
+    Python frame per AST level and raised an uncaught RecursionError on deeply
+    nested sources. Descendants are pushed reversed, so they pop before the
+    remaining siblings and `defs` keeps its depth-first pre-order.
+    """
+    stack: list[tuple[Node, str]] = [(node, parent)]
+    while stack:
+        current, scope = stack.pop()
+        if current.type in _JAVA_TYPE_KINDS:
+            name = current.child_by_field_name("name")
+            if name:
+                n = _text(name, source)
+                defs.append(SymbolDef(name=n, kind=_JAVA_TYPE_KINDS[current.type]))
+                body = current.child_by_field_name("body")
+                if body:
+                    stack.extend((c, n) for c in reversed(body.children))
+                continue
+            # Unnamed: fall through, exactly as the recursive form did — its
+            # `return` sat inside `if name:`.
+        if current.type in ("method_declaration", "constructor_declaration"):
+            name = current.child_by_field_name("name")
+            if name:
+                n = _text(name, source)
+                full = f"{scope}.{n}" if scope else n
+                defs.append(
+                    SymbolDef(name=full, kind="method" if scope else "function")
+                )
+            continue
+        stack.extend((c, scope) for c in reversed(current.children))
 
 
 # ── Kotlin ──────────────────────────────────────────────────────────────────
@@ -87,24 +98,37 @@ def extract_kotlin_definitions(root: Node, source: bytes) -> list[SymbolDef]:
 
 
 def _walk_kotlin(node: Node, source: bytes, defs: list[SymbolDef], parent: str) -> None:
-    """Recursively extract Kotlin definitions, qualifying members by type."""
-    if node.type in ("class_declaration", "object_declaration"):
-        ident = _find_children(node, "type_identifier")
-        if ident:
-            n = _text(ident[0], source)
-            is_iface = any(c.type == "interface" for c in node.children)
-            defs.append(SymbolDef(name=n, kind="interface" if is_iface else "class"))
-            for child in node.children:
-                if child.type == "class_body":
-                    for member in child.children:
-                        _walk_kotlin(member, source, defs, n)
-            return
-    if node.type == "function_declaration":
-        ident = _find_children(node, "simple_identifier")
-        if ident:
-            n = _text(ident[0], source)
-            full = f"{parent}.{n}" if parent else n
-            defs.append(SymbolDef(name=full, kind="method" if parent else "function"))
-        return
-    for child in node.children:
-        _walk_kotlin(child, source, defs, parent)
+    """Extract Kotlin definitions, qualifying members by type.
+
+    Iterative for the same reason as `_walk_java`; traversal order preserved.
+    """
+    stack: list[tuple[Node, str]] = [(node, parent)]
+    while stack:
+        current, scope = stack.pop()
+        if current.type in ("class_declaration", "object_declaration"):
+            ident = _find_children(current, "type_identifier")
+            if ident:
+                n = _text(ident[0], source)
+                is_iface = any(c.type == "interface" for c in current.children)
+                defs.append(
+                    SymbolDef(name=n, kind="interface" if is_iface else "class")
+                )
+                members = [
+                    (member, n)
+                    for child in current.children
+                    if child.type == "class_body"
+                    for member in child.children
+                ]
+                stack.extend(reversed(members))
+                continue
+            # Unnamed: fall through, as the recursive form did.
+        if current.type == "function_declaration":
+            ident = _find_children(current, "simple_identifier")
+            if ident:
+                n = _text(ident[0], source)
+                full = f"{scope}.{n}" if scope else n
+                defs.append(
+                    SymbolDef(name=full, kind="method" if scope else "function")
+                )
+            continue
+        stack.extend((c, scope) for c in reversed(current.children))

--- a/mcp_server/core/ast_extractors_scripting.py
+++ b/mcp_server/core/ast_extractors_scripting.py
@@ -49,24 +49,33 @@ def extract_ruby_definitions(root: Node, source: bytes) -> list[SymbolDef]:
 
 
 def _walk_ruby(node: Node, source: bytes, defs: list[SymbolDef], parent: str) -> None:
-    """Recursively extract Ruby definitions, qualifying methods by class."""
-    if node.type in _RUBY_KINDS:
-        name = node.child_by_field_name("name")
-        if name:
-            n = _text(name, source)
-            defs.append(SymbolDef(name=n, kind=_RUBY_KINDS[node.type]))
-            for child in node.children:
-                _walk_ruby(child, source, defs, n)
-            return
-    if node.type == "method":
-        name = node.child_by_field_name("name")
-        if name:
-            n = _text(name, source)
-            full = f"{parent}.{n}" if parent else n
-            defs.append(SymbolDef(name=full, kind="method" if parent else "function"))
-        return
-    for child in node.children:
-        _walk_ruby(child, source, defs, parent)
+    """Extract Ruby definitions, qualifying methods by class.
+
+    Iterative (see `ast_extractors._walk_type`): one Python frame per AST level
+    raised an uncaught RecursionError on deeply nested sources. Descendants are
+    pushed reversed, so `defs` keeps its depth-first pre-order.
+    """
+    stack: list[tuple[Node, str]] = [(node, parent)]
+    while stack:
+        current, scope = stack.pop()
+        if current.type in _RUBY_KINDS:
+            name = current.child_by_field_name("name")
+            if name:
+                n = _text(name, source)
+                defs.append(SymbolDef(name=n, kind=_RUBY_KINDS[current.type]))
+                stack.extend((c, n) for c in reversed(current.children))
+                continue
+            # Unnamed: fall through, as the recursive form did.
+        if current.type == "method":
+            name = current.child_by_field_name("name")
+            if name:
+                n = _text(name, source)
+                full = f"{scope}.{n}" if scope else n
+                defs.append(
+                    SymbolDef(name=full, kind="method" if scope else "function")
+                )
+            continue
+        stack.extend((c, scope) for c in reversed(current.children))
 
 
 # ── PHP ───────────────────────────────────────────────────────────────────────
@@ -98,22 +107,33 @@ def extract_php_definitions(root: Node, source: bytes) -> list[SymbolDef]:
 
 
 def _walk_php(node: Node, source: bytes, defs: list[SymbolDef], parent: str) -> None:
-    """Recursively extract PHP definitions, qualifying methods by type."""
-    if node.type in _PHP_KINDS:
-        name = node.child_by_field_name("name")
-        if name:
-            n = _text(name, source)
-            defs.append(SymbolDef(name=n, kind=_PHP_KINDS[node.type]))
-            for child in _find_children(node, "declaration_list"):
-                for member in child.children:
-                    _walk_php(member, source, defs, n)
-            return
-    if node.type in ("function_definition", "method_declaration"):
-        name = node.child_by_field_name("name")
-        if name:
-            n = _text(name, source)
-            full = f"{parent}.{n}" if parent else n
-            defs.append(SymbolDef(name=full, kind="method" if parent else "function"))
-        return
-    for child in node.children:
-        _walk_php(child, source, defs, parent)
+    """Extract PHP definitions, qualifying methods by type.
+
+    Iterative for the same reason as `_walk_ruby`; traversal order preserved.
+    """
+    stack: list[tuple[Node, str]] = [(node, parent)]
+    while stack:
+        current, scope = stack.pop()
+        if current.type in _PHP_KINDS:
+            name = current.child_by_field_name("name")
+            if name:
+                n = _text(name, source)
+                defs.append(SymbolDef(name=n, kind=_PHP_KINDS[current.type]))
+                members = [
+                    (member, n)
+                    for child in _find_children(current, "declaration_list")
+                    for member in child.children
+                ]
+                stack.extend(reversed(members))
+                continue
+            # Unnamed: fall through, as the recursive form did.
+        if current.type in ("function_definition", "method_declaration"):
+            name = current.child_by_field_name("name")
+            if name:
+                n = _text(name, source)
+                full = f"{scope}.{n}" if scope else n
+                defs.append(
+                    SymbolDef(name=full, kind="method" if scope else "function")
+                )
+            continue
+        stack.extend((c, scope) for c in reversed(current.children))

--- a/tests_py/core/test_ast_extractor_depth.py
+++ b/tests_py/core/test_ast_extractor_depth.py
@@ -1,0 +1,137 @@
+"""Depth contract for the tree-sitter extractors that walk a whole AST.
+
+The extractors walk an AST whose depth is set by untrusted input: Cortex
+indexes third-party repositories, and minified or generated sources nest far
+deeper than hand-written code. Every full-tree walker used to spend one Python
+frame per AST level, so a deep file raised `RecursionError` — and nothing in
+`mcp_server/` catches it (`grep -rn "RecursionError" mcp_server/` is empty), so
+it propagated out of the indexer and failed the run for the whole repository.
+Reproduced before the fix at an AST depth of ~1003 against the default
+recursion limit of 1000.
+
+Two properties are asserted per case, because either alone is insufficient:
+
+1. The fixture's AST is genuinely deeper than the interpreter's limit. Without
+   this a parser change that flattens the tree would leave the test green while
+   testing nothing.
+2. The nesting sits where the walker actually descends. The language walkers
+   `return` at a method node without entering its body, so deep nesting inside
+   a method body never reaches the recursive path — every fixture below was
+   verified to raise `RecursionError` against the pre-fix implementation, and a
+   method-body fixture was rejected for exactly this reason.
+
+`extract_python_definitions` and `extract_js_definitions` are deliberately
+absent: neither descends the full tree (`_extract_js_node` recurses only
+through `export_statement`), so a depth case for them would be vacuous. The
+JS/Python exposure runs through `_walk_type`, covered in
+`test_ast_extractors.py::TestWalkType`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+from mcp_server.core.ast_parser import is_available
+
+pytestmark = pytest.mark.skipif(
+    not is_available(), reason="tree-sitter not installed; extractors are unreachable"
+)
+
+# 1500 > the default recursion limit of 1000, with margin.
+_NESTING = 1500
+_OPEN = b"(" * _NESTING
+_CLOSE = b")" * _NESTING
+
+
+def _ast_depth(node) -> int:
+    """Measure depth iteratively — the code under test cannot be trusted to."""
+    depth, stack = 0, [(node, 1)]
+    while stack:
+        current, level = stack.pop()
+        depth = max(depth, level)
+        stack.extend((child, level + 1) for child in current.children)
+    return depth
+
+
+# (language, source, module, entry point). Every source nests inside a field or
+# top-level initializer, which is the region the catch-all descent traverses.
+_CASES = [
+    (
+        "java",
+        b"class A { int x = " + _OPEN + b"1" + _CLOSE + b"; }",
+        "mcp_server.core.ast_extractors_jvm",
+        "extract_java_definitions",
+    ),
+    (
+        "kotlin",
+        b"class A { val x = " + _OPEN + b"1" + _CLOSE + b" }",
+        "mcp_server.core.ast_extractors_jvm",
+        "extract_kotlin_definitions",
+    ),
+    (
+        "c_sharp",
+        b"class A { int X = " + _OPEN + b"1" + _CLOSE + b"; }",
+        "mcp_server.core.ast_extractors_clike",
+        "extract_csharp_definitions",
+    ),
+    (
+        "ruby",
+        b"class A\n X = " + _OPEN + b"1" + _CLOSE + b"\nend\n",
+        "mcp_server.core.ast_extractors_scripting",
+        "extract_ruby_definitions",
+    ),
+    (
+        "php",
+        b"<?php $x = " + _OPEN + b"1" + _CLOSE + b";",
+        "mcp_server.core.ast_extractors_scripting",
+        "extract_php_definitions",
+    ),
+    (
+        "swift",
+        b"let x = " + _OPEN + b"1" + _CLOSE,
+        "mcp_server.core.ast_extractors_extra",
+        "extract_swift_definitions",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("language", "source", "module", "entry_point"),
+    _CASES,
+    ids=[case[0] for case in _CASES],
+)
+def test_extractor_survives_an_ast_deeper_than_the_recursion_limit(
+    language: str, source: bytes, module: str, entry_point: str
+) -> None:
+    from tree_sitter_language_pack import get_parser
+
+    root = get_parser(language).parse(source).root_node
+
+    depth = _ast_depth(root)
+    assert depth > sys.getrecursionlimit(), (
+        f"{language}: fixture is only {depth} deep against a recursion limit of "
+        f"{sys.getrecursionlimit()} — it can no longer reach the defect it guards"
+    )
+
+    getattr(importlib.import_module(module), entry_point)(root, source)
+
+
+def test_call_extraction_survives_a_deep_ast() -> None:
+    """`extract_calls_per_function` drives `_walk_for_calls`, the second
+    full-tree walker in `ast_extractors` and the one carrying class scope.
+    """
+    from tree_sitter_language_pack import get_parser
+
+    from mcp_server.core.ast_extractors import extract_calls_per_function
+
+    source = (
+        b"class C:\n    def m(self):\n        return " + _OPEN + b"1" + _CLOSE + b"\n"
+    )
+    root = get_parser("python").parse(source).root_node
+    assert _ast_depth(root) > sys.getrecursionlimit()
+
+    out = extract_calls_per_function(root, source)
+    assert "C.m" in out, "scope tracking must survive the iterative rewrite"

--- a/tests_py/core/test_ast_extractors.py
+++ b/tests_py/core/test_ast_extractors.py
@@ -149,3 +149,55 @@ func NewServer(port int) *Server {
         else:
             r = parse_file_ast("main.go", code)
             assert r.language == "go"
+
+
+class TestWalkType:
+    """`_walk_type` is the shared descendant search behind every extractor
+    module (clike, extra, jvm, scripting), so its depth ceiling and its
+    ordering are contracts, not implementation details.
+    """
+
+    def _js_root(self, code: bytes):
+        from tree_sitter_language_pack import get_parser
+
+        return get_parser("javascript").parse(code).root_node
+
+    def test_deep_nesting_does_not_exhaust_the_interpreter_stack(self) -> None:
+        """Regression: the recursive form raised RecursionError at AST depth
+        ~1003 (default limit 1000). 1500 is comfortably past that, and no
+        caller anywhere in mcp_server/ catches RecursionError.
+        """
+        if not _HAS_TREE_SITTER:
+            return
+        from mcp_server.core.ast_extractors import _walk_type
+
+        depth = 1500
+        code = (b"(" * depth) + b"1" + (b")" * depth) + b";"
+        assert _walk_type(self._js_root(code), "import_statement") == []
+
+    def test_returns_matches_in_document_order(self) -> None:
+        if not _HAS_TREE_SITTER:
+            return
+        from mcp_server.core.ast_extractors import _walk_type
+
+        code = b"import a from 'a';\nimport b from 'b';\nimport c from 'c';\n"
+        found = _walk_type(self._js_root(code), "import_statement")
+        starts = [n.start_byte for n in found]
+        assert len(found) == 3
+        assert starts == sorted(starts)
+
+    def test_includes_the_start_node_itself(self) -> None:
+        if not _HAS_TREE_SITTER:
+            return
+        from mcp_server.core.ast_extractors import _walk_type
+
+        root = self._js_root(b"const x = 1;\n")
+        assert _walk_type(root, root.type) == [root]
+
+    def test_returns_empty_when_nothing_matches(self) -> None:
+        if not _HAS_TREE_SITTER:
+            return
+        from mcp_server.core.ast_extractors import _walk_type
+
+        root = self._js_root(b"const x = 1;\n")
+        assert _walk_type(root, "no_such_node_type") == []


### PR DESCRIPTION
## Problem

Every full-tree AST walker in the extractor layer spent one Python frame per AST level. On a source nested deeper than the interpreter's recursion limit, they raised `RecursionError` — and nothing catches it:

```
$ grep -rn "RecursionError\|setrecursionlimit" mcp_server/
(no matches)
```

`ast_parser.py` catches `ImportError` and `DownloadError` only, so the error propagated out of the indexer and failed the run for the entire repository, not just the offending file.

Reproduced before the fix:

```
recursionlimit: 1000
nesting=  500 ast_depth= 503 -> OK
nesting= 1000 ast_depth=1003 -> RecursionError: maximum recursion depth exceeded
```

This is reachable in normal operation. Cortex indexes third-party repositories, and minified or generated sources nest far deeper than hand-written code. It is not reachable from the current first-party corpus: I parsed 400 JS files in `cortex-viz` and none hit the limit. So this is a latent robustness defect on untrusted input, not an active outage.

## Scope

The defect was not one function. A sweep for self-recursive walkers found nine, and seven of them descend the whole tree:

| Function | Module | Converted |
|---|---|---|
| `_walk_type` | `ast_extractors.py` | yes |
| `_walk_for_calls` | `ast_extractors.py` | yes |
| `_walk_java` | `ast_extractors_jvm.py` | yes |
| `_walk_kotlin` | `ast_extractors_jvm.py` | yes |
| `_walk_csharp` | `ast_extractors_clike.py` | yes |
| `_walk_ruby` | `ast_extractors_scripting.py` | yes |
| `_walk_php` | `ast_extractors_scripting.py` | yes |
| `_extract_swift_node` | `ast_extractors_extra.py` | yes |
| `_extract_js_node` | `ast_extractors.py` | **no — see below** |

`_extract_js_node` recurses only through `export_statement`, so its depth is bounded by export nesting rather than tree depth. Converting it would be churn without a defect behind it, so it is left alone deliberately rather than by omission.

Fixing only `_walk_type` would have left Java, Kotlin, C#, Ruby, PHP, Swift and Python call-extraction with the identical crash in the same module family. That is the half-implementation §15 forbids.

## Approach

Each walker keeps an explicit `list[tuple[Node, str]]` stack carrying the enclosing class scope, with descendants pushed **reversed** so they pop before the remaining siblings. That preserves depth-first pre-order, and with it the order of `defs` and the insertion order of `extract_calls_per_function`'s dict — which a naive breadth-first rewrite would silently change.

Control flow is preserved exactly, including two subtleties:

- In the JVM/clike/scripting walkers the recursive `return` sat *inside* `if name:`, so an unnamed type node fell through to the method check. The iterative form reproduces that with a `continue` inside `if name:`, and says so at the site.
- `_extract_swift_node` is `if/elif/else`, so a `_SWIFT_KIND_MAP` node never reaches the catch-all descent and an unnamed one descends nowhere. Preserved.

## Behaviour preservation

Unit tests are weak evidence for an order-preserving rewrite, so the primary evidence is a differential harness that runs the **old implementations from `HEAD`** and the new ones side by side over the same corpus and compares output, including dict key order.

```
ast_extractors (Python + JS):   1344 real files    0 mismatches
  compared: extract_calls_per_function (values AND key order),
            _walk_type over 4 node types

six language walkers:            885 sources       0 mismatches
  java 14 · kotlin 403 · c_sharp 9 · ruby 50 · php 7 · swift 402
  (403 Kotlin and 402 Swift are real files from this machine's corpus)
```

Files where the old code raised `RecursionError` were excluded from the comparison rather than counted as mismatches, since there is no old output to compare against.

## Tests

`tests_py/core/test_ast_extractor_depth.py` asserts the depth contract for all six language entry points plus `extract_calls_per_function`. `tests_py/core/test_ast_extractors.py::TestWalkType` covers `_walk_type` directly.

Each depth case asserts **two** properties, because either alone is insufficient:

1. the fixture's AST is genuinely deeper than `sys.getrecursionlimit()`, so a future parser change that flattens the tree cannot leave the test green while testing nothing;
2. the nesting sits where the walker actually descends.

Property 2 is not theoretical. My first version of this test was **vacuous for 8 of 9 cases**: the language walkers `return` at a method node without entering its body, so nesting inside a method body never reached the recursive path. It was caught only by running the new test against the pre-fix code and seeing just one case fail. Every fixture in the committed version was verified to raise `RecursionError` against the old implementation before being accepted.

```
pre-fix : 7 failed
post-fix: 7 passed
```

## Completion Ledger

| § | Item | Evidence |
|---|---|---|
| A1 | Happy paths | `pytest tests_py -k "ast or extractor or codebase"` → **1157 passed, 5968 deselected** |
| A2 | Edge cases | Unnamed type node (falls through, preserved + commented); node with no body; `_SWIFT_KIND_MAP` node that never reaches the catch-all; empty children; no-match search — `TestWalkType::test_returns_empty_when_nothing_matches`, `::test_includes_the_start_node_itself` |
| A3 | Failure paths | The failure path *is* the subject: `RecursionError` is no longer reachable by depth. Asserted by 7 cases that fail on pre-fix code. |
| A4 | Trust boundary | Input is untrusted third-party source. Depth is now bounded by heap, not by the C stack. |
| A5 | Invariants | Stated in each docstring: depth-first pre-order preserved; scope carried per node. Verified differentially over 2229 sources. |
| A6 | Idempotency | Pure functions over a parsed tree; no state. |
| B1–B3 | Concurrency | N/A — no concurrency touched; the walkers are pure and hold no shared state. |
| C1 | Scalability | Unchanged O(n) in node count. Heap allocation replaces stack frames; the stack holds at most the frontier, which is bounded by tree width. |
| C2 | Resource lifecycle | No handles, no allocation outside the local list. |
| C3 | Hot path | Not measured. The traversal is the same node count with the same per-node work; the change is where the frame lives. No regression claimed and none measured. |
| D1–D3 | Security | Removes an uncaught-exception denial path on adversarial input: one deeply nested file previously failed the whole repository's index run. No secrets, no injection surface. |
| E1 | API compatibility | All seven are module-private (`_`-prefixed) except through unchanged public entry points. No signature changed. |
| E2 | Downstream consumers | `extract_calls_per_function`, `extract_{java,kotlin,csharp,ruby,php,swift}_definitions`, and the `_walk_type` importers in four modules. All verified by the differential above, not by inspection. |
| E3 | Persisted data | None. |
| E4 | Cross-platform | Pure Python; no paths, encoding, or process spawning. |
| F1 | Signals | No new failure mode to signal. The removed one was an uncaught exception. |
| F2 | Degraded modes | None introduced. |
| G1 | Path→test ledger | 7 converted functions → 7 depth cases + 4 `TestWalkType` cases + the differential harness. |
| G2 | Regression test fails pre-fix | **Yes, quoted above: 7 failed pre-fix, 7 passed post-fix.** |
| G3 | Determinism | Suite re-run after formatting: 1157 passed both times. |
| G4 | Negative assertions | `test_returns_empty_when_nothing_matches`; the depth guard asserts the fixture is deeper than the limit, failing loudly if it stops being so. |
| G5 | Full gate | `ruff check .` → All checks passed! · `ruff format --check .` → 1275 files already formatted · `pyright mcp_server/` → **0 errors, 0 warnings, 0 informations** |
| H1 | Standards | No layer change; `core/` still imports only `shared/` + stdlib. Function sizes unchanged in order of magnitude and under the 40-line local cap. |
| H2 | Readability | Each converted walker's docstring states why it is iterative and what ordering guarantee the reversed push buys. |
| H3 | Conventions | Matches the module's existing style; one language per file. |
| H4 | CHANGELOG | See the entry in this PR. |
| H5 | Commit hygiene | Logic and formatting in the same commit is avoided: formatting was applied by `ruff format` to the touched files only. |
| H6 | CI green | To be confirmed on the pushed tree before merge. |
| H7 | Boy-scout (§14) | Sweep for the defect class run across all five extractor modules, not just the reported one; that is how the other six were found. Mutation survivors: see below. |

## Mutation (§12)

Scoped run over the five changed files, against HEAD as a paired control (same tool, same source scope):

| | mutants | killed | no tests | survived |
|---|---|---|---|---|
| HEAD | 1554 | 475 | 851 | 228 |
| this PR | 1486 | 571 | 492 | **423** |

The rise in `survived` is reclassification, not regression: the new depth tests execute walker code no test previously reached, so mutants moved from "never run" into "run but not detected". The comparable metric is **not-killed = survived + no tests**, and it improves in every converted function:

| function | HEAD | this PR |
|---|---|---|
| `_walk_for_calls` | 40 | 13 |
| `_walk_java` | 59 | 37 |
| `_walk_kotlin` | 77 | 54 |
| `_walk_csharp` | 59 | 36 |
| `_walk_ruby` | 53 | 33 |
| `_walk_php` | 61 | 51 |
| `_extract_swift_node` | 19 | 17 |
| `_walk_type` | 0 | 0 |
| **total** | **368** | **241** |

241 mutants remain unpinned in these walkers. That is inherited debt — the Java, Kotlin, C#, Ruby, PHP and Swift extractors have almost no behavioural tests — reduced 34% by this PR and not introduced by it, so per §12.5 it is not treated as a blocker here. **Filed as #369** with the reproduction command and acceptance criteria, per §14.3; not deferred as prose.

**A tooling defect found while doing this, also in #369.** `scripts/mutation_check.sh` printed `none — 0 surviving mutants 🎉` on this exact run while its own progress counter ended at `🙁 423`, and `mutmut results` returns a 915-line non-empty list. Its grep-based survivor detection produced a false green, and its cleanup trap deletes `mutants/` and `.mutmut-cache` on exit, so the discrepancy is uninvestigable after the fact. Every mutation number quoted above comes from a direct `mutmut run` + `mutmut results` with artifacts retained, not from the script's verdict. A mutation gate that can report a false clean is worse than no gate.
