### PR TITLE
feat(mutation): teach the gate what an accepted equivalent is — fail-closed, diff-pinned registry

### DIFF
--- a/memory/mutation-equivalents.json
+++ b/memory/mutation-equivalents.json
@@ -1,0 +1,405 @@
+{
+  "schema_version": 1,
+  "equivalents": [
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__callee_basename__mutmut_16",
+      "removed": "base = text.rsplit(\".\", 1)[-1]",
+      "added": "base = text.rsplit(\".\", )[-1]",
+      "kind": "equivalent-by-construction",
+      "rationale": "`rsplit(sep, n)[-1]` is the text after the LAST separator for every value of n, so maxsplit cannot change the selected element. Only the split direction matters, and that is pinned by TestCalleeBasenameEdges.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__callee_basename__mutmut_19",
+      "removed": "base = text.rsplit(\".\", 1)[-1]",
+      "added": "base = text.rsplit(\".\", 2)[-1]",
+      "kind": "equivalent-by-construction",
+      "rationale": "`rsplit(sep, n)[-1]` is the text after the LAST separator for every value of n, so maxsplit cannot change the selected element. Only the split direction matters, and that is pinned by TestCalleeBasenameEdges.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__callee_basename__mutmut_27",
+      "removed": "base = base.split(c, 1)[0]",
+      "added": "base = base.split(c, )[0]",
+      "kind": "equivalent-by-construction",
+      "rationale": "`split(sep, n)[0]` is the text before the FIRST separator for every value of n, so maxsplit cannot change the selected element. The direction is pinned by test_a_nested_subscript_callee_keeps_only_the_root_name.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__callee_basename__mutmut_29",
+      "removed": "base = base.split(c, 1)[0]",
+      "added": "base = base.split(c, 2)[0]",
+      "kind": "equivalent-by-construction",
+      "rationale": "`split(sep, n)[0]` is the text before the FIRST separator for every value of n, so maxsplit cannot change the selected element. The direction is pinned by test_a_nested_subscript_callee_keeps_only_the_root_name.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__callee_basename__mutmut_6",
+      "removed": "return \"\"",
+      "added": "return \"XXXX\"",
+      "kind": "unreachable-branch",
+      "rationale": "A call node always exposes a `function` field in every grammar in use, so the early return for a missing callee cannot execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_js_func__mutmut_21",
+      "removed": "sig = _text(params, source)[:120] if params else \"\"",
+      "added": "sig = _text(params, source)[:120] if params else \"XXXX\"",
+      "kind": "unreachable-branch",
+      "rationale": "A JS/TS function node always carries a parameters node, so the empty-signature fallback cannot execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_js_node__mutmut_4",
+      "removed": "if node.type in (\"function_declaration\", \"function\"):",
+      "added": "if node.type in (\"function_declaration\", \"XXfunctionXX\"):",
+      "kind": "unreachable-branch",
+      "rationale": "\"function\" is a legacy tree-sitter node type. The current grammar emits function_expression for anonymous function expressions, so nothing reaches the second entry of this tuple; kept for grammar compatibility.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_js_node__mutmut_5",
+      "removed": "if node.type in (\"function_declaration\", \"function\"):",
+      "added": "if node.type in (\"function_declaration\", \"FUNCTION\"):",
+      "kind": "unreachable-branch",
+      "rationale": "\"function\" is a legacy tree-sitter node type. The current grammar emits function_expression for anonymous function expressions, so nothing reaches the second entry of this tuple; kept for grammar compatibility.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_js_node__mutmut_65",
+      "removed": "_extract_js_node(child, source, defs, parent)",
+      "added": "_extract_js_node(child, source, defs, None)",
+      "kind": "equivalent-by-construction",
+      "rationale": "Passing None instead of \"\" as the initial scope is unobservable: every use of that parameter is a truthiness test (`if scope` / `f\"{scope}.\" if scope else ...`), and both values are falsy.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_js_node__mutmut_82",
+      "removed": "full = f\"{parent}.{_text(name, source)}\" if parent else _text(name, source)",
+      "added": "full = f\"{parent}.{_text(name, source)}\" if parent else _text(None, source)",
+      "kind": "unreachable-branch",
+      "rationale": "The method_definition arm is only reached from _extract_js_class, which always supplies a class name, so `parent` is never falsy here and this else branch cannot execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_js_node__mutmut_83",
+      "removed": "full = f\"{parent}.{_text(name, source)}\" if parent else _text(name, source)",
+      "added": "full = f\"{parent}.{_text(name, source)}\" if parent else _text(name, None)",
+      "kind": "unreachable-branch",
+      "rationale": "The method_definition arm is only reached from _extract_js_class, which always supplies a class name, so `parent` is never falsy here and this else branch cannot execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_js_node__mutmut_84",
+      "removed": "full = f\"{parent}.{_text(name, source)}\" if parent else _text(name, source)",
+      "added": "full = f\"{parent}.{_text(name, source)}\" if parent else _text(source)",
+      "kind": "unreachable-branch",
+      "rationale": "The method_definition arm is only reached from _extract_js_class, which always supplies a class name, so `parent` is never falsy here and this else branch cannot execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_js_node__mutmut_85",
+      "removed": "full = f\"{parent}.{_text(name, source)}\" if parent else _text(name, source)",
+      "added": "full = f\"{parent}.{_text(name, source)}\" if parent else _text(name, )",
+      "kind": "unreachable-branch",
+      "rationale": "The method_definition arm is only reached from _extract_js_class, which always supplies a class name, so `parent` is never falsy here and this else branch cannot execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_js_node__mutmut_9",
+      "removed": "_extract_js_func(node, source, defs, parent)",
+      "added": "_extract_js_func(node, source, defs, None)",
+      "kind": "equivalent-by-construction",
+      "rationale": "Passing None instead of \"\" as the initial scope is unobservable: every use of that parameter is a truthiness test (`if scope` / `f\"{scope}.\" if scope else ...`), and both values are falsy.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_python_class__mutmut_14",
+      "removed": "cls_name = _text(name_node, source) if name_node else \"\"",
+      "added": "cls_name = _text(name_node, source) if name_node else \"XXXX\"",
+      "kind": "unreachable-branch",
+      "rationale": "A Python class_definition always carries a name child, so this fallback cannot execute. The superclasses fallback on the next line IS reachable and is pinned by test_a_class_with_no_base_list_has_an_empty_signature.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_python_func__mutmut_14",
+      "removed": "name = _text(name_node, source) if name_node else \"\"",
+      "added": "name = _text(name_node, source) if name_node else \"XXXX\"",
+      "kind": "unreachable-branch",
+      "rationale": "A Python function_definition always carries a name child, so this fallback cannot execute. Kept as a guard against a grammar that stops guaranteeing it.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__extract_python_func__mutmut_21",
+      "removed": "sig = _text(params_node, source)[:120] if params_node else \"\"",
+      "added": "sig = _text(params_node, source)[:120] if params_node else \"XXXX\"",
+      "kind": "unreachable-branch",
+      "rationale": "A Python function_definition always carries a parameters child, so the empty-signature fallback cannot execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__walk_for_calls__mutmut_16",
+      "removed": "body = child.child_by_field_name(\"body\") or child",
+      "added": "body = child.child_by_field_name(\"body\") and child",
+      "kind": "equivalent-by-construction",
+      "rationale": "The body node is itself a child of the class node, so descending child.children reaches it via the catch-all arm and finds the same definitions in the same order. The `or child` fallback stays for grammars whose class node exposes no body field.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__walk_for_calls__mutmut_18",
+      "removed": "body = child.child_by_field_name(\"body\") or child",
+      "added": "body = child.child_by_field_name(\"XXbodyXX\") or child",
+      "kind": "equivalent-by-construction",
+      "rationale": "The body node is itself a child of the class node, so descending child.children reaches it via the catch-all arm and finds the same definitions in the same order. The `or child` fallback stays for grammars whose class node exposes no body field.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__walk_for_calls__mutmut_19",
+      "removed": "body = child.child_by_field_name(\"body\") or child",
+      "added": "body = child.child_by_field_name(\"BODY\") or child",
+      "kind": "equivalent-by-construction",
+      "rationale": "The body node is itself a child of the class node, so descending child.children reaches it via the catch-all arm and finds the same definitions in the same order. The `or child` fallback stays for grammars whose class node exposes no body field.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__walk_for_calls__mutmut_25",
+      "removed": "elif ntype == \"decorated_definition\":",
+      "added": "elif ntype == \"XXdecorated_definitionXX\":",
+      "kind": "seam-pending-implementation",
+      "rationale": "The decorated_definition arm is byte-identical to the else that follows it, so mutating its node-type string is undetectable. Kept, not deleted: it mirrors _extract_python_children's dispatch (where the same branch IS load-bearing) and is the seam for decorator-call attribution, which produces no graph edge today. See #372.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__walk_for_calls__mutmut_26",
+      "removed": "elif ntype == \"decorated_definition\":",
+      "added": "elif ntype == \"DECORATED_DEFINITION\":",
+      "kind": "seam-pending-implementation",
+      "rationale": "The decorated_definition arm is byte-identical to the else that follows it, so mutating its node-type string is undetectable. Kept, not deleted: it mirrors _extract_python_children's dispatch (where the same branch IS load-bearing) and is the seam for decorator-call attribution, which produces no graph edge today. See #372.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x__walk_for_calls__mutmut_39",
+      "removed": "fn_name = _text(name_node, source) if name_node else \"\"",
+      "added": "fn_name = _text(name_node, source) if name_node else \"XXXX\"",
+      "kind": "unreachable-branch",
+      "rationale": "Every node type in _FUNCTION_NODE_TYPES carries a name in all grammars in use (verified by sweep), so the empty-name fallback cannot execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x_extract_calls_per_function__mutmut_3",
+      "removed": "_walk_for_calls(root, \"\", source, out)",
+      "added": "_walk_for_calls(root, None, source, out)",
+      "kind": "equivalent-by-construction",
+      "rationale": "Passing None instead of \"\" as the initial scope is unobservable: every use of that parameter is a truthiness test (`if scope` / `f\"{scope}.\" if scope else ...`), and both values are falsy.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x_extract_js_definitions__mutmut_5",
+      "removed": "_extract_js_node(node, source, defs, \"\")",
+      "added": "_extract_js_node(node, source, defs, None)",
+      "kind": "equivalent-by-construction",
+      "rationale": "Passing None instead of \"\" as the initial scope is unobservable: every use of that parameter is a truthiness test (`if scope` / `f\"{scope}.\" if scope else ...`), and both values are falsy.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors.x_extract_python_imports__mutmut_29",
+      "removed": "module = _text(mod_node, source) if mod_node else \"\"",
+      "added": "module = _text(mod_node, source) if mod_node else \"XXXX\"",
+      "kind": "unreachable-branch",
+      "rationale": "An import_from_statement always carries a module_name field, including the bare relative form `from . import x`, so this fallback cannot execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_clike.x__declarator_name__mutmut_17",
+      "removed": "if node.type in (\"qualified_identifier\", \"destructor_name\", \"operator_name\"):",
+      "added": "if node.type in (\"qualified_identifier\", \"XXdestructor_nameXX\", \"operator_name\"):",
+      "kind": "equivalent-by-construction",
+      "rationale": "_declarator_name's two `if` branches have identical bodies (`return _text(node, source)`), so which tuple a node type sits in is not observable. Removing a type only matters if it is the terminal declarator, which in practice is identifier or qualified_identifier.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_clike.x__declarator_name__mutmut_18",
+      "removed": "if node.type in (\"qualified_identifier\", \"destructor_name\", \"operator_name\"):",
+      "added": "if node.type in (\"qualified_identifier\", \"DESTRUCTOR_NAME\", \"operator_name\"):",
+      "kind": "equivalent-by-construction",
+      "rationale": "_declarator_name's two `if` branches have identical bodies (`return _text(node, source)`), so which tuple a node type sits in is not observable. Removing a type only matters if it is the terminal declarator, which in practice is identifier or qualified_identifier.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_clike.x__declarator_name__mutmut_19",
+      "removed": "if node.type in (\"qualified_identifier\", \"destructor_name\", \"operator_name\"):",
+      "added": "if node.type in (\"qualified_identifier\", \"destructor_name\", \"XXoperator_nameXX\"):",
+      "kind": "equivalent-by-construction",
+      "rationale": "_declarator_name's two `if` branches have identical bodies (`return _text(node, source)`), so which tuple a node type sits in is not observable. Removing a type only matters if it is the terminal declarator, which in practice is identifier or qualified_identifier.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_clike.x__declarator_name__mutmut_20",
+      "removed": "if node.type in (\"qualified_identifier\", \"destructor_name\", \"operator_name\"):",
+      "added": "if node.type in (\"qualified_identifier\", \"destructor_name\", \"OPERATOR_NAME\"):",
+      "kind": "equivalent-by-construction",
+      "rationale": "_declarator_name's two `if` branches have identical bodies (`return _text(node, source)`), so which tuple a node type sits in is not observable. Removing a type only matters if it is the terminal declarator, which in practice is identifier or qualified_identifier.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_clike.x__declarator_name__mutmut_29",
+      "removed": "return \"\"",
+      "added": "return \"XXXX\"",
+      "kind": "unreachable-branch",
+      "rationale": "The declarator chain of any function_definition reached here terminates at a matched node type, so the loop never exhausts and this final return cannot execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_clike.x__declarator_name__mutmut_6",
+      "removed": "if node.type in (\"identifier\", \"field_identifier\", \"type_identifier\"):",
+      "added": "if node.type in (\"identifier\", \"XXfield_identifierXX\", \"type_identifier\"):",
+      "kind": "equivalent-by-construction",
+      "rationale": "_declarator_name's two `if` branches have identical bodies (`return _text(node, source)`), so which tuple a node type sits in is not observable. Removing a type only matters if it is the terminal declarator, which in practice is identifier or qualified_identifier.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_clike.x__declarator_name__mutmut_7",
+      "removed": "if node.type in (\"identifier\", \"field_identifier\", \"type_identifier\"):",
+      "added": "if node.type in (\"identifier\", \"FIELD_IDENTIFIER\", \"type_identifier\"):",
+      "kind": "equivalent-by-construction",
+      "rationale": "_declarator_name's two `if` branches have identical bodies (`return _text(node, source)`), so which tuple a node type sits in is not observable. Removing a type only matters if it is the terminal declarator, which in practice is identifier or qualified_identifier.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_clike.x__declarator_name__mutmut_8",
+      "removed": "if node.type in (\"identifier\", \"field_identifier\", \"type_identifier\"):",
+      "added": "if node.type in (\"identifier\", \"field_identifier\", \"XXtype_identifierXX\"):",
+      "kind": "equivalent-by-construction",
+      "rationale": "_declarator_name's two `if` branches have identical bodies (`return _text(node, source)`), so which tuple a node type sits in is not observable. Removing a type only matters if it is the terminal declarator, which in practice is identifier or qualified_identifier.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_clike.x__declarator_name__mutmut_9",
+      "removed": "if node.type in (\"identifier\", \"field_identifier\", \"type_identifier\"):",
+      "added": "if node.type in (\"identifier\", \"field_identifier\", \"TYPE_IDENTIFIER\"):",
+      "kind": "equivalent-by-construction",
+      "rationale": "_declarator_name's two `if` branches have identical bodies (`return _text(node, source)`), so which tuple a node type sits in is not observable. Removing a type only matters if it is the terminal declarator, which in practice is identifier or qualified_identifier.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_clike.x_extract_csharp_definitions__mutmut_5",
+      "removed": "_walk_csharp(root, source, defs, \"\")",
+      "added": "_walk_csharp(root, source, defs, None)",
+      "kind": "equivalent-by-construction",
+      "rationale": "Passing None instead of \"\" as the initial scope is unobservable: every use of that parameter is a truthiness test (`if scope` / `f\"{scope}.\" if scope else ...`), and both values are falsy.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_extra.x__extract_go_receiver__mutmut_13",
+      "removed": "return \"\"",
+      "added": "return \"XXXX\"",
+      "kind": "unreachable-branch",
+      "rationale": "_extract_go_receiver is only called from the method_declaration arm, where a receiver is always present and always contains a type_identifier, so neither empty return can execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_extra.x__extract_go_receiver__mutmut_2",
+      "removed": "return \"\"",
+      "added": "return \"XXXX\"",
+      "kind": "unreachable-branch",
+      "rationale": "_extract_go_receiver is only called from the method_declaration arm, where a receiver is always present and always contains a type_identifier, so neither empty return can execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_extra.x_extract_go_definitions__mutmut_19",
+      "removed": "sig = _text(params, source)[:120] if params else \"\"",
+      "added": "sig = _text(params, source)[:120] if params else \"XXXX\"",
+      "kind": "unreachable-branch",
+      "rationale": "A Go function_declaration always carries a parameters node \u2014 `func F()` still has an empty one \u2014 so the empty-signature fallback cannot execute.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_extra.x_extract_go_definitions__mutmut_54",
+      "removed": "full = f\"{recv}.{_text(name, source)}\" if recv else _text(name, source)",
+      "added": "full = f\"{recv}.{_text(name, source)}\" if recv else _text(None, source)",
+      "kind": "unreachable-branch",
+      "rationale": "A Go method_declaration always carries a receiver, and a receiver always contains a type_identifier, so _extract_go_receiver never returns empty here and this else cannot run.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_extra.x_extract_go_definitions__mutmut_55",
+      "removed": "full = f\"{recv}.{_text(name, source)}\" if recv else _text(name, source)",
+      "added": "full = f\"{recv}.{_text(name, source)}\" if recv else _text(name, None)",
+      "kind": "unreachable-branch",
+      "rationale": "A Go method_declaration always carries a receiver, and a receiver always contains a type_identifier, so _extract_go_receiver never returns empty here and this else cannot run.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_extra.x_extract_go_definitions__mutmut_56",
+      "removed": "full = f\"{recv}.{_text(name, source)}\" if recv else _text(name, source)",
+      "added": "full = f\"{recv}.{_text(name, source)}\" if recv else _text(source)",
+      "kind": "unreachable-branch",
+      "rationale": "A Go method_declaration always carries a receiver, and a receiver always contains a type_identifier, so _extract_go_receiver never returns empty here and this else cannot run.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_extra.x_extract_go_definitions__mutmut_57",
+      "removed": "full = f\"{recv}.{_text(name, source)}\" if recv else _text(name, source)",
+      "added": "full = f\"{recv}.{_text(name, source)}\" if recv else _text(name, )",
+      "kind": "unreachable-branch",
+      "rationale": "A Go method_declaration always carries a receiver, and a receiver always contains a type_identifier, so _extract_go_receiver never returns empty here and this else cannot run.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_extra.x_extract_swift_definitions__mutmut_5",
+      "removed": "_extract_swift_node(root, source, defs, \"\")",
+      "added": "_extract_swift_node(root, source, defs, None)",
+      "kind": "equivalent-by-construction",
+      "rationale": "Passing None instead of \"\" as the initial scope is unobservable: every use of that parameter is a truthiness test (`if scope` / `f\"{scope}.\" if scope else ...`), and both values are falsy.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_jvm.x_extract_java_definitions__mutmut_5",
+      "removed": "_walk_java(root, source, defs, \"\")",
+      "added": "_walk_java(root, source, defs, None)",
+      "kind": "equivalent-by-construction",
+      "rationale": "Passing None instead of \"\" as the initial scope is unobservable: every use of that parameter is a truthiness test (`if scope` / `f\"{scope}.\" if scope else ...`), and both values are falsy.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_jvm.x_extract_kotlin_definitions__mutmut_5",
+      "removed": "_walk_kotlin(root, source, defs, \"\")",
+      "added": "_walk_kotlin(root, source, defs, None)",
+      "kind": "equivalent-by-construction",
+      "rationale": "Passing None instead of \"\" as the initial scope is unobservable: every use of that parameter is a truthiness test (`if scope` / `f\"{scope}.\" if scope else ...`), and both values are falsy.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_scripting.x_extract_php_definitions__mutmut_5",
+      "removed": "_walk_php(root, source, defs, \"\")",
+      "added": "_walk_php(root, source, defs, None)",
+      "kind": "equivalent-by-construction",
+      "rationale": "Passing None instead of \"\" as the initial scope is unobservable: every use of that parameter is a truthiness test (`if scope` / `f\"{scope}.\" if scope else ...`), and both values are falsy.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_scripting.x_extract_php_imports__mutmut_10",
+      "removed": "mod = _text(clause, source).strip().rstrip(\";\").strip()",
+      "added": "mod = _text(clause, source).strip().lstrip(\";\").strip()",
+      "kind": "equivalent-by-construction",
+      "rationale": "The PHP clause node text excludes the statement terminator, so `rstrip(\";\")` is already a no-op; swapping it for lstrip or whitespace-strip changes nothing, and the leading `.strip()` has already removed surrounding whitespace.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_scripting.x_extract_php_imports__mutmut_9",
+      "removed": "mod = _text(clause, source).strip().rstrip(\";\").strip()",
+      "added": "mod = _text(clause, source).strip().rstrip(None).strip()",
+      "kind": "equivalent-by-construction",
+      "rationale": "The PHP clause node text excludes the statement terminator, so `rstrip(\";\")` is already a no-op; swapping it for lstrip or whitespace-strip changes nothing, and the leading `.strip()` has already removed surrounding whitespace.",
+      "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.ast_extractors_scripting.x_extract_ruby_definitions__mutmut_5",
+      "removed": "_walk_ruby(root, source, defs, \"\")",
+      "added": "_walk_ruby(root, source, defs, None)",
+      "kind": "equivalent-by-construction",
+      "rationale": "Passing None instead of \"\" as the initial scope is unobservable: every use of that parameter is a truthiness test (`if scope` / `f\"{scope}.\" if scope else ...`), and both values are falsy.",
+      "issue": "#369"
+    }
+  ]
+}

