### PR TITLE
ci: restore the release pipeline work (#391, #387, #393, #394)

### DIFF
--- a/.github/actions/test-suite/action.yml
+++ b/.github/actions/test-suite/action.yml
@@ -1,0 +1,323 @@
+name: "Run the PostgreSQL-backed pytest suite"
+description: >-
+  Shared step list for ci.yml's `test` matrix: provision PostgreSQL +
+  pgvector on the runner, warm every model and grammar cache, then run
+  pytest offline.
+
+# Extracted per issue #336, originally shared between ci.yml's `test` matrix
+# and release.yml's own pre-release test job: the two jobs ran the exact
+# same suite against the same Postgres service as two separate copies with
+# non-overlapping triggers — a tag push never reaches ci.yml — so every
+# hardening pass applied to one copy silently drifted from the other, with
+# nothing to report it. Release run 30741657854 (v4.17.0) is what that cost:
+# the FlashRank fetch hung until pytest-timeout killed the suite, blocking
+# every downstream publish job on a tag whose tree had just passed 20 green
+# checks on PR #334; #335 restored parity by hand, this action made the
+# next divergence structurally impossible instead of merely visible.
+#
+# Issue #392 removed the second caller: release.yml no longer runs a test
+# job at all (the tag is now an output of `ci.yml`'s own `release-gate`, run
+# only after `ci-green` succeeds — see that job's comment). This action is
+# ci.yml's `test` matrix's sole caller now; its two former per-caller inputs
+# (`requirements-file`, `include-tree-sitter`) were retired as speculative
+# generality once a single value was all either of them could ever carry
+# (coding-standards.md §9) — see `run-extended-checks` below for the one
+# input that still varies, across the matrix's four legs.
+#
+# WHY A COMPOSITE ACTION AND NOT A REUSABLE WORKFLOW. The first attempt at
+# #336 shared this as `.github/workflows/test-suite.yml` behind a
+# `workflow_call`. A job that delegates via `uses:` reports its check as
+# "<caller job name> / <called job name>", so the four matrix legs published
+# "Test (Python X.Y) / Test (Python X.Y)" instead of the bare
+# "Test (Python X.Y)" that branch protection on `main` requires — GitHub
+# always composes the two names and offers no way to suppress the prefix.
+# The PR sat BLOCKED with zero red checks, because the four required
+# contexts were reported by nobody. source: run 31250898534 on PR #387.
+# Sharing at the STEP level instead leaves the caller's job name — and
+# therefore every required status-check context — untouched. That rationale
+# survives the second caller's removal: a reusable workflow would still
+# rename this action's one remaining caller's four matrix-leg contexts.
+#
+# Callers must check the repository out before invoking this action: a local
+# `uses: ./...` reference is resolved from the checked-out tree.
+
+inputs:
+  python-version:
+    description: "Python version to run the suite under."
+    required: true
+  run-extended-checks:
+    description: "Run coverage, the Claude/Codex MCP host contract check, the advertised-test-count/badge check, and upload the coverage artifact. Scoped to a single matrix leg (Python 3.12) — the other three legs skip it. Compared against the literal 'true'."
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+
+  steps:
+    # A reusable workflow could carry this as a job-level `env:`; a composite
+    # action has no job scope, so the value is published once here and read by
+    # every step below (and by pytest itself) instead of being repeated.
+    - name: Export DATABASE_URL for the suite
+      shell: bash
+      run: echo "DATABASE_URL=postgresql://cortex:cortex@localhost:5432/cortex" >> "$GITHUB_ENV"
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    # Provision PostgreSQL + pgvector on the runner itself, instead of a
+    # Docker-Hub service container. Anonymous `pgvector/pgvector:pg17` pulls
+    # from registry-1.docker.io are rate-limited and outage-prone (observed:
+    # "context deadline exceeded" failing container init before any test ran,
+    # CI run 27190427877). The runner ships PostgreSQL preinstalled; pgvector
+    # comes from the PGDG apt repo (apt.postgresql.org) — no registry, no pull
+    # rate limit. source: runner image (actions/runner-images) + PGDG.
+    - name: Set up PostgreSQL + pgvector (runner-local, no registry pull)
+      shell: bash
+      run: |
+        set -euxo pipefail
+        sudo systemctl start postgresql
+        PG_VER="$(pg_lsclusters -h | awk 'NR==1 {print $1}')"
+        # Ensure the PGDG apt repo (canonical pgvector source); idempotent.
+        sudo install -d /usr/share/postgresql-common/pgdg
+        sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+          -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+        echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+          | sudo tee /etc/apt/sources.list.d/pgdg.list
+        # Structured retry (not `A && break || sleep`, shellcheck SC2015: that
+        # form silently swallows exhaustion — see issue #247): each loop fails
+        # the step loudly if every attempt is exhausted, and reports the
+        # attempt number it is on (shellcheck SC2034: the counter must be read).
+        apt_update_ok=""
+        for attempt in 1 2 3; do
+          if sudo apt-get update; then apt_update_ok=1; break; fi
+          echo "apt-get update attempt ${attempt}/3 failed; retrying in 5s" >&2
+          sleep 5
+        done
+        [ -n "$apt_update_ok" ] || { echo "apt-get update failed after 3 attempts" >&2; exit 1; }
+        apt_install_ok=""
+        for attempt in 1 2 3; do
+          if sudo apt-get install -y "postgresql-${PG_VER}-pgvector"; then apt_install_ok=1; break; fi
+          echo "apt-get install attempt ${attempt}/3 failed; retrying in 5s" >&2
+          sleep 5
+        done
+        [ -n "$apt_install_ok" ] || { echo "apt-get install postgresql-${PG_VER}-pgvector failed after 3 attempts" >&2; exit 1; }
+        # Role + DB expected by DATABASE_URL.
+        sudo -u postgres psql -v ON_ERROR_STOP=1 \
+          -c "CREATE ROLE cortex LOGIN SUPERUSER PASSWORD 'cortex';"
+        sudo -u postgres createdb -O cortex cortex
+        sudo -u postgres psql -v ON_ERROR_STOP=1 -d cortex \
+          -c "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+        # Wait until reachable over TCP with password auth.
+        pg_ready=""
+        for attempt in $(seq 1 30); do
+          if PGPASSWORD=cortex pg_isready -h localhost -U cortex -d cortex; then pg_ready=1; break; fi
+          echo "postgres not ready yet (attempt ${attempt}/30); retrying in 1s" >&2
+          sleep 1
+        done
+        [ -n "$pg_ready" ] || { echo "postgres failed to become ready after 30 attempts" >&2; exit 1; }
+        PGPASSWORD=cortex psql -h localhost -U cortex -d cortex -c "SELECT version();"
+
+    # Both callers install a hash-pinned requirements file into the same
+    # OS/Python combination; sharing one pip cache keyspace is safe (pip's
+    # own cache is keyed by wheel hash internally, regardless of which
+    # requirements file requested a given wheel). Previously this step
+    # existed only in ci.yml — release.yml's test job had no pip cache at
+    # all, an unremarked asymmetry (not documented as intentional anywhere)
+    # closed here as part of the issue #336 extraction.
+    - name: Cache pip
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ inputs.python-version }}-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ inputs.python-version }}-
+
+    - name: Cache HuggingFace models
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/huggingface
+        key: ${{ runner.os }}-hf-all-MiniLM-L6-v2
+
+    # FlashRank is NOT huggingface_hub. It fetches its ONNX model with a bare
+    # `requests.get(..., stream=True)` carrying no timeout, so HF_HUB_OFFLINE
+    # never reaches it and a stalled connect blocks the thread indefinitely
+    # instead of raising — reranker.py's `except Exception` cannot engage
+    # against a hang. CI run 30263190266 (main, Python 3.13, 2026-07-27) hung
+    # in `sock.connect` inside a recall test until pytest-timeout killed the
+    # whole suite at 300s, while every other leg happened to download fine.
+    # Cache the model so the fetch happens once, not once per leg.
+    - name: Cache FlashRank reranker model
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/flashrank
+        key: ${{ runner.os }}-flashrank-ms-marco-MiniLM-L-12-v2
+
+    - name: Install dependencies
+      shell: bash
+      # Hash-pinned from uv.lock (scripts/generate_pip_constraints.py).
+      # --no-deps on the project install because the file above IS the
+      # complete dependency graph; re-resolving here would be unpinned.
+      # requirements/ci-postgresql.txt inline: this action's sole caller
+      # (ci.yml's `test` matrix) always installs it — issue #392 removed the
+      # only other caller, which installed requirements/release.txt instead.
+      run: |
+        pip install --require-hashes -r requirements/ci-postgresql.txt
+        pip install --no-deps -e .
+
+    # Populate the HuggingFace cache before the (offline) test run. A transient
+    # huggingface.co blip must not leave the cache empty — that surfaced as 58
+    # spurious "couldn't connect to huggingface.co" test failures on a single
+    # matrix leg (CI run 28495801728, Python 3.10, 2026-07-01) while every other
+    # leg was fine. Retry with backoff so a blip self-heals; fail loudly here (no
+    # continue-on-error) instead of cascading into a misleading test failure.
+    - name: Pre-download embedding model
+      shell: bash
+      run: |
+        for attempt in 1 2 3 4 5; do
+          python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2', device='cpu')" && exit 0
+          echo "HF pre-download attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
+          sleep $((attempt * 10))
+        done
+        echo "HF pre-download failed after 5 attempts" >&2
+        exit 1
+
+    # Same retry-and-fail-loudly shape as the step above, for the reranker.
+    # Deliberately runs WITHOUT CORTEX_RERANKER_OFFLINE: this is the one place
+    # allowed to download the model, so that the test steps below never can.
+    # `ensure_reranker_loaded` reports the load state instead of degrading
+    # silently, so a failed fetch fails this step rather than surfacing later
+    # as first-stage-only recall scores (the 2026-07-10 FlashRank incident).
+    - name: Pre-download reranker model
+      shell: bash
+      run: |
+        for attempt in 1 2 3 4 5; do
+          python -c "from mcp_server.core.reranker import ensure_reranker_loaded as e; s = e(); assert s.state == 'loaded', s" && exit 0
+          echo "FlashRank pre-download attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
+          sleep $((attempt * 10))
+        done
+        echo "FlashRank pre-download failed after 5 attempts" >&2
+        exit 1
+
+    # tree-sitter-language-pack fetches each grammar's shared library lazily
+    # over the network at `get_parser()` call time, not at install time — a
+    # cold cache mid-suite is a real, previously-uncaught `DownloadError`
+    # (main-red, CI run 30592244731, 2026-07-31:
+    # tests_py/core/test_ast_extractors.py + benchmarks/test_codebase_
+    # alteration.py). Needs the package importable, so — unlike the HF/
+    # FlashRank cache steps above — this must come after "Install
+    # dependencies"; same cache-then-prefetch-with-retries shape otherwise,
+    # for the same reason: fetch once here so `pytest` itself never touches
+    # the network for a grammar.
+    #
+    # requirements/ci-postgresql.txt (installed above) always includes
+    # tree-sitter-language-pack, so this action's sole caller always needs
+    # these three steps — unlike the removed requirements/release.txt
+    # caller, which omitted tree-sitter + tree-sitter-language-pack (as it
+    # omits igraph/leidenalg/texttable) and would ImportError on the import
+    # below. No `if:` gate remains now that only one caller exists.
+    - name: Resolve tree-sitter cache directory
+      shell: bash
+      run: echo "TREE_SITTER_CACHE_DIR=$(python -c 'from tree_sitter_language_pack import cache_dir; print(cache_dir())')" >> "$GITHUB_ENV"
+
+    - name: Cache tree-sitter grammars
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ env.TREE_SITTER_CACHE_DIR }}
+        key: ${{ runner.os }}-tree-sitter-grammars-${{ hashFiles('pyproject.toml') }}
+
+    # The language set is read from AST_SUPPORTED (not hand-copied here) so
+    # this step cannot drift from the languages ast_parser.py actually uses.
+    - name: Prefetch tree-sitter grammars
+      shell: bash
+      run: |
+        for attempt in 1 2 3 4 5; do
+          python -c "from mcp_server.core.ast_parser import AST_SUPPORTED; from tree_sitter_language_pack import prefetch; prefetch(sorted(AST_SUPPORTED))" && exit 0
+          echo "tree-sitter grammar prefetch attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
+          sleep $((attempt * 10))
+        done
+        echo "tree-sitter grammar prefetch failed after 5 attempts" >&2
+        exit 1
+
+    # Offline: both models are already cached by the steps above, so tests must
+    # never reach out to huggingface.co mid-suite — deterministic and flake-free.
+    - name: Run tests
+      shell: bash
+      env:
+        HF_HUB_OFFLINE: "1"
+        TRANSFORMERS_OFFLINE: "1"
+        CORTEX_RERANKER_OFFLINE: "1"
+      run: pytest --tb=short -q
+
+    # The four steps below are CI-only: they run on the single matrix leg
+    # the ci.yml caller marks run-extended-checks: true (Python 3.12).
+    # release.yml never sets run-extended-checks — its test job is a
+    # pass/fail gate before publishing, not the leg that owns coverage, the
+    # MCP host contract check, or the advertised-test-count/badge check.
+    - name: Run tests with coverage
+      if: inputs.run-extended-checks == 'true'
+      shell: bash
+      env:
+        HF_HUB_OFFLINE: "1"
+        TRANSFORMERS_OFFLINE: "1"
+        CORTEX_RERANKER_OFFLINE: "1"
+      # --cov-fail-under is the statement-coverage floor (issue #196
+      # criterion 4): seeded at the number this job itself achieved
+      # (82.02% — 30,229 of 36,854 statements, run 30316539703,
+      # coverage.py 7.15.2) so the figure can only ratchet up, never
+      # silently fall back. Raise the floor when coverage rises.
+      run: pytest --cov=mcp_server --cov-report=xml --cov-report=term-missing --cov-fail-under=82
+
+    # Match the primary Claude and additive Codex client identities against
+    # a real, explicitly configured PostgreSQL instance. Explicit targets
+    # cannot fall back, so successful memory_stats calls prove PostgreSQL
+    # was selected for both host contracts.
+    - name: Verify Claude and Codex PostgreSQL-first MCP contracts
+      if: inputs.run-extended-checks == 'true'
+      shell: bash
+      env:
+        CORTEX_RUNTIME: cowork
+        HF_HUB_OFFLINE: "1"
+        TRANSFORMERS_OFFLINE: "1"
+        CORTEX_RERANKER_OFFLINE: "1"
+      run: >-
+        python scripts/verify_mcp_hosts.py
+        --clients claude-code codex-cli --profiles lean
+        --storage-selection auto
+        -- hypermnesia-mcp
+
+    # The advertised test count is the one claim the static gate cannot check
+    # without collecting the suite, so it is checked in the job that already
+    # has the suite installed. `--collect-only` re-collects (~seconds) rather
+    # than parsing the run above, so the number is the collector's own.
+    - name: Check advertised test count
+      if: inputs.run-extended-checks == 'true'
+      shell: bash
+      env:
+        HF_HUB_OFFLINE: "1"
+        TRANSFORMERS_OFFLINE: "1"
+        CORTEX_RERANKER_OFFLINE: "1"
+      run: |
+        set -euo pipefail
+        # Parse the collector's own summary line ("N tests collected in Xs")
+        # by its label rather than by position, and fail loudly if the line
+        # is not there — an unparsed count must never silently skip the check.
+        collected="$(pytest --collect-only -q | sed -n 's/^\([0-9][0-9]*\) tests collected.*/\1/p' | tail -1)"
+        if [ -z "${collected}" ]; then
+          echo "could not parse the collected test count from pytest" >&2
+          exit 1
+        fi
+        echo "collected ${collected} tests"
+        python scripts/check_doc_claims.py --test-count "${collected}"
+        # The tests badge is a committed SVG carrying this same number, so
+        # it is checked where the number is known. The other repo-derived
+        # badges are checked in the static job, which needs no suite.
+        python scripts/generate_repo_badges.py --check --test-count "${collected}"
+
+    - name: Upload coverage
+      if: inputs.run-extended-checks == 'true'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: coverage-report
+        path: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Uses the composite action at .github/actions/test-suite/action.yml for
+  # the step-level rationale, including why the shared unit is a composite
+  # action and not a reusable workflow: a job delegating via `uses:` reports
+  # its check as "<caller job name> / <called job name>", which would rename
+  # all four required contexts on `main`. Sharing at the step level leaves
+  # this job's name — and therefore its status-check context — untouched.
+  # Originally shared with release.yml's own `test` job (issue #336); issue
+  # #392 removed that second caller (see the action's header comment) —
+  # `requirements/ci-postgresql.txt` and tree-sitter grammars are now
+  # installed unconditionally inside the action rather than passed in.
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
@@ -23,240 +33,20 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
-    env:
-      DATABASE_URL: postgresql://cortex:cortex@localhost:5432/cortex
-
     steps:
