### PR TITLE
ci: gate main on one aggregate check instead of eleven job names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,6 +599,14 @@ jobs:
       - name: Check documentation claims
         run: python scripts/check_doc_claims.py
 
+      # The `ci-green` job below is the single status check branch protection
+      # names; the list of jobs it covers lives in its `needs:`. A job added
+      # to ci.yml but not to that list would run outside the gate and could
+      # fail without blocking a merge. Static only (no imports), same reason
+      # as the doc-claim gate above.
+      - name: Check the aggregate CI gate covers every job
+        run: python scripts/check_ci_gate_complete.py
+
       # The README's repo-derived badges are committed SVGs, not hotlinked
       # images, so nothing regenerates them on view: a figure that moves
       # leaves the badge asserting the old one. Checked here, on every push
@@ -866,3 +874,59 @@ jobs:
         run: scripts/docker_smoke.sh --skip-build
         env:
           CORTEX_SMOKE_IMAGE: cortex-smoke:local
+
+  # The one status check branch protection on `main` names. Everything else
+  # in this workflow is reached through its `needs:` list, so renaming a job,
+  # resizing the matrix, or delegating steps to a reusable workflow (which
+  # rewrites check names to "<caller> / <callee>", issue #336) no longer
+  # touches the protection settings — the contract is this file, in git,
+  # visible in review, instead of eleven job-name strings in GitHub settings
+  # that no diff ever shows.
+  #
+  # `if: always()` is load-bearing: without it this job is itself skipped the
+  # moment any need fails, the required context is never reported, and the PR
+  # blocks with no explanation instead of a red X naming the culprit.
+  #
+  # scripts/check_ci_gate_complete.py (run by `lint`) refuses a merge if any
+  # job here is missing from `needs`, or if a job carrying a job-level `if:`
+  # is absent from ALLOWED_SKIPS below.
+  ci-green:
+    name: CI Green
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - test-sqlite
+      - mcp-host-config
+      - test-windows
+      - lint
+      - typecheck
+      - build
+      - docker-runtime-build
+      - devcontainer-build
+      - docker-smoke
+    steps:
+      - name: Require every job above to have succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          # Jobs permitted to report `skipped`, with the reason. ONLY jobs
+          # carrying a job-level `if:` belong here; anything else that skips
+          # is a gap, not an exemption.
+          #   mcp-host-config — `if: github.event_name != 'pull_request' ||
+          #   github.event.pull_request.head.repo.fork == false`: a fork PR
+          #   has no access to the secrets it needs, so it cannot run there.
+          ALLOWED_SKIPS: mcp-host-config
+        run: |
+          set -euo pipefail
+          echo "$NEEDS"
+          failed=$(printf '%s' "$NEEDS" | jq -r --arg allowed "$ALLOWED_SKIPS" '
+            ($allowed | split(",") | map(ltrimstr(" ") | rtrimstr(" "))) as $ok
+            | to_entries[]
+            | select(.value.result != "success")
+            | select(.value.result != "skipped" or ([.key] | inside($ok) | not))
+            | "\(.key)=\(.value.result)"')
+          if [ -n "$failed" ]; then
+            echo "::error::CI Green refuses the merge — $(echo "$failed" | tr '\n' ' ')"
+            exit 1
+          fi
+          echo "every required job succeeded"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,27 @@ CI's install ever drift apart.
 - One mechanism per PR when adding new biological mechanisms.
 - Conventional commit messages preferred.
 
+### The one required status check
+
+Branch protection on `main` names a single `ci.yml` context, **`CI Green`**
+(plus `CodeQL`, which GitHub reports from its own default setup). `CI Green`
+is the `ci-green` job at the bottom of `.github/workflows/ci.yml`: it needs
+every other job in that workflow and fails on any result other than
+`success`, except for the jobs listed in its `ALLOWED_SKIPS` — which may
+contain only jobs carrying a job-level `if:`, each with its reason.
+
+Naming individual jobs in the protection settings instead put the contract
+outside git, where no diff shows it and every rename breaks it: extracting
+the test steps into a reusable workflow (issue #336) renamed the four matrix
+legs to `Test (Python X.Y) / Test (Python X.Y)`, the four bare contexts
+`main` required were never reported again, and a fully green PR sat BLOCKED
+(#387). With one aggregate context, renaming a job, resizing the matrix, or
+delegating steps costs nothing.
+
+**Adding a job to `ci.yml` means adding it to `ci-green.needs`.**
+`scripts/check_ci_gate_complete.py` (run by `lint`) fails the build
+otherwise — an ungated job could fail without blocking a merge.
+
 ---
 
 ## Adding a biological mechanism

--- a/scripts/check_ci_gate_complete.py
+++ b/scripts/check_ci_gate_complete.py
@@ -1,0 +1,205 @@
+"""CI-gate completeness: every ci.yml job must be behind the aggregate gate.
+
+Branch protection on ``main`` names required status checks as strings, in
+GitHub settings — outside git, invisible in review, and unversioned. Naming
+individual jobs there makes the contract break on every rename: extracting
+the test steps into a reusable workflow (issue #336) renamed the four matrix
+legs to ``Test (Python X.Y) / Test (Python X.Y)``, so the four bare contexts
+``main`` required were never reported again and a fully green PR sat BLOCKED
+(PR #387, run 31250898534). Renaming the contexts fixes that one PR and
+leaves the next rename to rediscover it.
+
+So protection names ONE ci.yml context — ``CI Green`` — and the real list
+lives here, in git, where a diff shows it. That moves the failure mode: the
+gate is only as good as its ``needs:`` list, and a job added later that
+nobody adds to it is silently ungated. That is what this script refuses.
+
+It also refuses the second escape hatch. The gate treats any result other
+than ``success`` as failure, EXCEPT for jobs named in its ``ALLOWED_SKIPS``
+env — because a job carrying a job-level ``if:`` legitimately reports
+``skipped``. An unlisted conditional would therefore let a job skip its way
+past the gate, so every job with an ``if:`` must be declared, and every
+declared exemption must correspond to a job that actually has one (a stale
+exemption is a hole nobody is watching).
+
+Checks, all of them fatal:
+
+1. the gate job exists;
+2. every other ci.yml job appears in the gate's ``needs:``;
+3. every name in ``needs:`` is a real job;
+4. every job carrying a job-level ``if:`` is listed in ``ALLOWED_SKIPS``;
+5. every name in ``ALLOWED_SKIPS`` is a job that carries an ``if:``.
+
+Static only — regex over the workflow text, no PyYAML. The Lint job installs
+ruff and nothing else, and this script runs there alongside
+``check_doc_claims.py``, which is static for the same reason.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+# The single job branch protection points at. Renaming it is a protection
+# change, not a refactor — hence a named constant rather than a literal.
+GATE_JOB = "ci-green"
+
+_JOB_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
+_JOB_IF_RE = re.compile(r"^    if:\s*(\S.*)$")
+_NEEDS_BLOCK_RE = re.compile(r"^    needs:\s*$")
+_NEEDS_ITEM_RE = re.compile(r"^      - ([A-Za-z0-9_-]+)\s*$")
+_ALLOWED_SKIPS_RE = re.compile(r"^\s*ALLOWED_SKIPS:\s*(\S.*?)\s*$")
+
+
+# Shortest string that can carry a matched quote pair: the two quotes.
+_QUOTED_MIN_LEN = 2
+
+
+def _strip_quotes(value: str) -> str:
+    if len(value) >= _QUOTED_MIN_LEN and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def _job_bodies(text: str) -> dict[str, list[str]]:
+    """Return job id -> the lines of its block, in file order."""
+    bodies: dict[str, list[str]] = {}
+    in_jobs = False
+    current: str | None = None
+
+    for line in text.splitlines():
+        if line.startswith("jobs:"):
+            in_jobs = True
+            continue
+        if not in_jobs:
+            continue
+        # A new top-level key (indent 0) ends the jobs mapping.
+        if line and not line.startswith(" ") and not line.startswith("#"):
+            break
+        job_match = _JOB_RE.match(line)
+        if job_match:
+            current = job_match.group(1)
+            bodies[current] = []
+            continue
+        if current is not None:
+            bodies[current].append(line)
+
+    return bodies
+
+
+def _parse_needs(body: list[str]) -> list[str]:
+    """Return the job ids listed under this block's ``needs:`` sequence."""
+    needs: list[str] = []
+    collecting = False
+
+    for line in body:
+        if _NEEDS_BLOCK_RE.match(line):
+            collecting = True
+            continue
+        if not collecting:
+            continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        item = _NEEDS_ITEM_RE.match(line)
+        if not item:
+            collecting = False
+            continue
+        needs.append(item.group(1))
+
+    return needs
+
+
+def _parse_allowed_skips(body: list[str]) -> list[str]:
+    """Return the job ids named by this block's ``ALLOWED_SKIPS`` env."""
+    for line in body:
+        match = _ALLOWED_SKIPS_RE.match(line)
+        if match is None:
+            continue
+        raw = _strip_quotes(match.group(1))
+        return [name.strip() for name in raw.split(",") if name.strip()]
+    return []
+
+
+def parse_workflow(text: str) -> tuple[dict[str, bool], list[str], list[str]]:
+    """Return (job_id -> has job-level ``if:``, gate needs, allowed skips).
+
+    Pre:  ``text`` is the ci.yml source.
+    Post: jobs are the top-level keys under ``jobs:`` (indent 2); needs and
+          allowed-skips are read from the gate job's block only.
+    """
+    bodies = _job_bodies(text)
+    jobs = {
+        job: any(_JOB_IF_RE.match(line) for line in body)
+        for job, body in bodies.items()
+    }
+    gate_body = bodies.get(GATE_JOB, [])
+    return jobs, _parse_needs(gate_body), _parse_allowed_skips(gate_body)
+
+
+def check(text: str) -> list[str]:
+    """Return the list of failures; empty means the gate is complete."""
+    jobs, needs, allowed_skips = parse_workflow(text)
+    failures: list[str] = []
+
+    if GATE_JOB not in jobs:
+        return [
+            f"job '{GATE_JOB}' is missing from ci.yml — branch protection "
+            f"requires its status check, so main would block on a context "
+            f"nothing reports"
+        ]
+
+    gated = set(needs)
+    for job, _ in sorted(jobs.items()):
+        if job == GATE_JOB:
+            continue
+        if job not in gated:
+            failures.append(
+                f"job '{job}' is not in {GATE_JOB}.needs — it would run "
+                f"outside the gate and could fail without blocking a merge"
+            )
+
+    for name in needs:
+        if name not in jobs:
+            failures.append(
+                f"{GATE_JOB}.needs lists '{name}', which is not a job in ci.yml"
+            )
+
+    conditional = {job for job, has_if in jobs.items() if has_if and job != GATE_JOB}
+    for job in sorted(conditional - set(allowed_skips)):
+        failures.append(
+            f"job '{job}' carries a job-level 'if:' but is not in "
+            f"ALLOWED_SKIPS — it can report 'skipped' and slip past the gate. "
+            f"Declare it (with the reason) or drop the condition"
+        )
+    for name in sorted(set(allowed_skips) - conditional):
+        failures.append(
+            f"ALLOWED_SKIPS lists '{name}', which has no job-level 'if:' in "
+            f"ci.yml — a stale exemption lets a real skip go unnoticed"
+        )
+
+    return failures
+
+
+def main() -> int:
+    if not CI_WORKFLOW.exists():
+        print(f"FAIL: {CI_WORKFLOW} not found", file=sys.stderr)
+        return 1
+
+    failures = check(CI_WORKFLOW.read_text(encoding="utf-8"))
+    if failures:
+        print("CI gate completeness: FAIL", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print("CI gate completeness: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_py/scripts/test_check_ci_gate_complete.py
+++ b/tests_py/scripts/test_check_ci_gate_complete.py
@@ -1,0 +1,128 @@
+"""Tests for scripts/check_ci_gate_complete.py — the aggregate-CI-gate guard.
+
+Branch protection names one status check, ``CI Green``, and the real list of
+gated jobs lives in that job's ``needs:``. This guard is the only thing
+standing between that design and its failure mode: a job added to ci.yml but
+never added to ``needs`` runs outside the gate and can fail without blocking
+a merge — silently, exactly like the eleven-context arrangement it replaced.
+
+So the guard's own failure mode is silence. Each check below is pinned by a
+fixture that must FAIL, plus a live assertion that the repository's real
+ci.yml passes — a parser that quietly stopped matching would otherwise be
+indistinguishable from a clean tree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+# Dotted, path-derived module name: mutmut keys its trampolines on
+# "scripts.check_ci_gate_complete.*" and a bare name makes every mutant look
+# unreached (issue #293, same idiom as test_check_doc_claims.py).
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "scripts.check_ci_gate_complete", _SCRIPTS / "check_ci_gate_complete.py"
+)
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
+
+
+def _workflow(jobs: str) -> str:
+    """Wrap job definitions in the minimal ci.yml envelope the parser reads."""
+    return "name: CI\n\non:\n  push:\n    branches: [main]\n\njobs:\n" + jobs
+
+
+_COMPLETE = _workflow(
+    """  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: ruff check .
+
+  mcp-host-config:
+    name: Validate MCP host configurations
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.fork == false
+    steps:
+      - run: true
+
+  ci-green:
+    name: CI Green
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - mcp-host-config
+    steps:
+      - name: Require every job above to have succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          ALLOWED_SKIPS: mcp-host-config
+        run: true
+"""
+)
+
+
+class CheckCompleteGate(unittest.TestCase):
+    def test_complete_workflow_has_no_failures(self) -> None:
+        self.assertEqual(gate.check(_COMPLETE), [])
+
+    def test_parses_jobs_needs_and_allowed_skips(self) -> None:
+        jobs, needs, allowed = gate.parse_workflow(_COMPLETE)
+        self.assertEqual(set(jobs), {"lint", "mcp-host-config", "ci-green"})
+        self.assertFalse(jobs["lint"])
+        self.assertTrue(jobs["mcp-host-config"])
+        self.assertEqual(needs, ["lint", "mcp-host-config"])
+        self.assertEqual(allowed, ["mcp-host-config"])
+
+
+class RefusesIncompleteGate(unittest.TestCase):
+    def _only_failure(self, workflow: str) -> str:
+        failures = gate.check(workflow)
+        self.assertEqual(len(failures), 1, failures)
+        return failures[0]
+
+    def test_missing_gate_job_fails(self) -> None:
+        workflow = _workflow(
+            "  lint:\n    name: Lint\n    runs-on: ubuntu-latest\n"
+            "    steps:\n      - run: true\n"
+        )
+        self.assertIn(gate.GATE_JOB, self._only_failure(workflow))
+
+    def test_job_absent_from_needs_fails(self) -> None:
+        workflow = _COMPLETE.replace("      - lint\n", "")
+        self.assertIn("'lint' is not in", self._only_failure(workflow))
+
+    def test_needs_naming_a_nonexistent_job_fails(self) -> None:
+        workflow = _COMPLETE.replace("      - lint\n", "      - lint\n      - ghost\n")
+        self.assertIn("'ghost'", self._only_failure(workflow))
+
+    def test_conditional_job_missing_from_allowed_skips_fails(self) -> None:
+        workflow = _COMPLETE.replace("          ALLOWED_SKIPS: mcp-host-config\n", "")
+        failure = self._only_failure(workflow)
+        self.assertIn("mcp-host-config", failure)
+        self.assertIn("ALLOWED_SKIPS", failure)
+
+    def test_stale_allowed_skips_entry_fails(self) -> None:
+        # `lint` carries no `if:`, so exempting it guards nothing and hides a
+        # real skip if one ever appears.
+        workflow = _COMPLETE.replace(
+            "ALLOWED_SKIPS: mcp-host-config", "ALLOWED_SKIPS: mcp-host-config, lint"
+        )
+        self.assertIn("'lint'", self._only_failure(workflow))
+
+
+class RepositoryWorkflowIsGated(unittest.TestCase):
+    def test_live_ci_workflow_passes(self) -> None:
+        """The guard must agree with the tree it ships in, not just fixtures."""
+        self.assertTrue(gate.CI_WORKFLOW.exists(), gate.CI_WORKFLOW)
+        self.assertEqual(
+            gate.check(gate.CI_WORKFLOW.read_text(encoding="utf-8")),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Branch protection on `main` names **eleven** `ci.yml` jobs as required status checks. That contract lives in GitHub settings — outside git, invisible in review, unversioned — and breaks on every rename.

It broke: #336 extracts the test steps into a reusable workflow, and a job delegating via `uses:` always reports as `"<caller> / <callee>"`. The four matrix legs became `Test (Python X.Y) / Test (Python X.Y)`, the four bare contexts `main` requires were never reported again, and **#387 sits BLOCKED with every check green** (run 31250898534). Renaming the four contexts unblocks that one PR and leaves the next rename to rediscover the same defect.

## What

One required `ci.yml` context, `CI Green` (the `ci-green` job), needing every other job in the workflow. The covered list is in the file, in git, visible in a diff.

`if: always()` is load-bearing — without it the job is itself skipped when a need fails, the context is never reported, and the PR blocks with no explanation instead of a red X naming the culprit.

## The two escape hatches, closed

An aggregate gate moves the failure mode rather than removing it, so `scripts/check_ci_gate_complete.py` (run by `lint`) refuses:

- a job in `ci.yml` that is **not** in `ci-green.needs` — it would run outside the gate and could fail without blocking a merge;
- a job carrying a job-level `if:` that is **not** in `ALLOWED_SKIPS` — it can report `skipped` and slip past;
- a **stale** `ALLOWED_SKIPS` entry naming a job with no `if:` — an exemption guarding nothing hides a real skip.

Today `ALLOWED_SKIPS` holds exactly `mcp-host-config` (cannot run on fork PRs), with the reason inline.

## Side effect worth stating

`mcp-host-config` and the two `Docker Build` jobs were required by **nothing** before this PR. They are gated now.

## Not covered, deliberately

`fuzz.yml` and `upstream-identity.yml` are separate workflows, out of reach of a `ci.yml` aggregate. They are not required checks today and this PR does not make them so.

## Merge order

1. Merge this PR — it renames nothing, the eleven contexts still report, so it is not self-blocking.
2. Set protection's required contexts to `CI Green` + `CodeQL`.
3. #387 then merges with no further protection change — now, and for every future rename.

## Verification

- `scripts/check_ci_gate_complete.py` fails on `main` as it stands today (no `ci-green` job), passes here.
- 8 unit tests: one per refusal, plus a live assertion against the repository's real `ci.yml`.
- gate shell logic exercised on 5 result sets: all-success, allowed skip, unlisted skip, failure, cancelled.
- `ruff format --check` + `ruff check` clean; `actionlint` 0 finding; `check_doc_claims.py` 0 finding.