--- a/scripts/mutation_check.sh
+++ b/scripts/mutation_check.sh
@@ -109,8 +109,34 @@ fi
 
 if [ "$LISTED" -gt 0 ]; then
   printf '%s\n' "$RESULTS" | grep -E ': *survived[[:space:]]*$'
-  echo ">>> re-verifying against the FULL test selection before trusting the verdict (issue #269):"
-  printf '%s\n' "$RESULTS" | uv run python3 "$ROOT/scripts/mutation_recheck_survivors.py" "$ROOT/mutants" "${TEST_ARR[@]}"
+
+  # Registered equivalents first, re-verification second. The order is load-
+  # bearing: a mutant the #269 recheck would reclassify as RECOVERED is not in
+  # the registry, so running the registry check on what the recheck already
+  # cleared would be fine, but running the recheck on registered equivalents
+  # wastes a full test selection per mutant and reports them as genuine.
+  # Filter what is justified, then re-verify only what is left.
+  #
+  # §12.4 is "0 surviving NON-EQUIVALENT mutants, or each survivor documented".
+  # Before this, the second half was inexpressible: any survivor failed, so a
+  # module whose every survivor carried a rationale looked identical to one
+  # nobody had read, and the blocking tier became something to bypass.
+  echo ">>> checking survivors against the registered-equivalents registry:"
+  set +e
+  UNREGISTERED="$(printf '%s\n' "$RESULTS" \
+    | uv run python3 "$ROOT/scripts/mutation_equivalents.py" "$@")"
+  REG_RC=$?
+  set -e
+  [ "$REG_RC" -eq 2 ] && exit 2          # malformed registry: never tolerated
+  [ "$REG_RC" -eq 1 ] && exit 1          # drifted or stale entry: needs a human
+
+  if [ -z "$UNREGISTERED" ]; then
+    echo "  every survivor is a registered, justified equivalent 🎉"
+    exit 0
+  fi
+
+  echo ">>> re-verifying the UNREGISTERED ones against the FULL test selection (issue #269):"
+  printf '%s\n' "$UNREGISTERED" | uv run python3 "$ROOT/scripts/mutation_recheck_survivors.py" "$ROOT/mutants" "${TEST_ARR[@]}"
 else
   echo "  none — 0 surviving mutants 🎉"
 fi