+      # A local `uses: ./...` is resolved from the checked-out tree, so the
+      # checkout cannot itself live inside the shared action.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - uses: ./.github/actions/test-suite
         with:
           python-version: ${{ matrix.python-version }}
-
-      # Provision PostgreSQL + pgvector on the runner itself, instead of a
-      # Docker-Hub service container. Anonymous `pgvector/pgvector:pg17` pulls
-      # from registry-1.docker.io are rate-limited and outage-prone (observed:
-      # "context deadline exceeded" failing container init before any test ran,
-      # CI run 27190427877). The runner ships PostgreSQL preinstalled; pgvector
-      # comes from the PGDG apt repo (apt.postgresql.org) — no registry, no pull
-      # rate limit. source: runner image (actions/runner-images) + PGDG.
-      - name: Set up PostgreSQL + pgvector (runner-local, no registry pull)
-        run: |
-          set -euxo pipefail
-          sudo systemctl start postgresql
-          PG_VER="$(pg_lsclusters -h | awk 'NR==1 {print $1}')"
-          # Ensure the PGDG apt repo (canonical pgvector source); idempotent.
-          sudo install -d /usr/share/postgresql-common/pgdg
-          sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
-          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list
-          # Structured retry (not `A && break || sleep`, shellcheck SC2015: that
-          # form silently swallows exhaustion — see issue #247): each loop fails
-          # the step loudly if every attempt is exhausted, and reports the
-          # attempt number it is on (shellcheck SC2034: the counter must be read).
-          apt_update_ok=""
-          for attempt in 1 2 3; do
-            if sudo apt-get update; then apt_update_ok=1; break; fi
-            echo "apt-get update attempt ${attempt}/3 failed; retrying in 5s" >&2
-            sleep 5
-          done
-          [ -n "$apt_update_ok" ] || { echo "apt-get update failed after 3 attempts" >&2; exit 1; }
-          apt_install_ok=""
-          for attempt in 1 2 3; do
-            if sudo apt-get install -y "postgresql-${PG_VER}-pgvector"; then apt_install_ok=1; break; fi
-            echo "apt-get install attempt ${attempt}/3 failed; retrying in 5s" >&2
-            sleep 5
-          done
-          [ -n "$apt_install_ok" ] || { echo "apt-get install postgresql-${PG_VER}-pgvector failed after 3 attempts" >&2; exit 1; }
-          # Role + DB expected by DATABASE_URL.
-          sudo -u postgres psql -v ON_ERROR_STOP=1 \
-            -c "CREATE ROLE cortex LOGIN SUPERUSER PASSWORD 'cortex';"
-          sudo -u postgres createdb -O cortex cortex
-          sudo -u postgres psql -v ON_ERROR_STOP=1 -d cortex \
-            -c "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pg_trgm;"
-          # Wait until reachable over TCP with password auth.
-          pg_ready=""
-          for attempt in $(seq 1 30); do
-            if PGPASSWORD=cortex pg_isready -h localhost -U cortex -d cortex; then pg_ready=1; break; fi
-            echo "postgres not ready yet (attempt ${attempt}/30); retrying in 1s" >&2
-            sleep 1
-          done
-          [ -n "$pg_ready" ] || { echo "postgres failed to become ready after 30 attempts" >&2; exit 1; }
-          PGPASSWORD=cortex psql -h localhost -U cortex -d cortex -c "SELECT version();"
-
-      - name: Cache pip
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-
-      - name: Cache HuggingFace models
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/huggingface
-          key: ${{ runner.os }}-hf-all-MiniLM-L6-v2
-
-      # FlashRank is NOT huggingface_hub. It fetches its ONNX model with a bare
-      # `requests.get(..., stream=True)` carrying no timeout, so HF_HUB_OFFLINE
-      # never reaches it and a stalled connect blocks the thread indefinitely
-      # instead of raising — reranker.py's `except Exception` cannot engage
-      # against a hang. CI run 30263190266 (main, Python 3.13, 2026-07-27) hung
-      # in `sock.connect` inside a recall test until pytest-timeout killed the
-      # whole suite at 300s, while every other leg happened to download fine.
-      # Cache the model so the fetch happens once, not once per leg.
-      - name: Cache FlashRank reranker model
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/flashrank
-          key: ${{ runner.os }}-flashrank-ms-marco-MiniLM-L-12-v2
-
-      - name: Install dependencies
-        # Hash-pinned from uv.lock (scripts/generate_pip_constraints.py).
-        # --no-deps on the project install because the file above IS the
-        # complete dependency graph; re-resolving here would be unpinned.
-        run: |
-          pip install --require-hashes -r requirements/ci-postgresql.txt
-          pip install --no-deps -e .
-
-      # Populate the HuggingFace cache before the (offline) test run. A transient
-      # huggingface.co blip must not leave the cache empty — that surfaced as 58
-      # spurious "couldn't connect to huggingface.co" test failures on a single
-      # matrix leg (CI run 28495801728, Python 3.10, 2026-07-01) while every other
-      # leg was fine. Retry with backoff so a blip self-heals; fail loudly here (no
-      # continue-on-error) instead of cascading into a misleading test failure.
-      - name: Pre-download embedding model
-        run: |
-          for attempt in 1 2 3 4 5; do
-            python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2', device='cpu')" && exit 0
-            echo "HF pre-download attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
-            sleep $((attempt * 10))
-          done
-          echo "HF pre-download failed after 5 attempts" >&2
-          exit 1
-
-      # Same retry-and-fail-loudly shape as the step above, for the reranker.
-      # Deliberately runs WITHOUT CORTEX_RERANKER_OFFLINE: this is the one place
-      # allowed to download the model, so that the test steps below never can.
-      # `ensure_reranker_loaded` reports the load state instead of degrading
-      # silently, so a failed fetch fails this step rather than surfacing later
-      # as first-stage-only recall scores (the 2026-07-10 FlashRank incident).
-      - name: Pre-download reranker model
-        run: |
-          for attempt in 1 2 3 4 5; do
-            python -c "from mcp_server.core.reranker import ensure_reranker_loaded as e; s = e(); assert s.state == 'loaded', s" && exit 0
-            echo "FlashRank pre-download attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
-            sleep $((attempt * 10))
-          done
-          echo "FlashRank pre-download failed after 5 attempts" >&2
-          exit 1
-
-      # tree-sitter-language-pack fetches each grammar's shared library lazily
-      # over the network at `get_parser()` call time, not at install time — a
-      # cold cache mid-suite is a real, previously-uncaught `DownloadError`
-      # (main-red, CI run 30592244731, 2026-07-31:
-      # tests_py/core/test_ast_extractors.py + benchmarks/test_codebase_
-      # alteration.py). Needs the package importable, so — unlike the HF/
-      # FlashRank cache steps above — this must come after "Install
-      # dependencies"; same cache-then-prefetch-with-retries shape otherwise,
-      # for the same reason: fetch once here so `pytest` itself never touches
-      # the network for a grammar.
-      - name: Resolve tree-sitter cache directory
-        run: echo "TREE_SITTER_CACHE_DIR=$(python -c 'from tree_sitter_language_pack import cache_dir; print(cache_dir())')" >> "$GITHUB_ENV"
-
-      - name: Cache tree-sitter grammars
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ env.TREE_SITTER_CACHE_DIR }}
-          key: ${{ runner.os }}-tree-sitter-grammars-${{ hashFiles('pyproject.toml') }}
-
-      # The language set is read from AST_SUPPORTED (not hand-copied here) so
-      # this step cannot drift from the languages ast_parser.py actually uses.
-      - name: Prefetch tree-sitter grammars
-        run: |
-          for attempt in 1 2 3 4 5; do
-            python -c "from mcp_server.core.ast_parser import AST_SUPPORTED; from tree_sitter_language_pack import prefetch; prefetch(sorted(AST_SUPPORTED))" && exit 0
-            echo "tree-sitter grammar prefetch attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
-            sleep $((attempt * 10))
-          done
-          echo "tree-sitter grammar prefetch failed after 5 attempts" >&2
-          exit 1
-
-      # Offline: both models are already cached by the steps above, so tests must
-      # never reach out to huggingface.co mid-suite — deterministic and flake-free.
-      - name: Run tests
-        env:
-          HF_HUB_OFFLINE: "1"
-          TRANSFORMERS_OFFLINE: "1"
-          CORTEX_RERANKER_OFFLINE: "1"
-        run: pytest --tb=short -q
-
-      - name: Run tests with coverage
-        if: matrix.python-version == '3.12'
-        env:
-          HF_HUB_OFFLINE: "1"
-          TRANSFORMERS_OFFLINE: "1"
-          CORTEX_RERANKER_OFFLINE: "1"
-        # --cov-fail-under is the statement-coverage floor (issue #196
-        # criterion 4): seeded at the number this job itself achieved
-        # (82.02% — 30,229 of 36,854 statements, run 30316539703,
-        # coverage.py 7.15.2) so the figure can only ratchet up, never
-        # silently fall back. Raise the floor when coverage rises.
-        run: pytest --cov=mcp_server --cov-report=xml --cov-report=term-missing --cov-fail-under=82
-
-      # Match the primary Claude and additive Codex client identities against
-      # a real, explicitly configured PostgreSQL instance. Explicit targets
-      # cannot fall back, so successful memory_stats calls prove PostgreSQL
-      # was selected for both host contracts.
-      - name: Verify Claude and Codex PostgreSQL-first MCP contracts
-        if: matrix.python-version == '3.12'
-        env:
-          CORTEX_RUNTIME: cowork
-          HF_HUB_OFFLINE: "1"
-          TRANSFORMERS_OFFLINE: "1"
-          CORTEX_RERANKER_OFFLINE: "1"
-        run: >-
-          python scripts/verify_mcp_hosts.py
-          --clients claude-code codex-cli --profiles lean
-          --storage-selection auto
-          -- hypermnesia-mcp
-
-      # The advertised test count is the one claim the static gate cannot check
-      # without collecting the suite, so it is checked in the job that already
-      # has the suite installed. `--collect-only` re-collects (~seconds) rather
-      # than parsing the run above, so the number is the collector's own.
-      - name: Check advertised test count
-        if: matrix.python-version == '3.12'
-        env:
-          HF_HUB_OFFLINE: "1"
-          TRANSFORMERS_OFFLINE: "1"
-          CORTEX_RERANKER_OFFLINE: "1"
-        run: |
-          set -euo pipefail
-          # Parse the collector's own summary line ("N tests collected in Xs")
-          # by its label rather than by position, and fail loudly if the line
-          # is not there — an unparsed count must never silently skip the check.
-          collected="$(pytest --collect-only -q | sed -n 's/^\([0-9][0-9]*\) tests collected.*/\1/p' | tail -1)"
-          if [ -z "${collected}" ]; then
-            echo "could not parse the collected test count from pytest" >&2
-            exit 1
-          fi
-          echo "collected ${collected} tests"
-          python scripts/check_doc_claims.py --test-count "${collected}"
-          # The tests badge is a committed SVG carrying this same number, so
-          # it is checked where the number is known. The other repo-derived
-          # badges are checked in the static job, which needs no suite.
-          python scripts/generate_repo_badges.py --check --test-count "${collected}"
-
-      - name: Upload coverage
-        if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-report
-          path: coverage.xml
+          # Coverage, the MCP host contract check, and the advertised-test-count
+          # check are expensive and gain nothing from running on all four legs —
+          # ci.yml has always scoped them to Python 3.12 only; the shared action
+          # makes that scoping an explicit input instead of an inline `if:` per
+          # step.
+          run-extended-checks: ${{ matrix.python-version == '3.12' }}
 
   test-sqlite:
     name: Test (SQLite backend)
