### PR TITLE
ci: gate every version site against pyproject.toml in one place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,13 +380,26 @@ jobs:
       - name: Check linting
         run: ruff check .
 
-      # Advertised counts (tools, references, mechanisms, version) must match
-      # the repository. Runs here — on every push and PR — because doc drift is
+      # Advertised counts (tools, references, mechanisms) must match the
+      # repository. Runs here — on every push and PR — because doc drift is
       # introduced at commit time, not at release time: on 2026-07-27 README,
       # CONTRIBUTING, CLAUDE.md and the MCPB manifest each advertised a
       # different tool count, and nothing failed. Static only (no imports).
       - name: Check documentation claims
         run: python scripts/check_doc_claims.py
+
+      # [project].version in pyproject.toml against every one of the 14
+      # version sites across 11 files (manifests, plugin.jsons, the
+      # marketplace's metadata AND primary-entry version, the MCP registry
+      # package entry, the four textual occurrences in the version badge,
+      # and uv.lock's own root-package version). Two of these sites
+      # (server.json packages[0].version, marketplace.json metadata.version)
+      # were covered by nothing before this gate existed, and the one gate
+      # that came closest — marketplace-pins.yml — is path-filtered, so it
+      # sits outside ci-green and only fires on its weekly cron (issue #392).
+      # Static only (no imports), same reason as the doc-claim gate above.
+      - name: Check version surfaces
+        run: python scripts/check_version_surfaces.py
 
       # The `ci-green` job below is the single status check branch protection
       # names; the list of jobs it covers lives in its `needs:`. A job added

--- a/scripts/check_doc_claims.py
+++ b/scripts/check_doc_claims.py
@@ -1,6 +1,6 @@
 """Doc-claim gate: the numbers the docs advertise must match the repository.
 
-Cortex advertises counts in prose — tools, references, mechanisms, version,
+Cortex advertises counts in prose — tools, references, mechanisms,
 tests. Each one is a claim a reader can check, and each one drifts silently:
 between 2026-07-12 and 2026-07-27 the tool count moved from 49 to 52 while
 README, CONTRIBUTING and the MCPB manifest still said 50, 43 and 49, and
@@ -19,7 +19,6 @@ tool counts          ``docs/mcp-tools.md`` header, itself pinned to the live
                      test_standalone_baseline_is_52_tools``
 reference count      entries counted in ``docs/papers/bibliography.md``
 mechanism count      the count declared in that bibliography's header
-version              ``[project].version`` in ``pyproject.toml``
 test count           ``assets/badge-tests.svg`` alone (issue #293) — the
                      one artifact that still states an absolute figure. No
                      prose file (nor ``.bestpractices.json``) states this
@@ -33,6 +32,12 @@ test count           ``assets/badge-tests.svg`` alone (issue #293) — the
                      advance; only an OVER-claim is reported. See
                      ``doc_claim_structural.check_badge_floor``.
 ===================  =====================================================
+
+Version-site coherence (``[project].version`` in ``pyproject.toml`` against
+every manifest, plugin, and badge occurrence that restates it) is NOT this
+gate's job any more — it moved to ``scripts/check_version_surfaces.py``,
+which is a strict superset of what this gate's own ``check_versions`` used
+to compare (issue #392).
 
 Release history is exempt: a line describing v4.13.0 may legitimately say
 "49 memory tools". Lines carrying a ``**vX.Y.Z`` marker, and files that are
@@ -64,7 +69,6 @@ module's docstring for why they take these as parameters instead).
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 from pathlib import Path
@@ -177,29 +181,6 @@ def check_counts(pattern: re.Pattern[str], expected: int, label: str) -> list[st
     return doc_claim_scan.check_counts(pattern, expected, label, SCANNED_FILES, read)
 
 
-def check_versions(expected: str) -> list[str]:
-    """The version in the packaging metadata, the badge and every manifest."""
-    failures: list[str] = []
-    for relative_path, key in (
-        ("manifest.json", "version"),
-        ("server.json", "version"),
-        ("package.json", "version"),
-    ):
-        actual = json.loads(read(relative_path)).get(key)
-        if actual != expected:
-            failures.append(
-                f"{relative_path}: version {actual!r}, pyproject says {expected!r}"
-            )
-    failures += doc_claim_structural.check_badge(
-        "assets/badge-version.svg",
-        doc_claim_structural.VERSION_BADGE,
-        expected,
-        "version",
-        read,
-    )
-    return failures
-
-
 def check_no_hotlinked_badges() -> list[str]:
     """The README's repo-derived badges stay self-hosted."""
     return doc_claim_structural.check_no_hotlinked_badges(read)
