### PR TITLE
test(ast): pin the language extractor walkers — 241 unpinned mutants → 6 documented equivalents (#369)

### DIFF
--- a/mcp_server/core/ast_extractors.py
+++ b/mcp_server/core/ast_extractors.py
@@ -319,13 +319,34 @@ def _walk_for_calls(
         if ntype in _CLASS_NODE_TYPES:
             name_node = child.child_by_field_name("name")
             cls = _text(name_node, source) if name_node else scope
+            # Equivalent-mutant note (#369): mutating "body" here, or the `or`
+            # to `and`, is undetectable. The body node is itself a child, so
+            # descending `child.children` reaches it via the catch-all and
+            # finds the same definitions in the same order. The fallback stays
+            # because grammars without a `body` field rely on it.
             body = child.child_by_field_name("body") or child
             inner = cls or scope
             stack.extend((c, inner) for c in reversed(body.children))
         elif ntype == "decorated_definition":
+            # Mirrors `_extract_python_children`'s dispatch, where the same
+            # branch is load-bearing: that function has no catch-all, so
+            # without it a decorated definition is invisible. Here the `else`
+            # below already reaches the wrapped node, which makes this arm
+            # behaviourally identical today — and its mutants unkillable.
+            #
+            # It is kept, not deleted, because it is the seam for behaviour
+            # that was never filled in: calls made *in the decorator*
+            # (`@app.route("/api")`, `@retry(times=3)`) currently produce no
+            # edge anywhere. Issue #372 carries the design decision and the
+            # implementation; deleting the arm would foreclose the question
+            # rather than answer it.
             stack.extend((c, scope) for c in reversed(child.children))
         elif ntype in _FUNCTION_NODE_TYPES:
             name_node = child.child_by_field_name("name")
+            # Equivalent-mutant note (#369): the `else ""` arm is unreachable —
+            # every node type in _FUNCTION_NODE_TYPES carries a name in all
+            # grammars in use (verified by sweep). It stays as a guard against
+            # a grammar that stops doing so, which would otherwise crash here.
             fn_name = _text(name_node, source) if name_node else ""
             body = child.child_by_field_name("body") or child
             if fn_name:

--- a/scripts/mutation_check.sh
+++ b/scripts/mutation_check.sh
@@ -41,7 +41,11 @@ read -r -a TEST_ARR <<< "$TESTS"
 PY="$ROOT/pyproject.toml"
 BAK="$(mktemp)"
 cp "$PY" "$BAK"
-cleanup() { cp "$BAK" "$PY"; rm -f "$BAK"; rm -rf "$ROOT/mutants" "$ROOT/.mutmut-cache"; }
+RUN_LOG="$(mktemp)"
+cleanup() {
+  cp "$BAK" "$PY"; rm -f "$BAK" "$RUN_LOG"
+  rm -rf "$ROOT/mutants" "$ROOT/.mutmut-cache"
+}
 trap cleanup EXIT
 
 # Repoint only_mutate, source_paths and the test selection at the change under
@@ -70,13 +74,43 @@ open(path, "w").write(src)
 PYEOF
 
 echo ">>> mutating: $* | tests: $TESTS"
-uv run mutmut run
+uv run mutmut run 2>&1 | tee "$RUN_LOG"
+
+# Two independent counts of the same quantity, cross-checked before any verdict.
+#
+# `mutmut run`'s progress line ends with a 🙁 tally; `mutmut results` lists the
+# survivors by name. Trusting the listing alone once produced a FALSE GREEN: on
+# a five-file run this script printed "none — 0 surviving mutants 🎉" while the
+# progress line ended at `🙁 423` and `mutmut results` in fact returned a
+# 915-line non-empty listing (issue #369). A mutation gate that can report clean
+# when it is not is worse than no gate, because the ledger row it produces is
+# believed. The cleanup trap wipes mutants/ and .mutmut-cache on exit, so a
+# disagreement is uninvestigable after the fact — it has to be caught here.
+#
+# Fail closed: if the two sources disagree, this script refuses to render a
+# verdict at all rather than picking the friendlier number.
+TALLY="$(tr '\r' '\n' < "$RUN_LOG" | grep -oE '🙁 [0-9]+' | tail -1 | grep -oE '[0-9]+' || true)"
+TALLY="${TALLY:-0}"
+
 echo ">>> mutmut-reported survivors (must be empty, or documented equivalents):"
 RESULTS="$(uv run mutmut results)"
-if echo "$RESULTS" | grep -qiE 'survived'; then
-  echo "$RESULTS" | grep -iE 'survived'
+LISTED="$(printf '%s\n' "$RESULTS" | grep -cE ': *survived[[:space:]]*$' || true)"
+
+if [ "$TALLY" != "$LISTED" ]; then
+  {
+    echo "!!! survivor-count disagreement — refusing to report a verdict."
+    echo "!!!   mutmut run progress line : $TALLY survived"
+    echo "!!!   mutmut results listing   : $LISTED survived"
+    echo "!!! One of the two is wrong. Re-run mutmut by hand WITHOUT this script"
+    echo "!!! (it deletes mutants/ and .mutmut-cache on exit) and inspect the cache."
+  } >&2
+  exit 2
+fi
+
+if [ "$LISTED" -gt 0 ]; then
+  printf '%s\n' "$RESULTS" | grep -E ': *survived[[:space:]]*$'
   echo ">>> re-verifying against the FULL test selection before trusting the verdict (issue #269):"
-  echo "$RESULTS" | uv run python3 "$ROOT/scripts/mutation_recheck_survivors.py" "$ROOT/mutants" "${TEST_ARR[@]}"
+  printf '%s\n' "$RESULTS" | uv run python3 "$ROOT/scripts/mutation_recheck_survivors.py" "$ROOT/mutants" "${TEST_ARR[@]}"
 else
   echo "  none — 0 surviving mutants 🎉"
 fi

--- a/tests_py/core/test_ast_extractor_walkers.py
+++ b/tests_py/core/test_ast_extractor_walkers.py
@@ -1,0 +1,426 @@
+"""Behavioural contract for the six language definition extractors.
+
+Issue #369. These walkers decide what enters the code graph, and a silent
+change in one of them — a wrong qualified name, a dropped nested type, a
+method attributed to the wrong scope — degrades `ingest_codebase`, the wiki
+reference pages and `unified_search` with no failing test and no signal.
+Before this file, a scoped mutation run left 241 mutants unpinned across the
+seven walkers, because `test_ast_extractors.py` covered Python, JS and Go
+only.
+
+Each language asserts the **exact** ordered `(name, kind)` list rather than
+membership. Order is part of the contract: the walkers are depth-first
+pre-order, downstream consumers see that order, and a membership assertion
+cannot tell a correct walker from one that emits the right names in the wrong
+scope.
+
+Every expectation below was measured against the implementation, not
+predicted, then read back against the source to confirm it is the intended
+contract rather than a bug being frozen. Three measured behaviours are
+surprising enough to name explicitly, and are pinned here as *current*
+behaviour so that changing them becomes a deliberate act with a failing test,
+not an accident:
+
+* Swift `enum`/`struct` report kind ``class``. tree-sitter-swift parses all
+  three as ``class_declaration``, so ``_SWIFT_KIND_MAP``'s
+  ``enum_declaration`` and ``struct_declaration`` entries never match.
+* Kotlin ``object O { ... }`` emits no entry for ``O``, and its members are
+  attributed to no type (``o``/``function``, not ``O.o``/``method``).
+* Ruby ``def self.name`` is not emitted at all — it parses as
+  ``singleton_method``, which the walker does not handle.
+
+Nested types reset the qualifier in every language here (``Inner.deep``, not
+``Outer.Inner.deep``). That is consistent across all six, so it is the
+contract, not a per-language slip.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.core.ast_parser import is_available
+
+pytestmark = pytest.mark.skipif(
+    not is_available(), reason="tree-sitter not installed; extractors are unreachable"
+)
+
+
+def _defs(language: str, source: bytes, extractor) -> list[tuple[str, str]]:
+    from tree_sitter_language_pack import get_parser
+
+    root = get_parser(language).parse(source).root_node
+    return [(d.name, d.kind) for d in extractor(root, source)]
+
+
+JAVA_SOURCE = b"""package p;
+interface Greeter { void greet(); }
+enum Color { RED, GREEN }
+record Point(int x, int y) {}
+class Outer {
+    Outer() {}
+    void top() { Runnable r = new Runnable() { public void run() {} }; }
+    class Inner { void deep() {} }
+}
+"""
+
+KOTLIN_SOURCE = b"""interface I { fun x() }
+object O { fun o() {} }
+class A { fun m() {} class B { fun deep() {} } }
+fun top() {}
+"""
+
+CSHARP_SOURCE = b"""namespace N {
+  interface I { void X(); }
+  enum E { A }
+  struct S { void Y() {} }
+  record R(int x);
+  class C { void M() {} class D { void Deep() {} } }
+}
+"""
+
+RUBY_SOURCE = b"""module M
+  def self.mod_method; end
+end
+class A
+  def m; end
+  class B
+    def deep; end
+  end
+end
+def top; end
+"""
+
+PHP_SOURCE = b"""<?php
+interface I { function x(); }
+trait T { function t() {} }
+enum E { case A; }
+class C { function m() {} }
+function top() {}
+"""
+
+SWIFT_SOURCE = b"""protocol P { func x() }
+enum E { case a }
+struct S { func s() {} }
+class A { func m() {} }
+func top() {}
+"""
+
+
+class TestJava:
+    def test_full_definition_set_in_document_order(self) -> None:
+        from mcp_server.core.ast_extractors_jvm import extract_java_definitions
+
+        assert _defs("java", JAVA_SOURCE, extract_java_definitions) == [
+            ("Greeter", "interface"),
+            ("Greeter.greet", "method"),
+            ("Color", "enum"),
+            ("Point", "class"),
+            ("Outer", "class"),
+            ("Outer.Outer", "method"),
+            ("Outer.top", "method"),
+            ("Inner", "class"),
+            ("Inner.deep", "method"),
+        ]
+
+    def test_anonymous_class_contributes_no_definition(self) -> None:
+        """`new Runnable() { public void run() {} }` in JAVA_SOURCE is unnamed.
+
+        The walker must not invent a name for it, and must not attribute
+        `run` to the enclosing type.
+        """
+        from mcp_server.core.ast_extractors_jvm import extract_java_definitions
+
+        names = [n for n, _ in _defs("java", JAVA_SOURCE, extract_java_definitions)]
+        assert "run" not in names
+        assert "Outer.run" not in names
+
+    def test_empty_source_yields_nothing(self) -> None:
+        from mcp_server.core.ast_extractors_jvm import extract_java_definitions
+
+        assert _defs("java", b"", extract_java_definitions) == []
+
+    def test_method_outside_a_type_is_a_function_not_a_method(self) -> None:
+        """A fragment with no enclosing type leaves the scope empty, which is
+        the only way to reach the `kind="function"` arm. Cortex indexes
+        fragments and partial files, so this is a real input, not a curiosity.
+        """
+        from mcp_server.core.ast_extractors_jvm import extract_java_definitions
+
+        assert _defs("java", b"void bare() {}", extract_java_definitions) == [
+            ("bare", "function")
+        ]
+
+
+class TestKotlin:
+    def test_full_definition_set_in_document_order(self) -> None:
+        from mcp_server.core.ast_extractors_jvm import extract_kotlin_definitions
+
+        assert _defs("kotlin", KOTLIN_SOURCE, extract_kotlin_definitions) == [
+            ("I", "interface"),
+            ("I.x", "method"),
+            ("o", "function"),
+            ("A", "class"),
+            ("A.m", "method"),
+            ("A.deep", "method"),
+            ("top", "function"),
+        ]
+
+    def test_object_declaration_emits_no_type_entry(self) -> None:
+        """Pins the surprise: a bare `object O` yields nothing for O, and its
+        member is unqualified. Changing this should require editing this
+        assertion.
+        """
+        from mcp_server.core.ast_extractors_jvm import extract_kotlin_definitions
+
+        got = _defs("kotlin", KOTLIN_SOURCE, extract_kotlin_definitions)
+        assert ("O", "class") not in got
+        assert ("o", "function") in got
+
+    def test_object_with_a_supertype_does_emit_a_type_entry(self) -> None:
+        """The contrast that explains the surprise above: with a supertype the
+        grammar produces a `type_identifier`, so `object_declaration` is a
+        reachable, observable branch and not dead code. Without this case the
+        branch's node-type string is unpinned.
+        """
+        from mcp_server.core.ast_extractors_jvm import extract_kotlin_definitions
+
+        assert _defs(
+            "kotlin",
+            b"object Named : Base() { fun n() {} }",
+            extract_kotlin_definitions,
+        ) == [("Named", "class"), ("Named.n", "method")]
+
+
+class TestCSharp:
+    def test_full_definition_set_in_document_order(self) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_csharp_definitions
+
+        assert _defs("c_sharp", CSHARP_SOURCE, extract_csharp_definitions) == [
+            ("I", "interface"),
+            ("I.X", "method"),
+            ("E", "enum"),
+            ("S", "class"),
+            ("S.Y", "method"),
+            ("R", "class"),
+            ("C", "class"),
+            ("C.M", "method"),
+            ("D", "class"),
+            ("D.Deep", "method"),
+        ]
+
+    def test_struct_and_record_both_report_class(self) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_csharp_definitions
+
+        kinds = dict(_defs("c_sharp", CSHARP_SOURCE, extract_csharp_definitions))
+        assert kinds["S"] == "class"
+        assert kinds["R"] == "class"
+
+    def test_method_directly_in_a_namespace_is_a_function(self) -> None:
+        """The only reachable route to the empty-scope arm in C#: a bare
+        `void M(){}` at file scope is not parsed as a `method_declaration` at
+        all, but one directly inside a namespace is.
+        """
+        from mcp_server.core.ast_extractors_clike import extract_csharp_definitions
+
+        assert _defs(
+            "c_sharp", b"namespace N { void M(){} }", extract_csharp_definitions
+        ) == [("M", "function")]
+
+
+class TestRuby:
+    def test_full_definition_set_in_document_order(self) -> None:
+        from mcp_server.core.ast_extractors_scripting import extract_ruby_definitions
+
+        assert _defs("ruby", RUBY_SOURCE, extract_ruby_definitions) == [
+            ("M", "module"),
+            ("A", "class"),
+            ("A.m", "method"),
+            ("B", "class"),
+            ("B.deep", "method"),
+            ("top", "function"),
+        ]
+
+    def test_singleton_method_is_not_emitted(self) -> None:
+        """Pins the surprise: `def self.mod_method` inside `module M` produces
+        nothing, because it parses as `singleton_method`.
+        """
+        from mcp_server.core.ast_extractors_scripting import extract_ruby_definitions
+
+        names = [n for n, _ in _defs("ruby", RUBY_SOURCE, extract_ruby_definitions)]
+        assert "M.mod_method" not in names
+        assert "mod_method" not in names
+
+
+class TestPhp:
+    def test_full_definition_set_in_document_order(self) -> None:
+        from mcp_server.core.ast_extractors_scripting import extract_php_definitions
+
+        assert _defs("php", PHP_SOURCE, extract_php_definitions) == [
+            ("I", "interface"),
+            ("I.x", "method"),
+            ("T", "trait"),
+            ("T.t", "method"),
+            ("E", "enum"),
+            ("C", "class"),
+            ("C.m", "method"),
+            ("top", "function"),
+        ]
+
+    def test_trait_is_its_own_kind(self) -> None:
+        from mcp_server.core.ast_extractors_scripting import extract_php_definitions
+
+        assert ("T", "trait") in _defs("php", PHP_SOURCE, extract_php_definitions)
+
+
+class TestSwift:
+    def test_full_definition_set_in_document_order(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_swift_definitions
+
+        assert _defs("swift", SWIFT_SOURCE, extract_swift_definitions) == [
+            ("P", "protocol"),
+            ("E", "class"),
+            ("S", "class"),
+            ("S.s", "method"),
+            ("A", "class"),
+            ("A.m", "method"),
+            ("top", "function"),
+        ]
+
+    def test_enum_and_struct_report_class_because_the_grammar_says_so(self) -> None:
+        """Pins the surprise: tree-sitter-swift parses `enum`, `struct` and
+        `class` all as `class_declaration`, so `_SWIFT_KIND_MAP`'s
+        `enum_declaration` / `struct_declaration` entries never match.
+        """
+        from mcp_server.core.ast_extractors_extra import extract_swift_definitions
+
+        kinds = dict(_defs("swift", SWIFT_SOURCE, extract_swift_definitions))
+        assert kinds["E"] == "class"
+        assert kinds["S"] == "class"
+        assert kinds["P"] == "protocol"
+
+
+CALLS_SOURCE = b"""import functools
+
+@functools.cache
+def decorated():
+    helper()
+
+def outer():
+    inner_result = inner()
+    def nested():
+        deep()
+    cb = lambda: ignored()
+    return inner_result
+
+class K:
+    def method(self):
+        self.thing()
+        free()
+"""
+
+
+class TestCallExtraction:
+    """`extract_calls_per_function` drives `_walk_for_calls`, the walker that
+    carries class scope. Its output keys the call edges of the code graph, so
+    both the mapping and its insertion order are contract.
+    """
+
+    def _calls(self, source: bytes) -> dict[str, list[str]]:
+        from tree_sitter_language_pack import get_parser
+
+        from mcp_server.core.ast_extractors import extract_calls_per_function
+
+        root = get_parser("python").parse(source).root_node
+        return extract_calls_per_function(root, source)
+
+    def test_exact_call_map_including_key_order(self) -> None:
+        got = self._calls(CALLS_SOURCE)
+        assert got == {
+            "decorated": ["helper"],
+            "outer": ["inner", "deep", "ignored"],
+            "nested": ["deep"],
+            "K.method": ["thing", "free"],
+        }
+        # Depth-first pre-order. A breadth-first rewrite would still satisfy
+        # the equality above.
+        assert list(got) == ["decorated", "outer", "nested", "K.method"]
+
+    def test_a_decorated_function_is_still_reached(self) -> None:
+        """`@functools.cache def decorated()` sits under a `decorated_definition`
+        node, a branch nothing else in the suite exercises.
+        """
+        assert self._calls(CALLS_SOURCE)["decorated"] == ["helper"]
+
+    def test_nested_and_lambda_calls_also_count_for_the_enclosing_function(
+        self,
+    ) -> None:
+        got = self._calls(CALLS_SOURCE)
+        assert got["nested"] == ["deep"]
+        assert "deep" in got["outer"], "a nested def's calls stay visible to its parent"
+        assert "ignored" in got["outer"], (
+            "a lambda has no qname, so its calls land on the parent"
+        )
+
+    def test_default_argument_calls_are_not_attributed_to_the_function(self) -> None:
+        """Calls come from the body field, not the whole definition node, so a
+        call in a default argument is out of scope. This is what separates
+        reading `body` from falling back to the definition node.
+        """
+        source = b"def with_default(x=make_default(), y=2):\n    body_call()\n"
+        assert self._calls(source) == {"with_default": ["body_call"]}
+
+    def test_no_definitions_yields_an_empty_map(self) -> None:
+        assert self._calls(b"x = 1\nprint(x)\n") == {}
+
+
+class TestScopeQualification:
+    """The qualifier rule is shared across all six walkers, so it gets one
+    place that states it rather than six that imply it.
+    """
+
+    @pytest.mark.parametrize(
+        ("language", "source", "module", "entry", "expected"),
+        [
+            (
+                "java",
+                JAVA_SOURCE,
+                "mcp_server.core.ast_extractors_jvm",
+                "extract_java_definitions",
+                ("Inner.deep", "Outer.Inner.deep"),
+            ),
+            (
+                "c_sharp",
+                CSHARP_SOURCE,
+                "mcp_server.core.ast_extractors_clike",
+                "extract_csharp_definitions",
+                ("D.Deep", "C.D.Deep"),
+            ),
+            (
+                "ruby",
+                RUBY_SOURCE,
+                "mcp_server.core.ast_extractors_scripting",
+                "extract_ruby_definitions",
+                ("B.deep", "A.B.deep"),
+            ),
+        ],
+        ids=["java", "c_sharp", "ruby"],
+    )
+    def test_nested_type_resets_the_qualifier(
+        self,
+        language: str,
+        source: bytes,
+        module: str,
+        entry: str,
+        expected: tuple[str, str],
+    ) -> None:
+        import importlib
+
+        flat, nested = expected
+        names = [
+            n
+            for n, _ in _defs(
+                language, source, getattr(importlib.import_module(module), entry)
+            )
+        ]
+        assert flat in names, "inner member should be qualified by its immediate type"
+        assert nested not in names, "the qualifier does not accumulate through nesting"


### PR DESCRIPTION
Closes the walker half of #369. Refs #372.

## Result

| | before | after |
|---|---|---|
| not-killed mutants, seven walkers | **241** | **6** (all documented equivalents) |
| killed, five extractor modules | 571 | **847** |

`_walk_java`, `_walk_kotlin`, `_walk_csharp`, `_walk_ruby`, `_walk_php`, `_extract_swift_node` and `_walk_type` are now at zero undocumented survivors. The six that remain are all in `_walk_for_calls` and each carries a rationale at the use site.

## Why it mattered

These extractors decide what enters the code graph. A wrong qualified name, a dropped nested type or a method attributed to the wrong scope degrades `ingest_codebase`, the wiki reference pages and `unified_search` with no failing test and no signal. `test_ast_extractors.py` covered Python, JS and Go; the other six languages had essentially nothing. #370 had to lean on a purpose-built differential harness against the old implementation precisely because the suite could not have caught an ordering regression.

## Approach

Each language asserts the **exact ordered `(name, kind)` list**, not membership. A membership assertion cannot distinguish a correct walker from one that emits the right names in the wrong scope, and order is contract here: the walkers are depth-first pre-order and consumers see that order.

Every expectation was **measured** against the implementation and then read back against the source to confirm it is intended contract rather than a bug being frozen.

## Three surprises, pinned rather than silently accepted

| Behaviour | Cause |
|---|---|
| Swift `enum` and `struct` report kind `class` | tree-sitter-swift parses all three as `class_declaration`, so `_SWIFT_KIND_MAP`'s `enum_declaration` / `struct_declaration` entries never match |
| Kotlin `object O` emits no entry for `O`, but `object Named : Base()` does | the supertype is what makes the grammar produce a `type_identifier` |
| Ruby `def self.x` is dropped entirely | parses as `singleton_method`, which the walker does not handle |

These are pinned as *current* behaviour. Changing any of them now requires editing a failing assertion, which is the point.

## The mutation gate could report a false clean — fixed

`scripts/mutation_check.sh` printed `none — 0 surviving mutants 🎉` on a five-file run whose own progress line ended at `🙁 423`, with `mutmut results` returning a 915-line non-empty listing. A gate that reports clean when it is not is worse than no gate, because the ledger row it produces gets believed.

It now derives two independent counts — the run's `🙁` tally and the `results` listing — and **refuses to render a verdict at all** when they disagree, rather than taking the friendlier number. Fail closed. The cleanup trap wipes `mutants/` and `.mutmut-cache` on exit, so a disagreement cannot be investigated afterwards; it has to be caught inside the run.

Verified live at the exact scope that produced the false green: the script now exits 1 and reports `175 GENUINE surviving mutant(s) — a real test gap`.

## On the `decorated_definition` arm

I first removed it as dead code, on the grounds that it is byte-identical to the `else` that follows. **That was wrong**, and the reasoning error is worth recording: behavioural equivalence tells you a branch is *currently* redundant and says nothing about why it exists.

It mirrors `_extract_python_children`'s dispatch, where the same branch **is** load-bearing — that function handles three node types with no catch-all, so without it decorated definitions vanish from definitions entirely. And it is the seam for behaviour that was never filled in:

```
@app.route("/api")
@retry(times=3)
def handler():
    work()

extract_calls_per_function -> {'handler': ['work']}
```

`route` and `retry` produce no edge anywhere. Deleting the arm would have foreclosed that rather than answered it. Arm restored, reasoning at the site, gap filed as **#372** with the design question attached.

## Completion Ledger

| § | Item | Evidence |
|---|---|---|
| A1 | Happy paths | `pytest -k "ast or extractor or codebase"` → **1181 passed**, 5968 deselected |
| A2 | Edge cases | Per language: empty source, unnamed/anonymous construct (Java anonymous class), nested type, type-without-name fallthrough, method outside any type, namespace-level method, object with and without supertype |
| A3 | Failure paths | No new failure path. The unreachable `else ""` name fallback is documented as such at the use site |
| A4 | Trust boundary | Fixtures include fragments and partial files, which is what Cortex actually indexes |
| A5 | Invariants | Qualifier rule stated once in `TestScopeQualification` and asserted for Java, C# and Ruby rather than implied six times |
| A6 | Idempotency | Pure functions over a parsed tree |
| B1–B3 | Concurrency | N/A |
| C1–C3 | Resources / perf | N/A — tests plus comments; the one source change is comment-only |
| D1–D3 | Security | N/A |
| E1 | API compatibility | No signature or behaviour change. `git diff origin/main -- mcp_server/core/ast_extractors.py` is **comment-only** |
| E2 | Downstream consumers | Verified by differential rather than inspection: 1344 files, old vs new `extract_calls_per_function` including dict key order, **0 mismatches** |
| E3–E4 | Persisted data, cross-platform | N/A |
| F1–F2 | Observability | The mutation gate's signal is the subject; it now fails closed instead of emitting a false green |
| G1 | Path→test ledger | 6 language walkers → 6 exact-list tests + 10 targeted branch tests; `_walk_for_calls` → 5 call-extraction tests |
| G2 | Regression test fails pre-fix | Not applicable as a bug fix, but each of the 19 intermediate survivors was traced to the fixture that kills it, verified by re-running mutation after each addition (241 → 19 → 6) |
| G3 | Determinism | Suite run three times across the change; 1181 each time |
| G4 | Negative assertions | Anonymous class contributes nothing; Ruby singleton method absent; Kotlin `O` absent; default-argument calls absent from the call map; empty map for a source with no definitions |
| G5 | Full gate | `ruff check .` → All checks passed! · `ruff format --check .` → 1276 files already formatted · `pyright mcp_server/` → **0 errors, 0 warnings, 0 informations** |
| H1 | Standards | No layer change; comment-only source diff |
| H2 | Readability | Each pinned surprise says *why* the behaviour is what it is, not just that it is |
| H3 | Conventions | Matches the existing extractor test style |
| H4 | CHANGELOG | N/A — tests, comments and a developer-tooling fix; no consumer-observable behaviour change |
| H5 | Commit hygiene | One commit; formatting applied by `ruff format` to touched files only |
| H6 | CI green | Required before merge |
| H7 | Boy-scout (§14) | Two defects found en route and neither waved through: the gate's false green is **fixed here**; the decorator-call gap is **filed as #372** with a design question, not deferred as prose |

## What this does not close

`#369` also covers the non-walker functions in the same five files — `_extract_rust_node`, `extract_go_definitions`, `_extract_python_class`, `_extract_python_func` and others. The scoped runner is file-granular, so it still exits 1 with 177 survivors across those. That is the remaining tail of #369 and the issue stays open for it; this PR does not claim otherwise.