@@ -568,6 +358,70 @@ jobs:
           tests_py/infrastructure/test_sqlite_backend.py
           tests_py/scripts/test_setup_py_backend_skip.py
 
+  # Validates `requirements/release.txt` — the dependency set release.yml
+  # installs before publishing (issue #392). Removing release.yml's own test
+  # job (see release-gate below) would otherwise leave that narrower
+  # dependency set validated NOWHERE until a PyPI/uvx install broke on it.
+  #
+  # Deliberately NOT the full pytest suite: this job's subject is the
+  # DEPENDENCY SET, not the suite — ci.yml's `test` matrix already covers the
+  # suite itself, against a wider dependency set. Re-running pytest here
+  # would duplicate that coverage at the release-narrowed dependency set's
+  # cost without adding a new claim.
+  #
+  # release.txt deliberately omits tree-sitter, tree-sitter-language-pack,
+  # igraph, leidenalg and texttable (`.github/actions/test-suite/action.yml`
+  # header comment) — so nothing this job runs may import from those
+  # packages, and it must not exercise codebase_analyze/AST paths.
+  #
+  # The check itself reuses the cheapest existing mechanism instead of
+  # inventing a new one: `scripts/verify_mcp_hosts.py`'s stdio initialize +
+  # tools/list + memory_stats round-trip (the same invocation the
+  # `test-sqlite` job's "Verify hook-free MCP host contract" step already
+  # runs) proves the server imports and its full tool surface registers
+  # under this narrower dependency set, with no PostgreSQL service needed
+  # (`--storage-selection sqlite` is the default).
+  release-deps:
+    name: Release dependency set (requirements/release.txt)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Cache HuggingFace models
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/huggingface
+          key: ${{ runner.os }}-hf-all-MiniLM-L6-v2
+
+      - name: Install the release dependency set (hash-pinned)
+        run: |
+          pip install --require-hashes -r requirements/release.txt
+          pip install --no-deps -e .
+
+      # Retry-with-backoff, fail-loudly: see the `test` job's pre-download
+      # step for the root-cause rationale (CI run 28495801728, 2026-07-01).
+      - name: Pre-download embedding model
+        run: |
+          for attempt in 1 2 3 4 5; do
+            python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2', device='cpu')" && exit 0
+            echo "HF pre-download attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
+            sleep $((attempt * 10))
+          done
+          echo "HF pre-download failed after 5 attempts" >&2
+          exit 1
+
+      - name: Verify hook-free MCP host contract under the release dependency set
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
+          CORTEX_RERANKER_OFFLINE: "1"
+        run: python scripts/verify_mcp_hosts.py -- hypermnesia-mcp
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -591,13 +445,34 @@ jobs:
       - name: Check linting
         run: ruff check .
 
-      # Advertised counts (tools, references, mechanisms, version) must match
-      # the repository. Runs here — on every push and PR — because doc drift is
+      # Advertised counts (tools, references, mechanisms) must match the
+      # repository. Runs here — on every push and PR — because doc drift is
       # introduced at commit time, not at release time: on 2026-07-27 README,
       # CONTRIBUTING, CLAUDE.md and the MCPB manifest each advertised a
       # different tool count, and nothing failed. Static only (no imports).
       - name: Check documentation claims
         run: python scripts/check_doc_claims.py
+
+      # [project].version in pyproject.toml against every one of the 14
+      # version sites across 11 files (manifests, plugin.jsons, the
+      # marketplace's metadata AND primary-entry version, the MCP registry
+      # package entry, the four textual occurrences in the version badge,
+      # and uv.lock's own root-package version). Two of these sites
+      # (server.json packages[0].version, marketplace.json metadata.version)
+      # were covered by nothing before this gate existed, and the one gate
+      # that came closest — marketplace-pins.yml — is path-filtered, so it
+      # sits outside ci-green and only fires on its weekly cron (issue #392).
+      # Static only (no imports), same reason as the doc-claim gate above.
+      - name: Check version surfaces
+        run: python scripts/check_version_surfaces.py
+
+      # The `ci-green` job below is the single status check branch protection
+      # names; the list of jobs it covers lives in its `needs:`. A job added
+      # to ci.yml but not to that list would run outside the gate and could
+      # fail without blocking a merge. Static only (no imports), same reason
+      # as the doc-claim gate above.
+      - name: Check the aggregate CI gate covers every job
+        run: python scripts/check_ci_gate_complete.py
 
       # The README's repo-derived badges are committed SVGs, not hotlinked
       # images, so nothing regenerates them on view: a figure that moves
@@ -866,3 +741,222 @@ jobs:
         run: scripts/docker_smoke.sh --skip-build
         env:
           CORTEX_SMOKE_IMAGE: cortex-smoke:local
+
+  # The one status check branch protection on `main` names. Everything else
+  # in this workflow is reached through its `needs:` list, so renaming a job,
+  # resizing the matrix, or delegating steps to a reusable workflow (which
+  # rewrites check names to "<caller> / <callee>", issue #336) no longer
+  # touches the protection settings — the contract is this file, in git,
+  # visible in review, instead of eleven job-name strings in GitHub settings
+  # that no diff ever shows.
+  #
+  # `if: always()` is load-bearing: without it this job is itself skipped the
+  # moment any need fails, the required context is never reported, and the PR
+  # blocks with no explanation instead of a red X naming the culprit.
+  #
+  # scripts/check_ci_gate_complete.py (run by `lint`) refuses a merge if any
+  # job here is missing from `needs`, or if a job carrying a job-level `if:`
+  # is absent from ALLOWED_SKIPS below.
+  ci-green:
+    name: CI Green
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - test-sqlite
+      - mcp-host-config
+      - test-windows
+      - release-deps
+      - lint
+      - typecheck
+      - build
+      - docker-runtime-build
+      - devcontainer-build
+      - docker-smoke
+    steps:
+      - name: Require every job above to have succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          # Jobs permitted to report `skipped`, with the reason. ONLY jobs
+          # carrying a job-level `if:` belong here; anything else that skips
+          # is a gap, not an exemption.
+          #   mcp-host-config — `if: github.event_name != 'pull_request' ||
+          #   github.event.pull_request.head.repo.fork == false`: a fork PR
+          #   has no access to the secrets it needs, so it cannot run there.
+          ALLOWED_SKIPS: mcp-host-config
+        run: |
+          set -euo pipefail
+          echo "$NEEDS"
+          failed=$(printf '%s' "$NEEDS" | jq -r --arg allowed "$ALLOWED_SKIPS" '
+            ($allowed | split(",") | map(ltrimstr(" ") | rtrimstr(" "))) as $ok
+            | to_entries[]
+            | select(.value.result != "success")
+            | select(.value.result != "skipped" or ([.key] | inside($ok) | not))
+            | "\(.key)=\(.value.result)"')
+          if [ -n "$failed" ]; then
+            echo "::error::CI Green refuses the merge — $(echo "$failed" | tr '\n' ' ')"
+            exit 1
+          fi
+          echo "every required job succeeded"
+
+  # The tag-as-output half of issue #392: a green push to `main` tags the
+  # exact SHA that just passed CI Green, instead of a human hand-picking
+  # which (possibly-unvalidated) tree to tag — the v4.17.0 root cause
+  # (release run 30741657854 tagged a tree release.yml's own test job had
+  # never actually validated against ci.yml's hardening).
+  #
+  # ci-gate-exempt: this job runs ONLY on a push to `main`, i.e. AFTER the PR
+  # it belongs to has already merged. There is nothing left for it to gate —
+  # it cannot block a PR that is already closed — so it does not appear in
+  # ci-green.needs (see scripts/check_ci_gate_complete.py's ci-gate-exempt
+  # marker convention). Putting it there would make the branch-protection
+  # context depend on a job that never runs on a PR in the first place,
+  # permanently blocking every PR.
+  release-gate:
+    name: Tag a release
+    needs: [ci-green]
+    # ci-gate-exempt: runs only on push to main, after the PR it belongs to
+    # has already merged — see the job comment above.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    # `contents: read`, NOT write, and that is deliberate. The tag is pushed
+    # with the RELEASE_TAG_SSH_KEY deploy key (persisted by the checkout step
+    # below), never
+    # with GITHUB_TOKEN — granting GITHUB_TOKEN `contents: write` here would
+    # be an unused permission (issue #178 least-privilege), and worse, it
+    # would let a future edit that drops `ssh-key:` from the checkout push the
+    # tag with GITHUB_TOKEN and SUCCEED — producing a tag that silently never
+    # starts release.yml. Read-only makes that mistake fail loudly instead.
+    permissions:
+      contents: read
+    # A DEDICATED group — not this workflow's `${{ github.workflow }}-${{
+    # github.ref }}` group above, which sets `cancel-in-progress: true`. A
+    # push to main that lands mid-tag-push would be cancelled by the very
+    # next push to main under that group, leaving a partially-created tag on
+    # the remote (a tag object pushed but no corresponding release started,
+    # or the reverse) — exactly the half-state a release process must never
+    # produce. This group instead serializes tag operations one at a time
+    # without ever cancelling one already in flight.
+    concurrency:
+      group: release-tag
+      cancel-in-progress: false
+    steps:
+      # secrets.RELEASE_TAG_SSH_KEY is the PRIVATE half of a repository deploy
+      # key (ed25519, read_only=false, created 2026-08-08). A deploy key, and
+      # not a PAT or a GitHub App token, because neither of those can be
+      # minted through the API — both require a browser — and the deploy key
+      # is the tighter credential anyway: scoped to this ONE repository,
+      # carrying no account access, and with no expiry to silently break
+      # releases. Per
+      # GitHub's docs, a ref pushed with the default GITHUB_TOKEN (unlike
+      # workflow_dispatch/repository_dispatch) does NOT start a new workflow
+      # run — a GITHUB_TOKEN-pushed tag would therefore never reach
+      # release.yml's `push: tags` trigger. Same guarded-optional-secret
+      # shape as sync-ccplugins-fork.yml's `has_pat` step: absence is a
+      # clean, loud skip, not a red job.
+      - name: Guard — skip cleanly when RELEASE_TAG_SSH_KEY is missing
+        id: guard
+        env:
+          SSH_KEY: ${{ secrets.RELEASE_TAG_SSH_KEY }}
+        run: |
+          if [ -z "$SSH_KEY" ]; then
+            echo "RELEASE_TAG_SSH_KEY secret not configured — skipping."
+            echo "Add the private half of a write-enabled repository deploy"
+            echo "key at Settings -> Secrets and variables -> Actions."
+            echo "Releases stay manual until it exists."
+            echo "has_deploy_key=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_deploy_key=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # fetch-depth: 0 so `git rev-parse --verify refs/tags/vX` below can see
+      # every existing tag, not just the tip commit. `ssh-key:` installs the
+      # deploy key as the credential `git push` uses later in this
+      # job (actions/checkout persists it by default) — the non-GITHUB_TOKEN
+      # credential the tag push requires (see the guard step's comment).
+      - name: Checkout the SHA that just went green
+        if: steps.guard.outputs.has_deploy_key == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_TAG_SSH_KEY }}
+
+      - name: Set up Python
+        if: steps.guard.outputs.has_deploy_key == 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      # Reuses doc_claim_sources.canonical_version — the same reader
+      # check_version_surfaces.py and check_doc_claims.py already trust —
+      # instead of re-deriving a second pyproject.toml version regex here.
+      # A push to `main` for a commit that does not bump the version is the
+      # NOMINAL case (most commits are not releases): tag v$VERSION already
+      # exists, and this step's job is to detect that and skip silently
+      # rather than fail or re-tag.
+      - name: Resolve the version and check for an existing tag
+        id: tag_check
+        if: steps.guard.outputs.has_deploy_key == 'true'
+        run: |
+          set -euo pipefail
+          VERSION="$(python3 -c "
+          import sys
+          sys.path.insert(0, 'scripts')
+          import doc_claim_sources
+          print(doc_claim_sources.canonical_version(lambda p: open(p, encoding='utf-8').read()))
+          ")"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
+            echo "tag v${VERSION} already exists — this push carries no version bump"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no existing tag v${VERSION} — this push is a version bump"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The last line of defence before a tag: `main` should never carry a
+      # partial bump anyway (the identical gate already runs in `lint` on
+      # every push and PR — commit 4781c134), so reaching this step with a
+      # mismatch means something bypassed the PR gate (a direct push, an
+      # admin-merge override). A failure here is a RED job, not a skip —
+      # silently tagging a mismatched tree is exactly the v4.17.0 failure
+      # mode this workflow exists to make structurally impossible.
+      - name: Check version surfaces
+        if: steps.guard.outputs.has_deploy_key == 'true' && steps.tag_check.outputs.exists == 'false'
+        run: python scripts/check_version_surfaces.py
+
+      - name: Configure git identity
+        if: steps.guard.outputs.has_deploy_key == 'true' && steps.tag_check.outputs.exists == 'false'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # Annotated (not lightweight): carries its own object, author, and
+      # message, which `git tag -a` computes but `git tag` alone does not —
+      # the shape release.yml's changelog step and GitHub's own release UI
+      # expect. Tagged at `github.sha` explicitly (not the checkout's
+      # working-tree HEAD) so the released commit is provably the one that
+      # went green, even if a future edit changes what this job checks out.
+      - name: Create and push the release tag
+        if: steps.guard.outputs.has_deploy_key == 'true' && steps.tag_check.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.tag_check.outputs.version }}"
+          git tag -a "v${VERSION}" -m "Release v${VERSION}" "${{ github.sha }}"
+          git push origin "refs/tags/v${VERSION}"
+
+      # Visible without opening logs: the decision (tagged / no-bump /
+      # no-token) is exactly the property issue #392's acceptance criteria
+      # ask to verify ("a green push to main with no version change tags
+      # nothing" — verifiable in the release-gate logs).
+      - name: Summarize the release-gate decision
+        if: always()
+        run: |
+          if [ "${{ steps.guard.outputs.has_deploy_key }}" != "true" ]; then
+            echo "## Release gate: skipped — RELEASE_TAG_SSH_KEY not configured" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.tag_check.outputs.exists }}" == "true" ]; then
+            echo "## Release gate: skipped — v${{ steps.tag_check.outputs.version }} already tagged (no version bump on this push)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Release gate: tagged v${{ steps.tag_check.outputs.version }} at \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,28 @@ name: Release
 # against the trusted-publisher entry configured for this workflow + environment
 # `pypi` — the same one that published versions up to 3.14.7.
 #