@@ -221,7 +202,6 @@ def collect_failures(test_count: int | None) -> list[str]:
     failures += check_counts(TOOL_TOTAL_CLAIM, total, "tools with integrations")
     failures += check_counts(REFERENCE_CLAIM, canonical_reference_count(), "references")
     failures += check_counts(MECHANISM_CLAIM, canonical_mechanism_count(), "mechanisms")
-    failures += check_versions(canonical_version())
     failures += check_no_hotlinked_badges()
     failures += check_no_conflict_markers()
     failures += check_scanned_json_parses()

--- a/scripts/check_version_surfaces.py
+++ b/scripts/check_version_surfaces.py
@@ -1,0 +1,257 @@
+"""Version-coherence gate: every version site in the repo must agree.
+
+Three gates already touch a version number, and each trusts a DIFFERENT
+canonical source:
+
+- ``check_doc_claims.py``'s (now removed) ``check_versions`` compared
+  ``manifest.json``/``server.json``/``package.json``/the version badge
+  against ``pyproject.toml``.
+- ``check_marketplace_pins.py`` compares ``server.json``/``manifest.json``
+  against the marketplace's *own* primary pin (not pyproject.toml), and only
+  for the two files it happens to enumerate.
+- ``tests_py/scripts/test_cross_host_manifests.py`` compares four more
+  manifests against ``package.json`` (not pyproject.toml either).
+
+Two sites were covered by NOTHING: ``server.json``'s
+``packages[0].version`` (the MCP-registry package entry, served to every
+registry client) and ``.claude-plugin/marketplace.json``'s
+``metadata.version``. A partial version bump can reach ``main`` and only be
+caught by the weekly ``marketplace-pins`` cron, which is not part of the
+``ci-green`` aggregate (issue #392).
+
+This module is the single authoritative source: every version site is
+compared against ONE canonical value, ``[project].version`` in
+``pyproject.toml`` (via ``doc_claim_sources.canonical_version``, the same
+reader ``check_doc_claims.py`` uses). ``SURFACES`` is DATA — a tuple of
+no-argument-bound check callables built by ``functools.partial`` over three
+small, pure functions (``_json_check``, ``_badge_check``,
+``_uv_lock_check``/``_marketplace_primary_plugin_check``) — so adding a 15th
+surface of an existing kind (another JSON file/key, another badge
+occurrence) is a one-line data edit, never a new branch in
+``check_version_surfaces`` itself (OCP).
+
+Badge parsing reuses ``doc_claim_structural.check_badge`` verbatim (fails
+closed on a missing file or an unmatched pattern) rather than reimplementing
+it; the pyproject version regex is reused from ``doc_claim_sources`` rather
+than re-derived here.
+
+Usage::
+
+    python scripts/check_version_surfaces.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections.abc import Callable
+from functools import partial
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Sibling modules, path-imported for the same reason check_doc_claims.py does
+# it: resolves identically whether this runs as a script or is loaded via
+# importlib.util.spec_from_file_location from a test.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+import doc_claim_sources  # noqa: E402
+import doc_claim_structural  # noqa: E402
+from doc_claim_sources import ClaimError  # noqa: E402  (re-export)
+
+ReadFn = Callable[[str], str]
+SurfaceCheck = Callable[[ReadFn, str], list[str]]
+
+
+def read(relative_path: str) -> str:
+    # encoding="utf-8" pinned explicitly — see check_doc_claims.read's own
+    # docstring for why (non-ASCII prose, locale-dependent defaults).
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def canonical_version() -> str:
+    return doc_claim_sources.canonical_version(read)
+
+
+def _json_check(
+    path: str, keys: tuple[str | int, ...], label: str, read_fn: ReadFn, expected: str
+) -> list[str]:
+    """A version nested at `keys` inside a JSON file must match `expected`."""
+    try:
+        body = read_fn(path)
+    except FileNotFoundError:
+        return [f"{path}: missing — the version-surfaces gate reads it"]
+    try:
+        value: object = json.loads(body)
+        for key in keys:
+            value = value[key]
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError) as error:
+        return [f"{path}: {label}: could not read a version there ({error})"]
+    if value != expected:
+        return [f"{path}: {label}: version {value!r}, pyproject says {expected!r}"]
+    return []
+
+
+def _badge_check(
+    pattern: re.Pattern[str], label: str, read_fn: ReadFn, expected: str
+) -> list[str]:
+    """One of the four textual version occurrences in the version-badge SVG.
+
+    Delegates entirely to doc_claim_structural.check_badge — no badge parsing
+    lives in this module.
+    """
+    return doc_claim_structural.check_badge(
+        "assets/badge-version.svg", pattern, expected, label, read_fn
+    )
+
+
+# The badge is a generated SVG (scripts/generate_repo_badges.py) that states
+# its version four times: the accessible aria-label, the <title> (reused
+# from doc_claim_structural.VERSION_BADGE below), and a drop-shadow + solid
+# <text> pair. Each occurrence can desync independently of the others (a
+# hand-edit, or a future template change to only one of them), so each is
+# its own surface rather than one "the badge" surface.
+_BADGE_ARIA_LABEL = re.compile(r'aria-label="Version (\d+\.\d+\.\d+)"')
+_BADGE_SHADOW_TEXT = re.compile(r'fill-opacity="0.25"[^>]*>(\d+\.\d+\.\d+)</text>')
+_BADGE_SOLID_TEXT = re.compile(r'fill="#fff"[^>]*>(\d+\.\d+\.\d+)</text>')
+
+
+def _marketplace_primary_plugin_check(read_fn: ReadFn, expected: str) -> list[str]:
+    """The self-hosted (primary) marketplace plugin entry's own version.
+
+    Selection rule mirrors check_marketplace_pins.main's own primary-entry
+    predicate (`source.strip("/") in ("", ".")`) verbatim, rather than
+    re-deriving a second notion of "the primary plugin" that could disagree
+    with it.
+    """
+    path = ".claude-plugin/marketplace.json"
+    label = "primary plugin entry version"
+    try:
+        data = json.loads(read_fn(path))
+    except (FileNotFoundError, json.JSONDecodeError) as error:
+        return [f"{path}: {label}: could not read the marketplace manifest ({error})"]
+    entries = [
+        plugin
+        for plugin in data.get("plugins", [])
+        if isinstance(plugin.get("source"), str)
+        and plugin["source"].strip("/") in ("", ".")
+    ]
+    if len(entries) != 1:
+        return [
+            f"{path}: {label}: expected exactly one self-hosted plugin entry, "
+            f"found {len(entries)}"
+        ]
+    value = entries[0].get("version")
+    if value != expected:
+        return [f"{path}: {label}: version {value!r}, pyproject says {expected!r}"]
+    return []
+
+
+# The root package uv.lock resolved from this repo's own pyproject.toml
+# (`source = { editable = "." }`).
+_UV_LOCK_PACKAGE = "hypermnesia-mcp"
+
+
+def _uv_lock_check(read_fn: ReadFn, expected: str) -> list[str]:
+    """The root `hypermnesia-mcp` package block's own version.
+
+    uv.lock is TOML, but read line-by-line rather than parsed: this repo's
+    floor is Python 3.10, where `tomllib` does not exist — the same
+    rationale scripts/generate_pip_constraints.py's lock_registries uses for
+    the identical [[package]]/name/version scan.
+    """
+    path = "uv.lock"
+    label = f"{_UV_LOCK_PACKAGE} package block"
+    name: str | None = None
+    version: str | None = None
+    for line in read_fn(path).splitlines():
+        if line.startswith("[[package]]"):
+            name, version = None, None
+        elif line.startswith('name = "'):
+            name = line.split('"')[1]
+        elif line.startswith('version = "'):
+            version = line.split('"')[1]
+        if name == _UV_LOCK_PACKAGE and version is not None:
+            break
+    else:
+        # The loop ran to completion without finding our package: whatever
+        # `version` last held belongs to a DIFFERENT package block.
+        version = None
+    if version is None:
+        return [f"{path}: {label}: no version found for {_UV_LOCK_PACKAGE!r}"]
+    if version != expected:
+        return [f"{path}: {label}: version {version!r}, pyproject says {expected!r}"]
+    return []
+
+
+# One row per version site (14 sites across 11 files). Adding a 15th JSON
+# site or badge occurrence is a one-line addition here; only a genuinely new
+# FILE FORMAT (neither JSON, regex-matchable text, nor uv.lock's own shape)
+# would need a new `_..._check` function alongside it.
+SURFACES: tuple[SurfaceCheck, ...] = (
+    partial(_json_check, "package.json", ("version",), "version"),
+    partial(_json_check, "server.json", ("version",), "version"),
+    partial(
+        _json_check, "server.json", ("packages", 0, "version"), "packages[0].version"
+    ),
+    partial(_json_check, "manifest.json", ("version",), "version"),
+    partial(_json_check, "gemini-extension.json", ("version",), "version"),
+    partial(_json_check, ".claude-plugin/plugin.json", ("version",), "version"),
+    partial(
+        _json_check,
+        ".claude-plugin/marketplace.json",
+        ("metadata", "version"),
+        "metadata.version",
+    ),
+    _marketplace_primary_plugin_check,
+    partial(
+        _json_check,
+        "plugins/hypermnesia-mcp-codex/.codex-plugin/plugin.json",
+        ("version",),
+        "version",
+    ),
+    partial(_badge_check, _BADGE_ARIA_LABEL, "aria-label"),
+    partial(_badge_check, doc_claim_structural.VERSION_BADGE, "<title>"),
+    partial(_badge_check, _BADGE_SHADOW_TEXT, "shadow <text>"),
+    partial(_badge_check, _BADGE_SOLID_TEXT, "solid <text>"),
+    _uv_lock_check,
+)
+
+
+def check_version_surfaces(read_fn: ReadFn) -> list[str]:
+    """Every version site's failures, against the canonical pyproject.toml one.
+
+    Raises ClaimError (uncaught) if pyproject.toml itself cannot be read —
+    the gate cannot run blind, the same contract check_doc_claims.py's
+    canonical readers use.
+    """
+    expected = doc_claim_sources.canonical_version(read_fn)
+    failures: list[str] = []
+    for surface_check in SURFACES:
+        failures += surface_check(read_fn, expected)
+    return failures
+
+
+def main() -> int:
+    try:
+        failures = check_version_surfaces(read)
+    except ClaimError as error:
+        print(f"version-surfaces gate could not run: {error}", file=sys.stderr)
+        return 2
+
+    if failures:
+        print("Version surfaces disagree with pyproject.toml:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+    print(
+        f"version surfaces OK ({len(SURFACES)} site(s) checked, "
+        "all agree with pyproject.toml)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests_py/scripts/test_check_doc_claims.py
+++ b/tests_py/scripts/test_check_doc_claims.py
@@ -536,66 +536,6 @@ class ScanTests(unittest.TestCase):
         self.assertIn(".bestpractices.json", gate.SCANNED_FILES)
 
 
-class VersionTests(unittest.TestCase):
-    def setUp(self):
-        self._real_read = gate.read
-
-    def tearDown(self):
-        gate.read = self._real_read
-
-    def _install(self, manifest: str, badge: str | None):
-        files = {
-            "manifest.json": '{"version": "%s"}' % manifest,
-            "server.json": '{"version": "4.16.0"}',
-            "package.json": '{"version": "4.16.0"}',
-        }
-        if badge is not None:
-            files["assets/badge-version.svg"] = f"<title>Version {badge}</title>"
-        gate.read = _FakeRepo(**files).read
-
-    def test_manifest_and_badge_must_match_pyproject(self):
-        self._install(manifest="4.16.0", badge="4.16.0")
-        self.assertEqual(gate.check_versions("4.16.0"), [])
-
-    def test_stale_manifest_version_is_reported(self):
-        self._install(manifest="4.15.0", badge="4.16.0")
-        failures = gate.check_versions("4.16.0")
-        self.assertEqual(len(failures), 1)
-        self.assertIn("manifest.json", failures[0])
-
-    def test_stale_committed_badge_is_reported(self):
-        self._install(manifest="4.16.0", badge="4.15.0")
-        failures = gate.check_versions("4.16.0")
-        self.assertEqual(len(failures), 1)
-        self.assertIn("version badge says 4.15.0", failures[0])
-
-    def test_a_missing_badge_file_fails_closed(self):
-        """Self-hosting moved the figure into a file that can be deleted.
-
-        The URL-shaped predecessor of this check silently passed when its
-        pattern stopped matching, so a gate that cannot find its subject must
-        report rather than shrug.
-        """
-        self._install(manifest="4.16.0", badge=None)
-        failures = gate.check_versions("4.16.0")
-        self.assertEqual(len(failures), 1)
-        self.assertIn("missing", failures[0])
-
-    def test_a_badge_without_a_version_title_fails_closed(self):
-        self._install(manifest="4.16.0", badge="4.16.0")
-        gate.read = _FakeRepo(
-            **{
-                "manifest.json": '{"version": "4.16.0"}',
-                "server.json": '{"version": "4.16.0"}',
-                "package.json": '{"version": "4.16.0"}',
-                "assets/badge-version.svg": "<svg><title>something else</title></svg>",
-            }
-        ).read
-        failures = gate.check_versions("4.16.0")
-        self.assertEqual(len(failures), 1)
-        self.assertIn("diverged", failures[0])
-
-
 class CollectFailuresTests(unittest.TestCase):
     """The composition: every family must reach the report.
 
