### PR TITLE
fix(ingest): stamp doc-snapshot provenance and supersede stale re-ingests

### DIFF
--- a/mcp_server/handlers/ingest_docs_content.py
+++ b/mcp_server/handlers/ingest_docs_content.py
@@ -49,12 +49,17 @@ async def run_docs_pass(
                    to it — verified against
                    ai-architect-mcp-codebase/src/indexer/walk.rs:237).
     Postcondition: returns counts (``docs_seen``, ``docs_written``,
-                   ``docs_skipped``, ``references_written``) plus any
-                   diagnostics; re-running against an unchanged graph
-                   writes zero new memories and zero new relationship
-                   rows (idempotent — see
-                   ``writers.find_existing_doc_memory`` and
+                   ``docs_superseded``, ``docs_skipped``,
+                   ``references_written``) plus any diagnostics;
+                   re-running against an unchanged graph writes zero new
+                   memories and zero new relationship rows (idempotent —
+                   see ``writers.find_existing_doc_memory`` and
                    ``insert_relationship``'s ``ON CONFLICT``).
+                   ``docs_superseded`` (issue #381) counts the subset of
+                   ``docs_written`` where a source file changed since its
+                   last capture and the stale snapshot memory was
+                   version-chained forward rather than left to be served
+                   as current — see ``writers.write_doc_memory``.
     Invariant:     no entity is inserted by this pass — every File node
                    (docs and binaries alike) already became an entity in
                    the caller's main entity phase; this function only
@@ -68,6 +73,7 @@ async def run_docs_pass(
     diagnostics.extend(diag)
 
     docs_written = 0
+    docs_superseded = 0
     docs_skipped = 0
     for f in doc_files:
         rel_path = f.get("path")
@@ -77,11 +83,13 @@ async def run_docs_pass(
         if content is None:
             docs_skipped += 1
             continue
-        _, created = writers.write_doc_memory(
+        _, written, superseded = writers.write_doc_memory(
             store, domain, directory_context, rel_path, content
         )
-        if created:
+        if written:
             docs_written += 1
+        if superseded:
+            docs_superseded += 1
 
     known_doc_paths = {f["path"] for f in doc_files if f.get("path")}
     refs, ref_diag = await cypher.fetch_doc_references(graph_path, known_doc_paths)
@@ -93,6 +101,7 @@ async def run_docs_pass(
     result: dict[str, Any] = {
         "docs_seen": len(doc_files),
         "docs_written": docs_written,
+        "docs_superseded": docs_superseded,
         "docs_skipped": docs_skipped,
         "references_written": references_written,
     }

--- a/mcp_server/handlers/ingest_docs_content_writers.py
+++ b/mcp_server/handlers/ingest_docs_content_writers.py
@@ -24,6 +24,7 @@ content-less file entities by the generic files phase, matching D6's
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from pathlib import Path
 from typing import Any
@@ -46,10 +47,47 @@ MAX_DOC_BYTES: int = 1_048_576
 
 _DOC_TAG_PREFIX = "ap-doc"
 
+# Provenance tags (issue #381 — doc snapshots need a decidable revision
+# stamp so a re-ingest can tell a stale snapshot from a current one).
+#
+# doc-sha256: the source file's content hash AT CAPTURE TIME — the
+#   "revision" half of the {source_path, revision, captured_at} triple the
+#   issue asks for. `captured_at` is not a separate tag: `created_at` is
+#   already a first-class memories column, already surfaced by `recall`
+#   (recall.py:297/361), and the DB default (now()) applies to every fresh
+#   insert/supersession this pass performs — duplicating it as a tag would
+#   be a second, driftable source of the same fact.
+# doc-path: the source-relative path, structured (machine-parseable)
+#   alongside the human-readable `[{rel_path}]` content header this pass
+#   already writes.
+#
+# Hash length mirrors mcp_server/infrastructure/artifact_store.py's
+# _ADDRESS_LEN (sha256 hex truncated to 16 chars / 64 bits — negligible
+# birthday-collision risk for a per-repo document corpus, short enough to
+# stay a readable tag); not a second, independently invented bound.
+_DOC_HASH_TAG_LEN = 16
+_DOC_HASH_TAG_PREFIX = "doc-sha256"
+_DOC_PATH_TAG_PREFIX = "doc-path"
+
 
 def doc_tag(domain: str, rel_path: str) -> str:
     """Canonical dedup tag anchoring a memory to one (domain, doc path)."""
     return f"{_DOC_TAG_PREFIX}:{domain}:{rel_path}"
+
+
+def doc_content_hash(content: str) -> str:
+    """Content-hash 'revision' stamp for a document snapshot (issue #381)."""
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:_DOC_HASH_TAG_LEN]
+
+
+def doc_hash_tag(content_hash: str) -> str:
+    """Tag encoding the source file's content hash at capture time."""
+    return f"{_DOC_HASH_TAG_PREFIX}:{content_hash}"
+
+
+def doc_path_tag(rel_path: str) -> str:
+    """Tag encoding the source-relative path this memory was captured from."""
+    return f"{_DOC_PATH_TAG_PREFIX}:{rel_path}"
 
 
 def _memory_tags(mem: dict) -> list:
@@ -57,14 +95,38 @@ def _memory_tags(mem: dict) -> list:
     return raw if isinstance(raw, list) else []
 
 
-def find_existing_doc_memory(store: Any, domain: str, rel_path: str) -> int | None:
-    """Return the memory id already written for this document, or None.
+def existing_content_hash(mem: dict) -> str | None:
+    """Extract the ``doc-sha256`` provenance tag from a stored doc memory.
+
+    Postcondition: returns the hash string, or None when the memory
+    predates this tag (pre-#381 doc snapshot, or a store that dropped
+    tags) — a caller comparing against None never equals a real hash, so
+    an untagged legacy snapshot is always treated as changed and gets
+    re-verified (re-written) exactly once on the next ingest.
+    """
+    prefix = f"{_DOC_HASH_TAG_PREFIX}:"
+    for tag in _memory_tags(mem):
+        if tag.startswith(prefix):
+            return tag[len(prefix) :]
+    return None
+
+
+def find_existing_doc_memory(store: Any, domain: str, rel_path: str) -> dict | None:
+    """Return the current chain-head memory already written for this
+    document, or None.
 
     Mirrors ``ingest_findings_writers.find_existing_memory``: stores
     without ``get_memories_by_tag`` (e.g. the SQLite fallback backend)
     degrade to "always create" rather than erroring — re-ingestion is
     then non-idempotent on that backend only, a pre-existing limitation
     of the tag-query API, not something this pass introduces.
+
+    Postcondition: returns the full memory record (not just its id) so
+    the caller can read its content-hash tag and decide whether the
+    source has changed since capture (issue #381) — filtered to
+    ``superseded_by_id is None`` so a supersession chain (this pass
+    revises a memory in place by superseding it, never leaves two
+    "current" rows) resolves to its open head, not an older link.
     """
     tag = doc_tag(domain, rel_path)
     try:
@@ -73,8 +135,8 @@ def find_existing_doc_memory(store: Any, domain: str, rel_path: str) -> int | No
         silent_failure.note("ingest_docs_content.find_existing_doc", exc)
         return None
     for mem in mems:
-        if tag in _memory_tags(mem):
-            return mem.get("id")
+        if tag in _memory_tags(mem) and mem.get("superseded_by_id") is None:
+            return mem
     return None
 
 
@@ -120,25 +182,49 @@ def write_doc_memory(
     directory_context: str,
     rel_path: str,
     content: str,
-) -> tuple[int, bool]:
-    """Write (or reuse) the one memory representing this document's content.
+) -> tuple[int, bool, bool]:
+    """Write, supersede, or reuse the memory representing this document.
 
-    Postcondition: returns ``(memory_id, created)``. ``created`` is False
-    when an earlier ingestion of the same ``(domain, rel_path)`` already
-    wrote this memory — re-ingesting an unchanged graph inserts no
-    duplicate row (idempotence, D6 acceptance criterion). Tags carry
-    ``doc`` (D6's own wording) and ``src:ap`` (D5 provenance: this pass
-    only ever runs over a graph AP produced) plus the per-document dedup
-    tag.
+    Postcondition: returns ``(memory_id, written, superseded)``.
+
+    - No prior memory for this ``(domain, rel_path)``: inserts one, tagged
+      with a content-hash "revision" stamp (issue #381) alongside the
+      existing ``doc``/``src:ap``/dedup tags. Returns ``(new_id, True, False)``.
+    - A prior memory exists and its stored content-hash tag still matches
+      this read (source file unchanged since capture, OR a store that
+      cannot tag-query and degrades to "no prior found" — see
+      ``find_existing_doc_memory``): no-op, ``(existing_id, False, False)``
+      — idempotence, D6's original acceptance criterion, now decided by
+      content identity rather than by tag presence alone.
+    - A prior memory exists and its content-hash tag differs (source file
+      edited since capture, OR the prior memory predates this tag and so
+      has none — see ``existing_content_hash``): the STALE snapshot is
+      SUPERSEDED (Nader/Schafe/LeDoux 2000 reconsolidation — same
+      ``store.supersede_atomic`` primitive ``remember`` uses for
+      ``supersedes_id``, not a second, parallel versioning mechanism) —
+      ``recall`` demotes a superseded row (pg_schema.py `current_memories`
+      view / final ORDER BY) so a consumer is served the current snapshot,
+      never the retracted one. Returns ``(new_id, True, True)``. On the
+      bounded rebase exhausting (pathological concurrent-supersede
+      contention — see ``supersede_atomic``'s own docstring), degrades to
+      a no-write rather than raising: the next ingest run re-tries the
+      comparison from a fresh read.
+
+    Tags on every written row carry ``doc`` (D6's own wording), ``src:ap``
+    (D5 provenance: this pass only ever runs over a graph AP produced),
+    the per-document dedup tag, plus the two provenance tags above.
     """
-    existing = find_existing_doc_memory(store, domain, rel_path)
-    if existing is not None:
-        return existing, False
-
     tag = doc_tag(domain, rel_path)
+    content_hash = doc_content_hash(content)
     record = {
         "content": f"[{rel_path}]\n\n{content}",
-        "tags": ["doc", "src:ap", tag],
+        "tags": [
+            "doc",
+            "src:ap",
+            tag,
+            doc_hash_tag(content_hash),
+            doc_path_tag(rel_path),
+        ],
         "source": "ingest_codebase:docs",
         "domain": domain,
         "directory_context": directory_context,
@@ -149,7 +235,18 @@ def write_doc_memory(
         # M-D2 (7.4): bulk docs-content ingestion from an AP graph.
         "write_class": "mechanical",
     }
-    return store.insert_memory(record), True
+
+    existing = find_existing_doc_memory(store, domain, rel_path)
+    if existing is None:
+        return store.insert_memory(record), True, False
+
+    if existing_content_hash(existing) == content_hash:
+        return existing["id"], False, False
+
+    new_id, _head_id = store.supersede_atomic(record, existing["id"])
+    if new_id is None:
+        return existing["id"], False, False
+    return new_id, True, True
 
 
 _REFERENCES_RELATIONSHIP_TYPE = "references"

--- a/tests_py/handlers/test_ingest_docs_content.py
+++ b/tests_py/handlers/test_ingest_docs_content.py
@@ -47,7 +47,7 @@ class TestRunDocsPass:
 
         def _write_doc_memory(store, domain, directory_context, rel_path, content):
             written_memories.append((rel_path, content))
-            return (1, True)
+            return (1, True, False)
 
         def _write_doc_reference_edge(store, src, dst):
             written_edges.append((src, dst))
@@ -66,6 +66,7 @@ class TestRunDocsPass:
 
         assert result["docs_seen"] == 3
         assert result["docs_written"] == 2
+        assert result["docs_superseded"] == 0
         assert result["docs_skipped"] == 1
         assert result["references_written"] == 1
         assert ("docs/a.md", "content A") in written_memories
@@ -85,6 +86,7 @@ class TestRunDocsPass:
         assert result == {
             "docs_seen": 0,
             "docs_written": 0,
+            "docs_superseded": 0,
             "docs_skipped": 0,
             "references_written": 0,
         }
@@ -106,7 +108,7 @@ class TestRunDocsPass:
         def _write_doc_memory_existing(
             store, domain, directory_context, rel_path, content
         ):
-            return (555, False)  # already ingested
+            return (555, False, False)  # already ingested, unchanged
 
         monkeypatch.setattr(cypher, "fetch_doc_files", _fetch_doc_files)
         monkeypatch.setattr(cypher, "fetch_doc_references", _fetch_doc_references)
@@ -116,7 +118,39 @@ class TestRunDocsPass:
             _FakeStore(), "/g", str(tmp_path), "code:proj"
         )
         assert result["docs_seen"] == 1
-        assert result["docs_written"] == 0  # created=False -> not counted
+        assert result["docs_written"] == 0  # written=False -> not counted
+        assert result["docs_superseded"] == 0
+
+    async def test_reingesting_changed_doc_counts_as_superseded(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Orchestrator-level regression for issue #381: a doc whose source
+        changed since capture must surface as both a write AND a
+        supersession, not merely a write (which would be indistinguishable
+        from a first-time capture in the response counts)."""
+        (tmp_path / "a.md").write_text("new content", encoding="utf-8")
+
+        async def _fetch_doc_files(graph_path):
+            return [{"path": "a.md"}], []
+
+        async def _fetch_doc_references(graph_path, known_doc_paths):
+            return [], []
+
+        def _write_doc_memory_changed(
+            store, domain, directory_context, rel_path, content
+        ):
+            return (556, True, True)  # stale snapshot superseded
+
+        monkeypatch.setattr(cypher, "fetch_doc_files", _fetch_doc_files)
+        monkeypatch.setattr(cypher, "fetch_doc_references", _fetch_doc_references)
+        monkeypatch.setattr(writers, "write_doc_memory", _write_doc_memory_changed)
+
+        result = await docs_content.run_docs_pass(
+            _FakeStore(), "/g", str(tmp_path), "code:proj"
+        )
+        assert result["docs_seen"] == 1
+        assert result["docs_written"] == 1
+        assert result["docs_superseded"] == 1
 
     async def test_diagnostics_from_both_fetchers_are_merged(
         self, tmp_path: Path, monkeypatch

--- a/tests_py/handlers/test_ingest_docs_content_writers.py
+++ b/tests_py/handlers/test_ingest_docs_content_writers.py
@@ -8,7 +8,10 @@ from pathlib import Path
 
 from mcp_server.handlers.ingest_docs_content_writers import (
     MAX_DOC_BYTES,
+    doc_content_hash,
+    doc_hash_tag,
     doc_tag,
+    existing_content_hash,
     find_existing_doc_memory,
     read_doc_content,
     write_doc_memory,
@@ -24,6 +27,7 @@ class _FakeStore:
     ):
         self.memories: list[dict] = []
         self.relationships: list[dict] = []
+        self.supersede_calls: list[tuple[dict, int]] = []
         self._next = 9000
         self._existing_by_tag = existing_by_tag or {}
         self._entities_by_name = entities_by_name or {}
@@ -44,6 +48,20 @@ class _FakeStore:
         self.relationships.append(data)
         return len(self.relationships)
 
+    def supersede_atomic(self, data: dict, target_id: int) -> tuple[int, int]:
+        self.supersede_calls.append((data, target_id))
+        new_id = self.insert_memory(data)
+        return new_id, target_id
+
+
+class _NoSupersedeStore(_FakeStore):
+    """A store whose supersede_atomic bounded-rebase exhausted — mirrors
+    supersede_atomic's own documented (None, last_head_id) contention
+    return, exercised without needing real concurrency."""
+
+    def supersede_atomic(self, data: dict, target_id: int) -> tuple[None, int]:
+        return None, target_id
+
 
 class TestDocTag:
     def test_deterministic_and_scoped_to_domain_and_path(self):
@@ -56,16 +74,35 @@ class TestFindExistingDocMemory:
         store = _FakeStore()
         assert find_existing_doc_memory(store, "code:proj", "README.md") is None
 
-    def test_returns_id_when_tag_present(self):
+    def test_returns_record_when_tag_present(self):
         tag = doc_tag("code:proj", "README.md")
         store = _FakeStore(existing_by_tag={tag: [{"id": 42, "tags": ["doc", tag]}]})
-        assert find_existing_doc_memory(store, "code:proj", "README.md") == 42
+        found = find_existing_doc_memory(store, "code:proj", "README.md")
+        assert found is not None
+        assert found["id"] == 42
 
     def test_degrades_to_none_when_store_lacks_tag_query(self):
         class _NoTagStore:
             pass
 
         assert find_existing_doc_memory(_NoTagStore(), "code:proj", "README.md") is None
+
+    def test_superseded_row_is_skipped_head_is_returned(self):
+        """A tag lands on every row in a supersession chain (issue #381) —
+        the OLD, superseded row must never be picked over its live head,
+        or a re-ingest would keep comparing against a retracted snapshot."""
+        tag = doc_tag("code:proj", "README.md")
+        store = _FakeStore(
+            existing_by_tag={
+                tag: [
+                    {"id": 99, "tags": ["doc", tag], "superseded_by_id": None},
+                    {"id": 42, "tags": ["doc", tag], "superseded_by_id": 99},
+                ]
+            }
+        )
+        found = find_existing_doc_memory(store, "code:proj", "README.md")
+        assert found is not None
+        assert found["id"] == 99
 
 
 class TestReadDocContent:
@@ -96,10 +133,11 @@ class TestReadDocContent:
 class TestWriteDocMemory:
     def test_writes_content_tagged_doc_and_src_ap(self):
         store = _FakeStore()
-        mem_id, created = write_doc_memory(
+        mem_id, written, superseded = write_doc_memory(
             store, "code:proj", "/repo", "docs/a.md", "distinctive phrase here"
         )
-        assert created is True
+        assert written is True
+        assert superseded is False
         record = store.memories[0]
         assert "doc" in record["tags"]
         assert "src:ap" in record["tags"]
@@ -109,15 +147,102 @@ class TestWriteDocMemory:
         assert record["directory_context"] == "/repo"
         assert record["is_protected"] is False
 
-    def test_reingesting_same_doc_does_not_duplicate(self):
+    def test_first_capture_stamps_provenance_hash_and_path_tags(self):
+        """Issue #381: a fresh doc memory carries a decidable revision stamp
+        (content hash) and a structured source-path tag, not just the
+        free-text `[{rel_path}]` header."""
+        store = _FakeStore()
+        content = "distinctive phrase here"
+        write_doc_memory(store, "code:proj", "/repo", "docs/a.md", content)
+        record = store.memories[0]
+        assert doc_hash_tag(doc_content_hash(content)) in record["tags"]
+        assert "doc-path:docs/a.md" in record["tags"]
+
+    def test_reingesting_unchanged_doc_is_a_no_op(self):
+        content = "content"
         tag = doc_tag("code:proj", "docs/a.md")
-        store = _FakeStore(existing_by_tag={tag: [{"id": 555, "tags": ["doc", tag]}]})
-        mem_id, created = write_doc_memory(
-            store, "code:proj", "/repo", "docs/a.md", "content"
+        existing = {
+            "id": 555,
+            "tags": ["doc", tag, doc_hash_tag(doc_content_hash(content))],
+            "superseded_by_id": None,
+        }
+        store = _FakeStore(existing_by_tag={tag: [existing]})
+        mem_id, written, superseded = write_doc_memory(
+            store, "code:proj", "/repo", "docs/a.md", content
         )
-        assert created is False
+        assert written is False
+        assert superseded is False
         assert mem_id == 555
         assert store.memories == []
+        assert store.supersede_calls == []
+
+    def test_reingesting_changed_doc_supersedes_the_stale_snapshot(self):
+        """Root-cause fix (issue #381): the source file changed since
+        capture -> the old snapshot's chain head is superseded, not left
+        to be served indistinguishably from current content."""
+        tag = doc_tag("code:proj", "docs/a.md")
+        existing = {
+            "id": 555,
+            "tags": ["doc", tag, doc_hash_tag(doc_content_hash("old content"))],
+            "superseded_by_id": None,
+        }
+        store = _FakeStore(existing_by_tag={tag: [existing]})
+        mem_id, written, superseded = write_doc_memory(
+            store, "code:proj", "/repo", "docs/a.md", "new content"
+        )
+        assert written is True
+        assert superseded is True
+        assert mem_id != 555
+        assert len(store.supersede_calls) == 1
+        assert store.supersede_calls[0][1] == 555
+        new_record = store.memories[0]
+        assert "new content" in new_record["content"]
+        assert doc_hash_tag(doc_content_hash("new content")) in new_record["tags"]
+
+    def test_legacy_untagged_doc_memory_is_treated_as_changed_once(self):
+        """A doc memory written before #381 carries no doc-sha256 tag —
+        it must be re-verified (superseded) exactly once, converting it
+        into a provenance-stamped snapshot, rather than being trusted
+        forever just because a row with the dedup tag exists."""
+        tag = doc_tag("code:proj", "docs/a.md")
+        legacy = {"id": 555, "tags": ["doc", tag], "superseded_by_id": None}
+        store = _FakeStore(existing_by_tag={tag: [legacy]})
+        mem_id, written, superseded = write_doc_memory(
+            store, "code:proj", "/repo", "docs/a.md", "content"
+        )
+        assert written is True
+        assert superseded is True
+        assert mem_id != 555
+
+    def test_supersede_rebase_exhaustion_degrades_to_no_op(self):
+        """supersede_atomic's own contract: (None, head_id) on bounded-rebase
+        exhaustion under pathological contention. write_doc_memory must not
+        raise or fabricate a memory id — it reports no write and lets the
+        next ingest run retry from a fresh read."""
+        tag = doc_tag("code:proj", "docs/a.md")
+        existing = {
+            "id": 555,
+            "tags": ["doc", tag, doc_hash_tag(doc_content_hash("old"))],
+            "superseded_by_id": None,
+        }
+        store = _NoSupersedeStore(existing_by_tag={tag: [existing]})
+        mem_id, written, superseded = write_doc_memory(
+            store, "code:proj", "/repo", "docs/a.md", "new"
+        )
+        assert written is False
+        assert superseded is False
+        assert mem_id == 555
+
+
+class TestExistingContentHash:
+    def test_extracts_hash_from_tag(self):
+        h = doc_content_hash("some content")
+        mem = {"tags": ["doc", doc_hash_tag(h)]}
+        assert existing_content_hash(mem) == h
+
+    def test_returns_none_when_tag_absent(self):
+        assert existing_content_hash({"tags": ["doc"]}) is None
+        assert existing_content_hash({}) is None
 
 
 class TestWriteDocReferenceEdge:


### PR DESCRIPTION
Closes #381.

Root cause: `write_doc_memory` (INC5.3 docs-content pass of `ingest_codebase`) was dedup-only — it returned any existing `(domain, rel_path)`-tagged memory without comparing content, and no revision stamp existed to make staleness decidable. Stale README/CLAUDE.md snapshots (incl. a retracted figure) were served as current.

Fix (options 1+2 of the issue):
- Provenance stamping: every doc memory carries `doc-sha256:<hash[:16]>` + `doc-path:<rel_path>`; `created_at` already serves as captured_at.
- Re-verify on re-ingest: hash comparison against the version-chain head; unchanged → no-op (idempotence preserved); changed or legacy untagged → `supersede_atomic` (existing chain primitive, no parallel mechanism). `find_existing_doc_memory` resolves the open chain head (`superseded_by_id IS NULL`).
- Option 3 (`core/staleness.py`) deliberately not wired: it scores file references embedded in free text, a different signal.

Tests: +10 (stamping, no-op, supersession, legacy self-heal once, rebase-exhaustion no-op, `docs_superseded` counter); touched suite 55/55; full suite 6946 passed / 260 skipped / 1 pre-existing unrelated failure (pg driver extra not installed in worktree). `ruff check` + `ruff format --check` clean.

Evidence trail: A/B bench rev.2, `results/COMPARISON-rev2.md` (cdeust/harness-comparison@2d7960c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)