-# This workflow runs the tests on tag push, creates a GitHub Release with
-# auto-generated notes, and attempts the secondary PyPI compatibility channel.
+# THIS WORKFLOW DOES NOT TEST ANYTHING (issue #392). Before this change it
+# ran its own `test` job on tag push — a duplicate, differently-triggered
+# copy of ci.yml's gate that every CI hardening pass silently skipped
+# (ci.yml triggers on `push: branches` + `pull_request`, this workflow on
+# `push: tags`, so a tag never reached it). Release run 30741657854
+# (v4.17.0) is what that cost: a reranker-fetch hang that ci.yml's own
+# hardening had already fixed hung this file's copy anyway, blocking every
+# downstream publish job on a tag whose tree had just passed 20 green
+# checks on PR #334.
+#
+# The test guarantee now comes from `ci.yml`'s `release-gate` job: it runs
+# ONLY after `ci-green` succeeds on a push to `main`, and tags the EXACT SHA
+# that just went green with an annotated `git tag` pushed via
+# `RELEASE_TAG_TOKEN` (a `GITHUB_TOKEN`-pushed tag does not start a new
+# workflow run, per GitHub's docs — this workflow would never fire from
+# one). The released tree is therefore bit-identical to the validated one;
+# this workflow's only job is to propagate what `ci.yml` already validated
+# and tagged — creating a GitHub Release with auto-generated notes, and
+# attempting the secondary PyPI compatibility channel.
+# `requirements/release.txt` — the dependency set the deprecated PyPI
+# channel installs into — is still validated: `ci.yml`'s `release-deps` job
+# smoke-imports the server under it on every push and PR.
 #
 # Supply-chain hardening (issue #178). Cortex reads and persists every
 # session transcript and installs session hooks with the user's full
@@ -43,6 +63,12 @@ name: Release
 # step that would create a GitHub Release, attach assets to one, or publish
 # to PyPI is gated `if: github.event_name == 'push'` so a manual dispatch
 # exercises the Node24 action bump only — it never mutates a release.
+#
+# This workflow deliberately stays TAG-TRIGGERED and NON-REUSABLE: PyPI
+# Trusted Publishing does not support reusable workflows, and this repo's
+# publisher entry is keyed on (release.yml, environment=pypi) specifically
+# — a `workflow_call` conversion would silently break `publish-pypi`,
+# silently because it carries `continue-on-error: true`.
 
 on:
   push:
@@ -56,152 +82,18 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Test before release
-    runs-on: ubuntu-latest
-
-    env:
-      DATABASE_URL: postgresql://cortex:cortex@localhost:5432/cortex
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-
-      # Runner-local PostgreSQL + pgvector (no Docker Hub pull). See ci.yml for
-      # the rationale: anonymous registry-1.docker.io pulls are rate-limited and
-      # outage-prone; PGDG apt is the canonical, unmetered pgvector source.
-      - name: Set up PostgreSQL + pgvector (runner-local, no registry pull)
-        run: |
-          set -euxo pipefail
-          sudo systemctl start postgresql
-          PG_VER="$(pg_lsclusters -h | awk 'NR==1 {print $1}')"
-          sudo install -d /usr/share/postgresql-common/pgdg
-          sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
-          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list
-          # Structured retry (not `A && break || sleep`, shellcheck SC2015: that
-          # form silently swallows exhaustion — see issue #247): each loop fails
-          # the step loudly if every attempt is exhausted, and reports the
-          # attempt number it is on (shellcheck SC2034: the counter must be read).
-          apt_update_ok=""
-          for attempt in 1 2 3; do
-            if sudo apt-get update; then apt_update_ok=1; break; fi
-            echo "apt-get update attempt ${attempt}/3 failed; retrying in 5s" >&2
-            sleep 5
-          done
-          [ -n "$apt_update_ok" ] || { echo "apt-get update failed after 3 attempts" >&2; exit 1; }
-          apt_install_ok=""
-          for attempt in 1 2 3; do
-            if sudo apt-get install -y "postgresql-${PG_VER}-pgvector"; then apt_install_ok=1; break; fi
-            echo "apt-get install attempt ${attempt}/3 failed; retrying in 5s" >&2
-            sleep 5
-          done
-          [ -n "$apt_install_ok" ] || { echo "apt-get install postgresql-${PG_VER}-pgvector failed after 3 attempts" >&2; exit 1; }
-          sudo -u postgres psql -v ON_ERROR_STOP=1 \
-            -c "CREATE ROLE cortex LOGIN SUPERUSER PASSWORD 'cortex';"
-          sudo -u postgres createdb -O cortex cortex
-          sudo -u postgres psql -v ON_ERROR_STOP=1 -d cortex \
-            -c "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pg_trgm;"
-          pg_ready=""
-          for attempt in $(seq 1 30); do
-            if PGPASSWORD=cortex pg_isready -h localhost -U cortex -d cortex; then pg_ready=1; break; fi
-            echo "postgres not ready yet (attempt ${attempt}/30); retrying in 1s" >&2
-            sleep 1
-          done
-          [ -n "$pg_ready" ] || { echo "postgres failed to become ready after 30 attempts" >&2; exit 1; }
-          PGPASSWORD=cortex psql -h localhost -U cortex -d cortex -c "SELECT version();"
-
-      # The network-hardening steps below mirror ci.yml's `test` job
-      # one-for-one (cache + retried prefetch + offline test run, per model).
-      # They are NOT optional here: this job runs the same suite on a tag
-      # push, but `ci.yml` triggers on `push: branches` + `pull_request`, so
-      # a tag never reaches it and every hardening pass CI received since
-      # 2026-07-27 skipped this file. Release run 30741657854 (v4.17.0) is
-      # what that divergence costs: the reranker fetch hung in `sock.connect`
-      # until pytest-timeout killed the suite, blocking all five downstream
-      # publish jobs on a tag whose tree had just passed 20 green checks on
-      # PR #334. Keep the two jobs in step — see ci.yml for the full
-      # per-incident rationale behind each step.
-      - name: Cache HuggingFace models
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/huggingface
-          key: ${{ runner.os }}-hf-all-MiniLM-L6-v2
-
-      # FlashRank bypasses HF_HUB_OFFLINE entirely: it fetches its ONNX model
-      # with a bare `requests.get(..., stream=True)` carrying no timeout, so a
-      # stalled connect blocks the thread instead of raising, and reranker.py's
-      # `except Exception` cannot engage against a hang.
-      - name: Cache FlashRank reranker model
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/flashrank
-          key: ${{ runner.os }}-flashrank-ms-marco-MiniLM-L-12-v2
-
-      - name: Install dependencies
-        # Hash-pinned from uv.lock (scripts/generate_pip_constraints.py).
-        run: |
-          pip install --require-hashes -r requirements/release.txt
-          pip install --no-deps -e .
-
-      # Retry with backoff and fail loudly (no continue-on-error): a transient
-      # blip must not leave the cache empty and cascade into a misleading test
-      # failure — or, worse here, into a silently degraded release gate.
-      - name: Pre-download embedding model
-        run: |
-          for attempt in 1 2 3 4 5; do
-            python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2', device='cpu')" && exit 0
-            echo "HF pre-download attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
-            sleep $((attempt * 10))
-          done
-          echo "HF pre-download failed after 5 attempts" >&2
-          exit 1
-
-      # Deliberately runs WITHOUT CORTEX_RERANKER_OFFLINE: this is the one
-      # place allowed to download the model, so the test step below never can.
-      # `ensure_reranker_loaded` reports the load state instead of degrading
-      # silently, so a failed fetch fails this step rather than surfacing later
-      # as first-stage-only recall scores (the 2026-07-10 FlashRank incident).
-      - name: Pre-download reranker model
-        run: |
-          for attempt in 1 2 3 4 5; do
-            python -c "from mcp_server.core.reranker import ensure_reranker_loaded as e; s = e(); assert s.state == 'loaded', s" && exit 0
-            echo "FlashRank pre-download attempt ${attempt} failed; retrying in $((attempt * 10))s" >&2
-            sleep $((attempt * 10))
-          done
-          echo "FlashRank pre-download failed after 5 attempts" >&2
-          exit 1
-
-      # No tree-sitter cache/prefetch pair here, unlike ci.yml: requirements/
-      # release.txt deliberately omits tree-sitter + tree-sitter-language-pack
-      # (as it omits igraph/leidenalg/texttable), so the AST tests skip in this
-      # job and there is no grammar to fetch. Should release.txt ever gain that
-      # dependency, port ci.yml's three tree-sitter steps across with it — the
-      # lazy `get_parser()` download is a real mid-suite DownloadError
-      # (main-red, CI run 30592244731, 2026-07-31).
-      #
-      # Offline: every model is already cached by the steps above, so tests
-      # must never reach out mid-suite — deterministic and flake-free.
-      - name: Run tests
-        env:
-          HF_HUB_OFFLINE: "1"
-          TRANSFORMERS_OFFLINE: "1"
-          CORTEX_RERANKER_OFFLINE: "1"
-        run: pytest --tb=short -q
-
   github-release:
     name: GitHub Release
-    needs: test
-    # Real releases only (issues #246 + #247 criterion 5) — a workflow_dispatch
-    # verification run must never create a GitHub Release; matches the
-    # `github.event_name == 'push'` gate documented in the header and used by
-    # every other release-producing step below.
-    if: github.event_name == 'push'
+    # Real releases only (issues #246 + #247 criterion 5) — a
+    # workflow_dispatch verification run must never create a GitHub Release.
+    # `startsWith(github.ref, 'refs/tags/')` alongside `event_name == 'push'`
+    # (boy-scout fix, issue #392): this job previously gated on event_name
+    # alone while its softprops/action-gh-release step below carries no
+    # `tag_name:` and falls back to `GITHUB_REF` — a push to a BRANCH would
+    # therefore have created (or updated) a "release" named after that
+    # branch. Every other job in this file already required the tag-ref
+    # form; this one was the exception.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write  # create the release + attach auto-generated notes
@@ -236,9 +128,10 @@ jobs:
   # blocks the primary channel; docs therefore label this path best-effort.
   build:
     name: Build sdist + wheel + attest (PyPI compatibility)
-    needs: test
     # Only the real tag-triggered event ships a release artifact; a
-    # workflow_dispatch verification run (issue #247 criterion 5) stops after `test`.
+    # workflow_dispatch verification run (issue #247 criterion 5) builds
+    # nothing — every job in this file is independent now that `test` (the
+    # thing they all used to wait on) is gone (issue #392).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
@@ -315,9 +208,9 @@ jobs:
   # hundred-MB torch download is not on the critical path.
   sbom:
     name: SBOM (CycloneDX, from uv.lock)
-    needs: test
     # Only the real tag-triggered event ships an SBOM to a release; a
