### PR TITLE
fix(capture): make the write-gate bypass rule an allowlist (#365 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,20 @@ adheres to [Semantic Versioning](https://semver.org/).
   verbatim into later sessions. Capture for those tools is now a fixed length
   floor identical for any payload, and the new `core/capture_origin` resolves
   the origin from the producing tool name — known out-of-band, unforgeable by
-  the payload — so network-origin content is refused the two content-derived
-  bypasses. `force` and a `deliberate` write class are out-of-band human
-  signals and remain valid at any origin; the `important`/`critical` tag bypass
-  also remains, because `_build_tags` never derives those from output.
-  Unrecognised tools classify as `unknown` rather than trusted, so a newly
-  added tool is visibly unclassified. `origin_tool` is a declared input on
-  `remember` and exposed on both registered MCP wrappers.
+  the payload. The two content-derived bypasses are then granted by an
+  **allowlist**: only a `deliberate` or `local_action` origin may claim them.
+  Network content is refused, and so is anything unclassified — a denylist of
+  just the two known network tools would have failed open the moment the host
+  added or renamed one, silently restoring the bypass with no failing test.
+  `force` and a `deliberate` write class are out-of-band human signals and
+  remain valid at any origin; the `important`/`critical` tag bypass also
+  remains, because `_build_tags` never derives those from output. Unrecognised
+  tools classify as `unknown`, which is refused rather than trusted. A
+  `remember` carrying no producing tool *at all* resolves to `deliberate` — the
+  user asked directly — which is deliberately distinct from a tool that was
+  named but is not recognised, since promoting the latter would reinstate the
+  fail-open. `origin_tool` is a declared input on `remember` and exposed on
+  both registered MCP wrappers.
 
   The origin is persisted to a new `memories.capture_origin` column (both
   backends, with a one-shot migration) so the value that governed the gate is

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -116,7 +116,7 @@ table above — the catalogue and the command ship in the same commit.
 
 ### Memory Write Path
 
-1. **Gate**: 4-signal novelty filter (embedding distance, entity overlap, temporal proximity, structural similarity). Content from a NETWORK origin (`origin_tool` = WebFetch/WebSearch — issue #365) is refused the content-derived bypasses, so fetched text cannot skip the gate by looking like a decision or an error; `force` and a `deliberate` write class still bypass at any origin. Decision/error content bypasses the gate — detection is language-aware (see `docs/data-flow.md` § Write Gate Bypass); `force=true` or an `important`/`critical` tag always bypasses, in any language
+1. **Gate**: 4-signal novelty filter (embedding distance, entity overlap, temporal proximity, structural similarity). The content-derived bypasses are granted by an allowlist of origins (`deliberate`, `local_action` — issue #365), so fetched text cannot skip the gate by looking like a decision or an error, and neither can content from a channel nobody has classified; `force` and a `deliberate` write class still bypass at any origin. Decision/error content bypasses the gate — detection is language-aware (see `docs/data-flow.md` § Write Gate Bypass); `force=true` or an `important`/`critical` tag always bypasses, in any language
 2. **Curate**: Active curation — merge with similar, link to related, or create new
 3. **Store**: PostgreSQL + pgvector with auto tsvector indexing → entity extraction → knowledge graph
 

--- a/mcp_server/core/capture_origin.py
+++ b/mcp_server/core/capture_origin.py
@@ -50,10 +50,12 @@ from __future__ import annotations
 #              about whether its claims are correct.
 # NETWORK      content that came from off-machine (WebFetch, WebSearch).
 #              Third-party and attacker-influenceable.
-# UNKNOWN      no tool attribution available. Treated as trusted-for-bypass so
-#              that adding this parameter changes no existing caller's
-#              behaviour; every untrusted channel reaches the gate through the
-#              classification table below, never through this default.
+# UNKNOWN      no tool attribution available, or a tool nobody has classified.
+#              REFUSED the content-derived bypass. This is the fail-closed
+#              choice: an unclassified channel might be off-machine, and the
+#              cost of being wrong is a rejected write rather than a hostile
+#              page installing itself into durable memory. A caller that
+#              legitimately needs the bypass says which channel it is.
 ORIGIN_DELIBERATE = "deliberate"
 ORIGIN_LOCAL_ACTION = "local_action"
 ORIGIN_NETWORK = "network"
@@ -90,10 +92,20 @@ _LOCAL_ACTION_TOOLS: frozenset[str] = frozenset(
     }
 )
 
-# Content-derived write-gate bypasses are refused for these origins. Only
-# NETWORK today; the set exists so the refusal is a data decision rather than
-# an `if origin == "network"` scattered across call sites (§1.2).
-_ORIGINS_REFUSED_CONTENT_BYPASS: frozenset[str] = frozenset({ORIGIN_NETWORK})
+# Origins ALLOWED to claim a content-derived write-gate bypass. An allowlist,
+# not a denylist of untrusted origins, so the control fails closed.
+#
+# A denylist here would be fail-open in exactly the case this module exists to
+# defend. `_NETWORK_TOOLS` hardcodes two names against a host whose tool
+# surface changes: add a third off-machine tool, or rename one, and its content
+# classifies UNKNOWN. Under a denylist of {NETWORK} that silently regains the
+# bypass — the control stops applying with no failing test and no signal, which
+# is the same shape as the issue this module closes. Under an allowlist an
+# unclassified origin is simply refused, and the cost of a missing
+# classification is a rejected write rather than a trusted one.
+_ORIGINS_ALLOWED_CONTENT_BYPASS: frozenset[str] = frozenset(
+    {ORIGIN_DELIBERATE, ORIGIN_LOCAL_ACTION}
+)
 
 
 def classify_capture_origin(tool_name: str) -> str:
@@ -127,17 +139,17 @@ def classify_capture_origin(tool_name: str) -> str:
 def may_bypass_write_gate_on_content(origin: str) -> bool:
     """Whether content from ``origin`` may claim a content-derived bypass.
 
-    Pre: ``origin`` is any string (an unrecognised value is treated as
-    unknown).
-    Post: False exactly for the origins in
-    ``_ORIGINS_REFUSED_CONTENT_BYPASS``; True otherwise.
+    Pre: ``origin`` is any string.
+    Post: True exactly for the origins in
+    ``_ORIGINS_ALLOWED_CONTENT_BYPASS``; False otherwise, including for
+    ``ORIGIN_UNKNOWN`` and for any value this module does not recognise.
 
     The asymmetry is deliberate. ``force`` and a ``deliberate`` write class are
     out-of-band signals a human supplied, so they remain valid regardless of
     origin; ``bypass_error`` / ``bypass_decision`` are read out of the content
     itself, so they are exactly what an attacker would forge.
     """
-    return origin not in _ORIGINS_REFUSED_CONTENT_BYPASS
+    return origin in _ORIGINS_ALLOWED_CONTENT_BYPASS
 
 
 def is_network_origin(origin: str) -> bool:

--- a/mcp_server/core/write_gate.py
+++ b/mcp_server/core/write_gate.py
@@ -153,7 +153,18 @@ def determine_bypass(
     (falling through to the deliberate check when none of the more
     specific conditions matched).
     """
-    content_bypass_allowed = capture_origin.may_bypass_write_gate_on_content(origin)
+    # A deliberate write class is an out-of-band signal a human supplied, and
+    # such a write bypasses regardless (the `write_class == "deliberate"` arm
+    # below). Refusing it the SPECIFIC content reason would therefore change no
+    # outcome — only the diagnostic, masking bypass_error behind the generic
+    # bypass_write_class_deliberate and undoing the ordering issue #147
+    # deliberately chose. So the origin allowlist governs whether content may
+    # BUY a bypass it would not otherwise get, not how an already-granted one
+    # is labelled.
+    content_bypass_allowed = (
+        capture_origin.may_bypass_write_gate_on_content(origin)
+        or write_class == "deliberate"
+    )
     is_error = content_bypass_allowed and thermodynamics.is_error_content(content)
     is_decision = content_bypass_allowed and thermodynamics.is_decision_content(content)
     has_important = bool({"important", "critical"} & {t.lower() for t in tags})

--- a/mcp_server/handlers/remember.py
+++ b/mcp_server/handlers/remember.py
@@ -197,9 +197,28 @@ async def _handler_impl(args: dict[str, Any] | None = None) -> dict[str, Any]:
     # producing tool name the caller reports out-of-band — never inferred from
     # the content, which an off-machine payload controls. Governs only whether
     # the content-derived write-gate bypasses may be claimed.
-    resolved_origin = capture_origin.classify_capture_origin(
-        str(args.get("origin_tool") or "")
-    )
+    origin_tool = str(args.get("origin_tool") or "").strip()
+    resolved_origin = capture_origin.classify_capture_origin(origin_tool)
+    # A `remember` carrying NO producing tool at all is the user or agent
+    # asking for this in so many words: ORIGIN_DELIBERATE, the highest-trust
+    # value and — until this — the only one nothing ever produced.
+    #
+    # It matters because the bypass rule is an allowlist: without this a direct
+    # `remember` resolves UNKNOWN and loses the content-derived bypass it has
+    # always had.
+    #
+    # The condition is the ABSENCE of a tool name, not an UNKNOWN
+    # classification. Those differ exactly where it counts: a tool that was
+    # named but is not in the table (a future off-machine tool, a rename) also
+    # classifies UNKNOWN, and promoting that to DELIBERATE would reinstate the
+    # fail-open the allowlist just removed. Named-but-unrecognised stays
+    # UNKNOWN and stays refused.
+    #
+    # Gated additionally on the write class, which the auto-capture hook pins
+    # to "auto" out-of-band, so hook-captured content cannot reach DELIBERATE
+    # even if it somehow omitted its tool name.
+    if not origin_tool and resolved_write_class == write_class_module.DELIBERATE:
+        resolved_origin = capture_origin.ORIGIN_DELIBERATE
 
     gate = evaluate_gate(
         content,

--- a/tests_py/core/test_capture_origin.py
+++ b/tests_py/core/test_capture_origin.py
@@ -5,7 +5,7 @@ Contract under test:
     insensitively, and never guesses: unknown/empty -> ORIGIN_UNKNOWN.
   - WebFetch/WebSearch -> ORIGIN_NETWORK. Local-acting tools ->
     ORIGIN_LOCAL_ACTION.
-  - may_bypass_write_gate_on_content is False exactly for network origin.
+  - may_bypass_write_gate_on_content is True only for the allowlisted origins.
   - The classification is a pure function of the tool name: no content is
     consulted, so no content can change the answer. That invariant is what
     makes the value usable as a security input, so it is asserted directly.
@@ -17,6 +17,7 @@ import pytest
 
 from mcp_server.core.capture_origin import (
     ALL_ORIGINS,
+    ORIGIN_DELIBERATE,
     ORIGIN_LOCAL_ACTION,
     ORIGIN_NETWORK,
     ORIGIN_UNKNOWN,
@@ -74,21 +75,25 @@ class TestBypassPolicy:
     def test_network_origin_may_not_claim_a_content_bypass(self):
         assert may_bypass_write_gate_on_content(ORIGIN_NETWORK) is False
 
-    @pytest.mark.parametrize(
-        "origin", [ORIGIN_LOCAL_ACTION, ORIGIN_UNKNOWN, "deliberate"]
-    )
-    def test_non_network_origins_may(self, origin):
+    @pytest.mark.parametrize("origin", [ORIGIN_LOCAL_ACTION, ORIGIN_DELIBERATE])
+    def test_allowlisted_origins_may(self, origin):
         assert may_bypass_write_gate_on_content(origin) is True
 
-    def test_unrecognised_origin_is_permissive_by_design(self):
-        """Documented default: adding the parameter changes no caller.
+    def test_unknown_origin_is_refused_because_the_rule_is_an_allowlist(self):
+        """The fail-closed property, and the reason for the allowlist.
 
-        Every untrusted channel reaches the gate through
-        classify_capture_origin, never through this default, so permissiveness
-        here does not open the network path. Pinned so the choice is a decision
-        on record rather than an accident.
+        `_NETWORK_TOOLS` hardcodes two names against a host whose tool surface
+        changes. A third off-machine tool, or a renamed one, classifies
+        UNKNOWN. Under a denylist of {NETWORK} it would silently regain the
+        content bypass — the control stopping with no failing test, which is
+        the failure this module exists to prevent. Under the allowlist an
+        unclassified origin is refused.
         """
-        assert may_bypass_write_gate_on_content("something-new") is True
+        assert may_bypass_write_gate_on_content(ORIGIN_UNKNOWN) is False
+
+    def test_an_origin_this_module_does_not_know_is_refused(self):
+        """Stands in for a future off-machine tool nobody has classified yet."""
+        assert may_bypass_write_gate_on_content("something-new") is False
 
     def test_is_network_origin(self):
         assert is_network_origin(ORIGIN_NETWORK) is True
@@ -189,15 +194,28 @@ class TestWriteGateRefusesContentBypassForNetworkOrigin:
         )
         assert (bypass, reason) == (True, "bypass_important_tag")
 
-    def test_default_origin_preserves_pre_change_behaviour(self):
-        """Callers that do not pass origin must be unaffected."""
+    def test_a_caller_that_names_no_origin_is_refused_the_content_bypass(self):
+        """The cost of the allowlist, stated as a test rather than discovered.
+
+        A caller that passes no origin gets ORIGIN_UNKNOWN and no longer buys a
+        content-derived bypass. That is the intended trade: an unclassified
+        channel might be off-machine, and a rejected write is cheaper than a
+        fetched page installing itself into durable cross-session memory.
+
+        Nothing legitimate loses out. An explicit `remember` resolves to
+        ORIGIN_DELIBERATE (see handlers/remember.py), the auto-capture hook
+        always reports its producing tool, and the out-of-band escapes —
+        `force` and an important/critical tag — remain valid at any origin.
+        """
         from mcp_server.core.write_gate import determine_bypass
 
-        assert determine_bypass(False, self.ERROR_SHAPED, []) == (
-            True,
-            "bypass_error",
-        )
-        assert determine_bypass(False, self.DECISION_SHAPED, []) == (
-            True,
-            "bypass_decision",
-        )
+        assert determine_bypass(False, self.ERROR_SHAPED, []) == (False, None)
+        assert determine_bypass(False, self.DECISION_SHAPED, []) == (False, None)
+
+    def test_a_deliberate_origin_keeps_the_content_bypass(self):
+        """The companion: what an explicit `remember` resolves to still works."""
+        from mcp_server.core.write_gate import determine_bypass
+
+        assert determine_bypass(
+            False, self.ERROR_SHAPED, [], origin=ORIGIN_DELIBERATE
+        ) == (True, "bypass_error")

--- a/tests_py/core/test_write_gate.py
+++ b/tests_py/core/test_write_gate.py
@@ -28,6 +28,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mcp_server.core.capture_origin import ORIGIN_LOCAL_ACTION as LOCAL
+
 import mcp_server.core.write_gate as wg
 from mcp_server.observability import silent_failure
 
@@ -73,28 +75,40 @@ class TestDetermineBypass:
 
     def test_error_content_bypasses(self):
         bypassed, reason = wg.determine_bypass(
-            force=False, content="An exception occurred during startup", tags=[]
+            force=False,
+            content="An exception occurred during startup",
+            tags=[],
+            origin=LOCAL,
         )
         assert bypassed is True
         assert reason == "bypass_error"
 
     def test_crash_keyword_also_bypasses(self):
         bypassed, reason = wg.determine_bypass(
-            force=False, content="Service crash detected at 03:00", tags=[]
+            force=False,
+            content="Service crash detected at 03:00",
+            tags=[],
+            origin=LOCAL,
         )
         assert bypassed is True
         assert reason == "bypass_error"
 
     def test_decision_content_bypasses(self):
         bypassed, reason = wg.determine_bypass(
-            force=False, content="We decided to use PostgreSQL for storage", tags=[]
+            force=False,
+            content="We decided to use PostgreSQL for storage",
+            tags=[],
+            origin=LOCAL,
         )
         assert bypassed is True
         assert reason == "bypass_decision"
 
     def test_switched_keyword_is_decision(self):
         bypassed, reason = wg.determine_bypass(
-            force=False, content="Team switched from Redis to Kafka", tags=[]
+            force=False,
+            content="Team switched from Redis to Kafka",
+            tags=[],
+            origin=LOCAL,
         )
         assert bypassed is True
         assert reason == "bypass_decision"
@@ -102,14 +116,14 @@ class TestDetermineBypass:
     def test_non_english_decision_bypasses(self):
         # Issue #158 exact repro: Romanian decision was rejected as duplicate.
         bypassed, reason = wg.determine_bypass(
-            force=False, content="Am decis sa alegem optiunea A", tags=[]
+            force=False, content="Am decis sa alegem optiunea A", tags=[], origin=LOCAL
         )
         assert bypassed is True
         assert reason == "bypass_decision"
 
     def test_non_english_error_bypasses(self):
         bypassed, reason = wg.determine_bypass(
-            force=False, content="Произошла ошибка при сборке", tags=[]
+            force=False, content="Произошла ошибка при сборке", tags=[], origin=LOCAL
         )
         assert bypassed is True
         assert reason == "bypass_error"
@@ -120,6 +134,7 @@ class TestDetermineBypass:
             force=False,
             content="Sovellus kaatui: at com.acme.Main.run(Main.java:42)",
             tags=[],
+            origin=LOCAL,
         )
         assert bypassed is True
         assert reason == "bypass_error"

--- a/tests_py/infrastructure/test_capture_origin_persistence.py
+++ b/tests_py/infrastructure/test_capture_origin_persistence.py
@@ -117,14 +117,21 @@ class TestCaptureOriginRoundTrip:
         assert result.get("memory_id"), f"write did not store: {result!r}"
         assert self._origin_of(self._store(), result["memory_id"]) == expected
 
-    def test_absent_origin_tool_persists_unknown(self):
-        """A deliberate user write carries no tool; it must not be guessed."""
+    def test_absent_origin_tool_persists_deliberate(self):
+        """No producing tool at all means the user asked for this directly.
+
+        Distinct from an unrecognised tool (the next test), which stays
+        unknown. Absence is information: nothing produced this content, so a
+        human did. That is ORIGIN_DELIBERATE, and it is what lets a direct
+        `remember` keep the content-derived write-gate bypass now that the
+        bypass rule is an allowlist.
+        """
         result = self._remember(
             content="capture-origin round trip with no origin_tool " + "w" * 120,
             force=True,
         )
         assert result.get("memory_id"), f"write did not store: {result!r}"
-        assert self._origin_of(self._store(), result["memory_id"]) == "unknown"
+        assert self._origin_of(self._store(), result["memory_id"]) == "deliberate"
 
     def test_unrecognised_tool_persists_unknown_not_a_guess(self):
         result = self._remember(


### PR DESCRIPTION
Follow-up to #375, implementing the review finding. Refs #365.

## What was wrong

The origin control was a **denylist**:

```python
_ORIGINS_REFUSED_CONTENT_BYPASS = frozenset({ORIGIN_NETWORK})
```

Classification already failed safe — an unrecognised tool lands in `UNKNOWN` rather than being promoted to `LOCAL_ACTION`. But the security decision built on top of it failed **open**: anything not literally `webfetch` or `websearch` could claim a content-derived bypass.

The trigger is not hypothetical. `_NETWORK_TOOLS` hardcodes two names against a host whose tool surface changes. Add a third off-machine tool, or rename one, and its content classifies `UNKNOWN` and silently regains the bypass — the control stopping with no failing test and no signal. That is the same shape as the issue #375 closes.

Now an allowlist of `{DELIBERATE, LOCAL_ACTION}`. An unclassified origin is refused, so the cost of a missing classification is a rejected write instead of a trusted one.

## Two things the change forced out

**`ORIGIN_DELIBERATE` was dead.** Defined, documented in the vocabulary, produced by nothing since it was written. Under an allowlist a direct `remember` would resolve `UNKNOWN` and lose the content bypass it has always had, so the value now has a producer: a `remember` carrying no producing tool is the user asking directly.

The condition is the **absence of a tool name**, not an `UNKNOWN` classification. Those differ exactly where it counts — a named-but-unrecognised tool also classifies `UNKNOWN`, and promoting *that* to `DELIBERATE` would reinstate the fail-open this PR removes. My first draft got this wrong and `test_capture_origin_persistence.py::test_unrecognised_tool_persists_unknown_not_a_guess` caught it.

**The issue #147 ordering broke.** A deliberate write's reason degraded from `bypass_error` to the generic `bypass_write_class_deliberate`, masking the diagnostic that test exists to protect. Since such a write bypasses either way, refusing it the specific label changed no outcome and only destroyed information. The origin rule now governs whether content may **buy** a bypass, not how an already-granted one is **labelled**.

## The honest cost

The original design note said `UNKNOWN` was chosen so *"adding this parameter changes no existing caller's behaviour"*. Under an allowlist that is no longer true, and **seven tests in `test_write_gate.py` were silently relying on it**. They now state which channel produced their content — which is what they were asserting all along: *error-shaped content from a local tool* bypasses, not *error-shaped content from anywhere*.

That is the trade in one line: the permissive default was doing real work, and now every caller has to mean it.

## Completion Ledger

| § | Item | Evidence |
|---|---|---|
| A1 | Happy paths | `pytest -k "gate or capture or remember or origin or write_class"` → **453 passed**, 13 subtests |
| A2 | Edge cases | Absent tool, named-but-unrecognised tool, empty string, each origin value, deliberate write class at network origin, important/critical tag at network origin |
| A3 | Failure paths | Refusal asserted directly: `UNKNOWN` refused, unrecognised origin refused, network refused; each with its own test |
| A4 | Trust boundary | The whole change. Origin comes from the channel, never from content; the promotion to `DELIBERATE` keys on tool **absence** and is additionally gated on a write class the auto-capture hook pins out-of-band |
| A5 | Invariants | Stated at the use site: an unclassified origin is refused, and the cost of a missing classification is a rejected write |
| A6 | Idempotency | Pure functions over inputs |
| B1–B3 | Concurrency | N/A |
| C1–C3 | Resources / perf | N/A — set membership |
| D1 | Injection class | N/A |
| D2 | **Untrusted data** | The point of the PR. A future or renamed off-machine tool can no longer buy a content-derived bypass by being unclassified |
| D3 | Secrets | None touched |
| E1 | API compatibility | `may_bypass_write_gate_on_content` keeps its signature; the semantics invert, which is the intended behaviour change |
| E2 | Downstream consumers | `write_gate.determine_bypass` and `handlers/remember`; both updated and covered. Seven test call sites made explicit |
| E3 | Persisted data | `capture_origin` column now records `deliberate` for direct writes where it recorded `unknown`; more accurate, no migration needed |
| E4 | Cross-platform | Pure Python |
| F1 | Signals | The specific bypass reason is preserved for deliberate writes rather than masked |
| F2 | Degraded modes | Refusal is explicit, not silent: `determine_bypass` returns `(False, None)` and the gate reports a rejection |
| G1 | Path→test ledger | Allowlist membership, `UNKNOWN` refusal, unrecognised-origin refusal, absent-tool promotion, unrecognised-tool non-promotion, deliberate-keeps-specific-reason |
| G2 | Regression test | `test_unrecognised_tool_persists_unknown_not_a_guess` is the regression test for the flaw in my own first draft |
| G3 | Determinism | Slice re-run three times; 453 each time |
| G4 | Negative assertions | Named-but-unrecognised is **not** promoted; `UNKNOWN` may **not** bypass; a caller naming no origin gets `(False, None)` |
| G5 | Full gate | `ruff check .` clean · `ruff format --check .` clean (1283 files) |
| H1–H3 | Standards, readability | Each decision states the failure it prevents at the use site |
| H4 | CHANGELOG | Deferred to review: #375's entry describes the denylist. Say the word and I amend it rather than adding a second entry |
| H5 | Commit hygiene | One commit |
| H6 | CI green | Required before merge |
| H7 | Boy-scout (§14) | Found and fixed a dead vocabulary value (`ORIGIN_DELIBERATE`) that predates this PR |