--- a/scripts/mutation_equivalents.py
+++ b/scripts/mutation_equivalents.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Registered-equivalent gate for mutation testing — coding-standards §12.4.
+
+The standard is "0 surviving non-equivalent mutants, or each survivor
+documented as equivalent". `scripts/mutation_check.sh` could express the first
+half and not the second: it failed on any survivor, so a module where every
+survivor carries a written rationale looked exactly like one nobody had
+examined. That makes the blocking per-commit tier unusable on such a module
+for even a one-line change, which in practice means it gets bypassed.
+
+This adds the missing half without reopening the hole the gate exists to
+close. Three properties, in order of importance:
+
+**Fail-closed on drift.** mutmut names mutants positionally
+(`x__walk_type__mutmut_16`), so the same name means a *different* mutation
+after the function changes. Registering a name alone would silently absolve
+whatever later occupies that slot. Every entry therefore pins the exact
+`removed`/`added` line pair, and an exemption applies only when the diff still
+matches. A changed mutation is an unregistered survivor and fails.
+
+**Fail-closed on absence.** Only listed mutants are exempt. There is no
+wildcard, no per-file suppression and no "ignore this module" — those are how
+a suppression mechanism becomes the next false green.
+
+**No silent rot.** An entry that no longer corresponds to a produced mutant is
+an error, not a shrug: either the code moved (so the rationale is unverified)
+or a test now kills it (so the entry is dead weight). Both need a human.
+
+Registry: `memory/mutation-equivalents.json`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY_PATH = REPO_ROOT / "memory" / "mutation-equivalents.json"
+
+# An entry states *why* it can never be killed, and the two kinds age
+# differently. `equivalent-by-construction` is a claim about the code's
+# semantics and cannot become false. `unreachable-branch` is a claim about the
+# current callers or grammar and CAN become false when either changes — which
+# is exactly when the diff-pinning above forces a re-read.
+KINDS = frozenset(
+    {
+        "equivalent-by-construction",
+        "unreachable-branch",
+        "seam-pending-implementation",
+    }
+)
+
+_MIN_RATIONALE = 40  # a sentence, not a shrug
+_SURVIVOR = re.compile(r"^\s*([\w.]+):\s*survived\s*$")
+
+
+class RegistryError(ValueError):
+    """The registry file is malformed. Never silently tolerated."""
+
+
+@dataclass(frozen=True)
+class Equivalent:
+    """One registered, justified, un-killable mutant."""
+
+    mutant: str
+    removed: str
+    added: str
+    kind: str
+    rationale: str
+    issue: str
+
+    @property
+    def module(self) -> str:
+        """`mcp_server.core.ast_extractors` from the mutant's dotted name."""
+        return self.mutant.rsplit(".", 1)[0]
+
+    @property
+    def source_path(self) -> str:
+        return self.module.replace(".", "/") + ".py"
+
+
+def _require(entry: dict, field: str, index: int) -> str:
+    value = entry.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise RegistryError(
+            f"entry {index}: '{field}' is required and must be non-empty"
+        )
+    return value
+
+
+def parse_registry(text: str) -> list[Equivalent]:
+    """Parse and validate the registry. Raises rather than skipping bad rows."""
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:  # noqa: TRY003 — message carries the position
+        raise RegistryError(f"not valid JSON: {exc}") from exc
+    rows = data.get("equivalents")
+    if not isinstance(rows, list):
+        raise RegistryError("top-level 'equivalents' must be a list")
+
+    out: list[Equivalent] = []
+    seen: set[str] = set()
+    for i, entry in enumerate(rows):
+        if not isinstance(entry, dict):
+            raise RegistryError(f"entry {i}: must be an object")
+        kind = _require(entry, "kind", i)
+        if kind not in KINDS:
+            raise RegistryError(
+                f"entry {i}: unknown kind {kind!r}; expected one of {sorted(KINDS)}"
+            )
+        rationale = _require(entry, "rationale", i)
+        if len(rationale) < _MIN_RATIONALE:
+            raise RegistryError(
+                f"entry {i}: rationale is {len(rationale)} chars; "
+                f"at least {_MIN_RATIONALE} required — state why it cannot be killed"
+            )
+        mutant = _require(entry, "mutant", i)
+        if mutant in seen:
+            raise RegistryError(f"entry {i}: duplicate mutant {mutant!r}")
+        seen.add(mutant)
+        out.append(
+            Equivalent(
+                mutant=mutant,
+                removed=_require(entry, "removed", i),
+                added=_require(entry, "added", i),
+                kind=kind,
+                rationale=rationale,
+                issue=_require(entry, "issue", i),
+            )
+        )
+    return out
+
+
+def load_registry(path: Path = REGISTRY_PATH) -> list[Equivalent]:
+    if not path.exists():
+        return []
+    return parse_registry(path.read_text(encoding="utf-8"))
+
+
+def parse_survivors(text: str) -> list[str]:
+    """Mutant names whose status is exactly 'survived'."""
+    names: list[str] = []
+    for line in text.splitlines():
+        m = _SURVIVOR.match(line)
+        if m and m.group(1) not in names:
+            names.append(m.group(1))
+    return names
+
+
+def mutant_diff(mutant: str, cwd: Path = REPO_ROOT) -> tuple[str, str]:
+    """The (removed, added) source lines of one mutant, via `mutmut show`."""
+    proc = subprocess.run(  # noqa: PLW1510 — a failed show yields ("", "") and is reported as a mismatch
+        ["uv", "run", "mutmut", "show", mutant],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    removed = added = ""
+    for line in proc.stdout.splitlines():
+        if line.startswith("---") or line.startswith("+++"):
+            continue
+        if line.startswith("-") and not removed:
+            removed = line[1:].strip()
+        elif line.startswith("+") and not added:
+            added = line[1:].strip()
+    return removed, added
+
+
+@dataclass(frozen=True)
+class Verdict:
+    accepted: list[tuple[str, Equivalent]]
+    unregistered: list[str]
+    mismatched: list[tuple[str, Equivalent]]
+    stale: list[Equivalent]
+
+    @property
+    def ok(self) -> bool:
+        return not (self.unregistered or self.mismatched or self.stale)
+
+
+def classify(
+    survivors: list[str],
+    registry: list[Equivalent],
+    diffs: dict[str, tuple[str, str]],
+    mutated_paths: frozenset[str],
+) -> Verdict:
+    """Split survivors into accepted / unregistered / drifted, and find rot.
+
+    `mutated_paths` scopes the staleness check: a scoped run mutates a few
+    files, so entries for files it never touched are not stale, they are
+    simply out of scope.
+    """
+    by_name = {e.mutant: e for e in registry}
+    accepted: list[tuple[str, Equivalent]] = []
+    unregistered: list[str] = []
+    mismatched: list[tuple[str, Equivalent]] = []
+
+    for name in survivors:
+        entry = by_name.get(name)
+        if entry is None:
+            unregistered.append(name)
+            continue
+        removed, added = diffs.get(name, ("", ""))
+        if (removed, added) == (entry.removed, entry.added):
+            accepted.append((name, entry))
+        else:
+            mismatched.append((name, entry))
+
+    survived = set(survivors)
+    stale = [
+        e
+        for e in registry
+        if e.source_path in mutated_paths and e.mutant not in survived
+    ]
+    return Verdict(accepted, unregistered, mismatched, stale)
+
+
+def format_report(v: Verdict) -> str:
+    lines: list[str] = []
+    if v.accepted:
+        by_kind: dict[str, int] = {}
+        for _, e in v.accepted:
+            by_kind[e.kind] = by_kind.get(e.kind, 0) + 1
+        summary = ", ".join(f"{n} {k}" for k, n in sorted(by_kind.items()))
+        lines.append(
+            f">>> {len(v.accepted)} registered equivalent(s) accepted: {summary}"
+        )
+    if v.mismatched:
+        lines.append(
+            f"!!! {len(v.mismatched)} registered mutant(s) NO LONGER MATCH "
+            "their recorded diff."
+        )
+        lines.append(
+            "!!! mutmut numbers mutants positionally, so the code moved and the "
+            "rationale is unverified. Re-read each and update or remove the entry."
+        )
+        for name, e in v.mismatched:
+            lines.append(
+                f"      {name}\n        registered: {e.removed!r} -> {e.added!r}"
+            )
+    if v.stale:
+        lines.append(f"!!! {len(v.stale)} registry entr(ies) match no produced mutant.")
+        lines.append(
+            "!!! Either a test now kills it (delete the entry) or the code moved "
+            "(the rationale is unverified). Both need a human."
+        )
+        for e in v.stale:
+            lines.append(f"      {e.mutant}")
+    if v.unregistered:
+        lines.append(
+            f"!!! {len(v.unregistered)} UNREGISTERED surviving mutant(s) "
+            "— a real test gap:"
+        )
+        for name in v.unregistered:
+            lines.append(f"      {name}")
+    if v.ok and not v.accepted:
+        lines.append("  none — 0 surviving mutants 🎉")
+    elif v.ok:
+        lines.append("  no unregistered survivors 🎉")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    """stdin: `mutmut results` output. argv: the mutated source paths.
+
+    stdout carries the UNREGISTERED survivor names, one per line, so the caller
+    can hand exactly those to `mutation_recheck_survivors.py` — the order
+    matters. The registry must filter first: a mutant the recheck would
+    reclassify as RECOVERED is not in the registry, and running the registry
+    check second would report it as an unjustified survivor. Filtering known
+    equivalents first, then re-verifying only what is left, composes correctly.
+
+    stderr carries the human report. The exit code covers only the failures
+    this script alone can judge — a drifted or stale entry — because whether an
+    unregistered survivor is real is the recheck's call, not ours.
+    """
+    if not argv:
+        print("usage: mutation_equivalents.py <mutated_source.py> ...", file=sys.stderr)
+        return 2
+    try:
+        registry = load_registry()
+    except RegistryError as exc:
+        print(f"!!! registry is malformed: {exc}", file=sys.stderr)
+        return 2
+
+    survivors = parse_survivors(sys.stdin.read())
+    diffs = {name: mutant_diff(name) for name in survivors}
+    verdict = classify(survivors, registry, diffs, frozenset(argv))
+    print(format_report(verdict), file=sys.stderr)
+    for name in verdict.unregistered:
+        print(f"    {name}: survived")
+    return 1 if (verdict.mismatched or verdict.stale) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests_py/core/test_ast_extractor_edges.py
+++ b/tests_py/core/test_ast_extractor_edges.py
@@ -309,6 +309,17 @@ class TestRubyRequireScanning:
             ("json", [], False)
         ]
 
