### PR TITLE
fix(core): remove dead ACT-R decay path, disambiguate ADAPTIVE_DECAY naming (#346)

### DIFF
--- a/mcp_server/core/decay_cycle.py
+++ b/mcp_server/core/decay_cycle.py
@@ -1,64 +1,42 @@
-"""Decay cycle — periodic heat decay with consolidation-dependent permastore.
+"""Decay cycle — entity heat decay only.
 
-Two decay models, both gated by consolidation stage and permastore floor:
+Memory heat decay is **not** computed here. It is computed lazily at
+read time by the ``effective_heat()`` PL/pgSQL function
+(``mcp_server/infrastructure/pg_schema.py``), which applies the
+stage-adjusted Ebbinghaus law and the consolidation-dependent
+permastore floor server-side. This module retained an eager, per-row
+Python decay path (including an alternative ACT-R base-level model)
+until the A3 migration moved memory decay to the SQL side; both were
+removed as dead code (zero production callers since that migration —
+see issue #346) rather than kept as inert reference implementations,
+per coding-standards.md §9 ("if it's built, it must be called").
+History: `git show b9997157` (the migration commit) and
+`docs/program/phase-3-a3-migration-design.md` §6 ("Decay cycle
+post-A3 — DELETE") record the decision and its rationale.
 
-1. Exponential (default): heat(t) = heat(0) * lambda^t  (Ebbinghaus 1885).
-   Decay rate is stage-adjusted via cascade_stages.compute_stage_adjusted_decay():
-   LABILE decays 2x faster, CONSOLIDATED decays 2x slower.
+What remains is **entity** heat decay: entities are not part of the
+A3 lazy-heat migration (they retain an eager ``heat`` column), so they
+still decay via a simple exponential law, applied per consolidation
+pass by ``mcp_server/handlers/consolidation/decay.py``.
 
-2. ACT-R base-level activation (adaptive_decay=True):
-   Anderson JR, Lebiere C (1998) "The Atomic Components of Thought", Eq. 4.4.
-   B_i = ln(n) - d * ln(L)  where n=accesses, L=lifetime, d=0.5.
+Naming note — do not confuse with ``ADAPTIVE_DECAY``: the
+``ADAPTIVE_DECAY`` mechanism reported in the LoCoMo v3 ablation table
+(``benchmarks/results/ablation/locomo_v3/summary.csv``) is an adaptive
+*decay rate* on the memory-heat Ebbinghaus path — it lives in
+``mcp_server/core/thermodynamics.py`` (``compute_decay``'s
+``Mechanism.ADAPTIVE_DECAY`` gate), ``mcp_server/core/pg_recall.py``,
+and is configured by ``ADAPTIVE_DECAY_ENABLED`` /
+``ADAPTIVE_DECAY_MIN_RATE`` / ``ADAPTIVE_DECAY_MAX_RATE`` in
+``mcp_server/infrastructure/memory_config.py``. It has never lived in
+this module and is unrelated to entity decay or to the ACT-R model
+that used to live here.
 
-Both paths enforce a consolidation-dependent heat floor (permastore):
-  - LABILE, EARLY_LTP: floor = 0.0 (can decay to zero)
-  - LATE_LTP: floor = 0.05 (partial structural support)
-  - CONSOLIDATED: floor = 0.10 (permanent — Bahrick 1984, Kandel 2001)
-  - RECONSOLIDATING: floor = 0.05 (was consolidated, temporarily labile)
-
-The permastore mechanism is grounded in:
-  - Bahrick HP (1984) "Semantic memory content in permastore" —
-    30-year retention plateau without rehearsal.
-  - Kandel ER (2001) "Molecular biology of memory storage" —
-    at 72h post-encoding, structural synaptic changes are permanent.
-  - Benna MK & Fusi S (2016) "Computational principles of synaptic memory
-    consolidation" — cascade models produce non-zero retention floors.
-
-Pure business logic — receives memory data, returns updated heat values.
+Pure business logic — receives entity data, returns updated heat values.
 """
 
 from __future__ import annotations
 
-import math
 from datetime import datetime, timezone
-
-from mcp_server.core.cascade_stages import (
-    compute_stage_adjusted_decay,
-    get_heat_floor,
-)
-from mcp_server.core.thermodynamics import compute_decay
-
-# -- ACT-R Constants (Anderson & Lebiere 1998) ---------------------------------
-
-# d: base decay parameter. Standard ACT-R value is 0.5.
-_ACT_R_DECAY_D: float = 0.5
-
-# s: noise parameter for activation → probability mapping.
-# Standard ACT-R value is s ≈ 0.4 (Anderson & Lebiere 1998, Eq. 4.5).
-# We use s = 1.0 rather than 0.4.
-# Source: engineering choice — ACT-R's 0.4 is calibrated to millisecond
-# RT experiments on word recognition; Cortex operates at an hours-to-days
-# timescale where the logistic needs a wider spread to avoid saturating at
-# heat=1.0 for young memories.  The value 1.0 is hand-tuned and deviates
-# from the paper; calibration pending — see benchmarks/beam/ablation.py.
-_ACT_R_NOISE_S: float = 1.0
-
-# Minimum hours to avoid log(0)
-_MIN_LIFETIME_HOURS: float = 0.01
-
-# source: pre-existing tuned value, extracted unchanged (#197 family 3);
-# provenance not recorded at introduction
-_HIGH_IMPORTANCE_THRESHOLD: float = 0.7
 
 # Minimum heat change worth persisting as an update.
 # source: pre-existing tuned value, extracted unchanged (#197 family 3);
@@ -89,224 +67,13 @@ def _parse_datetime(value) -> datetime | None:
     return None
 
 
-def _hours_since_access(mem: dict, now: datetime) -> float | None:
-    """Return hours elapsed since last access, or None if unparseable.
-
-    Fallback chain: last_accessed → ingested_at → created_at. The
-    ingested_at fallback (added for the consolidation-cadence fix —
-    docs/benchmarks/e1-v3-locomo-smoke-finding.md) ensures backfilled memories
-    with a backdated created_at do not falsely register as
-    "last-accessed years ago" when last_accessed is missing.
-    """
-    last_accessed = (
-        mem.get("last_accessed") or mem.get("ingested_at") or mem.get("created_at", "")
-    )
-    last_dt = _parse_datetime(last_accessed)
-    if last_dt is None:
-        return None
-    hours = (now - last_dt).total_seconds() / 3600.0
-    return hours if hours > 0 else None
-
-
-def _hours_since_creation(mem: dict, now: datetime) -> float | None:
-    """Return hours elapsed since the memory entered THIS system.
-
-    ACT-R "lifetime L" in B_i = ln(n) − d·ln(L) is lifetime in the
-    learner's system since acquisition (Anderson & Lebiere 1998), not
-    elapsed time since the original-source event. For Cortex this is
-    ``ingested_at``: backfilled / imported memories with backdated
-    ``created_at`` would otherwise return a wrongly-large L on first
-    decay pass and collapse heat to near-zero before any access.
-    Source: docs/benchmarks/e1-v3-locomo-smoke-finding.md.
-
-    Falls back to ``created_at`` only for in-memory dicts that never
-    round-tripped through PG (schema backfills ingested_at=created_at
-    for legacy rows, so PG-sourced dicts always have the field).
-    """
-    raw = mem.get("ingested_at") or mem.get("created_at", "")
-    ingested_dt = _parse_datetime(raw)
-    if ingested_dt is None:
-        return None
-    hours = (now - ingested_dt).total_seconds() / 3600.0
-    return max(_MIN_LIFETIME_HOURS, hours)
-
-
-def compute_actr_base_level(
-    access_count: int,
-    lifetime_hours: float,
-    d: float = _ACT_R_DECAY_D,
-) -> float:
-    """ACT-R base-level activation (Anderson & Lebiere 1998, Eq. 4.4).
-
-    B_i = ln(sum_j(t_j^{-d}))
-
-    Approximation assuming uniformly spaced accesses over lifetime:
-    B_i ≈ ln(n) - d * ln(L)
-
-    where n = access_count (minimum 1), L = lifetime in hours.
-
-    Returns raw activation (can be negative = below retrieval threshold).
-    """
-    n = max(1, access_count)
-    clamped_lifetime_hours = max(_MIN_LIFETIME_HOURS, lifetime_hours)
-    return math.log(n) - d * math.log(clamped_lifetime_hours)
-
-
-def actr_activation_to_heat(
-    base_level: float,
-    s: float = _ACT_R_NOISE_S,
-) -> float:
-    """Map ACT-R base-level activation to heat [0, 1] via logistic.
-
-    P(recall) = 1 / (1 + exp(-B_i / s))  (Anderson & Lebiere 1998, Eq. 4.5)
-
-    This is the standard ACT-R retrieval probability equation.
-    """
-    return 1.0 / (1.0 + math.exp(-base_level / s))
-
-
-def _compute_actr_decay(
-    mem: dict,
-    now: datetime,
-    importance: float = 0.5,
-    valence: float = 0.0,
-) -> float | None:
-    """Compute heat via ACT-R base-level activation.
-
-    Importance and valence modulate d (decay rate):
-    - High importance (>0.7): d reduced by 20% (slower decay)
-    - High |valence|: d reduced proportionally (emotional resistance)
-
-    These modulations follow the general finding that meaningful and
-    emotional memories decay slower (McGaugh 2004), adapted to the
-    ACT-R framework.
-    """
-    lifetime = _hours_since_creation(mem, now)
-    if lifetime is None:
-        return None
-
-    access_count = mem.get("access_count", 1)
-
-    # Modulate d based on importance and emotion
-    d = _ACT_R_DECAY_D
-    if importance > _HIGH_IMPORTANCE_THRESHOLD:
-        d *= 0.8  # Important memories decay 20% slower
-    d *= 1.0 - abs(valence) * 0.3  # Emotional memories resist decay
-    d = max(0.1, d)  # Floor to prevent d=0
-
-    base_level = compute_actr_base_level(access_count, lifetime, d)
-    return actr_activation_to_heat(base_level)
-
-
-def _compute_single_decay(
-    mem: dict,
-    now: datetime,
-    decay_factor: float,
-    importance_decay_factor: float,
-    emotional_decay_resistance: float,
-    adaptive_decay: bool = False,
-) -> tuple[int, float] | None:
-    """Compute decay for a single memory. Returns (id, new_heat) or None.
-
-    Incorporates two critical mechanisms:
-    1. Stage-adjusted decay rate (Kandel 2001): consolidated memories
-       decay slower via compute_stage_adjusted_decay().
-    2. Heat floor / permastore (Bahrick 1984, Benna & Fusi 2016):
-       consolidated memories never decay below their stage's heat_floor.
-    """
-    current_heat = mem.get("heat", 0.0)
-    stage = mem.get("consolidation_stage", "labile")
-
-    # Permastore floor: consolidated memories are always retrievable
-    floor = get_heat_floor(stage)
-
-    if adaptive_decay:
-        # ACT-R path: compute heat from base-level activation
-        new_heat = _compute_actr_decay(
-            mem,
-            now,
-            importance=mem.get("importance", 0.5),
-            valence=mem.get("emotional_valence", 0.0),
-        )
-        if new_heat is None:
-            return None
-        new_heat = min(current_heat, new_heat)
-    else:
-        # Ebbinghaus exponential path with stage-adjusted rate
-        hours = _hours_since_access(mem, now)
-        if hours is None:
-            return None
-
-        # Apply consolidation stage multiplier (Kandel 2001)
-        adj_decay = compute_stage_adjusted_decay(decay_factor, stage)
-        adj_imp_decay = compute_stage_adjusted_decay(importance_decay_factor, stage)
-
-        new_heat = compute_decay(
-            current_heat,
-            hours,
-            importance=mem.get("importance", 0.5),
-            valence=mem.get("emotional_valence", 0.0),
-            confidence=mem.get("confidence", 1.0),
-            value=mem.get("value", 0.5),
-            decay_factor=adj_decay,
-            importance_decay_factor=adj_imp_decay,
-            emotional_decay_resistance=emotional_decay_resistance,
-        )
-
-    # Enforce permastore floor (Bahrick 1984)
-    new_heat = max(floor, new_heat)
-
-    if abs(new_heat - current_heat) > _MIN_HEAT_DELTA:
-        return (mem["id"], round(new_heat, 6))
-    return None
-
-
-def compute_decay_updates(
-    memories: list[dict],
-    now: datetime | None = None,
-    *,
-    decay_factor: float = 0.95,
-    importance_decay_factor: float = 0.998,
-    emotional_decay_resistance: float = 0.5,
-    cold_threshold: float = 0.05,
-    adaptive_decay: bool = False,
-) -> list[tuple[int, float]]:
-    """Compute new heat values for all memories.
-
-    Returns list of (memory_id, new_heat) tuples for memories that changed.
-    Skips protected memories and already-cold memories.
-
-    When adaptive_decay=True, uses ACT-R base-level activation
-    (Anderson & Lebiere 1998) instead of exponential forgetting.
-    """
-    if now is None:
-        now = datetime.now(timezone.utc)
-
-    updates: list[tuple[int, float]] = []
-    for mem in memories:
-        if mem.get("is_protected") or mem.get("heat", 0.0) < cold_threshold:
-            continue
-        result = _compute_single_decay(
-            mem,
-            now,
-            decay_factor,
-            importance_decay_factor,
-            emotional_decay_resistance,
-            adaptive_decay=adaptive_decay,
-        )
-        if result is not None:
-            updates.append(result)
-
-    return updates
-
-
 def _parse_hours_since_access(record: dict, now: datetime) -> float | None:
-    """Parse hours since last access from a memory or entity record.
+    """Parse hours since last access from an entity record.
 
-    Fallback chain mirrors _hours_since_access: last_accessed →
-    ingested_at → created_at. Entities do not currently carry
-    ingested_at, so this is a no-op for entity records but defensive
-    for memory dicts that take this path.
+    Fallback chain: last_accessed → ingested_at → created_at. Entities
+    do not currently carry ingested_at, so this falls through to
+    created_at for them, but the same fallback order is used so entity
+    and memory records can share a parsing convention if that changes.
     """
     last_accessed = (
         record.get("last_accessed")

--- a/tests_py/benchmarks/benchmark_harness.py
+++ b/tests_py/benchmarks/benchmark_harness.py
@@ -753,100 +753,6 @@ def benchmark_microglial_pruning() -> dict[str, float]:
     }
 
 
-def benchmark_decay_with_emotional_resistance() -> dict[str, dict[str, float]]:
-    """Benchmark heat decay: do emotional/important memories resist decay better?
-
-    Tests: Emotional memories should survive longer (amygdala-hippocampal coupling).
-    """
-    from mcp_server.core.decay_cycle import compute_decay_updates
-    from datetime import datetime, timezone
-
-    now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
-
-    # Create memories with different properties
-    memories = [
-        # High importance + emotional
-        {
-            "id": 1,
-            "heat": 0.9,
-            "importance": 0.9,
-            "emotional_valence": 0.8,
-            "confidence": 0.9,
-            "last_accessed": "2026-03-22T00:00:00+00:00",
-            "is_protected": False,
-            "store_type": "episodic",
-        },
-        # Low importance + neutral
-        {
-            "id": 2,
-            "heat": 0.9,
-            "importance": 0.3,
-            "emotional_valence": 0.0,
-            "confidence": 0.5,
-            "last_accessed": "2026-03-22T00:00:00+00:00",
-            "is_protected": False,
-            "store_type": "episodic",
-        },
-        # High importance + neutral
-        {
-            "id": 3,
-            "heat": 0.9,
-            "importance": 0.9,
-            "emotional_valence": 0.0,
-            "confidence": 0.9,
-            "last_accessed": "2026-03-22T00:00:00+00:00",
-            "is_protected": False,
-            "store_type": "episodic",
-        },
-        # Low importance + emotional
-        {
-            "id": 4,
-            "heat": 0.9,
-            "importance": 0.3,
-            "emotional_valence": 0.8,
-            "confidence": 0.5,
-            "last_accessed": "2026-03-22T00:00:00+00:00",
-            "is_protected": False,
-            "store_type": "episodic",
-        },
-        # Protected (anchor)  # noqa: ERA001 -- fixture row label, not code
-        {
-            "id": 5,
-            "heat": 0.9,
-            "importance": 0.5,
-            "emotional_valence": 0.0,
-            "confidence": 0.5,
-            "last_accessed": "2026-03-22T00:00:00+00:00",
-            "is_protected": True,
-            "store_type": "episodic",
-        },
-    ]
-
-    updates = compute_decay_updates(memories, now)
-    update_map = {uid: new_heat for uid, new_heat in updates}
-
-    labels = [
-        "important+emotional",
-        "unimportant+neutral",
-        "important+neutral",
-        "unimportant+emotional",
-        "protected",
-    ]
-
-    results = {}
-    for i, mem in enumerate(memories):
-        new_heat = update_map.get(mem["id"], mem["heat"])
-        results[labels[i]] = {
-            "initial_heat": mem["heat"],
-            "heat_after_36h": round(new_heat, 4),
-            "heat_retained_pct": round(new_heat / max(mem["heat"], 0.001) * 100, 1),
-            "importance": mem["importance"],
-            "emotional_valence": mem["emotional_valence"],
-        }
-
-    return results
-
-
 def benchmark_pattern_separation() -> dict[str, dict[str, float]]:
     """Benchmark pattern separation: does orthogonalization reduce interference?
 
@@ -1363,46 +1269,8 @@ def run_all_benchmarks() -> str:
     sections.append(_table(["Metric", "Value"], rows))
     sections.append(f"\n*Benchmark duration: {dur:.1f}ms*\n")
 
-    # ── 7. Heat Decay with Emotional Resistance ──────────────────────────
-    sections.append("## 7. Decay Resistance (Emotional × Importance Interaction)")
-    sections.append("")
-    sections.append(
-        "**Question**: Do important/emotional memories resist heat decay?\n"
-    )
-
-    t0 = time.monotonic()
-    dr = benchmark_decay_with_emotional_resistance()
-    dur = (time.monotonic() - t0) * 1000
-
-    rows = []
-    for label, metrics in dr.items():
-        rows.append(
-            [
-                label,
-                f"{metrics['initial_heat']:.2f}",
-                f"{metrics['heat_after_36h']:.4f}",
-                f"{metrics['heat_retained_pct']:.1f}%",
-                f"{metrics['importance']:.1f}",
-                f"{metrics['emotional_valence']:.1f}",
-            ]
-        )
-    sections.append(
-        _table(
-            [
-                "Memory Type",
-                "Initial",
-                "After 36h",
-                "Retained%",
-                "Importance",
-                "Emotion",
-            ],
-            rows,
-        )
-    )
-    sections.append(f"\n*Benchmark duration: {dur:.1f}ms*\n")
-
     # ── 8. Pattern Separation ────────────────────────────────────────────
-    sections.append("## 8. Pattern Separation (DG Orthogonalization)")
+    sections.append("## 7. Pattern Separation (DG Orthogonalization)")
     sections.append("")
     sections.append("**Question**: Does orthogonalization reduce interference between")
     sections.append("similar memories while preserving semantic content?\n")
@@ -1435,7 +1303,7 @@ def run_all_benchmarks() -> str:
     )
 
     # ── 9. Consolidation Cascade ─────────────────────────────────────────
-    sections.append("## 9. Consolidation Cascade (Stage Progression)")
+    sections.append("## 8. Consolidation Cascade (Stage Progression)")
     sections.append("")
     sections.append(
         "**Question**: Do memories advance through stages with proper gating?"
@@ -1493,7 +1361,7 @@ def run_all_benchmarks() -> str:
     sections.append(f"\n*Benchmark duration: {dur:.1f}ms*\n")
 
     # ── 10. Homeostatic Plasticity ───────────────────────────────────────
-    sections.append("## 10. Homeostatic Plasticity (Synaptic Scaling)")
+    sections.append("## 9. Homeostatic Plasticity (Synaptic Scaling)")
     sections.append("")
     sections.append(
         "**Question**: Does the system self-correct when heat is too high or too low?\n"

--- a/tests_py/core/test_decay_cycle.py
+++ b/tests_py/core/test_decay_cycle.py
@@ -1,123 +1,16 @@
-"""Tests for mcp_server.core.decay_cycle — periodic heat decay."""
+"""Tests for mcp_server.core.decay_cycle — entity heat decay.
+
+Memory heat decay is covered separately by the SQL-side
+``effective_heat()`` tests (``tests_py/infrastructure/test_pg_alpha_integral.py``,
+``test_pg_effective_stage_parity.py``, ``test_pg_decay_clock_anchor.py``) —
+see decay_cycle.py's module docstring and issue #346 for why the
+Python-side per-row memory decay path (including its ACT-R alternative)
+was removed rather than kept as untested reference code.
+"""
 
 from datetime import datetime, timezone, timedelta
 
-from mcp_server.core.decay_cycle import (
-    compute_decay_updates,
-    compute_entity_decay,
-)
-
-
-class TestComputeDecayUpdates:
-    def test_recent_memories_no_decay(self):
-        now = datetime.now(timezone.utc)
-        mems = [
-            {
-                "id": 1,
-                "heat": 1.0,
-                "last_accessed": now.isoformat(),
-                "importance": 0.5,
-                "emotional_valence": 0.0,
-                "confidence": 1.0,
-            }
-        ]
-        updates = compute_decay_updates(mems, now=now)
-        assert len(updates) == 0  # No time elapsed
-
-    def test_old_memories_decay(self):
-        now = datetime.now(timezone.utc)
-        old = (now - timedelta(hours=24)).isoformat()
-        mems = [
-            {
-                "id": 1,
-                "heat": 1.0,
-                "last_accessed": old,
-                "importance": 0.3,
-                "emotional_valence": 0.0,
-                "confidence": 1.0,
-            }
-        ]
-        updates = compute_decay_updates(mems, now=now)
-        assert len(updates) == 1
-        assert updates[0][0] == 1
-        assert updates[0][1] < 1.0
-
-    def test_protected_skipped(self):
-        now = datetime.now(timezone.utc)
-        old = (now - timedelta(hours=24)).isoformat()
-        mems = [
-            {
-                "id": 1,
-                "heat": 1.0,
-                "last_accessed": old,
-                "is_protected": True,
-            }
-        ]
-        updates = compute_decay_updates(mems, now=now)
-        assert len(updates) == 0
-
-    def test_already_cold_skipped(self):
-        now = datetime.now(timezone.utc)
-        mems = [
-            {
-                "id": 1,
-                "heat": 0.01,
-                "last_accessed": now.isoformat(),
-            }
-        ]
-        updates = compute_decay_updates(mems, now=now, cold_threshold=0.05)
-        assert len(updates) == 0
-
-    def test_important_decays_slower(self):
-        now = datetime.now(timezone.utc)
-        old = (now - timedelta(hours=48)).isoformat()
-        normal = [
-            {
-                "id": 1,
-                "heat": 1.0,
-                "last_accessed": old,
-                "importance": 0.3,
-                "emotional_valence": 0.0,
-                "confidence": 1.0,
-            }
-        ]
-        important = [
-            {
-                "id": 2,
-                "heat": 1.0,
-                "last_accessed": old,
-                "importance": 0.9,
-                "emotional_valence": 0.0,
-                "confidence": 1.0,
-            }
-        ]
-        n_updates = compute_decay_updates(normal, now=now)
-        i_updates = compute_decay_updates(important, now=now)
-        assert i_updates[0][1] > n_updates[0][1]
-
-    def test_multiple_memories(self):
-        now = datetime.now(timezone.utc)
-        old = (now - timedelta(hours=12)).isoformat()
-        mems = [
-            {
-                "id": 1,
-                "heat": 0.9,
-                "last_accessed": old,
-                "importance": 0.5,
-                "emotional_valence": 0.0,
-                "confidence": 1.0,
-            },
-            {
-                "id": 2,
-                "heat": 0.5,
-                "last_accessed": old,
-                "importance": 0.3,
-                "emotional_valence": 0.0,
-                "confidence": 1.0,
-            },
-        ]
-        updates = compute_decay_updates(mems, now=now)
-        assert len(updates) == 2
+from mcp_server.core.decay_cycle import compute_entity_decay
 
 
 class TestComputeEntityDecay:
@@ -140,66 +33,3 @@ class TestComputeEntityDecay:
         entities = [{"id": 1, "heat": 0.01, "last_accessed": now.isoformat()}]
         updates = compute_entity_decay(entities, now=now, cold_threshold=0.05)
         assert len(updates) == 0
-
-
-class TestIngestRelativeCadence:
-    """Regression: cadence reasoning uses ingested_at, not created_at.
-
-    Source: docs/benchmarks/e1-v3-locomo-smoke-finding.md.
-    """
-
-    def test_adaptive_decay_uses_ingested_at_not_created_at(self):
-        """Backfilled memory with backdated created_at must NOT collapse.
-
-        ACT-R lifetime L = elapsed time since acquisition by THIS system.
-        For a 3-year-old created_at but a fresh ingested_at, L should be
-        ~hours (just-ingested), not ~3-years. Otherwise the ACT-R base
-        level B = ln(n) - 0.5*ln(L) sinks far below threshold and heat
-        collapses to near-zero on first decay pass.
-        """
-        now = datetime.now(timezone.utc)
-        years_ago = (now - timedelta(days=365 * 3)).isoformat()
-        # Just-ingested 5 minutes ago.
-        fresh_ingest = (now - timedelta(minutes=5)).isoformat()
-        mems = [
-            {
-                "id": 1,
-                "heat": 0.8,
-                "created_at": years_ago,
-                "ingested_at": fresh_ingest,
-                "last_accessed": fresh_ingest,
-                "access_count": 1,
-                "importance": 0.5,
-                "emotional_valence": 0.0,
-                "confidence": 1.0,
-            }
-        ]
-        updates = compute_decay_updates(mems, now=now, adaptive_decay=True)
-        # If cadence used created_at, lifetime would be ~26 280 hours and
-        # heat would collapse to near-zero (<<0.1). With ingested_at it
-        # stays close to its initial 0.8.
-        if updates:
-            new_heat = updates[0][1]
-            assert new_heat > 0.4, (
-                f"freshly-ingested backdated memory collapsed to {new_heat}"
-            )
-
-    def test_legacy_dict_falls_back_to_created_at(self):
-        """Pre-migration rows (no ingested_at) keep the old behaviour."""
-        now = datetime.now(timezone.utc)
-        old = (now - timedelta(hours=48)).isoformat()
-        mems = [
-            {
-                "id": 1,
-                "heat": 1.0,
-                "last_accessed": old,
-                "created_at": old,
-                "importance": 0.3,
-                "emotional_valence": 0.0,
-                "confidence": 1.0,
-            }
-        ]
-        updates = compute_decay_updates(mems, now=now)
-        # Decays normally — fallback chain kept intact.
-        assert len(updates) == 1
-        assert updates[0][1] < 1.0


### PR DESCRIPTION
## Summary

`decay_cycle.py`'s ACT-R base-level-activation block (`compute_decay_updates`,
`compute_actr_base_level`, `actr_activation_to_heat`, `_compute_actr_decay`)
had zero production callers, and its name (`adaptive_decay=True`) collides
with the live, published `ADAPTIVE_DECAY` mechanism that lives elsewhere.

## Investigation before deleting

The maintainer flagged mid-task that dead code is more often *mis-wired*
than *abandoned*, and asked for git-history evidence before deleting. Traced
the full history of the block:

1. **Wired at the original commit** (`b80a5998`).
2. **Replaced** by an ACT-R model in the "zetetic rewrite" commit
   (`10359edc`, "faithful paper implementations") — still wired.
3. **Deliberately unwired** by the A3 migration (`b9997157`), per an
   explicit design decision:
   [`docs/program/phase-3-a3-migration-design.md` §6](../blob/main/docs/program/phase-3-a3-migration-design.md)
   *"Decay cycle post-A3 — DELETE"* instructs: *"keep the pure-math helpers
   referenced by tests, but unwire from the consolidate handler"* — because
   memory heat decay moved to the SQL-side lazy `effective_heat()`
   (`pg_schema.py`).
4. The design doc's planned test migration (§6 table:
   `test_effective_heat_stage_coefficients` etc.) was in fact completed,
   just under different file names:
   `tests_py/infrastructure/test_pg_alpha_integral.py`,
   `test_pg_effective_stage_parity.py`, `test_pg_decay_clock_anchor.py`
   cover the SQL-side equivalent of what `test_decay_cycle.py` asserted for
   the Python path.

This is a **traced, documented supersession decision**, not a missed
wiring — deletion is the correct outcome per `coding-standards.md` §9
("if it's built, it must be called").

## Changes

- `mcp_server/core/decay_cycle.py`: deleted the ACT-R block, `_compute_single_decay`,
  and the now-dead-only helpers (`_hours_since_access`, `_hours_since_creation`,
  `_ACT_R_DECAY_D`, `_ACT_R_NOISE_S`, `_MIN_LIFETIME_HOURS`,
  `_HIGH_IMPORTANCE_THRESHOLD`). Kept `compute_entity_decay` (the only
  production-called function). New module docstring explicitly disambiguates
  the deleted ACT-R model from the live `ADAPTIVE_DECAY` mechanism
  (`thermodynamics.py` / `pg_recall.py` / `memory_config.py`, behind the
  LoCoMo v3 ablation ΔMRR −0.0163/ΔR@10 −0.020 figure) — closing the
  name-collision.
- `tests_py/core/test_decay_cycle.py`: removed the dead-path test classes,
  kept `TestComputeEntityDecay`.
- `tests_py/benchmarks/benchmark_harness.py` (boy-scout): removed
  `benchmark_decay_with_emotional_resistance` (a standalone `__main__`
  script, never pytest-collected, calling the now-deleted function) and its
  report section, renumbering the remaining sections to avoid introducing a
  fresh numbering gap.

## Acceptance criteria (issue #346)

- [x] `grep -rn "compute_decay_updates\|compute_actr_base_level" mcp_server/ tests_py/` returns nothing.
- [x] `ADAPTIVE_DECAY` now resolves to exactly one mechanism (thermodynamics/pg_recall/memory_config), documented at the point a reader is most likely to conflate it (decay_cycle.py's module docstring).
- [x] No benchmark regression possible — the deleted code had zero production callers, so no live retrieval path changes. Not re-running the full LoCoMo/BEAM suite (machine under heavy shared load; the argument is structural, not measured: an uncalled function cannot change a benchmark result).

## Test plan

- `pytest tests_py/core/test_decay_cycle.py tests_py/handlers/consolidation/` — 100 passed
- `pytest tests_py/benchmarks/ tests_py/infrastructure/test_pg_alpha_integral.py tests_py/infrastructure/test_pg_effective_stage_parity.py tests_py/infrastructure/test_pg_decay_clock_anchor.py tests_py/invariants/test_I2_canonical_writer.py` — 71 passed
- Manual smoke of the standalone `benchmark_harness.run_all_benchmarks()` — runs clean, section numbering verified contiguous
- `ruff check .` / `ruff format --check .` — clean on the full tree
- Mutation testing (`scripts/mutation_check.sh`) — **not yet run**, machine load-gated by the maintainer; exact command below, ready on request:
  ```
  scripts/mutation_check.sh "tests_py/core/test_decay_cycle.py tests_py/handlers/consolidation/test_decay.py" mcp_server/core/decay_cycle.py
  ```

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)