### PR TITLE
test(ast): pin the remaining extractor surface — 639 unpinned → 51 classified equivalents, 0 uncovered (#369)

### DIFF
--- a/mcp_server/core/ast_extractors.py
+++ b/mcp_server/core/ast_extractors.py
@@ -105,7 +105,13 @@ def _extract_python_func(
     defs: list[SymbolDef],
     parent: str,
 ) -> None:
-    """Extract a single Python function definition."""
+    """Extract a single Python function definition.
+
+    Equivalent-mutant note (#369): a `function_definition` node always carries
+    both a `name` and a `parameters` child, so the two `else ""` fallbacks here
+    are unreachable. They are guards against a grammar that stops guaranteeing
+    it, not live branches.
+    """
     name_node = node.child_by_field_name("name")
     params_node = node.child_by_field_name("parameters")
     name = _text(name_node, source) if name_node else ""
@@ -132,7 +138,13 @@ def _extract_python_class(
     source: bytes,
     defs: list[SymbolDef],
 ) -> None:
-    """Extract a class and recurse into its body for methods."""
+    """Extract a class and recurse into its body for methods.
+
+    Equivalent-mutant note (#369): a `class_definition` always carries a
+    `name`, so that `else ""` is unreachable. The `superclasses` fallback is
+    NOT — `class C: pass` has no base list — and is pinned in
+    `test_ast_extractor_edges.py::TestSignatureTruncation`.
+    """
     name_node = node.child_by_field_name("name")
     superclass_node = node.child_by_field_name("superclasses")
     cls_name = _text(name_node, source) if name_node else ""
@@ -171,7 +183,22 @@ def _extract_js_node(
     defs: list[SymbolDef],
     parent: str,
 ) -> None:
-    """Recursively extract JS definitions with scope tracking."""
+    """Recursively extract JS definitions with scope tracking.
+
+    Equivalent-mutant notes (#369), all turning on which callers supply a
+    non-empty `parent`:
+
+    * `parent` is `""` at both entry points here (`extract_js_definitions` and
+      the `export_statement` recursion) and is only non-empty when
+      `_extract_js_class` recurses into a class body. Passing `None` instead of
+      `""` is therefore unobservable — every use is a truthiness test.
+    * `method_definition` is only reached from that class-body recursion, so
+      `parent` is always set when the arm below runs and its `else` branch is
+      unreachable. Mutating the arguments inside it cannot be detected.
+    * `"function"` is a legacy tree-sitter node type. The current grammar emits
+      `function_expression` for anonymous function expressions, so nothing
+      reaches the second entry of the tuple. Kept for grammar compatibility.
+    """
     if node.type in ("function_declaration", "function"):
         _extract_js_func(node, source, defs, parent)
     elif node.type == "class_declaration":
@@ -264,7 +291,14 @@ def _callee_basename(call_node: Node, source: bytes) -> str:
 
     Strategy: take the dotted/attribute chain's last segment and strip
     anything after the first ``(``, ``[``, or ``<`` (generics, subscripts,
-    argument lists that slip into tree-sitter's surface text)."""
+    argument lists that slip into tree-sitter's surface text).
+
+    Equivalent-mutant note (#369): the `1` in both splits is unobservable.
+    `rsplit(sep, n)[-1]` is the text after the last separator for every n, and
+    `split(sep, n)[0]` is the text before the first separator for every n. Only
+    the *direction* matters, and that is pinned — see
+    `test_ast_extractor_edges.py::TestCalleeBasenameEdges`.
+    """
     fn_ref = call_node.child_by_field_name("function")
     if fn_ref is None:
         return ""

--- a/mcp_server/core/ast_extractors_clike.py
+++ b/mcp_server/core/ast_extractors_clike.py
@@ -33,7 +33,19 @@ def extract_c_imports(root: Node, source: bytes) -> list[ImportInfo]:
 
 
 def _declarator_name(declarator: Node | None, source: bytes) -> str:
-    """Unwrap nested C/C++ declarators down to the identifier."""
+    """Unwrap nested C/C++ declarators down to the identifier.
+
+    Equivalent-mutant note (#369): the two checks below have identical bodies,
+    so which tuple a node type sits in is not observable, and mutating a type
+    string only changes behaviour if that type is the *terminal* declarator of
+    a `function_definition`. In practice the chain terminates at `identifier`
+    (free functions) or `qualified_identifier` (out-of-line members, including
+    `C::~C`), so the remaining four names are carried for grammars and forms
+    that do not currently reach here. They are kept rather than pruned because
+    the split reads as a deliberate plain-vs-qualified distinction that a
+    future caller may need to act on differently — the same judgement as the
+    `decorated_definition` arm in `ast_extractors._walk_for_calls`.
+    """
     node = declarator
     while node is not None:
         if node.type in ("identifier", "field_identifier", "type_identifier"):

--- a/mcp_server/core/ast_extractors_extra.py
+++ b/mcp_server/core/ast_extractors_extra.py
@@ -29,7 +29,17 @@ def extract_go_imports(root: Node, source: bytes) -> list[ImportInfo]:
 
 
 def extract_go_definitions(root: Node, source: bytes) -> list[SymbolDef]:
-    """Extract Go func, type, and method definitions."""
+    """Extract Go func, type, and method definitions.
+
+    Equivalent-mutant notes (#369): a Go `function_declaration` always carries
+    a `parameters` node — `func F()` still has an empty one — so the `else ""`
+    signature fallback is unreachable. Likewise a `method_declaration` always
+    carries a receiver, and a receiver always contains a `type_identifier`, so
+    `_extract_go_receiver` never returns `""` from this call site and the
+    unqualified `else` branch below is unreachable. Both fallbacks are kept as
+    guards; the reachable behaviour is pinned in
+    `test_ast_extractor_definitions.py::TestGoDefinitions`.
+    """
     defs: list[SymbolDef] = []
     for node in root.children:
         if node.type == "function_declaration":

--- a/tests_py/core/test_ast_extractor_definitions.py
+++ b/tests_py/core/test_ast_extractor_definitions.py
@@ -1,0 +1,369 @@
+"""Behavioural contract for the remaining definition extractors (issue #369).
+
+Companion to `test_ast_extractor_walkers.py`, which covered the six
+scope-tracking walkers. This file covers what was left: C, C++, Go, Rust,
+Python and JS/TS definition extraction, plus the callee-basename resolution
+that turns a call node into a graph edge.
+
+Same discipline as the walker file: assert the **exact ordered** result, and
+measure the expectation against the implementation before asserting it rather
+than predicting it. Order matters — several of these extractors run separate
+passes per node type, so the output is not source order and a consumer reading
+it positionally depends on the pass order.
+
+Rough edges are pinned as current behaviour with the cause named, not quietly
+frozen. Where one looks like a defect, it says so.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.core.ast_parser import is_available
+
+pytestmark = pytest.mark.skipif(
+    not is_available(), reason="tree-sitter not installed; extractors are unreachable"
+)
+
+
+def _defs(language: str, source: bytes, extractor) -> list[tuple[str, str]]:
+    from tree_sitter_language_pack import get_parser
+
+    root = get_parser(language).parse(source).root_node
+    return [(d.name, d.kind) for d in extractor(root, source)]
+
+
+def _sigs(language: str, source: bytes, extractor) -> dict[str, str]:
+    from tree_sitter_language_pack import get_parser
+
+    root = get_parser(language).parse(source).root_node
+    return {d.name: getattr(d, "signature", "") for d in extractor(root, source)}
+
+
+class TestCDefinitions:
+    SOURCE = (
+        b"#include <s.h>\n"
+        b"struct P { int x; };\n"
+        b"typedef struct P Point;\n"
+        b"int add(int a, int b) { return a+b; }\n"
+        b"static void helper(void) {}\n"
+    )
+
+    def test_exact_definition_list_functions_then_types(self) -> None:
+        """Not source order: `extract_c_definitions` runs one `_walk_type` pass
+        per node kind, so every function precedes every struct and typedef.
+        """
+        from mcp_server.core.ast_extractors_clike import extract_c_definitions
+
+        assert _defs("c", self.SOURCE, extract_c_definitions) == [
+            ("add", "function"),
+            ("helper", "function"),
+            ("P", "class"),
+            ("P", "class"),
+            ("Point", "type"),
+        ]
+
+    def test_a_struct_named_in_a_typedef_is_emitted_twice(self) -> None:
+        """Rough edge, pinned. `struct P {...};` and `typedef struct P Point;`
+        each contain a `struct_specifier`, and both passes emit it, so `P`
+        appears twice with no deduplication. A consumer counting definitions
+        over-counts, and a symbol table keyed by name silently collapses them.
+        """
+        from mcp_server.core.ast_extractors_clike import extract_c_definitions
+
+        names = [n for n, _ in _defs("c", self.SOURCE, extract_c_definitions)]
+        assert names.count("P") == 2
+
+    def test_struct_alone_is_emitted_once(self) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_c_definitions
+
+        assert _defs("c", b"struct P { int x; };\n", extract_c_definitions) == [
+            ("P", "class")
+        ]
+
+
+class TestCppDefinitions:
+    SOURCE = (
+        b"namespace ns { class C { public: void m(); }; struct S {}; }\n"
+        b"void ns::C::m() {}\n"
+        b"int free_fn(int a) { return a; }\n"
+        b"using namespace std;\n"
+    )
+
+    def test_exact_definition_list(self) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_cpp_definitions
+
+        assert _defs("cpp", self.SOURCE, extract_cpp_definitions) == [
+            ("C", "class"),
+            ("ns", "namespace"),
+            ("ns::C::m", "method"),
+            ("free_fn", "function"),
+        ]
+
+    def test_a_struct_inside_a_namespace_is_not_emitted(self) -> None:
+        """Rough edge, pinned: C++ extraction looks for `class_specifier`, so
+        `struct S {}` produces nothing — unlike the C extractor, which does
+        pick struct up. Same keyword, two different answers per language.
+        """
+        from mcp_server.core.ast_extractors_clike import extract_cpp_definitions
+
+        assert "S" not in [
+            n for n, _ in _defs("cpp", self.SOURCE, extract_cpp_definitions)
+        ]
+
+    def test_out_of_line_member_definition_keeps_its_qualified_name(self) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_cpp_definitions
+
+        assert ("ns::C::m", "method") in _defs(
+            "cpp", self.SOURCE, extract_cpp_definitions
+        )
+
+
+class TestGoDefinitions:
+    SOURCE = (
+        b"package main\n"
+        b"type Server struct { port int }\n"
+        b"type Handler interface { Serve() }\n"
+        b"func (s *Server) Start() error { return nil }\n"
+        b"func (s Server) Stop() {}\n"
+        b"func New(p int) *Server { return nil }\n"
+    )
+
+    def test_exact_definition_list(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_go_definitions
+
+        assert _defs("go", self.SOURCE, extract_go_definitions) == [
+            ("Server", "struct"),
+            ("Handler", "interface"),
+            ("Server.Start", "method"),
+            ("Server.Stop", "method"),
+            ("New", "function"),
+        ]
+
+    def test_pointer_and_value_receivers_qualify_identically(self) -> None:
+        """`*Server` and `Server` both yield `Server.` — the star is stripped,
+        so the two receiver forms do not fragment the symbol table.
+        """
+        from mcp_server.core.ast_extractors_extra import extract_go_definitions
+
+        names = [n for n, _ in _defs("go", self.SOURCE, extract_go_definitions)]
+        assert "Server.Start" in names and "Server.Stop" in names
+
+    def test_function_signature_is_captured(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_go_definitions
+
+        assert _sigs("go", self.SOURCE, extract_go_definitions)["New"] == "(p int)"
+
+
+class TestRustDefinitions:
+    SOURCE = (
+        b"pub struct S { x: i32 }\n"
+        b"enum E { A, B }\n"
+        b"trait T { fn t(&self); }\n"
+        b"impl S { pub fn new() -> Self { S{x:0} } fn helper(&self) {} }\n"
+        b"impl T for S { fn t(&self) {} }\n"
+        b"fn free() {}\n"
+        b"mod m { fn inner() {} }\n"
+    )
+
+    def test_exact_definition_list(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_rust_definitions
+
+        assert _defs("rust", self.SOURCE, extract_rust_definitions) == [
+            ("S", "class"),
+            ("E", "enum"),
+            ("T", "trait"),
+            ("S.new", "method"),
+            ("S.helper", "method"),
+            ("S.t", "method"),
+            ("free", "function"),
+        ]
+
+    def test_inherent_and_trait_impl_methods_both_qualify_by_the_type(self) -> None:
+        """`impl S` and `impl T for S` both attribute to `S`, so a trait
+        implementation is not lost and not filed under the trait.
+        """
+        from mcp_server.core.ast_extractors_extra import extract_rust_definitions
+
+        names = [n for n, _ in _defs("rust", self.SOURCE, extract_rust_definitions)]
+        assert "S.new" in names and "S.t" in names
+        assert "T.t" not in names
+
+    def test_functions_inside_a_module_block_are_dropped(self) -> None:
+        """Rough edge, pinned: `mod m { fn inner() {} }` yields nothing for
+        `inner`. Rust codebases that group code in inline modules lose those
+        definitions entirely.
+        """
+        from mcp_server.core.ast_extractors_extra import extract_rust_definitions
+
+        names = [n for n, _ in _defs("rust", self.SOURCE, extract_rust_definitions)]
+        assert "inner" not in names
+        assert "m.inner" not in names
+
+
+class TestPythonDefinitions:
+    SOURCE = (
+        b"@deco\n"
+        b"class C(Base):\n"
+        b"    @property\n"
+        b"    def p(self): pass\n"
+        b"    async def a(self): pass\n"
+        b"async def top(): pass\n"
+        b"@wrap\n"
+        b"def decorated(x=1): pass\n"
+    )
+
+    def test_exact_definition_list(self) -> None:
+        from mcp_server.core.ast_extractors import extract_python_definitions
+
+        assert _defs("python", self.SOURCE, extract_python_definitions) == [
+            ("C", "class"),
+            ("C.p", "method"),
+            ("C.a", "method"),
+            ("top", "function"),
+            ("decorated", "function"),
+        ]
+
+    def test_decorated_class_and_decorated_function_are_both_unwrapped(self) -> None:
+        """`_extract_python_children` has no catch-all, so a decorated
+        definition is only reached by its dedicated arm. Both `@deco class C`
+        and `@wrap def decorated` depend on it.
+        """
+        from mcp_server.core.ast_extractors import extract_python_definitions
+
+        names = [n for n, _ in _defs("python", self.SOURCE, extract_python_definitions)]
+        assert "C" in names and "decorated" in names
+
+    def test_async_def_is_a_definition_like_any_other(self) -> None:
+        from mcp_server.core.ast_extractors import extract_python_definitions
+
+        assert ("top", "function") in _defs(
+            "python", self.SOURCE, extract_python_definitions
+        )
+
+    def test_signatures_carry_parameters_and_superclasses(self) -> None:
+        from mcp_server.core.ast_extractors import extract_python_definitions
+
+        sigs = _sigs("python", self.SOURCE, extract_python_definitions)
+        assert sigs["C"] == "(Base)"
+        assert sigs["decorated"] == "(x=1)"
+        assert sigs["C.p"] == "(self)"
+
+
+class TestJsDefinitions:
+    SOURCE = (
+        b"export class R { get(p){} static s(){} }\n"
+        b"export interface I { k: string }\n"
+        b"export type T = { v: boolean };\n"
+        b"export function f(a){}\n"
+        b"function g(){}\n"
+    )
+
+    def test_exact_definition_list(self) -> None:
+        from mcp_server.core.ast_extractors import extract_js_definitions
+
+        assert _defs("typescript", self.SOURCE, extract_js_definitions) == [
+            ("R", "class"),
+            ("R.get", "method"),
+            ("R.s", "method"),
+            ("I", "interface"),
+            ("T", "type"),
+            ("f", "function"),
+            ("g", "function"),
+        ]
+
+    def test_export_wrapper_is_transparent(self) -> None:
+        """`_extract_js_node` descends `export_statement` explicitly. Without
+        that arm every exported definition — the majority of a TS codebase —
+        would be invisible.
+        """
+        from mcp_server.core.ast_extractors import extract_js_definitions
+
+        assert _defs(
+            "typescript", b"export function only(){}\n", extract_js_definitions
+        ) == [("only", "function")]
+
+    def test_static_and_instance_methods_qualify_identically(self) -> None:
+        from mcp_server.core.ast_extractors import extract_js_definitions
+
+        names = [n for n, _ in _defs("typescript", self.SOURCE, extract_js_definitions)]
+        assert "R.get" in names and "R.s" in names
+
+
+class TestCalleeBasename:
+    """`_callee_basename` turns a call node into the name the resolver looks
+    up. Every call edge in the graph goes through it.
+    """
+
+    def _calls(self, language: str, source: bytes) -> dict[str, list[str]]:
+        from tree_sitter_language_pack import get_parser
+
+        from mcp_server.core.ast_extractors import extract_calls_per_function
+
+        root = get_parser(language).parse(source).root_node
+        return extract_calls_per_function(root, source)
+
+    SOURCE = (
+        b"def f():\n"
+        b"    plain()\n"
+        b"    obj.attr_call()\n"
+        b"    a.b.c.deep()\n"
+        b'    d["k"].sub()\n'
+        b"    (lambda: 1)()\n"
+        b"    Klass()\n"
+        b"    self.method()\n"
+        b"    plain()\n"
+    )
+
+    def test_basename_resolution_across_callee_shapes(self) -> None:
+        """Attribute, chained-attribute and subscript callees all reduce to the
+        final name. An immediately-invoked lambda has no name and contributes
+        nothing. The repeated `plain()` appears once — the list is deduped and
+        order-preserving.
+        """
+        assert self._calls("python", self.SOURCE) == {
+            "f": ["plain", "attr_call", "deep", "sub", "Klass", "method"]
+        }
+
+    def test_javascript_new_expression_is_not_a_call(self) -> None:
+        """Rough edge, pinned: `new Klass()` is a `new_expression`, which is
+        not in `_CALL_NODE_TYPES`, so construction produces no edge.
+        """
+        source = b"function f() { plain(); obj.attr(); a.b.c.deep(); new Klass(); }\n"
+        assert self._calls("javascript", source) == {"f": ["plain", "attr", "deep"]}
+
+    def test_absurdly_long_callee_names_are_dropped(self) -> None:
+        """`_MAX_CALL_NAME_LEN` is a sanity cap: a callee name at or beyond it
+        is noise, not a symbol. Pins the constant so a silent bump is visible.
+        """
+        source = b"def f():\n    " + b"x" * 150 + b"()\n"
+        assert self._calls("python", source) == {"f": []}
+
+    def test_a_name_just_under_the_cap_is_kept(self) -> None:
+        name = b"y" * 99
+        source = b"def f():\n    " + name + b"()\n"
+        assert self._calls("python", source) == {"f": [name.decode()]}
+
+
+class TestCppDeclaratorName:
+    """`_declarator_name` resolves the name out of a C++ declarator. Its two
+    node-type tuples cover the plain and the qualified/special forms, and a
+    simple `void f()` fixture only ever reaches the first entry of the first
+    tuple.
+    """
+
+    def test_an_out_of_line_destructor_keeps_its_qualified_name(self) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_cpp_definitions
+
+        source = b"class C { public: ~C(); };\nC::~C() {}\n"
+        assert _defs("cpp", source, extract_cpp_definitions) == [
+            ("C", "class"),
+            ("C::~C", "method"),
+        ]
+
+    def test_a_plain_free_function_uses_the_identifier_form(self) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_cpp_definitions
+
+        assert _defs(
+            "cpp", b"int f(int a) { return a; }\n", extract_cpp_definitions
+        ) == [("f", "function")]

--- a/tests_py/core/test_ast_extractor_edges.py
+++ b/tests_py/core/test_ast_extractor_edges.py
@@ -1,0 +1,348 @@
+"""Boundary and detail contract for the extractors (issue #369, round two).
+
+`test_ast_extractor_imports.py` and `test_ast_extractor_definitions.py` pinned
+the shape of the output. Mutation testing then showed what shape alone misses:
+fields nobody asserted (`ImportInfo.names`), the exact truncation boundary of a
+signature, the exact length cap on a callee name, and the character sets used
+to clean up module strings. Each of those is a constant or a field that a
+change could move silently while every existing assertion still passed.
+
+The fixtures here are deliberately awkward — module paths ending in ``X``, a
+callee containing ``X``, a name of exactly the cap length, bytes that are not
+valid UTF-8. That awkwardness is the point: an ordinary fixture cannot
+distinguish ``rstrip(";")`` from ``rstrip("X;X")`` or ``len(x) < 100`` from
+``<= 100``, so an ordinary fixture leaves those free to drift.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.core.ast_parser import is_available
+
+pytestmark = pytest.mark.skipif(
+    not is_available(), reason="tree-sitter not installed; extractors are unreachable"
+)
+
+
+def _root(language: str, source: bytes):
+    from tree_sitter_language_pack import get_parser
+
+    return get_parser(language).parse(source).root_node
+
+
+def _full_imports(
+    language: str, source: bytes, extractor
+) -> list[tuple[str, list[str], bool]]:
+    return [
+        (i.module, list(i.names), i.is_relative)
+        for i in extractor(_root(language, source), source)
+    ]
+
+
+class TestImportNames:
+    """`ImportInfo.names` carries the imported symbols. Nothing asserted it
+    before, so the whole name-collection path was free to change silently —
+    which matters because the resolver uses those names to bind a reference to
+    a definition, not just the module.
+    """
+
+    def test_python_names_are_collected_and_exclude_the_module(self) -> None:
+        from mcp_server.core.ast_extractors import extract_python_imports
+
+        source = b"from ..pkg import thing, other as o\nfrom a.b import c\nimport os\n"
+        assert _full_imports("python", source, extract_python_imports) == [
+            # The module node itself must not leak into names.
+            ("..pkg", ["thing", "other as o"], True),
+            ("a.b", ["c"], False),
+            # A plain `import os` has a module and no names.
+            ("os", [], False),
+        ]
+
+    def test_an_alias_is_kept_verbatim_in_names(self) -> None:
+        """Rough edge, pinned: `other as o` is stored as one string rather than
+        resolved to either side, so a consumer matching on `other` misses it.
+        """
+        from mcp_server.core.ast_extractors import extract_python_imports
+
+        source = b"from m import other as o\n"
+        assert _full_imports("python", source, extract_python_imports) == [
+            ("m", ["other as o"], False)
+        ]
+
+
+class TestGoTypeKind:
+    def test_a_non_struct_non_interface_type_reports_kind_type(self) -> None:
+        """`type ID int` is the only route to the `type` kind; struct and
+        interface take the other two arms.
+        """
+        from mcp_server.core.ast_extractors_extra import extract_go_definitions
+
+        source = b"package m\ntype ID int\n"
+        got = [
+            (d.name, d.kind)
+            for d in extract_go_definitions(_root("go", source), source)
+        ]
+        assert got == [("ID", "type")]
+
+    def test_a_type_alias_is_not_emitted(self) -> None:
+        """Rough edge, pinned: `type Alias = string` produces nothing."""
+        from mcp_server.core.ast_extractors_extra import extract_go_definitions
+
+        source = b"package m\ntype Alias = string\n"
+        assert extract_go_definitions(_root("go", source), source) == []
+
+
+class TestSignatureTruncation:
+    """Signatures are capped at 120 characters. The cap is a constant nobody
+    pinned, so it could move a character in either direction unnoticed.
+    """
+
+    LONG_PARAMS = b"def f(" + b", ".join(b"p%d=1" % i for i in range(40)) + b"): pass\n"
+
+    def test_a_long_python_signature_is_cut_at_exactly_120(self) -> None:
+        from mcp_server.core.ast_extractors import extract_python_definitions
+
+        defs = extract_python_definitions(
+            _root("python", self.LONG_PARAMS), self.LONG_PARAMS
+        )
+        assert [d.name for d in defs] == ["f"]
+        assert len(defs[0].signature) == 120
+
+    def test_a_long_python_superclass_list_is_cut_at_exactly_120(self) -> None:
+        from mcp_server.core.ast_extractors import extract_python_definitions
+
+        bases = b", ".join(b"Base%d" % i for i in range(40))
+        source = b"class C(" + bases + b"): pass\n"
+        defs = extract_python_definitions(_root("python", source), source)
+        assert len(defs[0].signature) == 120
+
+    def test_a_class_with_no_base_list_has_an_empty_signature(self) -> None:
+        """`class C: pass` has no `superclasses` node, so the signature falls
+        back to the empty string. That fallback is otherwise never exercised.
+        """
+        from mcp_server.core.ast_extractors import extract_python_definitions
+
+        source = b"class C: pass\n"
+        defs = extract_python_definitions(_root("python", source), source)
+        assert [(d.name, d.signature) for d in defs] == [("C", "")]
+
+    def test_a_long_go_signature_is_cut_at_exactly_120(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_go_definitions
+
+        params = b", ".join(b"p%d int" % i for i in range(30))
+        source = b"package m\nfunc F(" + params + b") {}\n"
+        defs = extract_go_definitions(_root("go", source), source)
+        assert len(defs[0].signature) == 120
+
+    def test_a_short_signature_is_not_padded_or_cut(self) -> None:
+        from mcp_server.core.ast_extractors import extract_python_definitions
+
+        source = b"def f(a, b): pass\n"
+        defs = extract_python_definitions(_root("python", source), source)
+        assert defs[0].signature == "(a, b)"
+
+    def test_javascript_functions_carry_their_parameter_list(self) -> None:
+        from mcp_server.core.ast_extractors import extract_js_definitions
+
+        source = b"function f(a, b) {}\n"
+        defs = extract_js_definitions(_root("typescript", source), source)
+        assert [(d.name, d.signature) for d in defs] == [("f", "(a, b)")]
+
+    def test_a_long_javascript_signature_is_cut_at_exactly_120(self) -> None:
+        from mcp_server.core.ast_extractors import extract_js_definitions
+
+        params = b", ".join(b"p%d" % i for i in range(60))
+        source = b"function f(" + params + b") {}\n"
+        defs = extract_js_definitions(_root("typescript", source), source)
+        assert len(defs[0].signature) == 120
+
+    def test_go_functions_carry_their_parameter_list(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_go_definitions
+
+        source = b"package m\nfunc New(p int) *S { return nil }\n"
+        defs = extract_go_definitions(_root("go", source), source)
+        assert [(d.name, d.signature) for d in defs] == [("New", "(p int)")]
+
+
+class TestCalleeBasenameEdges:
+    def _calls(self, language: str, source: bytes) -> dict[str, list[str]]:
+        from mcp_server.core.ast_extractors import extract_calls_per_function
+
+        return extract_calls_per_function(_root(language, source), source)
+
+    def test_a_callee_containing_an_uppercase_x_is_not_truncated(self) -> None:
+        """The basename is split on each of `(`, `[`, `<`. Widening that
+        character set — even by an unrelated letter — silently mangles any name
+        containing it, and `X` is the character mutation testing inserts.
+        """
+        assert self._calls("python", b"def f():\n    maXker()\n") == {"f": ["maXker"]}
+
+    def test_a_generic_callee_keeps_only_the_name_before_the_first_bracket(
+        self,
+    ) -> None:
+        """`foo<Bar<Baz>>()` must reduce to `foo`, not `foo<Bar`. Splitting
+        from the right instead of the left gets this wrong.
+        """
+        source = b"function f() { foo<Bar<Baz>>(); }\n"
+        assert self._calls("typescript", source) == {"f": ["foo"]}
+
+    def test_the_length_cap_excludes_a_name_of_exactly_the_cap(self) -> None:
+        """`len(base) < _MAX_CALL_NAME_LEN`, strictly. A name of exactly 100
+        characters is dropped; 99 is kept. Pins the comparison, not just the
+        constant.
+        """
+        source = b"def f():\n    " + b"z" * 100 + b"()\n"
+        assert self._calls("python", source) == {"f": []}
+
+    def test_a_name_one_below_the_cap_is_kept(self) -> None:
+        name = b"z" * 99
+        source = b"def f():\n    " + name + b"()\n"
+        assert self._calls("python", source) == {"f": [name.decode()]}
+
+    def test_a_nested_subscript_callee_keeps_only_the_root_name(self) -> None:
+        """`a[b[c]]()` is the case with two of the same bracket in the callee
+        text. Splitting on the first `[` gives `a`; splitting on the last gives
+        `a[b`, a symbol that does not exist. One `[` cannot tell the two apart.
+        """
+        assert self._calls("python", b"def f():\n    a[b[c]]()\n") == {"f": ["a"]}
+
+    def test_a_parenthesised_callee_expression_yields_no_edge(self) -> None:
+        """`(a or b)()` has no resolvable name. Splitting the callee text on
+        the *first* bracket leaves an empty string, which is correctly
+        discarded; splitting on the last would leave `(a or b` and invent a
+        symbol that does not exist.
+        """
+        assert self._calls("python", b"def f():\n    (a or b)()\n") == {"f": []}
+
+
+class TestModuleStringCleanup:
+    """Each import extractor trims keywords, quotes and terminators from the
+    raw source text. The trimmed character sets are constants, and an ordinary
+    module path cannot tell a correct set from a wider one — every fixture here
+    ends in a character the wider set would eat.
+    """
+
+    def test_java_keeps_a_path_whose_segments_contain_the_keyword(self) -> None:
+        from mcp_server.core.ast_extractors_jvm import extract_java_imports
+
+        source = b"import com.importX.ThingX;\n"
+        assert _full_imports("java", source, extract_java_imports) == [
+            ("com.importX.ThingX", [], False)
+        ]
+
+    def test_java_static_import_strips_the_keyword_only_once(self) -> None:
+        """`import static a.staticX.b;` contains the word twice. Only the
+        leading keyword is a keyword; the one inside a path segment is part of
+        the name and must survive.
+        """
+        from mcp_server.core.ast_extractors_jvm import extract_java_imports
+
+        source = b"import static a.staticX.b;\n"
+        assert _full_imports("java", source, extract_java_imports) == [
+            ("a.staticX.b", [], False)
+        ]
+
+    def test_csharp_keeps_a_path_whose_segment_contains_the_keyword(self) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_csharp_imports
+
+        source = b"using Some.usingX;\n"
+        assert _full_imports("c_sharp", source, extract_csharp_imports) == [
+            ("Some.usingX", [], False)
+        ]
+
+    def test_php_strips_only_the_terminator(self) -> None:
+        from mcp_server.core.ast_extractors_scripting import extract_php_imports
+
+        source = b"<?php\nuse App\\ThingX;\n"
+        assert _full_imports("php", source, extract_php_imports) == [
+            ("App\\ThingX", [], False)
+        ]
+
+    def test_rust_strips_only_the_terminator(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_rust_imports
+
+        assert _full_imports("rust", b"use std::ioX;\n", extract_rust_imports) == [
+            ("std::ioX", [], False)
+        ]
+
+    def test_go_strips_only_the_quotes(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_go_imports
+
+        source = b'package m\nimport "fmtX"\n'
+        assert _full_imports("go", source, extract_go_imports) == [("fmtX", [], False)]
+
+    def test_c_strips_only_quotes_and_angle_brackets(self) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_c_imports
+
+        source = b'#include "XlocalX"\n'
+        assert _full_imports("c", source, extract_c_imports) == [("XlocalX", [], False)]
+
+    def test_javascript_strips_only_the_quotes(self) -> None:
+        from mcp_server.core.ast_extractors import extract_js_imports
+
+        source = b"import a from 'XmodX';\n"
+        assert _full_imports("javascript", source, extract_js_imports) == [
+            ("XmodX", [], False)
+        ]
+
+
+class TestRubyRequireScanning:
+    def test_non_require_calls_are_skipped_without_ending_the_scan(self) -> None:
+        """A `puts` between two `require`s must be skipped, not treated as a
+        stopping point. Turning the skip into a break would silently drop every
+        import after the first unrelated call — extremely common in Ruby.
+        """
+        from mcp_server.core.ast_extractors_scripting import extract_ruby_imports
+
+        source = b"puts 'hi'\nrequire 'json'\nputs 'bye'\nrequire 'yaml'\n"
+        assert _full_imports("ruby", source, extract_ruby_imports) == [
+            ("json", [], False),
+            ("yaml", [], False),
+        ]
+
+    def test_a_call_with_no_method_name_does_not_abort_the_scan(self) -> None:
+        from mcp_server.core.ast_extractors_scripting import extract_ruby_imports
+
+        source = b"require 'json'\n"
+        assert _full_imports("ruby", source, extract_ruby_imports) == [
+            ("json", [], False)
+        ]
+
+    def test_only_quotes_and_parentheses_are_trimmed_from_the_path(self) -> None:
+        """Both call forms are trimmed of their own punctuation and nothing
+        else. A path whose first and last characters are ordinary letters must
+        keep them, which is what distinguishes the real trim set from a wider
+        one.
+        """
+        from mcp_server.core.ast_extractors_scripting import extract_ruby_imports
+
+        source = b"require 'XjsonX'\nrequire('XyamlX')\n"
+        assert _full_imports("ruby", source, extract_ruby_imports) == [
+            ("XjsonX", [], False),
+            ("XyamlX", [], False),
+        ]
+
+
+class TestNonUtf8Source:
+    def test_invalid_bytes_inside_a_node_decode_to_the_replacement_character(
+        self,
+    ) -> None:
+        """`_text` decodes with `errors="replace"`. Cortex indexes whatever is
+        on disk, including files that are not valid UTF-8, and an unusable
+        error handler would raise `LookupError` out of the indexer the moment
+        one appeared. Valid UTF-8 never consults the handler, so only a
+        genuinely invalid byte exercises it.
+        """
+        from mcp_server.core.ast_extractors import extract_js_imports
+
+        source = b"import a from 'p\xffq';\n"
+        assert _full_imports("javascript", source, extract_js_imports) == [
+            ("p�q", [], False)
+        ]
+
+    def test_a_c_include_with_invalid_bytes_also_survives(self) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_c_imports
+
+        source = b'#include "h\xffk.h"\n'
+        assert _full_imports("c", source, extract_c_imports) == [("h�k.h", [], False)]

--- a/tests_py/core/test_ast_extractor_imports.py
+++ b/tests_py/core/test_ast_extractor_imports.py
@@ -1,0 +1,296 @@
+"""Behavioural contract for every import extractor (issue #369).
+
+Eleven languages, eleven extractors, and before this file most of them had no
+test at all — 238 of the 639 unpinned mutants in the extractor modules lived
+in import extraction. Imports are how the resolver links a symbol reference to
+the file that defines it, so a dropped or malformed module string silently
+degrades resolution across the whole graph rather than failing anywhere.
+
+Each case asserts the exact ordered `(module, is_relative)` list. Several of
+the expectations below are rough edges rather than polished behaviour. They
+are pinned as *current* behaviour, with the rough edge named, so that changing
+one is a deliberate act with a failing test rather than an accident. Where a
+rough edge looks like a defect worth fixing, it says so; fixing it is not this
+file's job.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.core.ast_parser import is_available
+
+pytestmark = pytest.mark.skipif(
+    not is_available(), reason="tree-sitter not installed; extractors are unreachable"
+)
+
+
+def _imports(language: str, source: bytes, extractor) -> list[tuple[str, bool]]:
+    from tree_sitter_language_pack import get_parser
+
+    root = get_parser(language).parse(source).root_node
+    return [(i.module, i.is_relative) for i in extractor(root, source)]
+
+
+class TestPythonImports:
+    SOURCE = (
+        b"import os\n"
+        b"import os.path as p\n"
+        b"from . import sibling\n"
+        b"from ..pkg import thing, other as o\n"
+        b"from collections.abc import Mapping\n"
+    )
+
+    def test_exact_import_list(self) -> None:
+        from mcp_server.core.ast_extractors import extract_python_imports
+
+        assert _imports("python", self.SOURCE, extract_python_imports) == [
+            ("os", False),
+            (".", True),
+            ("..pkg", True),
+            ("collections.abc", False),
+        ]
+
+    def test_aliased_plain_import_is_dropped(self) -> None:
+        """Rough edge, pinned: `import os.path as p` yields nothing. The alias
+        wraps the dotted_name in an `aliased_import`, so it is not a direct
+        child and `_find_children` misses it. `from x import y as z` is not
+        affected — only the plain `import a.b as c` form.
+        """
+        from mcp_server.core.ast_extractors import extract_python_imports
+
+        assert (
+            _imports("python", b"import os.path as p\n", extract_python_imports) == []
+        )
+        assert _imports("python", b"import os.path\n", extract_python_imports) == [
+            ("os.path", False)
+        ]
+
+    def test_relative_depth_is_preserved_in_the_module_string(self) -> None:
+        from mcp_server.core.ast_extractors import extract_python_imports
+
+        assert _imports(
+            "python", b"from ...deep import x\n", extract_python_imports
+        ) == [("...deep", True)]
+
+
+class TestJsImports:
+    SOURCE = (
+        b"import a from 'mod-a';\n"
+        b"import {b, c} from './rel';\n"
+        b"import * as ns from '../up';\n"
+        b"require('cjs');\n"
+    )
+
+    def test_exact_import_list(self) -> None:
+        from mcp_server.core.ast_extractors import extract_js_imports
+
+        assert _imports("javascript", self.SOURCE, extract_js_imports) == [
+            ("mod-a", False),
+            ("./rel", True),
+            ("../up", True),
+        ]
+
+    def test_commonjs_require_is_not_an_import(self) -> None:
+        """Rough edge, pinned: only ES `import` statements are extracted, so a
+        CommonJS `require()` contributes no edge. Real cost on Node codebases.
+        """
+        from mcp_server.core.ast_extractors import extract_js_imports
+
+        assert (
+            _imports("javascript", b"const x = require('cjs');\n", extract_js_imports)
+            == []
+        )
+
+    def test_quote_style_does_not_change_the_module(self) -> None:
+        from mcp_server.core.ast_extractors import extract_js_imports
+
+        assert _imports("javascript", b'import a from "dq";\n', extract_js_imports) == [
+            ("dq", False)
+        ]
+
+
+class TestJavaImports:
+    def test_exact_import_list_including_static_and_wildcard(self) -> None:
+        from mcp_server.core.ast_extractors_jvm import extract_java_imports
+
+        source = (
+            b"package p;\n"
+            b"import java.util.List;\n"
+            b"import static java.lang.Math.max;\n"
+            b"import java.io.*;\n"
+        )
+        assert _imports("java", source, extract_java_imports) == [
+            ("java.util.List", False),
+            # `static` is not marked; the member becomes part of the path.
+            ("java.lang.Math.max", False),
+            # The wildcard survives into the module string verbatim.
+            ("java.io.*", False),
+        ]
+
+    def test_package_declaration_is_not_an_import(self) -> None:
+        from mcp_server.core.ast_extractors_jvm import extract_java_imports
+
+        assert _imports("java", b"package p.q;\n", extract_java_imports) == []
+
+
+class TestKotlinImports:
+    def test_exact_import_list(self) -> None:
+        from mcp_server.core.ast_extractors_jvm import extract_kotlin_imports
+
+        source = b"package p\nimport kotlin.math.max\nimport foo.Bar as Baz\n"
+        assert _imports("kotlin", source, extract_kotlin_imports) == [
+            ("kotlin.math.max", False),
+            # The alias is dropped, keeping the original path.
+            ("foo.Bar", False),
+        ]
+
+
+class TestCImports:
+    def test_angle_and_quoted_includes_are_both_captured_without_delimiters(
+        self,
+    ) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_c_imports
+
+        source = b'#include <stdio.h>\n#include "local.h"\n'
+        assert _imports("c", source, extract_c_imports) == [
+            ("stdio.h", False),
+            # Pinned rough edge: a quoted include is project-local by
+            # convention, yet is_relative stays False.
+            ("local.h", False),
+        ]
+
+
+class TestCSharpImports:
+    def test_exact_using_list(self) -> None:
+        from mcp_server.core.ast_extractors_clike import extract_csharp_imports
+
+        source = (
+            b"using System;\n"
+            b"using System.Collections.Generic;\n"
+            b"using Alias = Some.Thing;\n"
+        )
+        assert _imports("c_sharp", source, extract_csharp_imports) == [
+            ("System", False),
+            ("System.Collections.Generic", False),
+            # Rough edge, pinned: an alias directive is captured verbatim,
+            # spaces and all, rather than resolved to `Some.Thing`.
+            ("Alias = Some.Thing", False),
+        ]
+
+
+class TestRubyImports:
+    def test_require_forms(self) -> None:
+        from mcp_server.core.ast_extractors_scripting import extract_ruby_imports
+
+        source = b"require 'json'\nrequire_relative 'helper'\nload 'x.rb'\n"
+        assert _imports("ruby", source, extract_ruby_imports) == [
+            ("json", False),
+            # Rough edge, pinned: `require_relative` is by definition relative
+            # and still reports is_relative False.
+            ("helper", False),
+            ("x.rb", False),
+        ]
+
+
+class TestPhpImports:
+    def test_use_and_group_use(self) -> None:
+        from mcp_server.core.ast_extractors_scripting import extract_php_imports
+
+        source = b"<?php\nuse App\\Models\\User;\nuse App\\{A, B};\nrequire 'f.php';\n"
+        assert _imports("php", source, extract_php_imports) == [
+            ("App\\Models\\User", False),
+            # Rough edge, pinned: a group use loses its `App\` prefix, so `A`
+            # and `B` are unresolvable as written.
+            ("A", False),
+            ("B", False),
+        ]
+
+
+class TestGoImports:
+    def test_single_grouped_and_aliased(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_go_imports
+
+        source = b'package main\nimport "fmt"\nimport (\n  "os"\n  m "math"\n)\n'
+        assert _imports("go", source, extract_go_imports) == [
+            ("fmt", False),
+            ("os", False),
+            # The alias is dropped and the real path kept — the opposite of
+            # C#'s behaviour above, and the more useful one.
+            ("math", False),
+        ]
+
+
+class TestSwiftImports:
+    def test_module_imports(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_swift_imports
+
+        assert _imports(
+            "swift", b"import Foundation\nimport UIKit\n", extract_swift_imports
+        ) == [("Foundation", False), ("UIKit", False)]
+
+
+class TestRustImports:
+    def test_use_declarations_are_captured_verbatim(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_rust_imports
+
+        source = (
+            b"use std::io;\n"
+            b"use std::collections::{HashMap, HashSet};\n"
+            b"use crate::thing as t;\n"
+        )
+        assert _imports("rust", source, extract_rust_imports) == [
+            ("std::io", False),
+            # Rough edges, pinned: a brace group is not expanded into its
+            # members, and an `as` clause is not stripped. Neither string
+            # resolves to a path.
+            ("std::collections::{HashMap, HashSet}", False),
+            ("crate::thing as t", False),
+        ]
+
+    def test_crate_relative_paths_are_not_marked_relative(self) -> None:
+        from mcp_server.core.ast_extractors_extra import extract_rust_imports
+
+        assert _imports("rust", b"use crate::a::b;\n", extract_rust_imports) == [
+            ("crate::a::b", False)
+        ]
+
+
+class TestEmptyAndUnparseable:
+    """Every extractor must return an empty list rather than raising on input
+    with nothing to find. Cortex indexes whatever is in the tree.
+    """
+
+    @pytest.mark.parametrize(
+        ("language", "module", "entry"),
+        [
+            ("python", "mcp_server.core.ast_extractors", "extract_python_imports"),
+            ("javascript", "mcp_server.core.ast_extractors", "extract_js_imports"),
+            ("java", "mcp_server.core.ast_extractors_jvm", "extract_java_imports"),
+            ("kotlin", "mcp_server.core.ast_extractors_jvm", "extract_kotlin_imports"),
+            ("c", "mcp_server.core.ast_extractors_clike", "extract_c_imports"),
+            (
+                "c_sharp",
+                "mcp_server.core.ast_extractors_clike",
+                "extract_csharp_imports",
+            ),
+            (
+                "ruby",
+                "mcp_server.core.ast_extractors_scripting",
+                "extract_ruby_imports",
+            ),
+            ("php", "mcp_server.core.ast_extractors_scripting", "extract_php_imports"),
+            ("go", "mcp_server.core.ast_extractors_extra", "extract_go_imports"),
+            ("swift", "mcp_server.core.ast_extractors_extra", "extract_swift_imports"),
+            ("rust", "mcp_server.core.ast_extractors_extra", "extract_rust_imports"),
+        ],
+    )
+    def test_empty_source_yields_no_imports(
+        self, language: str, module: str, entry: str
+    ) -> None:
+        import importlib
+
+        assert (
+            _imports(language, b"", getattr(importlib.import_module(module), entry))
+            == []
+        )


### PR DESCRIPTION
Finishes #369. #373 closed the seven scope-tracking walkers and named the rest as a tail; a named tail is still an unfinished PR.

## Result

| | at filing | after #373 | now |
|---|---|---|---|
| unpinned mutants, five modules | 639 | 594 | **51** |
| **mutants no test executes** | **462** | 462 | **0** |
| killed | 847 | 892 | **1435** of 1486 |

Zero uncovered is the number that matters most. Every mutant in these modules is now executed by a test; what remains is 51 that run and are not detected, and each of those has an argument rather than a shrug.

## What is covered

| file | scope |
|---|---|
| `test_ast_extractor_imports.py` | all eleven import extractors |
| `test_ast_extractor_definitions.py` | C, C++, Go, Rust, Python, JS/TS definitions + callee basename |
| `test_ast_extractor_edges.py` | fields, constants at their boundary, character sets |

The third file exists because shape assertions structurally cannot see three classes of drift, which only mutation exposed:

- **`ImportInfo.names`** was asserted nowhere. The resolver binds a reference to a definition through those names, so the whole name-collection path was free to change silently.
- **Constants at their boundary** — the `[:120]` signature cut and `len(base) < 100`. No ordinary fixture separates 120 from 121, or `<` from `<=`.
- **Character sets** — `rstrip(";")`, `strip('"<>')`, `replace("using", "", 1)`. An ordinary module path cannot tell the correct set from a wider one.

Hence the deliberately awkward fixtures: paths ending in `X`, a callee named `maXker`, a name of exactly 100 characters, `a[b[c]]()`, `(a or b)()`, and bytes that are not valid UTF-8. Each makes one specific drift observable and nothing else does.

Two are worth reading as behaviour rather than bookkeeping. The Ruby scanner test pins that a `puts` between two `require`s is *skipped* rather than *ending the scan* — turning that skip into a break would silently drop every import after the first unrelated call, which in Ruby is most of them. And `_text` decoding invalid bytes matters because Cortex indexes whatever is on disk; a broken error handler raises `LookupError` out of the indexer on the first non-UTF-8 file, and valid input never consults it.

## Seven rough edges, now pinned as current behaviour

Each with its cause stated, so changing one takes a failing test. Each is a plausible resolution defect. **None is fixed here** — that is a separate decision per item, and I would rather you pick than have me quietly change extraction semantics inside a test PR.

| behaviour | cause |
|---|---|
| C emits a struct **twice** when a typedef names it | two `_walk_type` passes, no dedup |
| C++ drops `struct S {}` while C keeps it | C++ looks for `class_specifier` only |
| Rust drops functions inside `mod m {}` | no descent into module blocks |
| Rust keeps `use a::{B, C}` and `use x as y` verbatim | no group expansion, no alias strip; neither string resolves |
| Python drops `import os.path as p` | the alias wraps the `dotted_name`, so it is not a direct child |
| JS ignores `require()` and `new Klass()` | ES imports only; `new_expression` is not a call node |
| PHP group `use App\{A, B}` loses its prefix | `A` and `B` are emitted bare and are unresolvable |

## The 51 survivors, classified

Two categories, and the distinction matters for how long each claim lasts.

**Provably equivalent by construction** — no fixture can ever distinguish them:
- `rsplit(sep, n)[-1]` is the text after the last separator for every `n`; `split(sep, n)[0]` the text before the first. Only *direction* matters, and direction is pinned by `a[b[c]]()`.
- `None` vs `""` as an initial scope, at seven call sites. Both falsy; every use is a truthiness test.
- `_declarator_name`'s two `if` branches have identical bodies, so which tuple a node type sits in is unobservable.

**Unreachable today** — verified by reading the callers, not by failing to find a fixture. These can become false if a grammar or a caller changes, which is why they are labelled differently:
- `_extract_js_node`'s `method_definition` arm is only reached from `_extract_js_class` (line 227), which always supplies a class name, so its `else` cannot run. `"function"` is a legacy node type; the grammar now emits `function_expression`.
- Go: `function_declaration` always has `parameters`, `method_declaration` always has a receiver.
- Python: `function_definition` always has a name and parameters; `class_definition` always has a name. The `superclasses` fallback is **not** dead, which is why `class C: pass` is a test.

**Kept with a filed follow-up:** the `decorated_definition` arm, #372.

## Source changes are documentation only

Proved rather than asserted — the parsed AST of each changed file, docstrings stripped, is identical to `HEAD`:

```
mcp_server/core/ast_extractors.py         AST identical ignoring docstrings: True
mcp_server/core/ast_extractors_clike.py   AST identical ignoring docstrings: True
mcp_server/core/ast_extractors_extra.py   AST identical ignoring docstrings: True
```

## Completion Ledger

| § | Item | Evidence |
|---|---|---|
| A1 | Happy paths | `pytest -k "ast or extractor or codebase"` → **1265 passed** |
| A2 | Edge cases | Empty source for all eleven import extractors; unnamed constructs; nested types; boundary-length names; non-UTF-8 bytes; fragments with no enclosing type |
| A3 | Failure paths | No new failure path; the decode-handler path is now exercised for the first time |
| A4 | Trust boundary | Fixtures include invalid UTF-8 and syntactically partial sources, which is what Cortex indexes |
| A5 | Invariants | Ordering asserted, not just membership — several extractors emit in pass order, not source order, and consumers read it positionally |
| A6 | Idempotency | Pure functions over a parsed tree |
| B1–B3 | Concurrency | N/A |
| C1–C3 | Resources / perf | N/A — tests and comments only |
| D1–D3 | Security | N/A |
| E1 | API compatibility | No behaviour change; AST-identical proof above |
| E2 | Downstream consumers | Unchanged by construction |
| E3–E4 | Persisted data, cross-platform | N/A |
| F1–F2 | Observability | N/A |
| G1 | Path→test ledger | Every public entry point in the five modules now has an exact-output test; enumerated by `grep -nE '^def [a-z]'` per module and checked off |
| G2 | Regression tests | N/A as a bugfix; each round's fixtures were verified to move the mutation count (639 → 99 → 58 → 52 → 51) rather than assumed to |
| G3 | Determinism | Suite run five times across the change; 1265 each time |
| G4 | Negative assertions | Aliased plain import dropped; `require()` ignored; `new` ignored; Rust `mod` contents absent; Go type alias absent; C++ struct absent; over-cap callee dropped |
| G5 | Full gate | `ruff check .` clean · `ruff format --check .` 1279 files formatted · `pyright mcp_server/` **0 errors, 0 warnings, 0 informations** |
| H1–H3 | Standards, readability, conventions | Documentation-only source diff; test style matches the existing extractor tests |
| H4 | CHANGELOG | N/A — tests and comments, no consumer-observable change |
| H5 | Commit hygiene | One commit; formatting applied by `ruff format` to touched files only |
| H6 | CI green | Required before merge |
| H7 | Boy-scout (§14) | Seven rough edges surfaced and documented rather than silently frozen; the gate's own limitation raised below |

## One thing this does not fix

`scripts/mutation_check.sh` still exits **1**, and will keep doing so. It has no notion of an accepted equivalent, so a module whose every survivor carries a written rationale is indistinguishable to it from one nobody has looked at. That makes the blocking per-commit gate unusable on these five files for any future one-line change.

I have not invented a suppression mechanism here, because a badly designed one is worse than none — a wildcard "ignore these" list would re-create the false-green this same script was just fixed for. It needs a typed, registered, fail-closed exemption keyed to a specific mutant with a required rationale. Worth its own issue and its own decision; say the word and I will file it with a proposed design.