+    def test_an_unquoted_parenthesised_argument_keeps_its_own_characters(self) -> None:
+        """`require(Xfoo)` trims the parentheses and nothing else. Without the
+        quotes there is no second trim to hide a widened set, so this is the
+        case that separates `strip("()")` from any superset of it.
+        """
+        from mcp_server.core.ast_extractors_scripting import extract_ruby_imports
+
+        assert _full_imports("ruby", b"require(Xfoo)\n", extract_ruby_imports) == [
+            ("Xfoo", [], False)
+        ]
+
     def test_only_quotes_and_parentheses_are_trimmed_from_the_path(self) -> None:
         """Both call forms are trimmed of their own punctuation and nothing
         else. A path whose first and last characters are ordinary letters must

--- a/tests_py/scripts/test_mutation_equivalents.py
+++ b/tests_py/scripts/test_mutation_equivalents.py
@@ -1,0 +1,189 @@
+"""The registered-equivalents gate must fail closed (§12.4).
+
+This gate exists to let a survivor be accepted with a written rationale. That
+is exactly the shape of a suppression mechanism, and a suppression mechanism
+that can be wrong quietly is worse than no gate at all — the same script
+already produced one false green (it reported `0 surviving mutants` on a run
+whose own counter said 423).
+
+So the tests here are mostly about what the registry must *refuse*: an entry
+whose recorded mutation no longer matches, an entry matching nothing, a
+rationale that says nothing, an unknown kind. The happy path is one test; the
+refusals are the point.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.mutation_equivalents import (
+    Equivalent,
+    RegistryError,
+    classify,
+    format_report,
+    parse_registry,
+    parse_survivors,
+)
+
+_PATHS = frozenset({"mcp_server/core/ast_extractors.py"})
+
+
+def _entry(**over) -> dict:
+    base = {
+        "mutant": "mcp_server.core.ast_extractors.x__walk_type__mutmut_1",
+        "removed": 'base = text.rsplit(".", 1)[-1]',
+        "added": 'base = text.rsplit(".", 2)[-1]',
+        "kind": "equivalent-by-construction",
+        "rationale": (
+            "rsplit(sep, n)[-1] selects the last element for every n, "
+            "so maxsplit cannot matter."
+        ),
+        "issue": "#369",
+    }
+    base.update(over)
+    return base
+
+
+def _registry(*entries: dict) -> str:
+    return json.dumps({"schema_version": 1, "equivalents": list(entries)})
+
+
+class TestRegistryValidation:
+    def test_a_well_formed_entry_loads(self) -> None:
+        (e,) = parse_registry(_registry(_entry()))
+        assert e.kind == "equivalent-by-construction"
+        assert e.source_path == "mcp_server/core/ast_extractors.py"
+
+    @pytest.mark.parametrize(
+        "field", ["mutant", "removed", "added", "kind", "rationale", "issue"]
+    )
+    def test_every_field_is_mandatory(self, field: str) -> None:
+        with pytest.raises(RegistryError, match=field):
+            parse_registry(_registry(_entry(**{field: ""})))
+
+    def test_an_unknown_kind_is_refused(self) -> None:
+        """The kind vocabulary is closed on purpose: 'equivalent-by-construction'
+        can never become false, 'unreachable-branch' can. A free-text kind would
+        let those two blur.
+        """
+        with pytest.raises(RegistryError, match="unknown kind"):
+            parse_registry(_registry(_entry(kind="probably-fine")))
+
+    def test_a_token_rationale_is_refused(self) -> None:
+        """'equivalent' as a bare word is the thing this gate exists to stop
+        anyone writing.
+        """
+        with pytest.raises(RegistryError, match="rationale"):
+            parse_registry(_registry(_entry(rationale="equivalent")))
+
+    def test_a_duplicate_mutant_is_refused(self) -> None:
+        with pytest.raises(RegistryError, match="duplicate"):
+            parse_registry(_registry(_entry(), _entry()))
+
+    def test_malformed_json_is_refused_rather_than_ignored(self) -> None:
+        with pytest.raises(RegistryError, match="not valid JSON"):
+            parse_registry("{not json")
+
+    def test_a_missing_equivalents_key_is_refused(self) -> None:
+        with pytest.raises(RegistryError, match="must be a list"):
+            parse_registry(json.dumps({"schema_version": 1}))
+
+
+class TestClassification:
+    NAME = "mcp_server.core.ast_extractors.x__walk_type__mutmut_1"
+
+    def _reg(self, **over) -> list[Equivalent]:
+        return parse_registry(_registry(_entry(**over)))
+
+    def test_a_matching_survivor_is_accepted(self) -> None:
+        reg = self._reg()
+        v = classify(
+            [self.NAME], reg, {self.NAME: (reg[0].removed, reg[0].added)}, _PATHS
+        )
+        assert v.ok
+        assert [n for n, _ in v.accepted] == [self.NAME]
+
+    def test_a_survivor_absent_from_the_registry_is_unregistered(self) -> None:
+        other = "mcp_server.core.ast_extractors.x__other__mutmut_9"
+        v = classify([other], self._reg(), {other: ("a", "b")}, _PATHS)
+        assert not v.ok
+        assert v.unregistered == [other]
+
+    def test_a_drifted_mutation_is_not_absolved(self) -> None:
+        """The load-bearing property. mutmut numbers mutants positionally, so
+        after the code moves the same name is a DIFFERENT mutation. Matching on
+        the name alone would silently absolve whatever now occupies the slot.
+        """
+        reg = self._reg()
+        drifted = {self.NAME: ("something = else()", "something = other()")}
+        v = classify([self.NAME], reg, drifted, _PATHS)
+        assert not v.ok
+        assert [n for n, _ in v.mismatched] == [self.NAME]
+        assert not v.accepted
+
+    def test_an_entry_matching_no_survivor_is_stale(self) -> None:
+        """Either a test now kills it, so the entry is dead weight, or the code
+        moved, so the rationale is unverified. Both need a human.
+        """
+        v = classify([], self._reg(), {}, _PATHS)
+        assert not v.ok
+        assert [e.mutant for e in v.stale] == [self.NAME]
+
+    def test_an_entry_for_a_file_this_run_did_not_mutate_is_not_stale(self) -> None:
+        """A scoped run mutates a few files; entries for the others are out of
+        scope, not rotten. Without this the gate would be unusable for scoped
+        runs, which is the tier it is meant to serve.
+        """
+        v = classify([], self._reg(), {}, frozenset({"mcp_server/core/other.py"}))
+        assert v.ok
+        assert not v.stale
+
+
+class TestSurvivorParsing:
+    def test_only_survived_rows_are_taken(self) -> None:
+        text = (
+            "    a.b.x__f__mutmut_1: survived\n"
+            "    a.b.x__f__mutmut_2: killed\n"
+            "    a.b.x__f__mutmut_3: no tests\n"
+            "    a.b.x__f__mutmut_4: survived\n"
+        )
+        assert parse_survivors(text) == ["a.b.x__f__mutmut_1", "a.b.x__f__mutmut_4"]
+
+    def test_duplicates_are_collapsed(self) -> None:
+        text = "  a.b.x__f__mutmut_1: survived\n  a.b.x__f__mutmut_1: survived\n"
+        assert parse_survivors(text) == ["a.b.x__f__mutmut_1"]
+
+    def test_empty_input_yields_nothing(self) -> None:
+        assert parse_survivors("") == []
+
+
+class TestReport:
+    def test_a_clean_run_says_so(self) -> None:
+        v = classify([], [], {}, _PATHS)
+        assert "0 surviving mutants" in format_report(v)
+
+    def test_drift_is_reported_with_the_recorded_diff(self) -> None:
+        reg = parse_registry(_registry(_entry()))
+        name = reg[0].mutant
+        v = classify([name], reg, {name: ("x", "y")}, _PATHS)
+        out = format_report(v)
+        assert "NO LONGER MATCH" in out
+        assert reg[0].removed in out, "the reader needs to see what was registered"
+
+
+class TestCommittedRegistry:
+    def test_the_repositorys_own_registry_is_valid(self) -> None:
+        """A malformed registry disables the exemption path, and the gate would
+        then fail on justified survivors — noisy, but also a signal nobody
+        reads. Validate it in CI rather than on first use.
+        """
+        from scripts.mutation_equivalents import load_registry
+
+        entries = load_registry()
+        assert entries, "registry should carry the documented equivalents"
+        for e in entries:
+            assert e.issue.startswith("#"), (
+                f"{e.mutant}: issue must reference a filed number"
+            )


