### PR TITLE
fix(provenance): name dead refs and the resolution root in the write-time hint

### DIFF
--- a/mcp_server/core/provenance.py
+++ b/mcp_server/core/provenance.py
@@ -289,20 +289,136 @@ _DELIBERATE_UNVERIFIABLE_SUFFIX = (
 )
 
 
-def write_time_hint(report: ProvenanceReport, write_class: str = "") -> str:
+def _named_dead_refs(dead_refs: list[str]) -> str:
+    """Up to 3 dead refs, comma-joined, with a "(+N more)" tail."""
+    named = ", ".join(dead_refs[:3])
+    remaining = len(dead_refs) - 3
+    return f"{named} (+{remaining} more)" if remaining > 0 else named
+
+
+def _dead_ref_hint_root_missing(report: ProvenanceReport, root: str) -> str:
+    """State 2a (issue #345): the resolution root itself is not a directory
+    on disk, so every file ref under it was necessarily unresolvable --
+    the dead-refs list says nothing about whether the PATHS are wrong."""
+    return (
+        f"{len(report.dead_refs)} checkable reference(s) could not be "
+        f"resolved because the resolution root '{root}' is not a directory "
+        f"on disk: {_named_dead_refs(report.dead_refs)}. Pass a valid "
+        "`directory`, then supersede this memory."
+    )
+
+
+def _dead_ref_hint_root_implicit(report: ProvenanceReport, root: str) -> str:
+    """State 2b (issue #345): no `directory` argument was given, so
+    resolution silently fell back to the server process's current working
+    directory, which need not be the writer's project root."""
+    total = sum(report.ref_counts.values())
+    return (
+        f"{len(report.dead_refs)} of {total} checkable reference(s) could "
+        f"not be resolved against '{root}' -- no `directory` was passed to "
+        "this write, so resolution defaulted to the process's current "
+        f"working directory: {_named_dead_refs(report.dead_refs)}. Pass "
+        "`directory` explicitly (your project root) and retry, or drop "
+        "the reference if it is genuinely gone."
+    )
+
+
+def _dead_ref_hint_root_explicit(report: ProvenanceReport, root: str) -> str:
+    """State 3 (issue #345): resolved against a real, explicitly-given
+    root, and the reference(s) are genuinely absent there."""
+    total = sum(report.ref_counts.values())
+    return (
+        f"{len(report.dead_refs)} of {total} checkable reference(s) could "
+        f"not be resolved against '{root}': {_named_dead_refs(report.dead_refs)}. "
+        "Fix the path/URL or drop it, then supersede this memory."
+    )
+
+
+def _unverifiable_hint(
+    report: ProvenanceReport,
+    *,
+    resolution_root: str,
+    resolution_root_explicit: bool,
+    resolution_root_exists: bool,
+) -> str:
+    """UNVERIFIABLE-branch hint (issue #345).
+
+    ``grade_provenance`` folds three distinct UNVERIFIABLE causes into one
+    grade -- ``report.dead_refs`` (from ``_build_reason`` above) already
+    separates "no reference at all" from "reference(s) resolved dead", but
+    a caller reproduction (memory 4341427, 2026-08-08) showed a second dead
+    -ref cause the naive fix still mislabels: refs that are perfectly real
+    but were checked against the WRONG resolution root because the caller
+    never passed ``directory`` (``grade_from_content``'s ``base_dir =
+    directory or os.getcwd()`` fallback, ``handlers/remember_helpers.py``).
+    Both a genuinely-dead ref and a wrong-root ref land in ``dead_refs``
+    identically from ``grade_provenance``'s point of view (it only sees
+    pre-resolved existence booleans) -- the distinction is caller-side
+    context (was ``directory`` explicit? does the resolved root even exist
+    on disk?), passed in here as booleans rather than re-derived with I/O
+    (core/ stays zero-I/O; see module docstring).
+
+    precondition: ``report.grade == UNVERIFIABLE``; ``resolution_root`` is
+        the directory refs were resolved against (may be "");
+        ``resolution_root_explicit`` is whether the caller passed
+        ``directory`` (False = implicit ``os.getcwd()`` fallback);
+        ``resolution_root_exists`` is whether that root is a real directory
+        on disk (always True when ``resolution_root_explicit`` is False,
+        since ``os.getcwd()`` cannot fail to exist for a running process).
+    postcondition: when ``report.dead_refs`` is empty, returns the
+        unchanged "no reference at all" wording (state 1). Otherwise names
+        up to 3 dead refs AND the resolution root used, picking exactly one
+        of three mutually exclusive branches: root missing on disk (state
+        2a), root implicit/unstated (state 2b), or root explicit and real
+        (state 3, genuinely dead).
+    """
+    if not report.dead_refs:
+        return _WRITE_TIME_HINTS[UNVERIFIABLE]
+    root = resolution_root or "(unresolved)"
+    if not resolution_root_exists:
+        return _dead_ref_hint_root_missing(report, root)
+    if not resolution_root_explicit:
+        return _dead_ref_hint_root_implicit(report, root)
+    return _dead_ref_hint_root_explicit(report, root)
+
+
+def write_time_hint(
+    report: ProvenanceReport,
+    write_class: str = "",
+    *,
+    resolution_root: str = "",
+    resolution_root_explicit: bool = True,
+    resolution_root_exists: bool = True,
+) -> str:
     """Deterministic, templated feedback for the write-time caller (M-D5).
 
     precondition: ``report`` came from ``grade_from_content``
         (``handlers/validate_memory.py``, write-path) or ``grade_provenance``
         generally; ``write_class`` is the resolved write class of the
         memory being written (M-D2, 7.4), or "" when not applicable.
-    postcondition: returns one of three fixed hint strings keyed only by
-        ``report.grade`` -- a pure lookup, no new inference -- with a
-        stronger call-to-action appended for UNVERIFIABLE writes whose
-        ``write_class == "deliberate"``. Never persisted; callers surface
-        this in the write response only.
+        ``resolution_root``/``resolution_root_explicit``/
+        ``resolution_root_exists`` (issue #345) describe the directory the
+        caller resolved file refs against -- default to the pre-#345
+        behaviour (explicit, existing, unnamed) so a caller that has not
+        been updated to pass them gets the old wording unchanged.
+    postcondition: returns a hint string keyed by ``report.grade``. For
+        VERIFIED/VERIFIABLE this is a pure lookup (no new inference). For
+        UNVERIFIABLE it further branches on ``report.dead_refs`` and the
+        resolution-root booleans (issue #345) so a write whose references
+        were extracted but resolved dead is told WHICH ones and AGAINST
+        WHAT ROOT, instead of being told none was found -- a stronger
+        call-to-action is appended when ``write_class == "deliberate"``.
+        Never persisted; callers surface this in the write response only.
     """