-    # workflow_dispatch verification run (issue #247 criterion 5) stops after `test`.
+    # workflow_dispatch verification run (issue #247 criterion 5) builds
+    # nothing (see `build`'s identical comment for why there is no `needs:`).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
@@ -385,9 +278,9 @@ jobs:
   #   5.8MB unpacked / 561 files / 222 ignored by .mcpbignore.
   mcpb-bundle:
     name: MCPB bundle + attest (Claude Desktop connector)
-    needs: test
     # Only the real tag-triggered event ships a bundle; a workflow_dispatch
-    # verification run (issue #247 criterion 5) stops after `test`.
+    # verification run (issue #247 criterion 5) builds nothing (see `build`'s
+    # identical comment for why there is no `needs:`).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,27 @@ CI's install ever drift apart.
 - One mechanism per PR when adding new biological mechanisms.
 - Conventional commit messages preferred.
 
+### The one required status check
+
+Branch protection on `main` names a single `ci.yml` context, **`CI Green`**
+(plus `CodeQL`, which GitHub reports from its own default setup). `CI Green`
+is the `ci-green` job at the bottom of `.github/workflows/ci.yml`: it needs
+every other job in that workflow and fails on any result other than
+`success`, except for the jobs listed in its `ALLOWED_SKIPS` — which may
+contain only jobs carrying a job-level `if:`, each with its reason.
+
+Naming individual jobs in the protection settings instead put the contract
+outside git, where no diff shows it and every rename breaks it: extracting
+the test steps into a reusable workflow (issue #336) renamed the four matrix
+legs to `Test (Python X.Y) / Test (Python X.Y)`, the four bare contexts
+`main` required were never reported again, and a fully green PR sat BLOCKED
+(#387). With one aggregate context, renaming a job, resizing the matrix, or
+delegating steps costs nothing.
+
+**Adding a job to `ci.yml` means adding it to `ci-green.needs`.**
+`scripts/check_ci_gate_complete.py` (run by `lint`) fails the build
+otherwise — an ungated job could fail without blocking a merge.
+
 ---
 
 ## Adding a biological mechanism

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -6,7 +6,7 @@
 # and commit the result; CI re-runs it with --check and fails on drift.
 #
 # Read by:
-#   .github/workflows/release.yml — verification job
+#   .github/workflows/ci.yml — release-deps
 ##########################################################################
 # An extra index widens where pip may look, which is normally how
 # dependency-confusion attacks land. It is safe HERE and only here

--- a/scripts/check_ci_gate_complete.py
+++ b/scripts/check_ci_gate_complete.py
@@ -1,0 +1,284 @@
+"""CI-gate completeness: every ci.yml job must be behind the aggregate gate.
+
+Branch protection on ``main`` names required status checks as strings, in
+GitHub settings — outside git, invisible in review, and unversioned. Naming
+individual jobs there makes the contract break on every rename: extracting
+the test steps into a reusable workflow (issue #336) renamed the four matrix
+legs to ``Test (Python X.Y) / Test (Python X.Y)``, so the four bare contexts
+``main`` required were never reported again and a fully green PR sat BLOCKED
+(PR #387, run 31250898534). Renaming the contexts fixes that one PR and
+leaves the next rename to rediscover it.
+
+So protection names ONE ci.yml context — ``CI Green`` — and the real list
+lives here, in git, where a diff shows it. That moves the failure mode: the
+gate is only as good as its ``needs:`` list, and a job added later that
+nobody adds to it is silently ungated. That is what this script refuses.
+
+It also refuses the second escape hatch. The gate treats any result other
+than ``success`` as failure, EXCEPT for jobs named in its ``ALLOWED_SKIPS``
+env — because a job carrying a job-level ``if:`` legitimately reports
+``skipped``. An unlisted conditional would therefore let a job skip its way
+past the gate, so every job with an ``if:`` must be declared, and every
+declared exemption must correspond to a job that actually has one (a stale
+exemption is a hole nobody is watching).
+
+A third case exists that ``needs:``/``ALLOWED_SKIPS`` cannot express:
+``release-gate`` (issue #392) runs ONLY on a push to ``main`` — after the PR
+it belongs to has already merged. There is nothing for it to gate: it cannot
+block a PR that is already closed, and putting it in ``ci-green.needs`` would
+make the branch-protection context depend on a job that never runs on a PR
+in the first place, permanently blocking every PR. Such a job declares itself
+with a ``# ci-gate-exempt: <reason>`` marker line in its body instead of
+appearing in ``needs:``. The marker is not a blank check: it is refused
+unless the job ALSO carries a job-level ``if:`` — an exempt job with no
+condition would run ungated on every push and PR, which is exactly the hole
+this script exists to close.
+
+Checks, all of them fatal:
+
+1. the gate job exists;
+2. every other ci.yml job appears in the gate's ``needs:`` OR carries a
+   ``# ci-gate-exempt:`` marker;
+3. every name in ``needs:`` is a real job;
+4. every job carrying a job-level ``if:`` and not exempt is listed in
+   ``ALLOWED_SKIPS``;
+5. every name in ``ALLOWED_SKIPS`` is a job that carries an ``if:``;
+6. every ``# ci-gate-exempt:`` job carries a job-level ``if:`` — an exemption
+   with no condition is not a narrower gate, it is no gate.
+
+Static only — regex over the workflow text, no PyYAML. The Lint job installs
+ruff and nothing else, and this script runs there alongside
+``check_doc_claims.py``, which is static for the same reason.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+# The single job branch protection points at. Renaming it is a protection
+# change, not a refactor — hence a named constant rather than a literal.
+GATE_JOB = "ci-green"
+
+_JOB_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
+_JOB_IF_RE = re.compile(r"^    if:\s*(\S.*)$")
+_NEEDS_BLOCK_RE = re.compile(r"^    needs:\s*$")
+_NEEDS_ITEM_RE = re.compile(r"^      - ([A-Za-z0-9_-]+)\s*$")
+_ALLOWED_SKIPS_RE = re.compile(r"^\s*ALLOWED_SKIPS:\s*(\S.*?)\s*$")
+_GATE_EXEMPT_RE = re.compile(r"^    # ci-gate-exempt:\s*(\S.*)$")
+
+
+# Shortest string that can carry a matched quote pair: the two quotes.
+_QUOTED_MIN_LEN = 2
+
+
+def _strip_quotes(value: str) -> str:
+    if len(value) >= _QUOTED_MIN_LEN and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def _job_bodies(text: str) -> dict[str, list[str]]:
+    """Return job id -> the lines of its block, in file order."""
+    bodies: dict[str, list[str]] = {}
+    in_jobs = False
+    current: str | None = None
+
+    for line in text.splitlines():
+        if line.startswith("jobs:"):
+            in_jobs = True
+            continue
+        if not in_jobs:
+            continue
+        # A new top-level key (indent 0) ends the jobs mapping.
+        if line and not line.startswith(" ") and not line.startswith("#"):
+            break
+        job_match = _JOB_RE.match(line)
+        if job_match:
+            current = job_match.group(1)
+            bodies[current] = []
+            continue
+        if current is not None:
+            bodies[current].append(line)
+
+    return bodies
+
+
+def _parse_needs(body: list[str]) -> list[str]:
+    """Return the job ids listed under this block's ``needs:`` sequence."""
+    needs: list[str] = []
+    collecting = False
+
+    for line in body:
+        if _NEEDS_BLOCK_RE.match(line):
+            collecting = True
+            continue
+        if not collecting:
+            continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        item = _NEEDS_ITEM_RE.match(line)
+        if not item:
+            collecting = False
+            continue
+        needs.append(item.group(1))
+
+    return needs
+
+
+def _parse_allowed_skips(body: list[str]) -> list[str]:
+    """Return the job ids named by this block's ``ALLOWED_SKIPS`` env."""
+    for line in body:
+        match = _ALLOWED_SKIPS_RE.match(line)
+        if match is None:
+            continue
+        raw = _strip_quotes(match.group(1))
+        return [name.strip() for name in raw.split(",") if name.strip()]
+    return []
+
+
+def _parse_gate_exempt(bodies: dict[str, list[str]]) -> set[str]:
+    """Return the job ids that declare a ``# ci-gate-exempt:`` marker.
+
+    Unlike ``needs:``/``ALLOWED_SKIPS`` (read from the gate job's own body),
+    this marker lives in the EXEMPT job's own body — the job declares its own
+    exemption, since by definition it is absent from the gate's ``needs:``.
+    """
+    return {
+        job
+        for job, body in bodies.items()
+        if any(_GATE_EXEMPT_RE.match(line) for line in body)
+    }
+
+
+def parse_workflow(
+    text: str,
+) -> tuple[dict[str, bool], list[str], list[str], set[str]]:
+    """Return (job_id -> has job-level ``if:``, gate needs, allowed skips, exempt).
+
+    Pre:  ``text`` is the ci.yml source.
+    Post: jobs are the top-level keys under ``jobs:`` (indent 2); needs and
+          allowed-skips are read from the gate job's block only; exempt is
+          read from every job's own body (see ``_parse_gate_exempt``).
+    """
+    bodies = _job_bodies(text)
+    jobs = {
+        job: any(_JOB_IF_RE.match(line) for line in body)
+        for job, body in bodies.items()
+    }
+    gate_body = bodies.get(GATE_JOB, [])
+    return (
+        jobs,
+        _parse_needs(gate_body),
+        _parse_allowed_skips(gate_body),
+        _parse_gate_exempt(bodies),
+    )
+
+
+def _check_every_job_is_gated(jobs: dict[str, bool], gated: set[str]) -> list[str]:
+    """Check 2: every job is either in the gate's needs or self-declared exempt."""
+    return [
+        f"job '{job}' is not in {GATE_JOB}.needs and carries no "
+        f"'# ci-gate-exempt:' marker — it would run outside the gate "
+        f"and could fail without blocking a merge"
+        for job in sorted(jobs)
+        if job != GATE_JOB and job not in gated
+    ]
+
+
+def _check_needs_are_real_jobs(jobs: dict[str, bool], needs: list[str]) -> list[str]:
+    """Check 3: the gate does not wait on a job id that no longer exists."""
+    return [
+        f"{GATE_JOB}.needs lists '{name}', which is not a job in ci.yml"
+        for name in needs
+        if name not in jobs
+    ]
+
+
+def _check_allowed_skips(
+    jobs: dict[str, bool], allowed_skips: list[str], exempt: set[str]
+) -> list[str]:
+    """Checks 4 and 5: ALLOWED_SKIPS and the set of conditional jobs agree.
+
+    Exempt jobs never appear in ``needs:``, so ci-green's jq never evaluates
+    their result — ALLOWED_SKIPS governs skip results INSIDE the gate only,
+    and does not apply to a job structurally outside it.
+    """
+    conditional = {
+        job
+        for job, has_if in jobs.items()
+        if has_if and job != GATE_JOB and job not in exempt
+    }
+    undeclared = [
+        f"job '{job}' carries a job-level 'if:' but is not in "
+        f"ALLOWED_SKIPS — it can report 'skipped' and slip past the gate. "
+        f"Declare it (with the reason) or drop the condition"
+        for job in sorted(conditional - set(allowed_skips))
+    ]
+    stale = [
+        f"ALLOWED_SKIPS lists '{name}', which has no job-level 'if:' in "
+        f"ci.yml — a stale exemption lets a real skip go unnoticed"
+        for name in sorted(set(allowed_skips) - conditional)
+    ]
+    return undeclared + stale
+
+
+def _check_exempt_jobs_are_conditional(
+    jobs: dict[str, bool], exempt: set[str]
+) -> list[str]:
+    """Check 6: an exemption without a condition is not a narrower gate."""
+    return [
+        f"job '{job}' carries a '# ci-gate-exempt:' marker but no "
+        f"job-level 'if:' — an exemption with no condition would run "
+        f"ungated on every push and PR, which is not a narrower gate, "
+        f"it is no gate"
+        for job in sorted(exempt)
+        if not jobs.get(job, False)
+    ]
+
+
+def check(text: str) -> list[str]:
+    """Return the list of failures; empty means the gate is complete."""
+    jobs, needs, allowed_skips, exempt = parse_workflow(text)
+
+    # Check 1 is fatal on its own: without the gate job there is no needs
+    # list and no ALLOWED_SKIPS to read, so every later check would report
+    # noise derived from an absent block.
+    if GATE_JOB not in jobs:
+        return [
+            f"job '{GATE_JOB}' is missing from ci.yml — branch protection "
+            f"requires its status check, so main would block on a context "
+            f"nothing reports"
+        ]
+
+    return (
+        _check_every_job_is_gated(jobs, set(needs) | exempt)
+        + _check_needs_are_real_jobs(jobs, needs)
+        + _check_allowed_skips(jobs, allowed_skips, exempt)
+        + _check_exempt_jobs_are_conditional(jobs, exempt)
+    )
+
+
+def main() -> int:
+    if not CI_WORKFLOW.exists():
+        print(f"FAIL: {CI_WORKFLOW} not found", file=sys.stderr)
+        return 1
+
+    failures = check(CI_WORKFLOW.read_text(encoding="utf-8"))
+    if failures:
+        print("CI gate completeness: FAIL", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print("CI gate completeness: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_doc_claims.py
+++ b/scripts/check_doc_claims.py
@@ -1,6 +1,6 @@
 """Doc-claim gate: the numbers the docs advertise must match the repository.
 
-Cortex advertises counts in prose — tools, references, mechanisms, version,
+Cortex advertises counts in prose — tools, references, mechanisms,
 tests. Each one is a claim a reader can check, and each one drifts silently:
 between 2026-07-12 and 2026-07-27 the tool count moved from 49 to 52 while
 README, CONTRIBUTING and the MCPB manifest still said 50, 43 and 49, and
@@ -19,7 +19,6 @@ tool counts          ``docs/mcp-tools.md`` header, itself pinned to the live
                      test_standalone_baseline_is_52_tools``
 reference count      entries counted in ``docs/papers/bibliography.md``
 mechanism count      the count declared in that bibliography's header
-version              ``[project].version`` in ``pyproject.toml``
 test count           ``assets/badge-tests.svg`` alone (issue #293) — the
                      one artifact that still states an absolute figure. No
                      prose file (nor ``.bestpractices.json``) states this
@@ -33,6 +32,12 @@ test count           ``assets/badge-tests.svg`` alone (issue #293) — the
                      advance; only an OVER-claim is reported. See
                      ``doc_claim_structural.check_badge_floor``.
 ===================  =====================================================
+
+Version-site coherence (``[project].version`` in ``pyproject.toml`` against
+every manifest, plugin, and badge occurrence that restates it) is NOT this
+gate's job any more — it moved to ``scripts/check_version_surfaces.py``,
+which is a strict superset of what this gate's own ``check_versions`` used
+to compare (issue #392).
 
 Release history is exempt: a line describing v4.13.0 may legitimately say
 "49 memory tools". Lines carrying a ``**vX.Y.Z`` marker, and files that are
@@ -64,7 +69,6 @@ module's docstring for why they take these as parameters instead).
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 from pathlib import Path
@@ -177,29 +181,6 @@ def check_counts(pattern: re.Pattern[str], expected: int, label: str) -> list[st
     return doc_claim_scan.check_counts(pattern, expected, label, SCANNED_FILES, read)
 
 
-def check_versions(expected: str) -> list[str]:
-    """The version in the packaging metadata, the badge and every manifest."""
-    failures: list[str] = []
-    for relative_path, key in (
-        ("manifest.json", "version"),
-        ("server.json", "version"),
-        ("package.json", "version"),
-    ):
-        actual = json.loads(read(relative_path)).get(key)
-        if actual != expected:
-            failures.append(
-                f"{relative_path}: version {actual!r}, pyproject says {expected!r}"
-            )
-    failures += doc_claim_structural.check_badge(
-        "assets/badge-version.svg",
-        doc_claim_structural.VERSION_BADGE,
-        expected,
-        "version",
-        read,
-    )
-    return failures
-
-
 def check_no_hotlinked_badges() -> list[str]:
     """The README's repo-derived badges stay self-hosted."""
     return doc_claim_structural.check_no_hotlinked_badges(read)
@@ -221,7 +202,6 @@ def collect_failures(test_count: int | None) -> list[str]:
     failures += check_counts(TOOL_TOTAL_CLAIM, total, "tools with integrations")
     failures += check_counts(REFERENCE_CLAIM, canonical_reference_count(), "references")
     failures += check_counts(MECHANISM_CLAIM, canonical_mechanism_count(), "mechanisms")
-    failures += check_versions(canonical_version())
     failures += check_no_hotlinked_badges()
     failures += check_no_conflict_markers()
     failures += check_scanned_json_parses()

--- a/scripts/check_version_surfaces.py
+++ b/scripts/check_version_surfaces.py
@@ -1,0 +1,257 @@
+"""Version-coherence gate: every version site in the repo must agree.
+
+Three gates already touch a version number, and each trusts a DIFFERENT
+canonical source:
+
+- ``check_doc_claims.py``'s (now removed) ``check_versions`` compared
+  ``manifest.json``/``server.json``/``package.json``/the version badge
+  against ``pyproject.toml``.
+- ``check_marketplace_pins.py`` compares ``server.json``/``manifest.json``
+  against the marketplace's *own* primary pin (not pyproject.toml), and only
+  for the two files it happens to enumerate.
+- ``tests_py/scripts/test_cross_host_manifests.py`` compares four more
+  manifests against ``package.json`` (not pyproject.toml either).
+
+Two sites were covered by NOTHING: ``server.json``'s
+``packages[0].version`` (the MCP-registry package entry, served to every
+registry client) and ``.claude-plugin/marketplace.json``'s
+``metadata.version``. A partial version bump can reach ``main`` and only be
+caught by the weekly ``marketplace-pins`` cron, which is not part of the
+``ci-green`` aggregate (issue #392).
+
+This module is the single authoritative source: every version site is
+compared against ONE canonical value, ``[project].version`` in
+``pyproject.toml`` (via ``doc_claim_sources.canonical_version``, the same
+reader ``check_doc_claims.py`` uses). ``SURFACES`` is DATA — a tuple of
+no-argument-bound check callables built by ``functools.partial`` over three
+small, pure functions (``_json_check``, ``_badge_check``,
+``_uv_lock_check``/``_marketplace_primary_plugin_check``) — so adding a 15th
+surface of an existing kind (another JSON file/key, another badge
+occurrence) is a one-line data edit, never a new branch in
+``check_version_surfaces`` itself (OCP).
+
+Badge parsing reuses ``doc_claim_structural.check_badge`` verbatim (fails
+closed on a missing file or an unmatched pattern) rather than reimplementing
+it; the pyproject version regex is reused from ``doc_claim_sources`` rather
+than re-derived here.
+
+Usage::
+
+    python scripts/check_version_surfaces.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections.abc import Callable
+from functools import partial
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Sibling modules, path-imported for the same reason check_doc_claims.py does
+# it: resolves identically whether this runs as a script or is loaded via
+# importlib.util.spec_from_file_location from a test.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+import doc_claim_sources  # noqa: E402
+import doc_claim_structural  # noqa: E402
+from doc_claim_sources import ClaimError  # noqa: E402  (re-export)
+
+ReadFn = Callable[[str], str]
+SurfaceCheck = Callable[[ReadFn, str], list[str]]
+
+
+def read(relative_path: str) -> str:
+    # encoding="utf-8" pinned explicitly — see check_doc_claims.read's own
+    # docstring for why (non-ASCII prose, locale-dependent defaults).
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def canonical_version() -> str:
+    return doc_claim_sources.canonical_version(read)
+
+
+def _json_check(
+    path: str, keys: tuple[str | int, ...], label: str, read_fn: ReadFn, expected: str
+) -> list[str]:
+    """A version nested at `keys` inside a JSON file must match `expected`."""
+    try:
+        body = read_fn(path)
+    except FileNotFoundError:
+        return [f"{path}: missing — the version-surfaces gate reads it"]
+    try:
+        value: object = json.loads(body)
+        for key in keys:
+            value = value[key]
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError) as error:
+        return [f"{path}: {label}: could not read a version there ({error})"]
+    if value != expected:
+        return [f"{path}: {label}: version {value!r}, pyproject says {expected!r}"]
+    return []
+
+
+def _badge_check(
+    pattern: re.Pattern[str], label: str, read_fn: ReadFn, expected: str
+) -> list[str]:
+    """One of the four textual version occurrences in the version-badge SVG.
+
+    Delegates entirely to doc_claim_structural.check_badge — no badge parsing
+    lives in this module.
+    """
+    return doc_claim_structural.check_badge(
+        "assets/badge-version.svg", pattern, expected, label, read_fn
+    )
+
+
+# The badge is a generated SVG (scripts/generate_repo_badges.py) that states
+# its version four times: the accessible aria-label, the <title> (reused
+# from doc_claim_structural.VERSION_BADGE below), and a drop-shadow + solid
+# <text> pair. Each occurrence can desync independently of the others (a
+# hand-edit, or a future template change to only one of them), so each is
+# its own surface rather than one "the badge" surface.
+_BADGE_ARIA_LABEL = re.compile(r'aria-label="Version (\d+\.\d+\.\d+)"')
+_BADGE_SHADOW_TEXT = re.compile(r'fill-opacity="0.25"[^>]*>(\d+\.\d+\.\d+)</text>')
+_BADGE_SOLID_TEXT = re.compile(r'fill="#fff"[^>]*>(\d+\.\d+\.\d+)</text>')
+
+
+def _marketplace_primary_plugin_check(read_fn: ReadFn, expected: str) -> list[str]:
+    """The self-hosted (primary) marketplace plugin entry's own version.
+
+    Selection rule mirrors check_marketplace_pins.main's own primary-entry
+    predicate (`source.strip("/") in ("", ".")`) verbatim, rather than
+    re-deriving a second notion of "the primary plugin" that could disagree
+    with it.
+    """
+    path = ".claude-plugin/marketplace.json"
+    label = "primary plugin entry version"
+    try:
+        data = json.loads(read_fn(path))
+    except (FileNotFoundError, json.JSONDecodeError) as error:
+        return [f"{path}: {label}: could not read the marketplace manifest ({error})"]
+    entries = [
+        plugin
+        for plugin in data.get("plugins", [])
+        if isinstance(plugin.get("source"), str)
+        and plugin["source"].strip("/") in ("", ".")
+    ]
+    if len(entries) != 1:
+        return [
+            f"{path}: {label}: expected exactly one self-hosted plugin entry, "
+            f"found {len(entries)}"
+        ]
+    value = entries[0].get("version")
+    if value != expected:
+        return [f"{path}: {label}: version {value!r}, pyproject says {expected!r}"]
+    return []
+
+
+# The root package uv.lock resolved from this repo's own pyproject.toml
+# (`source = { editable = "." }`).
+_UV_LOCK_PACKAGE = "hypermnesia-mcp"
+
+
+def _uv_lock_check(read_fn: ReadFn, expected: str) -> list[str]:
+    """The root `hypermnesia-mcp` package block's own version.
+
+    uv.lock is TOML, but read line-by-line rather than parsed: this repo's
+    floor is Python 3.10, where `tomllib` does not exist — the same
+    rationale scripts/generate_pip_constraints.py's lock_registries uses for
+    the identical [[package]]/name/version scan.
+    """
+    path = "uv.lock"
+    label = f"{_UV_LOCK_PACKAGE} package block"
+    name: str | None = None
+    version: str | None = None
+    for line in read_fn(path).splitlines():
+        if line.startswith("[[package]]"):
+            name, version = None, None
+        elif line.startswith('name = "'):
+            name = line.split('"')[1]
+        elif line.startswith('version = "'):
+            version = line.split('"')[1]
+        if name == _UV_LOCK_PACKAGE and version is not None:
+            break
+    else:
+        # The loop ran to completion without finding our package: whatever
+        # `version` last held belongs to a DIFFERENT package block.
+        version = None
+    if version is None:
+        return [f"{path}: {label}: no version found for {_UV_LOCK_PACKAGE!r}"]
+    if version != expected:
+        return [f"{path}: {label}: version {version!r}, pyproject says {expected!r}"]
+    return []
+
+
+# One row per version site (14 sites across 11 files). Adding a 15th JSON
+# site or badge occurrence is a one-line addition here; only a genuinely new
+# FILE FORMAT (neither JSON, regex-matchable text, nor uv.lock's own shape)
+# would need a new `_..._check` function alongside it.
+SURFACES: tuple[SurfaceCheck, ...] = (
+    partial(_json_check, "package.json", ("version",), "version"),
+    partial(_json_check, "server.json", ("version",), "version"),
+    partial(
+        _json_check, "server.json", ("packages", 0, "version"), "packages[0].version"
+    ),
+    partial(_json_check, "manifest.json", ("version",), "version"),
+    partial(_json_check, "gemini-extension.json", ("version",), "version"),
+    partial(_json_check, ".claude-plugin/plugin.json", ("version",), "version"),
+    partial(
+        _json_check,
+        ".claude-plugin/marketplace.json",
+        ("metadata", "version"),
+        "metadata.version",
+    ),
+    _marketplace_primary_plugin_check,
+    partial(
+        _json_check,
+        "plugins/hypermnesia-mcp-codex/.codex-plugin/plugin.json",
+        ("version",),
+        "version",
+    ),
+    partial(_badge_check, _BADGE_ARIA_LABEL, "aria-label"),
+    partial(_badge_check, doc_claim_structural.VERSION_BADGE, "<title>"),
+    partial(_badge_check, _BADGE_SHADOW_TEXT, "shadow <text>"),
+    partial(_badge_check, _BADGE_SOLID_TEXT, "solid <text>"),
+    _uv_lock_check,
+)
+
+
+def check_version_surfaces(read_fn: ReadFn) -> list[str]:
+    """Every version site's failures, against the canonical pyproject.toml one.
+
+    Raises ClaimError (uncaught) if pyproject.toml itself cannot be read —
+    the gate cannot run blind, the same contract check_doc_claims.py's
+    canonical readers use.
+    """
+    expected = doc_claim_sources.canonical_version(read_fn)
+    failures: list[str] = []
+    for surface_check in SURFACES:
+        failures += surface_check(read_fn, expected)
+    return failures
+
+
+def main() -> int:
+    try:
+        failures = check_version_surfaces(read)
+    except ClaimError as error:
+        print(f"version-surfaces gate could not run: {error}", file=sys.stderr)
+        return 2
+
+    if failures:
+        print("Version surfaces disagree with pyproject.toml:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+    print(
+        f"version surfaces OK ({len(SURFACES)} site(s) checked, "
+        "all agree with pyproject.toml)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pip_constraint_sets.py
+++ b/scripts/pip_constraint_sets.py
@@ -141,7 +141,7 @@ SETS: tuple[ConstraintSet, ...] = (
     ),
     ConstraintSet(
         filename="release.txt",
-        consumers=(".github/workflows/release.yml — verification job",),
+        consumers=(".github/workflows/ci.yml — release-deps",),
         extras=("dev", "postgresql"),
     ),
     ConstraintSet(

--- a/tests_py/scripts/test_check_ci_gate_complete.py
+++ b/tests_py/scripts/test_check_ci_gate_complete.py
@@ -1,0 +1,205 @@
+"""Tests for scripts/check_ci_gate_complete.py — the aggregate-CI-gate guard.
+
+Branch protection names one status check, ``CI Green``, and the real list of
+gated jobs lives in that job's ``needs:``. This guard is the only thing
+standing between that design and its failure mode: a job added to ci.yml but
+never added to ``needs`` runs outside the gate and can fail without blocking
+a merge — silently, exactly like the eleven-context arrangement it replaced.
+
+So the guard's own failure mode is silence. Each check below is pinned by a
+fixture that must FAIL, plus a live assertion that the repository's real
+ci.yml passes — a parser that quietly stopped matching would otherwise be
+indistinguishable from a clean tree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+# Dotted, path-derived module name: mutmut keys its trampolines on
+# "scripts.check_ci_gate_complete.*" and a bare name makes every mutant look
+# unreached (issue #293, same idiom as test_check_doc_claims.py).
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "scripts.check_ci_gate_complete", _SCRIPTS / "check_ci_gate_complete.py"
+)
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
+
+
+def _workflow(jobs: str) -> str:
+    """Wrap job definitions in the minimal ci.yml envelope the parser reads."""
+    return "name: CI\n\non:\n  push:\n    branches: [main]\n\njobs:\n" + jobs
+
+
+_COMPLETE = _workflow(
+    """  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: ruff check .
+
+  mcp-host-config:
+    name: Validate MCP host configurations
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.fork == false
+    steps:
+      - run: true
+
+  ci-green:
+    name: CI Green
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - mcp-host-config
+    steps:
+      - name: Require every job above to have succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          ALLOWED_SKIPS: mcp-host-config
+        run: true
+"""
+)
+
+
+class CheckCompleteGate(unittest.TestCase):
+    def test_complete_workflow_has_no_failures(self) -> None:
+        self.assertEqual(gate.check(_COMPLETE), [])
+
+    def test_parses_jobs_needs_and_allowed_skips(self) -> None:
+        jobs, needs, allowed, exempt = gate.parse_workflow(_COMPLETE)
+        self.assertEqual(set(jobs), {"lint", "mcp-host-config", "ci-green"})
+        self.assertFalse(jobs["lint"])
+        self.assertTrue(jobs["mcp-host-config"])
+        self.assertEqual(needs, ["lint", "mcp-host-config"])
+        self.assertEqual(allowed, ["mcp-host-config"])
+        self.assertEqual(exempt, set())
+
+
+class RefusesIncompleteGate(unittest.TestCase):
+    def _only_failure(self, workflow: str) -> str:
+        failures = gate.check(workflow)
+        self.assertEqual(len(failures), 1, failures)
+        return failures[0]
+
+    def test_missing_gate_job_fails(self) -> None:
+        workflow = _workflow(
+            "  lint:\n    name: Lint\n    runs-on: ubuntu-latest\n"
+            "    steps:\n      - run: true\n"
+        )
+        self.assertIn(gate.GATE_JOB, self._only_failure(workflow))
+
+    def test_job_absent_from_needs_fails(self) -> None:
+        workflow = _COMPLETE.replace("      - lint\n", "")
+        self.assertIn("'lint' is not in", self._only_failure(workflow))
+
+    def test_needs_naming_a_nonexistent_job_fails(self) -> None:
+        workflow = _COMPLETE.replace("      - lint\n", "      - lint\n      - ghost\n")
+        self.assertIn("'ghost'", self._only_failure(workflow))
+
+    def test_conditional_job_missing_from_allowed_skips_fails(self) -> None:
+        workflow = _COMPLETE.replace("          ALLOWED_SKIPS: mcp-host-config\n", "")
+        failure = self._only_failure(workflow)
+        self.assertIn("mcp-host-config", failure)
+        self.assertIn("ALLOWED_SKIPS", failure)
+
+    def test_stale_allowed_skips_entry_fails(self) -> None:
+        # `lint` carries no `if:`, so exempting it guards nothing and hides a
+        # real skip if one ever appears.
+        workflow = _COMPLETE.replace(
+            "ALLOWED_SKIPS: mcp-host-config", "ALLOWED_SKIPS: mcp-host-config, lint"
+        )
+        self.assertIn("'lint'", self._only_failure(workflow))
+
+
+_WITH_EXEMPT_JOB = _workflow(
+    """  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: ruff check .
+
+  mcp-host-config:
+    name: Validate MCP host configurations
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.fork == false
+    steps:
+      - run: true
+
+  release-gate:
+    name: Tag a release
+    needs: [ci-green]
+    # ci-gate-exempt: runs only on push to main, after the PR merged —
+    # there is nothing left for it to gate.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
+  ci-green:
+    name: CI Green
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - mcp-host-config
+    steps:
+      - name: Require every job above to have succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          ALLOWED_SKIPS: mcp-host-config
+        run: true
+"""
+)
+
+
+class GateExemptJobs(unittest.TestCase):
+    def test_exempt_job_outside_needs_has_no_failures(self) -> None:
+        self.assertEqual(gate.check(_WITH_EXEMPT_JOB), [])
+
+    def test_parses_exempt_set(self) -> None:
+        jobs, needs, allowed, exempt = gate.parse_workflow(_WITH_EXEMPT_JOB)
+        self.assertEqual(exempt, {"release-gate"})
+        self.assertNotIn("release-gate", needs)
+        self.assertTrue(jobs["release-gate"])
+
+    def test_exempt_job_without_if_fails(self) -> None:
+        workflow = _WITH_EXEMPT_JOB.replace(
+            "    if: github.event_name == 'push' && github.ref == 'refs/heads/main'\n",
+            "",
+        )
+        failures = gate.check(workflow)
+        self.assertTrue(
+            any("release-gate" in f and "no job-level" in f for f in failures),
+            failures,
+        )
+
+    def test_unexempt_unneeded_job_still_fails(self) -> None:
+        # Sanity: removing the marker (with no needs entry either) reverts to
+        # the original "runs outside the gate" failure — the marker is a
+        # deliberate escape hatch, not a parser blind spot.
+        workflow = _WITH_EXEMPT_JOB.replace(
+            "    # ci-gate-exempt: runs only on push to main, after the PR merged —\n"
+            "    # there is nothing left for it to gate.\n",
+            "",
+        )
+        failures = gate.check(workflow)
+        unmarked = [f for f in failures if "release-gate" in f and "carries no" in f]
+        self.assertTrue(unmarked, failures)
+
+
+class RepositoryWorkflowIsGated(unittest.TestCase):
+    def test_live_ci_workflow_passes(self) -> None:
+        """The guard must agree with the tree it ships in, not just fixtures."""
+        self.assertTrue(gate.CI_WORKFLOW.exists(), gate.CI_WORKFLOW)
+        self.assertEqual(
+            gate.check(gate.CI_WORKFLOW.read_text(encoding="utf-8")),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/scripts/test_check_doc_claims.py
+++ b/tests_py/scripts/test_check_doc_claims.py
@@ -536,66 +536,6 @@ class ScanTests(unittest.TestCase):
         self.assertIn(".bestpractices.json", gate.SCANNED_FILES)
 
 
-class VersionTests(unittest.TestCase):
-    def setUp(self):
-        self._real_read = gate.read
-
-    def tearDown(self):
-        gate.read = self._real_read
-
-    def _install(self, manifest: str, badge: str | None):
-        files = {
-            "manifest.json": '{"version": "%s"}' % manifest,
-            "server.json": '{"version": "4.16.0"}',
-            "package.json": '{"version": "4.16.0"}',
-        }
-        if badge is not None:
-            files["assets/badge-version.svg"] = f"<title>Version {badge}</title>"
-        gate.read = _FakeRepo(**files).read
-
-    def test_manifest_and_badge_must_match_pyproject(self):
-        self._install(manifest="4.16.0", badge="4.16.0")
-        self.assertEqual(gate.check_versions("4.16.0"), [])
-
-    def test_stale_manifest_version_is_reported(self):
-        self._install(manifest="4.15.0", badge="4.16.0")
-        failures = gate.check_versions("4.16.0")
-        self.assertEqual(len(failures), 1)
-        self.assertIn("manifest.json", failures[0])
-
-    def test_stale_committed_badge_is_reported(self):
-        self._install(manifest="4.16.0", badge="4.15.0")
-        failures = gate.check_versions("4.16.0")
-        self.assertEqual(len(failures), 1)
-        self.assertIn("version badge says 4.15.0", failures[0])
-
-    def test_a_missing_badge_file_fails_closed(self):
-        """Self-hosting moved the figure into a file that can be deleted.
-
-        The URL-shaped predecessor of this check silently passed when its
-        pattern stopped matching, so a gate that cannot find its subject must
-        report rather than shrug.
-        """
-        self._install(manifest="4.16.0", badge=None)
-        failures = gate.check_versions("4.16.0")
-        self.assertEqual(len(failures), 1)
-        self.assertIn("missing", failures[0])
-
-    def test_a_badge_without_a_version_title_fails_closed(self):
-        self._install(manifest="4.16.0", badge="4.16.0")
-        gate.read = _FakeRepo(
-            **{
-                "manifest.json": '{"version": "4.16.0"}',
-                "server.json": '{"version": "4.16.0"}',
-                "package.json": '{"version": "4.16.0"}',
-                "assets/badge-version.svg": "<svg><title>something else</title></svg>",
-            }
-        ).read
-        failures = gate.check_versions("4.16.0")
-        self.assertEqual(len(failures), 1)
-        self.assertIn("diverged", failures[0])
-
-
 class CollectFailuresTests(unittest.TestCase):
     """The composition: every family must reach the report.
 
@@ -627,12 +567,7 @@ class CollectFailuresTests(unittest.TestCase):
             "docs/mcp-tools.md": CATALOGUE,
             "tests_py/test_main.py": PINNED_TEST,
             "docs/papers/bibliography.md": BIBLIOGRAPHY,
-            "pyproject.toml": '[project]\nversion = "4.16.0"\n',
-            "manifest.json": '{"version": "4.16.0"}',
-            "server.json": '{"version": "4.16.0"}',
-            "package.json": '{"version": "4.16.0"}',
             "README.md": readme or '<img src="assets/badge-tests.svg" alt="tests">\n',
-            "assets/badge-version.svg": "<title>Version 4.16.0</title>",
         }
         # None omits the file entirely (a missing-badge scenario); any other
         # string is spliced into the <title> as-is, so a non-digit value

--- a/tests_py/scripts/test_cross_host_manifests.py
+++ b/tests_py/scripts/test_cross_host_manifests.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Version-site cross-file agreement is scripts/check_version_surfaces.py's
+# job (it is the single source of truth for every one of the 14 sites, not
+# just the 5 this file used to hand-maintain its own list of) — imported
+# rather than re-asserted here, so this file has one fewer place a new
+# version site could be added and forgotten.
+_spec = importlib.util.spec_from_file_location(
+    "scripts.check_version_surfaces",
+    REPO_ROOT / "scripts" / "check_version_surfaces.py",
+)
+_version_surfaces = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_version_surfaces)
 
 
 def _json(path: str) -> dict:
@@ -22,12 +35,4 @@ def test_gemini_extension_launches_the_published_stdio_entrypoint() -> None:
 
 
 def test_cross_host_manifest_versions_match_the_release() -> None:
-    expected = _json("package.json")["version"]
-    assert _json("gemini-extension.json")["version"] == expected
-    assert _json("server.json")["version"] == expected
-    assert _json("manifest.json")["version"] == expected
-    assert _json(".claude-plugin/plugin.json")["version"] == expected
-    assert (
-        _json("plugins/hypermnesia-mcp-codex/.codex-plugin/plugin.json")["version"]
-        == expected
-    )
+    assert _version_surfaces.check_version_surfaces(_version_surfaces.read) == []

--- a/tests_py/scripts/test_version_surfaces.py
+++ b/tests_py/scripts/test_version_surfaces.py
@@ -1,0 +1,343 @@
+"""Tests for scripts/check_version_surfaces.py — the version-coherence gate.
+
+The gate's own failure mode is silence: a JSON key that stops being read, a
+regex that stops matching a badge occurrence, or a canonical source it
+cannot read would let a version site drift unnoticed. Each test below
+desynchronises exactly ONE of the 14 version sites and asserts the gate
+names it — the point of the exercise, since a gate that reports "something,
+somewhere disagrees" is barely better than no gate.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+import unittest
+from pathlib import Path
+
+# Dotted, path-derived module name — see test_check_doc_claims.py's own
+# header comment for why (mutmut trampoline keys on this exact name).
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "scripts.check_version_surfaces", _SCRIPTS / "check_version_surfaces.py"
+)
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
+
+
+class _FakeRepo:
+    """Minimal stand-in for the repository files the gate reads.
+
+    Raises FileNotFoundError (not KeyError) on a missing path, matching what
+    the real read()'s Path.read_text raises — the same contract
+    test_check_doc_claims.py's own double honours.
+    """
+
+    def __init__(self, **files: str):
+        self.files = files
+
+    def read(self, relative_path: str) -> str:
+        try:
+            return self.files[relative_path]
+        except KeyError:
+            raise FileNotFoundError(relative_path) from None
+
+
+# One consistent version, "4.16.0", stated identically at all 14 sites.
+_V = "4.16.0"
+_BADGE_SVG_OK = (
+    f'<svg aria-label="Version {_V}">'
+    f"<title>Version {_V}</title>"
+    f'<text fill-opacity="0.25">{_V}</text>'
+    f'<text fill="#fff">{_V}</text>'
+    "</svg>"
+)
+_MARKETPLACE_OK = (
+    '{"metadata": {"version": "%s"}, "plugins": ['
+    '{"name": "hypermnesia-mcp", "source": "./", "version": "%s"}, '
+    '{"name": "other", "source": {"source": "github", "repo": "x/y"}, '
+    '"version": "9.9.9"}]}'
+) % (_V, _V)
+_UV_LOCK_OK = f"""version = 1
+revision = 1
+
+[[package]]
+name = "other-package"
+version = "1.2.3"
+source = {{ registry = "https://pypi.org/simple" }}
+
+[[package]]
+name = "hypermnesia-mcp"
+version = "{_V}"
+source = {{ editable = "." }}
+dependencies = [
+    {{ name = "other-package" }},
+]
+
+[[package]]
+name = "zzz-package"
+version = "9.9.9"
+source = {{ registry = "https://pypi.org/simple" }}
+"""
+
+OK_FILES: dict[str, str] = {
+    "pyproject.toml": f'[project]\nname = "hypermnesia-mcp"\nversion = "{_V}"\n',
+    "package.json": f'{{"version": "{_V}"}}',
+    "server.json": (f'{{"version": "{_V}", "packages": [{{"version": "{_V}"}}]}}'),
+    "manifest.json": f'{{"version": "{_V}"}}',
+    "gemini-extension.json": f'{{"version": "{_V}"}}',
+    ".claude-plugin/plugin.json": f'{{"version": "{_V}"}}',
+    ".claude-plugin/marketplace.json": _MARKETPLACE_OK,
+    "plugins/hypermnesia-mcp-codex/.codex-plugin/plugin.json": f'{{"version": "{_V}"}}',
+    "assets/badge-version.svg": _BADGE_SVG_OK,
+    "uv.lock": _UV_LOCK_OK,
+}
+
+
+class _GateTestCase(unittest.TestCase):
+    def setUp(self):
+        self._real_read = gate.read
+
+    def tearDown(self):
+        gate.read = self._real_read
+
+    def _install(self, **overrides: str) -> None:
+        files = dict(OK_FILES)
+        files.update(overrides)
+        gate.read = _FakeRepo(**files).read
+
+    def _failures(self) -> list[str]:
+        return gate.check_version_surfaces(gate.read)
+
+    def _assert_single_failure_about(self, path_fragment: str) -> str:
+        failures = self._failures()
+        self.assertEqual(len(failures), 1, failures)
+        self.assertIn(path_fragment, failures[0])
+        return failures[0]
+
+
+class NominalTests(_GateTestCase):
+    def test_a_fully_consistent_repository_reports_nothing(self):
+        self._install()
+        self.assertEqual(self._failures(), [])
+
+    def test_fourteen_surfaces_are_registered(self):
+        # source: the task's own site inventory — 11 files, 2 of them (server.json,
+        # marketplace.json) carrying 2 keys each, plus the badge's 4 occurrences:
+        # 9 JSON/uv.lock sites - 2 double-counted files + 2 extra keys + 3 extra
+        # badge occurrences = 14.
+        self.assertEqual(len(gate.SURFACES), 14)
+
+
+class PerSurfaceDesyncTests(_GateTestCase):
+    """Each test desyncs exactly one surface and names it in the failure."""
+
+    def test_package_json_version_desync_is_reported(self):
+        self._install(**{"package.json": '{"version": "9.9.9"}'})
+        self._assert_single_failure_about("package.json")
+
+    def test_server_json_version_desync_is_reported(self):
+        stale = f'{{"version": "9.9.9", "packages": [{{"version": "{_V}"}}]}}'
+        self._install(**{"server.json": stale})
+        failure = self._assert_single_failure_about("server.json")
+        self.assertIn("version", failure)
+        self.assertNotIn("packages[0]", failure)
+
+    def test_server_json_packages_0_version_desync_is_reported(self):
+        """Explicit, dedicated test: this site was covered by NOTHING before."""
+        stale = f'{{"version": "{_V}", "packages": [{{"version": "9.9.9"}}]}}'
+        self._install(**{"server.json": stale})
+        failure = self._assert_single_failure_about("server.json")
+        self.assertIn("packages[0].version", failure)
+
+    def test_manifest_json_version_desync_is_reported(self):
+        self._install(**{"manifest.json": '{"version": "9.9.9"}'})
+        self._assert_single_failure_about("manifest.json")
+
+    def test_gemini_extension_json_version_desync_is_reported(self):
+        self._install(**{"gemini-extension.json": '{"version": "9.9.9"}'})
+        self._assert_single_failure_about("gemini-extension.json")
+
+    def test_plugin_json_version_desync_is_reported(self):
+        self._install(**{".claude-plugin/plugin.json": '{"version": "9.9.9"}'})
+        self._assert_single_failure_about(".claude-plugin/plugin.json")
+
+    def test_marketplace_metadata_version_desync_is_reported(self):
+        """Explicit, dedicated test: this site was covered by NOTHING before."""
+        stale = (
+            '{"metadata": {"version": "9.9.9"}, "plugins": ['
+            f'{{"name": "hypermnesia-mcp", "source": "./", "version": "{_V}"}}]}}'
+        )
+        self._install(**{".claude-plugin/marketplace.json": stale})
+        failure = self._assert_single_failure_about(".claude-plugin/marketplace.json")
+        self.assertIn("metadata.version", failure)
+
+    def test_marketplace_primary_plugin_entry_version_desync_is_reported(self):
+        stale = (
+            '{"metadata": {"version": "%s"}, "plugins": ['
+            '{"name": "hypermnesia-mcp", "source": "./", "version": "9.9.9"}, '
+            '{"name": "other", "source": {"source": "github", "repo": "x/y"}, '
+            '"version": "%s"}]}'
+        ) % (_V, _V)
+        self._install(**{".claude-plugin/marketplace.json": stale})
+        failure = self._assert_single_failure_about(".claude-plugin/marketplace.json")
+        self.assertIn("primary plugin entry version", failure)
+
+    def test_marketplace_with_no_self_hosted_entry_fails_closed(self):
+        no_primary = (
+            '{"metadata": {"version": "%s"}, "plugins": ['
+            '{"name": "other", "source": {"source": "github", "repo": "x/y"}, '
+            '"version": "%s"}]}'
+        ) % (_V, _V)
+        self._install(**{".claude-plugin/marketplace.json": no_primary})
+        failure = self._assert_single_failure_about(".claude-plugin/marketplace.json")
+        self.assertIn("expected exactly one self-hosted plugin entry, found 0", failure)
+
+    def test_codex_plugin_json_version_desync_is_reported(self):
+        self._install(
+            **{
+                "plugins/hypermnesia-mcp-codex/.codex-plugin/plugin.json": (
+                    '{"version": "9.9.9"}'
+                )
+            }
+        )
+        self._assert_single_failure_about(
+            "plugins/hypermnesia-mcp-codex/.codex-plugin/plugin.json"
+        )
+
+    def test_badge_aria_label_desync_is_reported(self):
+        self._install(
+            **{
+                "assets/badge-version.svg": (
+                    '<svg aria-label="Version 9.9.9">'
+                    f"<title>Version {_V}</title>"
+                    f'<text fill-opacity="0.25">{_V}</text>'
+                    f'<text fill="#fff">{_V}</text>'
+                    "</svg>"
+                )
+            }
+        )
+        failure = self._assert_single_failure_about("assets/badge-version.svg")
+        self.assertIn("aria-label", failure)
+
+    def test_badge_title_desync_is_reported(self):
+        self._install(
+            **{
+                "assets/badge-version.svg": (
+                    f'<svg aria-label="Version {_V}">'
+                    "<title>Version 9.9.9</title>"
+                    f'<text fill-opacity="0.25">{_V}</text>'
+                    f'<text fill="#fff">{_V}</text>'
+                    "</svg>"
+                )
+            }
+        )
+        failure = self._assert_single_failure_about("assets/badge-version.svg")
+        self.assertIn("<title>", failure)
+
+    def test_badge_shadow_text_desync_is_reported(self):
+        self._install(
+            **{
+                "assets/badge-version.svg": (
+                    f'<svg aria-label="Version {_V}">'
+                    f"<title>Version {_V}</title>"
+                    '<text fill-opacity="0.25">9.9.9</text>'
+                    f'<text fill="#fff">{_V}</text>'
+                    "</svg>"
+                )
+            }
+        )
+        failure = self._assert_single_failure_about("assets/badge-version.svg")
+        self.assertIn("shadow <text>", failure)
+
+    def test_badge_solid_text_desync_is_reported(self):
+        self._install(
+            **{
+                "assets/badge-version.svg": (
+                    f'<svg aria-label="Version {_V}">'
+                    f"<title>Version {_V}</title>"
+                    f'<text fill-opacity="0.25">{_V}</text>'
+                    '<text fill="#fff">9.9.9</text>'
+                    "</svg>"
+                )
+            }
+        )
+        failure = self._assert_single_failure_about("assets/badge-version.svg")
+        self.assertIn("solid <text>", failure)
+
+    def test_uv_lock_root_package_version_desync_is_reported(self):
+        stale = _UV_LOCK_OK.replace(
+            f'name = "hypermnesia-mcp"\nversion = "{_V}"',
+            'name = "hypermnesia-mcp"\nversion = "9.9.9"',
+        )
+        self._install(**{"uv.lock": stale})
+        failure = self._assert_single_failure_about("uv.lock")
+        self.assertIn("hypermnesia-mcp", failure)
+
+    def test_uv_lock_missing_the_root_package_fails_closed(self):
+        """A block-scan bug could silently compare the WRONG package's version."""
+        root_block = (
+            f'name = "hypermnesia-mcp"\nversion = "{_V}"\n'
+            'source = { editable = "." }\n'
+            'dependencies = [\n    { name = "other-package" },\n]\n\n'
+        )
+        without_root = _UV_LOCK_OK.replace(root_block, "")
+        self._install(**{"uv.lock": without_root})
+        failure = self._assert_single_failure_about("uv.lock")
+        self.assertIn("no version found for", failure)
+
+
+class RealRepositoryTests(unittest.TestCase):
+    """The gate must pass against the actual, committed repository tree."""
+
+    def test_the_real_repository_agrees_on_every_surface(self):
+        self.assertEqual(gate.check_version_surfaces(gate.read), [])
+
+
+class MainTests(unittest.TestCase):
+    def setUp(self):
+        self._argv = sys.argv[:]
+        self._real_read = gate.read
+
+    def tearDown(self):
+        sys.argv = self._argv
+        gate.read = self._real_read
+
+    def _run(self):
+        sys.argv = ["check_version_surfaces.py"]
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = gate.main()
+        return code, out.getvalue(), err.getvalue()
+
+    def test_a_consistent_tree_exits_zero(self):
+        gate.read = _FakeRepo(**OK_FILES).read
+        code, out, err = self._run()
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        self.assertIn("version surfaces OK (14 site(s) checked", out)
+
+    def test_a_diverged_tree_exits_one_and_names_the_surface(self):
+        files = dict(OK_FILES)
+        files["package.json"] = '{"version": "9.9.9"}'
+        gate.read = _FakeRepo(**files).read
+        code, out, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertEqual(out, "")
+        self.assertIn("Version surfaces disagree with pyproject.toml:", err)
+        self.assertIn("package.json", err)
+
+    def test_an_unreadable_pyproject_aborts_with_exit_code_2(self):
+        files = dict(OK_FILES)
+        files["pyproject.toml"] = '[project]\nname = "hypermnesia-mcp"\n'
+        gate.read = _FakeRepo(**files).read
+        code, out, err = self._run()
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("version-surfaces gate could not run:", err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Réapplique l'arbre exact validé en `8b979947`, qui avait passé 22 checks sur la tête de #394. Vérifié : `git diff 8b979947` est vide, l'arbre est identique au bit près.

## Ce que ça contient

| PR reverté | apport |
|---|---|
| #391 | `scripts/check_ci_gate_complete.py` — l'agrégat `CI Green` |
| #387 | `.github/actions/test-suite/action.yml` — une suite de tests partagée par `ci.yml` et `release.yml` au lieu de deux copies qui divergent |
| #393 | `scripts/check_version_surfaces.py` — un seul gate sur les 14 sites de version, `pyproject.toml` comme source canonique unique |
| #394 | le tag devient une sortie d'un arbre vert au lieu d'une entrée poussée à la main |

## Aucun changement de protection de branche

Les onze contextes requis gardent leurs noms exacts — `Lint`, `Type Check`, `Build Package`, `Docker Smoke (bare-container DB-less contract)`, `Test (Python 3.10/3.11/3.12/3.13)`, `Test (SQLite backend)`, `Test (Windows, SQLite backend)`. Cette PR n'en renomme aucun et n'en supprime aucun : elle ajoute trois jobs à côté.

`CI Green` **n'est pas** proposé comme contexte requis. Son rôle ici est de conditionner la pose du tag, ce qui est appliqué par le workflow lui-même et n'exige aucune modification de la protection.

## Historique

Le premier passage de ce travail a été reverté de `main` (`2d73e95d`) à la demande du mainteneur. Le code n'était pas en cause : la PR #395 était restée bloquée parce que son trigger CodeQL avait été perdu par un rebase forcé suivi d'un retarget et d'un close/reopen. Cette PR est créée depuis `main` courant et ne sera ni retargetée ni rebasée de force.