### PR DESCRIPTION
Makes §12.4 expressible. Refs #369, #372.

## The problem

§12.4 reads *"0 surviving **non-equivalent** mutants on changed code — track the score, triage every survivor (killed, or documented-equivalent)"*. `scripts/mutation_check.sh` could express the first half and not the second: **any** survivor failed the gate.

After #376 the five extractor modules sit at 50 survivors, every one carrying a written rationale at its use site. To the gate that is indistinguishable from 50 nobody has read, so the blocking per-commit tier is permanently red there — for a *good* reason, which is worse, because a gate that is always red for a good reason is one people learn to route around. That is how §14.2 bypasses start.

## The design, and why each piece exists

This is a suppression mechanism, and a suppression mechanism that can be wrong quietly is worse than no gate. This same script produced a false green yesterday — `none — 0 surviving mutants 🎉` on a run whose own counter said `🙁 423`. So the properties are ordered by how badly they fail:

**1. Fail-closed on drift.** mutmut names mutants *positionally*. `x__walk_type__mutmut_16` means a **different mutation** once the function changes. A name-keyed exemption would silently absolve whatever later occupies that slot — the worst possible failure for this tool. Every entry therefore pins the exact `removed`/`added` pair and applies only while the diff still matches. A changed mutation is unregistered and fails. Tested: `test_a_drifted_mutation_is_not_absolved`.