-    hint = _WRITE_TIME_HINTS[report.grade]
+    if report.grade == UNVERIFIABLE:
+        hint = _unverifiable_hint(
+            report,
+            resolution_root=resolution_root,
+            resolution_root_explicit=resolution_root_explicit,
+            resolution_root_exists=resolution_root_exists,
+        )
+    else:
+        hint = _WRITE_TIME_HINTS[report.grade]
     if report.grade == UNVERIFIABLE and write_class == "deliberate":
         hint += _DELIBERATE_UNVERIFIABLE_SUFFIX
     return hint

--- a/mcp_server/handlers/remember_helpers.py
+++ b/mcp_server/handlers/remember_helpers.py
@@ -6,6 +6,7 @@ Extracted to keep remember.py under 300 lines with all methods under 40 lines.
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import Any
 
 from mcp_server.core import (
@@ -689,9 +690,40 @@ def _run_post_store(
     return tids, tagged, slot
 
 
-def _grade_content_best_effort(
-    content: str, *, directory: str
-) -> tuple[provenance.ProvenanceReport, str | None]:
+@dataclass
+class _GradeContext:
+    """Result of a best-effort write-time provenance grading pass.
+
+    ``resolution_root``/``resolution_root_explicit``/``resolution_root_exists``
+    (issue #345) are the caller-side context ``core/provenance.write_time_hint``
+    needs to distinguish "reference genuinely dead" from "reference resolved
+    against the wrong root" -- core/ stays zero-I/O (module docstring), so
+    the ``os.path.isdir`` check that produces ``resolution_root_exists``
+    happens here, in the handlers layer.
+    """
+
+    report: provenance.ProvenanceReport
+    grading_error: str | None
+    resolution_root: str
+    resolution_root_explicit: bool
+    resolution_root_exists: bool
+
+
+def _fallback_grade_context(
+    *, resolution_root: str, resolution_root_explicit: bool, error_type: str
+) -> _GradeContext:
+    return _GradeContext(
+        report=provenance.ProvenanceReport(
+            memory_id=0, grade=provenance.UNVERIFIABLE, ref_counts={}
+        ),
+        grading_error=error_type,
+        resolution_root=resolution_root,
+        resolution_root_explicit=resolution_root_explicit,
+        resolution_root_exists=bool(resolution_root) and os.path.isdir(resolution_root),
+    )
+
+
+def _grade_content_best_effort(content: str, *, directory: str) -> _GradeContext:
     """Best-effort wrapper around ``validate_memory.grade_from_content``.
 
     Root cause (issue #147): ``grade_from_content``'s ``base_dir`` fallback
@@ -705,36 +737,45 @@ def _grade_content_best_effort(
     the source by matching the established local pattern instead of
     special-casing ``os.getcwd()``.
 
-    Postcondition: NEVER raises. On success returns
-    ``(grade_report, None)``. On any failure returns a fallback
+    Postcondition: NEVER raises. Always returns a ``_GradeContext`` whose
+    ``resolution_root_explicit`` is ``bool(directory)`` -- issue #345:
+    when the caller passed no ``directory``, resolution silently fell back
+    to the server process's cwd, which need not be the writer's project
+    root (reproduced live on memory 4341427, 2026-08-08: 3 real paths in
+    the Cortex repo graded dead because the write's cwd was the repo's
+    *parent* directory). On any failure returns a fallback
     ``ProvenanceReport`` graded ``UNVERIFIABLE`` (the same "we don't know"
     default ``grade_provenance`` uses for zero extractable references) plus
     the failing exception's type name, so the caller can surface it as an
     observable tag instead of a silently absorbed enrichment.
     """
+    root_explicit = bool(directory)
     try:
         base_dir = directory or os.getcwd()
     except OSError as exc:
-        return (
-            provenance.ProvenanceReport(
-                memory_id=0, grade=provenance.UNVERIFIABLE, ref_counts={}
-            ),
-            type(exc).__name__,
+        return _fallback_grade_context(
+            resolution_root="",
+            resolution_root_explicit=root_explicit,
+            error_type=type(exc).__name__,
         )
+    root_exists = os.path.isdir(base_dir)
     try:
-        return (
-            validate_memory.grade_from_content(
-                content, directory_context=directory, base_dir=base_dir
-            ),
-            None,
+        report = validate_memory.grade_from_content(
+            content, directory_context=directory, base_dir=base_dir
         )
     except Exception as exc:  # noqa: BLE001 — grading must never block a write
-        return (
-            provenance.ProvenanceReport(
-                memory_id=0, grade=provenance.UNVERIFIABLE, ref_counts={}
-            ),
-            type(exc).__name__,
+        return _fallback_grade_context(
+            resolution_root=base_dir,
+            resolution_root_explicit=root_explicit,
+            error_type=type(exc).__name__,
         )
+    return _GradeContext(
+        report=report,
+        grading_error=None,
+        resolution_root=base_dir,
+        resolution_root_explicit=root_explicit,
+        resolution_root_exists=root_exists,
+    )
 
 
 def insert_and_post_process(
@@ -796,9 +837,8 @@ def insert_and_post_process(
     # evaluate_gate() (called by remember.py before this function), so the
     # tag can never influence the novelty/gate decision -- bench-neutral by
     # construction, no G-bench required for this increment.
-    grade_report, grading_error = _grade_content_best_effort(
-        content, directory=directory
-    )
+    grade_ctx = _grade_content_best_effort(content, directory=directory)
+    grade_report, grading_error = grade_ctx.report, grade_ctx.grading_error
     tags = [*tags, f"prov:{grade_report.grade}"]
     if grading_error is not None:
         # issue #147: grade_from_content's os.getcwd() fallback can raise
@@ -880,10 +920,28 @@ def insert_and_post_process(
     # comment above) so the writer sees, in the SAME response, whether
     # their claim carries a checkable reference and can complete it by
     # superseding this memory if not.
+    #
+    # issue #345: "hint" used to be a pure `grade` lookup that claimed "no
+    # checkable reference found" even when `checkable_refs` in this SAME
+    # dict counted several -- the diagnosis (`report.reason`/`dead_refs`)
+    # was computed and then discarded. `reason`/`dead_refs` are now also
+    # surfaced directly (capped at 3, matching `_build_reason`'s own cap --
+    # `core/provenance.py`), matching what `validate_memory`'s batch pass
+    # already exposes (`handlers/validate_memory.py:559-561`), and the hint
+    # itself names the dead refs AND the resolution root they were checked
+    # against (`_grade_content_best_effort`'s `_GradeContext`).
     response["provenance"] = {
         "grade": grade_report.grade,
         "checkable_refs": grade_report.ref_counts,
-        "hint": provenance.write_time_hint(grade_report, write_class),
+        "reason": grade_report.reason,
+        "dead_refs": grade_report.dead_refs[:3],
+        "hint": provenance.write_time_hint(
+            grade_report,
+            write_class,
+            resolution_root=grade_ctx.resolution_root,
+            resolution_root_explicit=grade_ctx.resolution_root_explicit,
+            resolution_root_exists=grade_ctx.resolution_root_exists,
+        ),
     }
     # C1 source / reality monitoring: surface the stored epistemic attribution
     # so the caller can see whether this memory was perceived / told / inferred.

--- a/memory/mutation-equivalents.json
+++ b/memory/mutation-equivalents.json
@@ -400,6 +400,14 @@
       "kind": "equivalent-by-construction",
       "rationale": "Passing None instead of \"\" as the initial scope is unobservable: every use of that parameter is a truthiness test (`if scope` / `f\"{scope}.\" if scope else ...`), and both values are falsy.",
       "issue": "#369"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_write_time_hint__mutmut_1",
+      "removed": "write_class: str = \"\",",
+      "added": "write_class: str = \"XXXX\",",
+      "kind": "equivalent-by-construction",
+      "rationale": "write_class's default value is read exactly once in the function body, in `write_class == \"deliberate\"` -- neither \"\" nor \"XXXX\" equals \"deliberate\", so no caller that omits the argument can ever observe which default was compiled in. Killing this would require asserting on a value the function provably never surfaces.",
+      "issue": "#345"
     }
   ]
 }

--- a/tests_py/core/test_provenance.py
+++ b/tests_py/core/test_provenance.py
@@ -274,3 +274,233 @@ class TestWriteTimeHint:
         # hidden state, no I/O (contract: deterministic lookup only).
         r = _report(UNVERIFIABLE)
         assert write_time_hint(r, "deliberate") == write_time_hint(r, "deliberate")
+
+
+# ── write_time_hint dead-ref states (issue #345) ────────────────────────────
+#
+# Reproduced live on memory 4341427 (2026-08-08): 3 real repo-relative paths
+# graded dead because `directory` was never passed to `remember`, so
+# resolution silently fell back to the process's cwd (the repo's PARENT,
+# not the repo itself). The naive "no ref found" -> "name the dead refs"
+# fix alone still misdiagnoses that case as "these paths are wrong" when
+# they are not -- the ROOT they were checked against is. Three mutually
+# exclusive states, per `_unverifiable_hint`'s contract:
+#   1. no references extracted at all (existing coverage above)
+#   2a. references extracted, resolution root is not a real directory
+#   2b. references extracted, root is real but was never explicitly given
+#   3.  references extracted, root explicit and real, refs genuinely absent
+
+
+def _dead_report(
+    dead_refs: list[str], *, file_count: int | None = None
+) -> ProvenanceReport:
+    n = file_count if file_count is not None else len(dead_refs)
+    return ProvenanceReport(
+        memory_id=0,
+        grade=UNVERIFIABLE,
+        ref_counts={"file": n, "commit": 0, "url": 0, "artifact": 0, "citation": 0},
+        dead_refs=list(dead_refs),
+        reason=f"dead_refs: {', '.join(dead_refs[:3])}",
+    )
+
+
+class TestWriteTimeHintDeadRefStates:
+    def test_state1_no_refs_at_all_keeps_plain_wording(self):
+        """State 1: zero extractable references — unchanged since before
+        #345 (nothing to name, no root to blame)."""
+        hint = write_time_hint(_report(UNVERIFIABLE))
+        assert "No checkable reference found" in hint
+
+    def test_state2a_root_missing_on_disk_names_root_not_paths(self):
+        """State 2a: the resolution root itself does not exist — the hint
+        must blame the ROOT, not imply the paths are individually wrong."""
+        report = _dead_report(["src/a.py"])
+        hint = write_time_hint(
+            report,
+            resolution_root="/no/such/directory",
+            resolution_root_explicit=True,
+            resolution_root_exists=False,
+        )
+        assert "/no/such/directory" in hint
+        assert "not a directory on disk" in hint
+        assert "src/a.py" in hint
+
+    def test_state2b_implicit_root_names_root_and_says_no_directory_passed(self):
+        """State 2b (the live repro): references are real, but `directory`
+        was never passed, so resolution used the implicit cwd — the hint
+        must name that root AND tell the writer to pass `directory`."""
+        report = _dead_report(
+            ["mcp_server/core/decay_cycle.py", "tests_py/core/test_decay_cycle.py"]
+        )
+        hint = write_time_hint(
+            report,
+            resolution_root="/Users/cdeust/Developments",
+            resolution_root_explicit=False,
+            resolution_root_exists=True,
+        )
+        assert "/Users/cdeust/Developments" in hint
+        assert "no `directory` was passed" in hint
+        assert "mcp_server/core/decay_cycle.py" in hint
+        assert "not a directory on disk" not in hint
+
+    def test_state3_explicit_root_names_root_and_dead_refs_only(self):
+        """State 3: a real, explicitly-given root — the classic dead-ref
+        case from the filed issue (#345 original repro)."""
+        report = _dead_report(["plugins/hypermnesia-mcp-codex/.mcp.json"])
+        hint = write_time_hint(
+            report,
+            resolution_root="/repo/Cortex",
+            resolution_root_explicit=True,
+            resolution_root_exists=True,
+        )
+        assert "/repo/Cortex" in hint
+        assert "plugins/hypermnesia-mcp-codex/.mcp.json" in hint
+        assert "no `directory` was passed" not in hint
+        assert "No checkable reference found" not in hint
+
+    def test_dead_ref_hint_never_claims_none_found(self):
+        """The exact defect from the issue: `checkable_refs` non-zero and
+        the hint claiming none was found must never co-occur."""
+        report = _dead_report(["a.py", "b.py", "c.py"])
+        hint = write_time_hint(
+            report,
+            resolution_root="/repo",
+            resolution_root_explicit=True,
+            resolution_root_exists=True,
+        )
+        assert "No checkable reference found" not in hint
+
+    def test_more_than_three_dead_refs_are_capped_with_a_count(self):
+        report = _dead_report(["a.py", "b.py", "c.py", "d.py", "e.py"])
+        hint = write_time_hint(
+            report,
+            resolution_root="/repo",
+            resolution_root_explicit=True,
+            resolution_root_exists=True,
+        )
+        assert "a.py" in hint and "b.py" in hint and "c.py" in hint
+        assert "d.py" not in hint
+        assert "+2 more" in hint
+
+    def test_deliberate_suffix_still_appended_on_dead_ref_hint(self):
+        report = _dead_report(["a.py"])
+        hint = write_time_hint(
+            report,
+            "deliberate",
+            resolution_root="/repo",
+            resolution_root_explicit=True,
+            resolution_root_exists=True,
+        )
+        assert "durable claim" in hint
+
+    def test_default_params_preserve_pre_345_explicit_real_root_behavior(self):
+        """Callers that have not been updated to pass the new keyword-only
+        params (default explicit=True, exists=True) get state-3 wording,
+        not a false "root missing" or "root implicit" claim."""
+        report = _dead_report(["a.py"])
+        hint = write_time_hint(report)
+        assert "not a directory on disk" not in hint
+        assert "no `directory` was passed" not in hint
+        assert "a.py" in hint
+
+    # ── Exact-text pins (mutation-kill coverage, issue #345) ────────────────
+    #
+    # The tests above assert substrings/absences; mutmut's string-literal and
+    # boundary mutants on these three state functions survive substring-only
+    # coverage (e.g. a case-flip or an "XX"-marker mutation on a sentence
+    # never individually asserted). These pin the FULL rendered string for
+    # one representative case per state, and the numeric/separator/boundary
+    # edges that substring checks cannot see.
+
+    def test_state2a_full_text_exact(self):
+        report = _dead_report(["src/a.py"])
+        hint = write_time_hint(
+            report,
+            resolution_root="/tmp/nope",
+            resolution_root_explicit=True,
+            resolution_root_exists=False,
+        )
+        assert hint == (
+            "1 checkable reference(s) could not be resolved because the "
+            "resolution root '/tmp/nope' is not a directory on disk: "
+            "src/a.py. Pass a valid `directory`, then supersede this memory."
+        )
+
+    def test_state2b_full_text_exact(self):
+        report = _dead_report(["src/a.py"])
+        hint = write_time_hint(
+            report,
+            resolution_root="/tmp/parent",
+            resolution_root_explicit=False,
+            resolution_root_exists=True,
+        )
+        assert hint == (
+            "1 of 1 checkable reference(s) could not be resolved against "
+            "'/tmp/parent' -- no `directory` was passed to this write, so "
+            "resolution defaulted to the process's current working "
+            "directory: src/a.py. Pass `directory` explicitly (your "
+            "project root) and retry, or drop the reference if it is "
+            "genuinely gone."
+        )
+
+    def test_state3_full_text_exact(self):
+        report = _dead_report(["src/a.py"])
+        hint = write_time_hint(
+            report,
+            resolution_root="/repo",
+            resolution_root_explicit=True,
+            resolution_root_exists=True,
+        )
+        assert hint == (
+            "1 of 1 checkable reference(s) could not be resolved against "
+            "'/repo': src/a.py. Fix the path/URL or drop it, then "
+            "supersede this memory."
+        )
+
+    def test_named_dead_refs_uses_comma_space_separator(self):
+        report = _dead_report(["a.py", "b.py"])
+        hint = write_time_hint(
+            report,
+            resolution_root="/repo",
+            resolution_root_explicit=True,
+            resolution_root_exists=True,
+        )
+        assert "a.py, b.py" in hint
+
+    def test_exactly_three_dead_refs_no_more_suffix(self):
+        # remaining == 0: must NOT show a "(+0 more)" tail.
+        report = _dead_report(["a.py", "b.py", "c.py"])
+        hint = write_time_hint(
+            report,
+            resolution_root="/repo",
+            resolution_root_explicit=True,
+            resolution_root_exists=True,
+        )
+        assert "(+" not in hint
+
+    def test_exactly_four_dead_refs_shows_plus_one_more(self):
+        # remaining == 1: the `> 0` boundary, distinct from the `> 1` and
+        # `>= 0` off-by-one mutants.
+        report = _dead_report(["a.py", "b.py", "c.py", "d.py"])
+        hint = write_time_hint(
+            report,
+            resolution_root="/repo",
+            resolution_root_explicit=True,
+            resolution_root_exists=True,
+        )
+        assert "(+1 more)" in hint
+
+    def test_default_resolution_root_falls_back_to_unresolved_marker(self):
+        """No `resolution_root` passed at all (default "") with dead refs
+        present -- the `resolution_root or "(unresolved)"` fallback must
+        fire, both proving the default is empty (not a non-empty marker)
+        and pinning the literal fallback text EXACTLY (not merely as a
+        substring -- a mutated marker like "XX(unresolved)XX" would also
+        satisfy a substring check)."""
+        report = _dead_report(["a.py"])
+        hint = write_time_hint(report)
+        assert hint == (
+            "1 of 1 checkable reference(s) could not be resolved against "
+            "'(unresolved)': a.py. Fix the path/URL or drop it, then "
+            "supersede this memory."
+        )

--- a/tests_py/handlers/test_issue_147_write_class_and_grading.py
+++ b/tests_py/handlers/test_issue_147_write_class_and_grading.py
@@ -154,16 +154,19 @@ class TestGradingNeverBlocksTheWrite:
         with patch(
             "os.getcwd", side_effect=FileNotFoundError(2, "No such file or directory")
         ):
-            report, error = _grade_content_best_effort("plain content", directory="")
-        assert report.grade == "unverifiable"
-        assert error == "FileNotFoundError"
+            ctx = _grade_content_best_effort("plain content", directory="")
+        assert ctx.report.grade == "unverifiable"
+        assert ctx.grading_error == "FileNotFoundError"
 
     def test_grade_content_best_effort_passes_through_on_success(self, tmp_path):
-        report, error = _grade_content_best_effort(
+        ctx = _grade_content_best_effort(
             "plain content with no refs", directory=str(tmp_path)
         )
-        assert error is None
-        assert report.grade == "unverifiable"
+        assert ctx.grading_error is None
+        assert ctx.report.grade == "unverifiable"
+        assert ctx.resolution_root == str(tmp_path)
+        assert ctx.resolution_root_explicit is True
+        assert ctx.resolution_root_exists is True
 
     def test_force_write_survives_missing_cwd(self):
         """End-to-end (issue repro): a force=True write must still insert

--- a/tests_py/handlers/test_remember_provenance_at_write.py
+++ b/tests_py/handlers/test_remember_provenance_at_write.py
@@ -150,6 +150,115 @@ class TestProvenanceNeverHitsNetwork:
         assert result["provenance"]["grade"] == "verifiable"
 
 
+class TestProvenanceDeadRefHint:
+    """Issue #345: the write-time hint must never claim "no checkable
+    reference found" when `checkable_refs` in the SAME response is
+    non-zero -- and must name which reference(s) failed and against what
+    root, not just repeat the grade."""
+
+    def test_acceptance_one_real_one_dead_path_names_the_dead_one(self, tmp_path):
+        """Issue #345 acceptance criterion, verbatim: a `remember` call
+        whose content cites one existing and one non-existent path returns
+        a `provenance` block that names the non-existent path and does not
+        claim that no reference was found."""
+        real = tmp_path / "real_module.py"
+        real.write_text("x = 1")
+        dead_rel = "src/definitely_missing_module.py"
+        result = asyncio.run(
+            handler(
+                {
+                    "content": (
+                        f"Root cause traced to {real} — see also "
+                        f"{dead_rel} for the caller."
+                    ),
+                    "force": True,
+                    "directory": str(tmp_path),
+                }
+            )
+        )
+        assert result["stored"] is True
+        prov = result["provenance"]
+        assert prov["grade"] == "unverifiable"
+        assert prov["checkable_refs"]["file"] == 2
+        assert "No checkable reference found" not in prov["hint"]
+        assert dead_rel in prov["hint"]
+
+    def test_dead_refs_and_reason_surfaced_on_response(self, tmp_path):
+        dead_rel = "src/another_missing_file.py"
+        result = asyncio.run(
+            handler(
+                {
+                    "content": f"See {dead_rel} for context.",
+                    "force": True,
+                    "directory": str(tmp_path),
+                }
+            )
+        )
+        prov = result["provenance"]
+        assert dead_rel in prov["dead_refs"]
+        assert prov["reason"].startswith("dead_refs:")
+        assert dead_rel in prov["reason"]
+
+    def test_implicit_directory_names_root_and_says_directory_not_passed(
+        self, tmp_path, monkeypatch
+    ):
+        """Live repro (memory 4341427, 2026-08-08): omit `directory` —
+        resolution silently uses the process cwd, which need not be the
+        writer's project root. The hint must name that root and say so,
+        never conflate this with a genuinely-dead path."""
+        monkeypatch.chdir(tmp_path)
+        dead_rel = "src/yet_another_missing_file.py"
+        result = asyncio.run(
+            handler(
+                {
+                    "content": f"See {dead_rel} for context.",
+                    "force": True,
+                    # directory omitted on purpose
+                }
+            )
+        )
+        prov = result["provenance"]
+        assert prov["grade"] == "unverifiable"
+        assert str(tmp_path) in prov["hint"]
+        assert "no `directory` was passed" in prov["hint"]
+
+    def test_nonexistent_directory_root_names_root_as_missing(self, tmp_path):
+        """State 2a: an explicitly-passed `directory` that is itself not a
+        real directory on disk — the hint must blame the root, not the
+        individually-named references (they were never even checkable)."""
+        missing_root = str(tmp_path / "does_not_exist_at_all")
+        result = asyncio.run(
+            handler(
+                {
+                    "content": "See src/some_file.py for context.",
+                    "force": True,
+                    "directory": missing_root,
+                }
+            )
+        )
+        prov = result["provenance"]
+        assert missing_root in prov["hint"]
+        assert "not a directory on disk" in prov["hint"]
+
+    def test_explicit_directory_gets_dead_ref_wording_not_implicit_wording(
+        self, tmp_path
+    ):
+        dead_rel = "src/explicit_root_missing_file.py"
+        result = asyncio.run(
+            handler(
+                {
+                    "content": f"See {dead_rel} for context.",
+                    "force": True,
+                    "directory": str(tmp_path),
+                }
+            )
+        )
+        prov = result["provenance"]
+        assert str(tmp_path) in prov["hint"]
+        assert "no `directory` was passed" not in prov["hint"]
+        assert dead_rel in prov["hint"]
+
+
 class TestProvenanceGradingIsAfterGateDecision:
     """The prov: tag must never influence the gate's novelty/bypass
     decision -- it is appended strictly after evaluate_gate() runs


### PR DESCRIPTION
## Root cause (Move 4)

- **Symptom**: `remember`'s `provenance.hint` said "No checkable reference found" while `checkable_refs` in the SAME response counted 3 files and 1 URL. The `unverifiable` grading was correct; the message was not.
- **Architectural cause**: `grade_provenance` (`mcp_server/core/provenance.py`) correctly folds two distinct causes into one UNVERIFIABLE grade — "no reference extracted at all" and "reference(s) extracted but resolved dead" — and `_build_reason` already computes which one applies (`dead_refs: <names>` vs `no_extractable_reference`). But `write_time_hint` keyed a *fixed* string off `report.grade` alone, discarding that diagnosis before it reached the writer.
- **A second cause behind the same symptom, found via live reproduction** (memory 4341427, 2026-08-08 — h/t the maintainer for the sharper repro): 3 *genuinely-existing* Cortex repo paths graded dead because `directory` was never passed to `remember()`. `handlers/validate_memory.grade_from_content`'s `base_dir = directory or os.getcwd()` fallback then resolved them against the wrong root (the repo's parent, not the repo). Naming the dead refs alone (the naive fix) would have told the writer their real, correct paths were wrong — they were not; the resolution root was.
- **Fix**: `core/provenance.write_time_hint` now branches the UNVERIFIABLE case on `report.dead_refs` plus two caller-supplied booleans (`resolution_root_explicit`, `resolution_root_exists`) into three mutually exclusive messages, each **naming the resolution root**:
  1. root is not a real directory on disk,
  2. root is real but was never explicitly passed (implicit `os.getcwd()` fallback — the live-repro case),
  3. root is real and explicit — the reference(s) are genuinely dead (the issue's original repro case).

  `handlers/remember_helpers._grade_content_best_effort` threads this context through a new `_GradeContext` dataclass; `resolution_root_explicit` is `bool(directory)` computed once at the call site (no re-derivation), and `resolution_root_exists` is an `os.path.isdir` check done in the handlers layer — `core/` stays zero-I/O (module docstring, coding-standards.md §2.2).

  `response["provenance"]` also now surfaces `reason` and `dead_refs` (capped at 3, matching `_build_reason`'s own cap) directly, matching what `validate_memory`'s batch pass already exposes (`handlers/validate_memory.py:559-561`) — not just baked into the hint string.

- **Verification**: acceptance criterion from the issue reproduced as a test verbatim (`TestProvenanceDeadRefHint::test_acceptance_one_real_one_dead_path_names_the_dead_one`), plus end-to-end coverage for all three resolution-root states and unit coverage for every branch/boundary in `core/provenance.py`.

## Layer assignment

- `mcp_server/core/provenance.py` — core/, pure logic (no new I/O; the new params are caller-supplied booleans, not derived here).
- `mcp_server/handlers/remember_helpers.py` — handlers/, the composition root that resolves `os.path.isdir` and threads the context through.

## Stakes classification

Medium — core business logic (write-time feedback loop, M-D5), not touching auth/billing/crypto/concurrency/migrations. `mcp_server/handlers/remember_helpers.py` exceeds coding-standards.md's file-count threshold for "touched by >1 author in 90 days" territory (it's a heavily-shared composition root), so I applied full Move 1–5 discipline anyway rather than relying on the Medium default.

## Evidence

**Tests** (`.venv` built fresh in this worktree, `--extra dev --extra sqlite`, no `postgresql` extra — sidesteps the shared main-repo venv's `cryptography` version drift without touching that venv; SQLite-backed, per `tests_py/conftest.py`'s documented PG-unavailable fallback):

```
tests_py/core/test_provenance.py .............................................  [49 passed]
tests_py/handlers/test_issue_147_write_class_and_grading.py ..................  [18 passed]
tests_py/handlers/test_remember_provenance_at_write.py .....................    [12 passed]
+ tests_py/core/test_pg_recall_pipeline.py, test_ble001_sweep_handlers.py,
  test_hierarchical_gate_wiring.py, test_memory_tier_model.py,
  test_remember_helpers_novelty_normalize.py, test_remember_helpers_silent_failures.py,
  test_remember_link_provenance.py, test_remember_supersede.py,
  test_remember_supersession_readpath.py, test_remember.py, test_s110_sweep_handlers.py
  ...........................................................  [159 passed]
tests_py/scripts/test_mutation_equivalents.py .......................            [23 passed]
```
233 tests total, 0 failures.

**Lint**: `ruff check` + `ruff format --check` clean on every touched file.

**Mutation** (`scripts/mutation_check.sh "tests_py/core/test_provenance.py" mcp_server/core/provenance.py`, standard: 0 surviving non-equivalent mutants on changed code):
- 0 unregistered survivors in every function this diff adds or modifies (`_named_dead_refs`, `_dead_ref_hint_root_missing/_implicit/_explicit`, `_unverifiable_hint`, `write_time_hint`).
- 1 mutant (`write_time_hint`'s `write_class` default-value literal) registered `equivalent-by-construction` in `memory/mutation-equivalents.json` — the default is read exactly once, via `write_class == "deliberate"`, which neither `""` nor the mutant's `"XXXX"` satisfies, so no test can ever observe which default compiled in.
- 43 pre-existing survivors in `grade_provenance`/`_build_reason`/`extract_*`/`_ref_counts` — functions this diff does not touch, and #345's own Non-goals section scopes away from ("not proposing to change the grading rule"). This module apparently never had a mutation pass before. Filed as **#389** rather than expanded into this PR.

## Boy-scout

No other defects observed in touched material this session (formatter/linter clean before I started, no dead code, no weak/flaky tests encountered). The one defect *seen* (pre-existing mutation-coverage gap in unrelated functions of the same file) is filed as #389 per §14.3 — genuinely outside this change's blast radius.

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)