@@ -627,12 +567,7 @@ class CollectFailuresTests(unittest.TestCase):
             "docs/mcp-tools.md": CATALOGUE,
             "tests_py/test_main.py": PINNED_TEST,
             "docs/papers/bibliography.md": BIBLIOGRAPHY,
-            "pyproject.toml": '[project]\nversion = "4.16.0"\n',
-            "manifest.json": '{"version": "4.16.0"}',
-            "server.json": '{"version": "4.16.0"}',
-            "package.json": '{"version": "4.16.0"}',
             "README.md": readme or '<img src="assets/badge-tests.svg" alt="tests">\n',
-            "assets/badge-version.svg": "<title>Version 4.16.0</title>",
         }
         # None omits the file entirely (a missing-badge scenario); any other
         # string is spliced into the <title> as-is, so a non-digit value

--- a/tests_py/scripts/test_cross_host_manifests.py
+++ b/tests_py/scripts/test_cross_host_manifests.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Version-site cross-file agreement is scripts/check_version_surfaces.py's
+# job (it is the single source of truth for every one of the 14 sites, not
+# just the 5 this file used to hand-maintain its own list of) — imported
+# rather than re-asserted here, so this file has one fewer place a new
+# version site could be added and forgotten.
+_spec = importlib.util.spec_from_file_location(
+    "scripts.check_version_surfaces",
+    REPO_ROOT / "scripts" / "check_version_surfaces.py",
+)
+_version_surfaces = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_version_surfaces)
 
 
 def _json(path: str) -> dict:
@@ -22,12 +35,4 @@ def test_gemini_extension_launches_the_published_stdio_entrypoint() -> None:
 
 
 def test_cross_host_manifest_versions_match_the_release() -> None:
-    expected = _json("package.json")["version"]
-    assert _json("gemini-extension.json")["version"] == expected
-    assert _json("server.json")["version"] == expected
-    assert _json("manifest.json")["version"] == expected
-    assert _json(".claude-plugin/plugin.json")["version"] == expected
-    assert (
-        _json("plugins/hypermnesia-mcp-codex/.codex-plugin/plugin.json")["version"]
-        == expected
-    )
+    assert _version_surfaces.check_version_surfaces(_version_surfaces.read) == []

--- a/tests_py/scripts/test_version_surfaces.py
+++ b/tests_py/scripts/test_version_surfaces.py
@@ -1,0 +1,343 @@
+"""Tests for scripts/check_version_surfaces.py — the version-coherence gate.
+
+The gate's own failure mode is silence: a JSON key that stops being read, a
+regex that stops matching a badge occurrence, or a canonical source it
+cannot read would let a version site drift unnoticed. Each test below
+desynchronises exactly ONE of the 14 version sites and asserts the gate
+names it — the point of the exercise, since a gate that reports "something,
+somewhere disagrees" is barely better than no gate.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+import unittest
+from pathlib import Path
+
+# Dotted, path-derived module name — see test_check_doc_claims.py's own
+# header comment for why (mutmut trampoline keys on this exact name).
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "scripts.check_version_surfaces", _SCRIPTS / "check_version_surfaces.py"
+)
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
+
+
+class _FakeRepo:
+    """Minimal stand-in for the repository files the gate reads.
+
+    Raises FileNotFoundError (not KeyError) on a missing path, matching what
+    the real read()'s Path.read_text raises — the same contract
+    test_check_doc_claims.py's own double honours.
+    """
+
+    def __init__(self, **files: str):
+        self.files = files
+
+    def read(self, relative_path: str) -> str:
+        try:
+            return self.files[relative_path]
+        except KeyError:
+            raise FileNotFoundError(relative_path) from None
+
+
+# One consistent version, "4.16.0", stated identically at all 14 sites.
+_V = "4.16.0"
+_BADGE_SVG_OK = (
+    f'<svg aria-label="Version {_V}">'
+    f"<title>Version {_V}</title>"
+    f'<text fill-opacity="0.25">{_V}</text>'
+    f'<text fill="#fff">{_V}</text>'
+    "</svg>"
+)
+_MARKETPLACE_OK = (
+    '{"metadata": {"version": "%s"}, "plugins": ['
+    '{"name": "hypermnesia-mcp", "source": "./", "version": "%s"}, '
+    '{"name": "other", "source": {"source": "github", "repo": "x/y"}, '
+    '"version": "9.9.9"}]}'
+) % (_V, _V)
+_UV_LOCK_OK = f"""version = 1
+revision = 1
+
+[[package]]
+name = "other-package"
+version = "1.2.3"
+source = {{ registry = "https://pypi.org/simple" }}
+
+[[package]]
+name = "hypermnesia-mcp"
+version = "{_V}"
+source = {{ editable = "." }}
+dependencies = [
+    {{ name = "other-package" }},
+]
+
+[[package]]
+name = "zzz-package"
+version = "9.9.9"
+source = {{ registry = "https://pypi.org/simple" }}
+"""
+
+OK_FILES: dict[str, str] = {
+    "pyproject.toml": f'[project]\nname = "hypermnesia-mcp"\nversion = "{_V}"\n',
+    "package.json": f'{{"version": "{_V}"}}',
+    "server.json": (f'{{"version": "{_V}", "packages": [{{"version": "{_V}"}}]}}'),
+    "manifest.json": f'{{"version": "{_V}"}}',
+    "gemini-extension.json": f'{{"version": "{_V}"}}',
+    ".claude-plugin/plugin.json": f'{{"version": "{_V}"}}',
+    ".claude-plugin/marketplace.json": _MARKETPLACE_OK,
+    "plugins/hypermnesia-mcp-codex/.codex-plugin/plugin.json": f'{{"version": "{_V}"}}',
+    "assets/badge-version.svg": _BADGE_SVG_OK,
+    "uv.lock": _UV_LOCK_OK,
+}
+
+
+class _GateTestCase(unittest.TestCase):
+    def setUp(self):
+        self._real_read = gate.read
+
+    def tearDown(self):
+        gate.read = self._real_read
+
+    def _install(self, **overrides: str) -> None:
+        files = dict(OK_FILES)
+        files.update(overrides)
+        gate.read = _FakeRepo(**files).read
+
+    def _failures(self) -> list[str]:
+        return gate.check_version_surfaces(gate.read)
+
+    def _assert_single_failure_about(self, path_fragment: str) -> str:
+        failures = self._failures()
+        self.assertEqual(len(failures), 1, failures)
+        self.assertIn(path_fragment, failures[0])
+        return failures[0]
+
+
+class NominalTests(_GateTestCase):
+    def test_a_fully_consistent_repository_reports_nothing(self):
+        self._install()
+        self.assertEqual(self._failures(), [])
+
+    def test_fourteen_surfaces_are_registered(self):
+        # source: the task's own site inventory — 11 files, 2 of them (server.json,
+        # marketplace.json) carrying 2 keys each, plus the badge's 4 occurrences:
+        # 9 JSON/uv.lock sites - 2 double-counted files + 2 extra keys + 3 extra
+        # badge occurrences = 14.
+        self.assertEqual(len(gate.SURFACES), 14)
+
+
+class PerSurfaceDesyncTests(_GateTestCase):
+    """Each test desyncs exactly one surface and names it in the failure."""
+
+    def test_package_json_version_desync_is_reported(self):
+        self._install(**{"package.json": '{"version": "9.9.9"}'})
+        self._assert_single_failure_about("package.json")
+
+    def test_server_json_version_desync_is_reported(self):
+        stale = f'{{"version": "9.9.9", "packages": [{{"version": "{_V}"}}]}}'
+        self._install(**{"server.json": stale})
+        failure = self._assert_single_failure_about("server.json")
+        self.assertIn("version", failure)
+        self.assertNotIn("packages[0]", failure)
+
+    def test_server_json_packages_0_version_desync_is_reported(self):
+        """Explicit, dedicated test: this site was covered by NOTHING before."""
+        stale = f'{{"version": "{_V}", "packages": [{{"version": "9.9.9"}}]}}'
+        self._install(**{"server.json": stale})
+        failure = self._assert_single_failure_about("server.json")
+        self.assertIn("packages[0].version", failure)
+
+    def test_manifest_json_version_desync_is_reported(self):
+        self._install(**{"manifest.json": '{"version": "9.9.9"}'})
+        self._assert_single_failure_about("manifest.json")
+
+    def test_gemini_extension_json_version_desync_is_reported(self):
+        self._install(**{"gemini-extension.json": '{"version": "9.9.9"}'})
+        self._assert_single_failure_about("gemini-extension.json")
+
+    def test_plugin_json_version_desync_is_reported(self):
+        self._install(**{".claude-plugin/plugin.json": '{"version": "9.9.9"}'})
+        self._assert_single_failure_about(".claude-plugin/plugin.json")
+
+    def test_marketplace_metadata_version_desync_is_reported(self):
+        """Explicit, dedicated test: this site was covered by NOTHING before."""
+        stale = (
+            '{"metadata": {"version": "9.9.9"}, "plugins": ['
+            f'{{"name": "hypermnesia-mcp", "source": "./", "version": "{_V}"}}]}}'
+        )
+        self._install(**{".claude-plugin/marketplace.json": stale})
+        failure = self._assert_single_failure_about(".claude-plugin/marketplace.json")
+        self.assertIn("metadata.version", failure)
+
+    def test_marketplace_primary_plugin_entry_version_desync_is_reported(self):
+        stale = (
+            '{"metadata": {"version": "%s"}, "plugins": ['
+            '{"name": "hypermnesia-mcp", "source": "./", "version": "9.9.9"}, '
+            '{"name": "other", "source": {"source": "github", "repo": "x/y"}, '
+            '"version": "%s"}]}'
+        ) % (_V, _V)
+        self._install(**{".claude-plugin/marketplace.json": stale})
+        failure = self._assert_single_failure_about(".claude-plugin/marketplace.json")
+        self.assertIn("primary plugin entry version", failure)
+
+    def test_marketplace_with_no_self_hosted_entry_fails_closed(self):
+        no_primary = (
+            '{"metadata": {"version": "%s"}, "plugins": ['
+            '{"name": "other", "source": {"source": "github", "repo": "x/y"}, '
+            '"version": "%s"}]}'
+        ) % (_V, _V)
+        self._install(**{".claude-plugin/marketplace.json": no_primary})
+        failure = self._assert_single_failure_about(".claude-plugin/marketplace.json")
+        self.assertIn("expected exactly one self-hosted plugin entry, found 0", failure)
+
+    def test_codex_plugin_json_version_desync_is_reported(self):
+        self._install(
+            **{
+                "plugins/hypermnesia-mcp-codex/.codex-plugin/plugin.json": (
+                    '{"version": "9.9.9"}'
+                )
+            }
+        )
+        self._assert_single_failure_about(
+            "plugins/hypermnesia-mcp-codex/.codex-plugin/plugin.json"
+        )
+
+    def test_badge_aria_label_desync_is_reported(self):
+        self._install(
+            **{
+                "assets/badge-version.svg": (
+                    '<svg aria-label="Version 9.9.9">'
+                    f"<title>Version {_V}</title>"
+                    f'<text fill-opacity="0.25">{_V}</text>'
+                    f'<text fill="#fff">{_V}</text>'
+                    "</svg>"
+                )
+            }
+        )
+        failure = self._assert_single_failure_about("assets/badge-version.svg")
+        self.assertIn("aria-label", failure)
+
+    def test_badge_title_desync_is_reported(self):
+        self._install(
+            **{
+                "assets/badge-version.svg": (
+                    f'<svg aria-label="Version {_V}">'
+                    "<title>Version 9.9.9</title>"
+                    f'<text fill-opacity="0.25">{_V}</text>'
+                    f'<text fill="#fff">{_V}</text>'
+                    "</svg>"
+                )
+            }
+        )
+        failure = self._assert_single_failure_about("assets/badge-version.svg")
+        self.assertIn("<title>", failure)
+
+    def test_badge_shadow_text_desync_is_reported(self):
+        self._install(
+            **{
+                "assets/badge-version.svg": (
+                    f'<svg aria-label="Version {_V}">'
+                    f"<title>Version {_V}</title>"
+                    '<text fill-opacity="0.25">9.9.9</text>'
+                    f'<text fill="#fff">{_V}</text>'
+                    "</svg>"
+                )
+            }
+        )
+        failure = self._assert_single_failure_about("assets/badge-version.svg")
+        self.assertIn("shadow <text>", failure)
+
+    def test_badge_solid_text_desync_is_reported(self):
+        self._install(
+            **{
+                "assets/badge-version.svg": (
+                    f'<svg aria-label="Version {_V}">'
+                    f"<title>Version {_V}</title>"
+                    f'<text fill-opacity="0.25">{_V}</text>'
+                    '<text fill="#fff">9.9.9</text>'
+                    "</svg>"
+                )
+            }
+        )
+        failure = self._assert_single_failure_about("assets/badge-version.svg")
+        self.assertIn("solid <text>", failure)
+
+    def test_uv_lock_root_package_version_desync_is_reported(self):
+        stale = _UV_LOCK_OK.replace(
+            f'name = "hypermnesia-mcp"\nversion = "{_V}"',
+            'name = "hypermnesia-mcp"\nversion = "9.9.9"',
+        )
+        self._install(**{"uv.lock": stale})
+        failure = self._assert_single_failure_about("uv.lock")
+        self.assertIn("hypermnesia-mcp", failure)
+
+    def test_uv_lock_missing_the_root_package_fails_closed(self):
+        """A block-scan bug could silently compare the WRONG package's version."""
+        root_block = (
+            f'name = "hypermnesia-mcp"\nversion = "{_V}"\n'
+            'source = { editable = "." }\n'
+            'dependencies = [\n    { name = "other-package" },\n]\n\n'
+        )
+        without_root = _UV_LOCK_OK.replace(root_block, "")
+        self._install(**{"uv.lock": without_root})
+        failure = self._assert_single_failure_about("uv.lock")
+        self.assertIn("no version found for", failure)
+
+
+class RealRepositoryTests(unittest.TestCase):
+    """The gate must pass against the actual, committed repository tree."""
+
+    def test_the_real_repository_agrees_on_every_surface(self):
+        self.assertEqual(gate.check_version_surfaces(gate.read), [])
+
+
+class MainTests(unittest.TestCase):
+    def setUp(self):
+        self._argv = sys.argv[:]
+        self._real_read = gate.read
+
+    def tearDown(self):
+        sys.argv = self._argv
+        gate.read = self._real_read
+
+    def _run(self):
+        sys.argv = ["check_version_surfaces.py"]
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = gate.main()
+        return code, out.getvalue(), err.getvalue()
+
+    def test_a_consistent_tree_exits_zero(self):
+        gate.read = _FakeRepo(**OK_FILES).read
+        code, out, err = self._run()
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        self.assertIn("version surfaces OK (14 site(s) checked", out)
+
+    def test_a_diverged_tree_exits_one_and_names_the_surface(self):
+        files = dict(OK_FILES)
+        files["package.json"] = '{"version": "9.9.9"}'
+        gate.read = _FakeRepo(**files).read
+        code, out, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertEqual(out, "")
+        self.assertIn("Version surfaces disagree with pyproject.toml:", err)
+        self.assertIn("package.json", err)
+
+    def test_an_unreadable_pyproject_aborts_with_exit_code_2(self):
+        files = dict(OK_FILES)
+        files["pyproject.toml"] = '[project]\nname = "hypermnesia-mcp"\n'
+        gate.read = _FakeRepo(**files).read
+        code, out, err = self._run()
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("version-surfaces gate could not run:", err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase 1 of #392.

## What was wrong

Three gates each compared a version number, and each trusted a **different** canonical source:

| Gate | Canonical source | Covers |
|---|---|---|
| `check_doc_claims.py` (`check_versions`) | `pyproject.toml` | manifest, server, package, badge |
| `check_marketplace_pins.py` | the marketplace's own primary pin | server + manifest only |
| `tests_py/scripts/test_cross_host_manifests.py` | `package.json` | four more manifests |

Two sites were covered by **nothing**: `server.json`'s `packages[0].version` — served to every MCP registry client — and `.claude-plugin/marketplace.json`'s `metadata.version`.

And the gate that came closest is path-filtered: `marketplace-pins.yml` only runs when `marketplace.json` itself changes, so it sits **outside `ci-green`**. A PR that bumps five surfaces and forgets the sixth is green, reaches `main`, and is caught up to seven days later by the Monday cron.

## What this does

One module, one canonical value (`[project].version` in `pyproject.toml`), all **14 sites across 11 files**. `SURFACES` is data — adding a 15th site of an existing kind is one tuple row, not a new branch (OCP).

Reuse over reimplementation: badge parsing comes from `doc_claim_structural.check_badge`, the pyproject regex from `doc_claim_sources`, and the marketplace primary-entry predicate mirrors `check_marketplace_pins.main` verbatim so the two cannot disagree about which entry is primary. Every check fails closed on a missing file, unparseable JSON, or an absent key.

Wired into the `lint` job, which `ci-green` already covers — a partial bump now turns the **PR** red.

## Deduplication, not a fourth overlapping gate

`check_doc_claims.check_versions` is **removed**: the new gate is a strict superset. Its orphaned tests, its dead fixture entries, and a then-unused `json` import go with it, and its docstring no longer advertises a claim family it does not check. `test_cross_host_manifests.py` now asserts through the new module instead of hand-maintaining a parallel list of five of the fourteen sites.

`check_marketplace_pins.py` is deliberately **untouched** — its `PIN_BEHIND_TAG` and third-party pin-staleness checks are a different and still-valuable concern.

## Proof the gate bites

On one of the two previously-uncovered sites:

```
$ # desync server.json packages[0].version → 9.9.9
$ python scripts/check_version_surfaces.py ; echo exit=$?
Version surfaces disagree with pyproject.toml:
  server.json: packages[0].version: version '9.9.9', pyproject says '4.17.2'
exit=1

$ python scripts/check_doc_claims.py >/dev/null ; echo exit=$?
exit=0        # ← the pre-existing gate is blind to this site
```

## Verification

```
python scripts/check_version_surfaces.py            → exit 0 (14/14 agree)
python scripts/check_doc_claims.py                  → exit 0 (still green after the dedup)
pytest test_version_surfaces test_check_doc_claims test_cross_host_manifests
                                                    → 129 passed, 14 subtests
ruff check .                                        → All checks passed
ruff format --check .                               → 1154 files already formatted
```

Tests cover the nominal case, one desync per surface, dedicated tests for both previously-uncovered sites, fail-closed paths (missing `uv.lock` package block, zero self-hosted marketplace entries), the real repo tree, and `main()`'s three exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01263uv1QqR8TVzw2jXYUrXn