**2. Fail-closed on absence.** Only named mutants are exempt. No wildcards, no per-file suppression, no ignore-module. Those are exactly how this becomes the next false green.

**3. No silent rot.** An entry matching no produced mutant is an **error**, not a shrug: either a test now kills it (dead weight) or the code moved (rationale unverified). Both need a human. Staleness is scoped to the files a run actually mutated, so a narrow run does not flag entries it never exercised — without that the gate would be unusable for the per-commit tier it serves.

**Ordering is load-bearing.** Registry filters first, the #269 recheck re-verifies only what is left. Reversed, every registered equivalent would burn a full test selection per mutant and be reported as genuine.

**`kind` is a closed enum of three** because the claims age differently. `equivalent-by-construction` is about semantics and cannot become false. `unreachable-branch` is about today's callers or grammar and **can**. A reader needs to know which one they are trusting. `rationale` has a minimum length because "equivalent" as a bare word is the thing this exists to make unwriteable.

## Registry: 50 entries, not 51

| kind | n |
|---|---|
| equivalent-by-construction | 27 |
| unreachable-branch | 21 |
| seam-pending-implementation (#372) | 2 |

#376 left 51 survivors. Writing the rationale for the Ruby `strip("()")` mutant, I could not actually justify it — so I tested instead of asserting. `require(Xfoo)` returns `Xfoo`; the widened strip set returns `foo`. **It was killable.** It got a test, not an exemption.

That is the only evidence that really matters here: the mechanism caught a bad exemption from the person building it, before it shipped.

## Evidence

```
gate on the five extractor modules            EXIT 0
  1486 mutants: 1436 killed, 0 uncovered, 50 registered equivalents accepted
  >>> 50 registered equivalent(s) accepted: 27 equivalent-by-construction,
      2 seam-pending-implementation, 21 unreachable-branch

NEGATIVE CONTROL — one entry removed      EXIT 1
  >>> 49 registered equivalent(s) accepted
  !!! 1 UNREGISTERED surviving mutant(s) — a real test gap
  >>> 1 GENUINE surviving mutant(s) — a real test gap
```

Both directions, end to end through the shell wiring, not just the unit tests.

## Completion Ledger

| § | Item | Evidence |
|---|---|---|
| A1 | Happy path | Gate exits 0 with all 50 accepted, quoted above |
| A2 | Edge cases | Missing field, unknown kind, token rationale, duplicate mutant, malformed JSON, drifted diff, stale entry, out-of-scope entry, empty input — one test each |
| A3 | Failure paths | Every arm asserted: `RegistryError` per malformed shape; exit 2 malformed registry; exit 1 drift/stale; unregistered handed to the recheck |
| A4 | Trust boundary | The registry is committed input and fully validated on load; a bad row raises rather than being skipped |
| A5 | Invariants | Stated in the module docstring: exemption applies only while the diff matches |
| A6 | Idempotency | Pure classification over inputs; no state |
| B1–B3 | Concurrency | N/A |
| C1 | Scalability | One `mutmut show` per **survivor**, not per mutant — 50 rather than 1486 |
| C2–C3 | Resources / perf | Registry filters before the recheck, which removes 50 full test-selection re-runs from the previous behaviour |
| D1–D3 | Security | N/A. No new egress, no secrets |
| E1 | API compatibility | `mutation_check.sh` keeps its CLI; a repo with no registry file behaves exactly as before (`load_registry` returns `[]`) |
| E2 | Downstream consumers | The pre-commit hook path and `mutation_recheck_survivors.py`; the latter now receives a filtered list, verified by the negative control |
| E3–E4 | Persisted data, cross-platform | JSON, stdlib only — `tomllib` is absent on this repo's 3.10 floor |
| F1 | Signals | Report names each failure class distinctly and prints the recorded diff on drift, so the reader can see what was registered |
| F2 | Degraded modes | None silent. A missing registry is the pre-existing behaviour; a malformed one is exit 2 |
| G1 | Path→test ledger | 23 tests across validation, classification, parsing, reporting, and the committed registry |
| G2 | Regression test | The negative control is the regression test for the mechanism itself |
| G3 | Determinism | Suite run repeatedly; 23 passed each time |
| G4 | Negative assertions | Drift is **not** absolved; out-of-scope entries are **not** stale; unregistered survivors are **not** accepted |
| G5 | Full gate | `ruff check .` clean · `ruff format --check .` clean · `bash -n` ok · 55 tests in the two touched test files |
| H1 | Standards | 286 lines (cap 300); every function under the 40-line cap |
| H2–H3 | Readability, conventions | Each design decision states the failure it prevents; JSON chosen because the repo's 3.10 floor has no `tomllib`, matching `generate_pip_constraints.py`'s stated reasoning |
| H4 | CHANGELOG | N/A — developer tooling, no consumer-observable behaviour change |
| H5 | Commit hygiene | One commit, conventional message |
| H6 | CI green | Required before merge |
| H7 | Boy-scout (§14) | A mutant I was about to register turned out killable and got a test instead |

## What this does not do

It does not lower the bar. An unregistered survivor still fails, a drifted one still fails, and a stale entry still fails. The only thing that now passes is a survivor a human has looked at and written down a reason for — which is what §12.4 asked for in the first place.
