### PR TITLE
fix(hooks): agent_briefing falls back on a degenerate roster, not just an absent directory

### DIFF
--- a/mcp_server/hooks/agent_briefing.py
+++ b/mcp_server/hooks/agent_briefing.py
@@ -43,6 +43,12 @@ Strategy:
     - At least 1 relevant memory found
     - Max 3 memories injected (keep context compact)
 
+Module split (issue #401, 300-line cap): keyword extraction lives in
+``agent_briefing_keywords.py``, the PG connect + query in
+``agent_briefing_query.py`` (both re-exported via ``__all__``). Event
+gating and the specialist-roster loader stay here — the latter reads the
+``CLAUDE_DIR`` attribute the test suite monkeypatches on this module.
+
 Installation
 ------------
 Add to ``~/.claude/settings.json`` under hooks::
@@ -77,7 +83,6 @@ Invariants
 from __future__ import annotations
 
 import json
-import os
 import re
 import sys
 from pathlib import Path
@@ -88,12 +93,26 @@ from mcp_server.handlers.injection_receipts import (
     receipt_marker,
     session_id_from_transcript,
 )
+from mcp_server.hooks.agent_briefing_keywords import _extract_task_keywords
+from mcp_server.hooks.agent_briefing_log import _log
+from mcp_server.hooks.agent_briefing_query import (
+    _DATABASE_URL,
+    _MAX_MEMORIES,
+    _MIN_HEAT,
+    _connect,
+    _fetch_agent_context,
+)
 from mcp_server.infrastructure.config import CLAUDE_DIR
 
-_LOG_PREFIX = "[cortex-agent-briefing]"
-_DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://localhost:5432/cortex")
-_MAX_MEMORIES = 3
-_MIN_HEAT = 0.2
+__all__ = [
+    "_DATABASE_URL",
+    "_MAX_MEMORIES",
+    "_MIN_HEAT",
+    "_connect",
+    "_fetch_agent_context",
+    "_extract_task_keywords",
+    "_log",
+]
 
 # Fallback set used when the discovered roster is unusable — see
 # _load_specialist_agents for what "unusable" means.
@@ -112,15 +131,18 @@ _FALLBACK_AGENTS: frozenset[str] = frozenset(
     }
 )
 
-# source: ~/.claude/agents/dispatch.md frontmatter, this repo, verified
-# 2026-08-09 — "Sole user-scope agent... It matches the problem against
-# the routing table and delegates; it never does the work itself" / body:
-# "You never implement, review, or research yourself." Under the
-# plugin-only-dispatch architecture (agents live in the zetetic-team-subagents
-# plugin, not under ~/.claude/agents/) this is the ONLY file ever present
-# in ~/.claude/agents/, so a discovered roster of exactly {"dispatch"} is
-# not a specialist set a briefing can scope memories to — it is
-# structurally equivalent to an empty roster.
+# Reserved meta-agent names: agents whose declared job is to ROUTE work to
+# other agents rather than perform it, so a roster reduced to only them is
+# not a specialist set a briefing can scope memories to (treated as empty).
+#
+# A convention of the *consumer* environment, not a fact about this repo —
+# `dispatch.md` lives under the reader's own ~/.claude/agents/, not in this
+# repository, so no path/commit/digest here would be independently
+# verifiable. What IS verifiable and pinned by tests: agent_briefing falls
+# back when the discovered roster reduces to a router (see
+# test_agents_dir_with_only_dispatch_falls_back_to_builtin_set and the
+# end-to-end reproduction in test_hook_receipts.py). A reader without that
+# setup loses nothing — the name is filtered only when present, and logged.
 _NON_SPECIALIST_META_AGENTS: frozenset[str] = frozenset({"dispatch"})
 
 # Matches `name: <slug>` or `name: "<slug>"` in agent-file YAML frontmatter.
@@ -148,24 +170,17 @@ def _load_specialist_agents() -> frozenset[str]:
     Scans ~/.claude/agents/*.md and ~/.claude/agents/genius/*.md, parses the
     `name:` frontmatter field of each, drops known non-specialist meta-agents
     (_NON_SPECIALIST_META_AGENTS), and returns the frozen set. Falls back to
-    _FALLBACK_AGENTS whenever the resulting roster is empty — whether because
-    the directory is absent (e.g., CI without install) or because it exists
-    but contains no usable specialist (e.g., the plugin-only-dispatch
-    architecture, where it holds only dispatch.md). An absent directory and
-    a degenerate one are the same failure mode for a briefing consumer: no
-    specialist to scope memories to. Result is cached for the process
-    lifetime — agents added after import are not picked up until restart
-    (acceptable for a hook process).
+    _FALLBACK_AGENTS whenever the resulting roster is empty — directory
+    absent (e.g., CI without install) and directory-present-but-degenerate
+    (e.g., plugin-only-dispatch, holding only dispatch.md) are the same
+    failure mode: no specialist to scope memories to. Cached for the process
+    lifetime — agents added after import need a restart to be picked up.
 
-    The root is CLAUDE_DIR (default ~/.claude, overridable via
-    CORTEX_CLAUDE_DIR — mcp_server/infrastructure/config.py), the same seam
-    every other real-data path in this project uses for test isolation
-    (issue #219).
-
-    Each zetetic agent declares `memory_scope:` in frontmatter; that scope
-    equals the name used as `agent_context` in Cortex memory rows. When the
-    /session:memory-sync drainer sets `agent_topic=<scope>`, the briefing
-    hook can filter by `agent_context = %s` and inject the right memories.
+    Root is CLAUDE_DIR (default ~/.claude, overridable via CORTEX_CLAUDE_DIR
+    — mcp_server/infrastructure/config.py), the project's test-isolation
+    seam (issue #219). Each zetetic agent declares `memory_scope:` in
+    frontmatter, equal to the `agent_context` used in Cortex memory rows —
+    the briefing hook filters recall by it once agent_topic is set.
     """
     root = CLAUDE_DIR / "agents"
     names: set[str] = set()
@@ -178,209 +193,15 @@ def _load_specialist_agents() -> frozenset[str]:
                 if name:
                     names.add(name)
     usable = names - _NON_SPECIALIST_META_AGENTS
+    dropped = names & _NON_SPECIALIST_META_AGENTS
+    if dropped:
+        _log(f"reserved meta-agent name(s) not briefed: {sorted(dropped)}")
     return frozenset(usable) if usable else _FALLBACK_AGENTS
 
 
 # Known specialist agents that benefit from briefing — dynamic load from
 # ~/.claude/agents/ (116+ zetetic agents when installed).
 _SPECIALIST_AGENTS = _load_specialist_agents()
-
-
-def _log(msg: str) -> None:
-    print(f"{_LOG_PREFIX} {msg}", file=sys.stderr)
-
-
-# source: "words longer than 3 chars" per _extract_task_keywords docstring
-_MIN_KEYWORD_CHARS = 3
-
-
-def _extract_task_keywords(prompt: str) -> list[str]:
-    """Extract key terms from the agent prompt for FTS query.
-
-    Takes the first 500 chars of the prompt and extracts words
-    longer than 3 chars, excluding common stop words.
-    """
-    stops = {
-        "the",
-        "and",
-        "for",
-        "that",
-        "this",
-        "with",
-        "from",
-        "your",
-        "have",
-        "will",
-        "been",
-        "they",
-        "what",
-        "when",
-        "where",
-        "which",
-        "there",
-        "their",
-        "about",
-        "would",
-        "could",
-        "should",
-        "into",
-        "more",
-        "some",
-        "than",
-        "them",
-        "then",
-        "these",
-        "those",
-        "each",
-        "make",
-        "like",
-        "just",
-        "over",
-        "such",
-        "take",
-        "also",
-        "back",
-        "after",
-        "only",
-        "come",
-        "made",
-        "find",
-        "here",
-        "thing",
-        "many",
-        "well",
-        "work",
-        "need",
-        "using",
-        "used",
-        "code",
-        "file",
-        "please",
-        "ensure",
-    }
-    words = prompt[:500].lower().split()
-    keywords = [
-        w.strip(".,;:!?\"'()[]{}")
-        for w in words
-        if len(w) > _MIN_KEYWORD_CHARS
-        and w.lower().strip(".,;:!?\"'()[]{}") not in stops
-    ]
-    # Return unique keywords, max 8
-    seen = set()
-    unique = []
-    for k in keywords:
-        if k not in seen and k:
-            seen.add(k)
-            unique.append(k)
-    return unique[:8]
-
-
-def _connect():
-    """Open the briefing's PG connection; None when PG is unreachable."""
-    try:
-        import psycopg  # noqa: PLC0415 — optional-feature probe: ImportError here is a handled degraded mode
-        from psycopg.rows import DictRow, dict_row  # noqa: PLC0415 — optional-feature probe: ImportError here is a handled degraded mode
-    except ImportError:
-        return None
-    try:
-        return psycopg.Connection[DictRow].connect(
-            _DATABASE_URL, row_factory=dict_row, autocommit=True
-        )
-    except psycopg.Error:
-        return None
-
-
-def _fetch_agent_context(conn, agent_name: str, keywords: list[str]) -> list[dict]:
-    """Fetch relevant memories for agent briefing.
-
-    Two-pass query:
-    1. Agent-scoped memories (agent_context matches) — prior work by this specialist
-    2. Team decisions (is_protected + is_global) — cross-agent knowledge (TMS directory)
-
-    Uses FTS plainto_tsquery for speed (no embedding model needed).
-    Each result keeps the memory ``id`` — the injection receipt (T2)
-    records exactly which memories entered the agent's context.
-    """
-    results = []
-
-    # Pass 1: Agent-scoped memories matching keywords
-    if keywords:
-        try:
-            rows = conn.execute(
-                """
-                -- memories.heat is not a stored column; use
-                -- effective_heat(m, NOW()) for lazy A3 decay (matches
-                -- production recall_memories semantics).
-                -- Source: pg_schema.py EFFECTIVE_HEAT_FN.
-                SELECT m.id, m.content,
-                       effective_heat(m, NOW()) AS heat,
-                       m.agent_context
-                -- JOIN current_memories: briefing content — chain heads
-                -- only; join keeps m table-typed for effective_heat().
-                FROM memories m
-                     JOIN current_memories cm ON cm.id = m.id
-                WHERE m.agent_context = %s
-                  AND effective_heat(m, NOW()) >= %s
-                  AND NOT m.is_benchmark
-                  -- Never brief an agent with a corrected (superseded)
-                  -- fact — decision 4255039 correction 8.
-                  AND m.superseded_by_id IS NULL
-                  AND m.content_tsv @@ plainto_tsquery('english', %s)
-                ORDER BY effective_heat(m, NOW()) DESC
-                LIMIT %s
-                """,
-                (agent_name, _MIN_HEAT, " ".join(keywords[:5]), _MAX_MEMORIES),
-            ).fetchall()
-            for r in rows:
-                results.append(
-                    {
-                        "id": r["id"],
-                        "content": r.get("content", "")[:300],
-                        "heat": r.get("heat", 0),
-                        "source": "agent-prior",
-                    }
-                )
-        except Exception as exc:  # noqa: BLE001 — hook boundary — failure is logged to the hook log; the hook stays non-fatal
-            _log(f"agent-scoped query failed: {exc}")
-
-    # Pass 2: Team decisions (protected + global)
-    remaining = _MAX_MEMORIES - len(results)
-    if remaining > 0:
-        try:
-            rows = conn.execute(
-                """
-                SELECT m.id, m.content,
-                       effective_heat(m, NOW()) AS heat,
-                       m.agent_context
-                -- JOIN current_memories: same pattern as pass 1.
-                FROM memories m
-                     JOIN current_memories cm ON cm.id = m.id
-                WHERE m.is_protected = TRUE
-                  AND m.is_global = TRUE
-                  AND m.agent_context != %s
-                  AND NOT m.is_benchmark
-                  -- Superseded decisions are corrected facts — never
-                  -- re-inject (decision 4255039 correction 8).
-                  AND m.superseded_by_id IS NULL
-                ORDER BY effective_heat(m, NOW()) DESC
-                LIMIT %s
-                """,
-                (agent_name, remaining),
-            ).fetchall()
-            for r in rows:
-                results.append(
-                    {
-                        "id": r["id"],
-                        "content": r.get("content", "")[:300],
-                        "heat": r.get("heat", 0),
-                        "source": f"team:{r.get('agent_context', '')}",
-                    }
-                )
-        except Exception as exc:  # noqa: BLE001 — hook boundary — failure is logged to the hook log; the hook stays non-fatal
-            _log(f"team decisions query failed: {exc}")
-
-    return results
-
 
 # source: pre-existing tuned value, extracted unchanged (#197 family 3);
 # provenance not recorded at introduction

--- a/mcp_server/hooks/agent_briefing.py
+++ b/mcp_server/hooks/agent_briefing.py
@@ -38,7 +38,7 @@ Strategy:
   matching memories as a context prefix.
 
   Gated by:
-    - Agent type must be a known specialist (engineer, tester, etc.)
+    - Agent type must be a known, usable specialist (engineer, tester, etc.)
     - Task description must be non-empty
     - At least 1 relevant memory found
     - Max 3 memories injected (keep context compact)
@@ -88,13 +88,15 @@ from mcp_server.handlers.injection_receipts import (
     receipt_marker,
     session_id_from_transcript,
 )
+from mcp_server.infrastructure.config import CLAUDE_DIR
 
 _LOG_PREFIX = "[cortex-agent-briefing]"
 _DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://localhost:5432/cortex")
 _MAX_MEMORIES = 3
 _MIN_HEAT = 0.2
 
-# Fallback set used when ~/.claude/agents/ is missing (e.g., CI without install).
+# Fallback set used when the discovered roster is unusable — see
+# _load_specialist_agents for what "unusable" means.
 _FALLBACK_AGENTS: frozenset[str] = frozenset(
     {
         "engineer",
@@ -109,6 +111,17 @@ _FALLBACK_AGENTS: frozenset[str] = frozenset(
         "ux",
     }
 )
+
+# source: ~/.claude/agents/dispatch.md frontmatter, this repo, verified
+# 2026-08-09 — "Sole user-scope agent... It matches the problem against
+# the routing table and delegates; it never does the work itself" / body:
+# "You never implement, review, or research yourself." Under the
+# plugin-only-dispatch architecture (agents live in the zetetic-team-subagents
+# plugin, not under ~/.claude/agents/) this is the ONLY file ever present
+# in ~/.claude/agents/, so a discovered roster of exactly {"dispatch"} is
+# not a specialist set a briefing can scope memories to — it is
+# structurally equivalent to an empty roster.
+_NON_SPECIALIST_META_AGENTS: frozenset[str] = frozenset({"dispatch"})
 
 # Matches `name: <slug>` or `name: "<slug>"` in agent-file YAML frontmatter.
 _YAML_NAME_RE = re.compile(r"^name:\s*['\"]?([A-Za-z0-9_.-]+)['\"]?\s*$", re.MULTILINE)
@@ -133,28 +146,39 @@ def _load_specialist_agents() -> frozenset[str]:
     """Dynamically load agent slugs from ~/.claude/agents/ at module import.
 
     Scans ~/.claude/agents/*.md and ~/.claude/agents/genius/*.md, parses the
-    `name:` frontmatter field of each, and returns the frozen set. Falls back
-    to _FALLBACK_AGENTS if the directory is absent. Result is cached for the
-    process lifetime — agents added after import are not picked up until
-    restart (acceptable for a hook process).
+    `name:` frontmatter field of each, drops known non-specialist meta-agents
+    (_NON_SPECIALIST_META_AGENTS), and returns the frozen set. Falls back to
+    _FALLBACK_AGENTS whenever the resulting roster is empty — whether because
+    the directory is absent (e.g., CI without install) or because it exists
+    but contains no usable specialist (e.g., the plugin-only-dispatch
+    architecture, where it holds only dispatch.md). An absent directory and
+    a degenerate one are the same failure mode for a briefing consumer: no
+    specialist to scope memories to. Result is cached for the process
+    lifetime — agents added after import are not picked up until restart
+    (acceptable for a hook process).
+
+    The root is CLAUDE_DIR (default ~/.claude, overridable via
+    CORTEX_CLAUDE_DIR — mcp_server/infrastructure/config.py), the same seam
+    every other real-data path in this project uses for test isolation
+    (issue #219).
 
     Each zetetic agent declares `memory_scope:` in frontmatter; that scope
     equals the name used as `agent_context` in Cortex memory rows. When the
     /session:memory-sync drainer sets `agent_topic=<scope>`, the briefing
     hook can filter by `agent_context = %s` and inject the right memories.
     """
-    root = Path.home() / ".claude" / "agents"
-    if not root.is_dir():
-        return _FALLBACK_AGENTS
+    root = CLAUDE_DIR / "agents"
     names: set[str] = set()
-    for pattern in ("*.md", "genius/*.md"):
-        for md in root.glob(pattern):
-            if md.name == "INDEX.md":
-                continue
-            name = _parse_frontmatter_name(md)
-            if name:
-                names.add(name)
-    return frozenset(names) if names else _FALLBACK_AGENTS
+    if root.is_dir():
+        for pattern in ("*.md", "genius/*.md"):
+            for md in root.glob(pattern):
+                if md.name == "INDEX.md":
+                    continue
+                name = _parse_frontmatter_name(md)
+                if name:
+                    names.add(name)
+    usable = names - _NON_SPECIALIST_META_AGENTS
+    return frozenset(usable) if usable else _FALLBACK_AGENTS
 
 
 # Known specialist agents that benefit from briefing — dynamic load from

--- a/mcp_server/hooks/agent_briefing_keywords.py
+++ b/mcp_server/hooks/agent_briefing_keywords.py
@@ -1,0 +1,94 @@
+"""Task-prompt keyword extraction for the agent_briefing hook's FTS query.
+
+Split out of ``agent_briefing.py`` (issue #401 — that file exceeded the
+project's 300-line cap, CLAUDE.md § Code Style) to isolate pure text
+processing (no I/O, no dependency on the rest of the hook) from prompt
+parsing/event control flow and the PG query.
+"""
+
+from __future__ import annotations
+
+# source: "words longer than 3 chars" per _extract_task_keywords docstring
+_MIN_KEYWORD_CHARS = 3
+
+_STOPWORDS = {
+    "the",
+    "and",
+    "for",
+    "that",
+    "this",
+    "with",
+    "from",
+    "your",
+    "have",
+    "will",
+    "been",
+    "they",
+    "what",
+    "when",
+    "where",
+    "which",
+    "there",
+    "their",
+    "about",
+    "would",
+    "could",
+    "should",
+    "into",
+    "more",
+    "some",
+    "than",
+    "them",
+    "then",
+    "these",
+    "those",
+    "each",
+    "make",
+    "like",
+    "just",
+    "over",
+    "such",
+    "take",
+    "also",
+    "back",
+    "after",
+    "only",
+    "come",
+    "made",
+    "find",
+    "here",
+    "thing",
+    "many",
+    "well",
+    "work",
+    "need",
+    "using",
+    "used",
+    "code",
+    "file",
+    "please",
+    "ensure",
+}
+
+
+def _extract_task_keywords(prompt: str) -> list[str]:
+    """Extract key terms from the agent prompt for FTS query.
+
+    Takes the first 500 chars of the prompt and extracts words
+    longer than 3 chars, excluding common stop words.
+    """
+    words = prompt[:500].lower().split()
+    keywords = [
+        w.strip(".,;:!?\"'()[]{}")
+        for w in words
+        if len(w) > _MIN_KEYWORD_CHARS
+        and w.lower().strip(".,;:!?\"'()[]{}") not in _STOPWORDS
+    ]
+    # Return unique keywords, max 8
+    seen = set()
+    unique = []
+    for k in keywords:
+        if k not in seen and k:
+            seen.add(k)
+            unique.append(k)
+    return unique[:8]

--- a/mcp_server/hooks/agent_briefing_log.py
+++ b/mcp_server/hooks/agent_briefing_log.py
@@ -1,0 +1,18 @@
+"""Stderr-only logging helper shared across the agent_briefing hook split.
+
+Extracted so the query module (``agent_briefing_query.py``) can log a
+degraded PG query without importing the hook's entry-point module
+(``agent_briefing.py``) — that direction would be a cycle, since the entry
+point imports the query module's functions. This module has zero
+dependents other than the agent_briefing split, so it sits below both.
+"""
+
+from __future__ import annotations
+
+import sys
+
+_LOG_PREFIX = "[cortex-agent-briefing]"
+
+
+def _log(msg: str) -> None:
+    print(f"{_LOG_PREFIX} {msg}", file=sys.stderr)

--- a/mcp_server/hooks/agent_briefing_query.py
+++ b/mcp_server/hooks/agent_briefing_query.py
@@ -1,0 +1,124 @@
+"""PostgreSQL connection + the two-pass briefing query for agent_briefing.
+
+Split out of ``agent_briefing.py`` (issue #401 — that file exceeded the
+project's 300-line cap, CLAUDE.md § Code Style) to isolate the hook's only
+I/O (PG connect + the two SELECT passes) from prompt parsing and
+event-processing control flow.
+"""
+
+from __future__ import annotations
+
+import os
+
+from mcp_server.hooks.agent_briefing_log import _log
+
+_DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://localhost:5432/cortex")
+_MAX_MEMORIES = 3
+_MIN_HEAT = 0.2
+
+
+def _connect():
+    """Open the briefing's PG connection; None when PG is unreachable."""
+    try:
+        import psycopg  # noqa: PLC0415 — optional-feature probe: ImportError here is a handled degraded mode
+        from psycopg.rows import DictRow, dict_row  # noqa: PLC0415 — optional-feature probe: ImportError here is a handled degraded mode
+    except ImportError:
+        return None
+    try:
+        return psycopg.Connection[DictRow].connect(
+            _DATABASE_URL, row_factory=dict_row, autocommit=True
+        )
+    except psycopg.Error:
+        return None
+
+
+def _fetch_agent_context(conn, agent_name: str, keywords: list[str]) -> list[dict]:
+    """Fetch relevant memories for agent briefing.
+
+    Two-pass query:
+    1. Agent-scoped memories (agent_context matches) — prior work by this specialist
+    2. Team decisions (is_protected + is_global) — cross-agent knowledge (TMS directory)
+
+    Uses FTS plainto_tsquery for speed (no embedding model needed).
+    Each result keeps the memory ``id`` — the injection receipt (T2)
+    records exactly which memories entered the agent's context.
+    """
+    results = []
+
+    # Pass 1: Agent-scoped memories matching keywords
+    if keywords:
+        try:
+            rows = conn.execute(
+                """
+                -- memories.heat is not a stored column; use
+                -- effective_heat(m, NOW()) for lazy A3 decay (matches
+                -- production recall_memories semantics).
+                -- Source: pg_schema.py EFFECTIVE_HEAT_FN.
+                SELECT m.id, m.content,
+                       effective_heat(m, NOW()) AS heat,
+                       m.agent_context
+                -- JOIN current_memories: briefing content — chain heads
+                -- only; join keeps m table-typed for effective_heat().
+                FROM memories m
+                     JOIN current_memories cm ON cm.id = m.id
+                WHERE m.agent_context = %s
+                  AND effective_heat(m, NOW()) >= %s
+                  AND NOT m.is_benchmark
+                  -- Never brief an agent with a corrected (superseded)
+                  -- fact — decision 4255039 correction 8.
+                  AND m.superseded_by_id IS NULL
+                  AND m.content_tsv @@ plainto_tsquery('english', %s)
+                ORDER BY effective_heat(m, NOW()) DESC
+                LIMIT %s
+                """,
+                (agent_name, _MIN_HEAT, " ".join(keywords[:5]), _MAX_MEMORIES),
+            ).fetchall()
+            for r in rows:
+                results.append(
+                    {
+                        "id": r["id"],
+                        "content": r.get("content", "")[:300],
+                        "heat": r.get("heat", 0),
+                        "source": "agent-prior",
+                    }
+                )
+        except Exception as exc:  # noqa: BLE001 — hook boundary — failure is logged to the hook log; the hook stays non-fatal
+            _log(f"agent-scoped query failed: {exc}")
+
+    # Pass 2: Team decisions (protected + global)
+    remaining = _MAX_MEMORIES - len(results)
+    if remaining > 0:
+        try:
+            rows = conn.execute(
+                """
+                SELECT m.id, m.content,
+                       effective_heat(m, NOW()) AS heat,
+                       m.agent_context
+                -- JOIN current_memories: same pattern as pass 1.
+                FROM memories m
+                     JOIN current_memories cm ON cm.id = m.id
+                WHERE m.is_protected = TRUE
+                  AND m.is_global = TRUE
+                  AND m.agent_context != %s
+                  AND NOT m.is_benchmark
+                  -- Superseded decisions are corrected facts — never
+                  -- re-inject (decision 4255039 correction 8).
+                  AND m.superseded_by_id IS NULL
+                ORDER BY effective_heat(m, NOW()) DESC
+                LIMIT %s
+                """,
+                (agent_name, remaining),
+            ).fetchall()
+            for r in rows:
+                results.append(
+                    {
+                        "id": r["id"],
+                        "content": r.get("content", "")[:300],
+                        "heat": r.get("heat", 0),
+                        "source": f"team:{r.get('agent_context', '')}",
+                    }
+                )
+        except Exception as exc:  # noqa: BLE001 — hook boundary — failure is logged to the hook log; the hook stays non-fatal
+            _log(f"team decisions query failed: {exc}")
+
+    return results

--- a/tests_py/hooks/test_agent_briefing.py
+++ b/tests_py/hooks/test_agent_briefing.py
@@ -59,17 +59,17 @@ def test_unreadable_agent_file_returns_none(tmp_path: Path):
 
 
 def test_missing_agents_dir_falls_back_to_builtin_set(tmp_path, monkeypatch):
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(hook, "CLAUDE_DIR", tmp_path)
     assert hook._load_specialist_agents() == hook._FALLBACK_AGENTS
 
 
 def test_agents_dir_names_are_loaded_and_index_skipped(tmp_path, monkeypatch):
-    agents = tmp_path / ".claude" / "agents"
+    agents = tmp_path / "agents"
     (agents / "genius").mkdir(parents=True)
     (agents / "engineer.md").write_text("---\nname: engineer\n---\n")
     (agents / "INDEX.md").write_text("---\nname: not-an-agent\n---\n")
     (agents / "genius" / "euler.md").write_text("---\nname: euler\n---\n")
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(hook, "CLAUDE_DIR", tmp_path)
 
     loaded = hook._load_specialist_agents()
 
@@ -78,11 +78,47 @@ def test_agents_dir_names_are_loaded_and_index_skipped(tmp_path, monkeypatch):
 
 
 def test_agents_dir_with_no_parsable_names_falls_back(tmp_path, monkeypatch):
-    agents = tmp_path / ".claude" / "agents"
+    agents = tmp_path / "agents"
     agents.mkdir(parents=True)
     (agents / "broken.md").write_text("no frontmatter at all")
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(hook, "CLAUDE_DIR", tmp_path)
     assert hook._load_specialist_agents() == hook._FALLBACK_AGENTS
+
+
+def test_agents_dir_with_only_dispatch_falls_back_to_builtin_set(tmp_path, monkeypatch):
+    """Regression for issue #400.
+
+    Under the plugin-only-dispatch architecture, ~/.claude/agents/ holds
+    exactly one file (dispatch.md, a router that "never does the work
+    itself" — see _NON_SPECIALIST_META_AGENTS). Before the fix, only an
+    ABSENT directory triggered the fallback; a present directory containing
+    only dispatch.md yielded a roster of {"dispatch"}, so "engineer" (and
+    every other specialist) was never briefable outside CI.
+    """
+    agents = tmp_path / "agents"
+    agents.mkdir(parents=True)
+    (agents / "dispatch.md").write_text("---\nname: dispatch\n---\n")
+    monkeypatch.setattr(hook, "CLAUDE_DIR", tmp_path)
+
+    loaded = hook._load_specialist_agents()
+
+    assert loaded == hook._FALLBACK_AGENTS
+    assert "engineer" in loaded
+
+
+def test_agents_dir_with_dispatch_and_a_real_specialist_excludes_dispatch(
+    tmp_path, monkeypatch
+):
+    agents = tmp_path / "agents"
+    agents.mkdir(parents=True)
+    (agents / "dispatch.md").write_text("---\nname: dispatch\n---\n")
+    (agents / "engineer.md").write_text("---\nname: engineer\n---\n")
+    monkeypatch.setattr(hook, "CLAUDE_DIR", tmp_path)
+
+    loaded = hook._load_specialist_agents()
+
+    assert loaded == frozenset({"engineer"})
+    assert "dispatch" not in loaded
 
 
 # ── Keyword extraction ────────────────────────────────────────────────

--- a/tests_py/hooks/test_hook_receipts.py
+++ b/tests_py/hooks/test_hook_receipts.py
@@ -113,9 +113,13 @@ def _receipt(conn, receipt_id: int) -> tuple[dict, list[dict]]:
     return header, items
 
 
-def _run_hook(module: str, event: dict) -> subprocess.CompletedProcess:
+def _run_hook(
+    module: str, event: dict, extra_env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env["DATABASE_URL"] = _TEST_DB_URL
+    if extra_env:
+        env.update(extra_env)
     repo_root = os.path.dirname(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     )
@@ -309,6 +313,71 @@ def test_agent_briefing_emits_receipt_with_marker(_db) -> None:
     assert team_id in injected
     assert injected.index(mid) < injected.index(team_id)
     assert "team:architect" in result.stdout
+
+
+def test_agent_briefing_falls_back_when_only_dispatch_agent_is_installed(
+    _db, tmp_path
+) -> None:
+    """Regression for issue #400.
+
+    ``_SPECIALIST_AGENTS`` is computed once, at module import
+    (agent_briefing.py:_load_specialist_agents, called at module scope) —
+    so the only faithful reproduction of the reported bug is a fresh
+    process that imports the hook with ``CORTEX_CLAUDE_DIR`` already
+    pointed at a throwaway tree, the same seam and ordering constraint
+    documented for issue #219 (env var must be set before the first
+    import; conftest.py's ``_redirect_real_data_roots`` uses the identical
+    pattern).
+
+    The throwaway tree here holds exactly ``agents/dispatch.md`` — the
+    real shape of ``~/.claude/agents/`` under the plugin-only-dispatch
+    architecture (dispatch.md's own frontmatter: "it never does the work
+    itself"). Before the fix, only an ABSENT agents directory triggered
+    ``_FALLBACK_AGENTS``; a present directory containing only the
+    dispatcher yielded a roster of ``{"dispatch"}``, so "engineer" was
+    never a known specialist and the briefing silently never fired.
+    """
+    mid = _seed(
+        _db,
+        "HOOKRCPT_TEST corvidae plangent isotherm dossier archive",
+        agent="engineer",
+    )
+
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    (agents_dir / "dispatch.md").write_text(
+        "---\nname: dispatch\n---\ndispatcher only\n"
+    )
+
+    result = _run_hook(
+        "mcp_server.hooks.agent_briefing",
+        {
+            "agent_name": "engineer",
+            "agent_type": "custom",
+            "prompt": "corvidae plangent isotherm dossier archive review",
+            "cwd": "/tmp",
+            "transcript_path": _TRANSCRIPT,
+            "session_id": _DIVERGENT_EVENT_SESSION,
+        },
+        extra_env={"CORTEX_CLAUDE_DIR": str(tmp_path)},
+    )
+
+    assert result.returncode == 0
+    assert "corvidae" in result.stdout.lower(), (
+        "engineer must fall back to _FALLBACK_AGENTS when the discovered "
+        f"roster is only {{'dispatch'}}; stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+
+    row = _db.execute(
+        "SELECT id FROM injection_receipts "
+        "WHERE channel = 'agent_briefing' AND session_id = %s "
+        "ORDER BY id DESC LIMIT 1",
+        (_EXPECTED_SESSION,),
+    ).fetchone()
+    assert row is not None, "agent_briefing receipt was not persisted"
+    _, items = _receipt(_db, row["id"])
+    assert mid in [r["memory_id"] for r in items]
 
 
 # ── channel enum on live PG (decision 4255039 correction 3) ──────────────


### PR DESCRIPTION
Closes #400. Closes #401.

## The defect

`_load_specialist_agents()` armed `_FALLBACK_AGENTS` only when
`~/.claude/agents/` was **absent**. Under the plugin-only-dispatch
architecture that directory exists and holds `dispatch.md` alone, so the
discovered roster was `{"dispatch"}`, `engineer` was never a known
specialist, and the briefing hook silently never fired. CI never saw it:
there the directory is absent, so the fallback armed and the bug was
invisible.

## The fix, at the root

The fallback predicate becomes "the roster is empty **after** removing
reserved meta-agent names" instead of "the directory is missing". An absent
directory and a degenerate one are the same failure mode for a briefing
consumer: no specialist to scope memories to. Nothing is special-cased at
the call site.

The agents root moves from `Path.home()/".claude"/"agents"` to
`config.CLAUDE_DIR/"agents"` — the `CORTEX_CLAUDE_DIR` seam (#219) every
other real-data path in this project already uses. That is what makes a
hermetic reproduction possible at all.

## Evidence

The regression test spawns the real hook in a subprocess with
`CORTEX_CLAUDE_DIR` pointed at a throwaway tree containing only
`agents/dispatch.md`, and asserts both that the briefing fires and that a
receipt row is persisted. Against the pre-fix source it fails with the
reported symptom verbatim — `skip: agent 'engineer' not a specialist` —
and passes after. Five roster shapes are covered: absent, empty, unparsable,
dispatch-only, and dispatch-plus-a-real-specialist.

Full suite in deterministic order: 7243 passed, 142 skipped, 0 failed.
`ruff check` and `ruff format --check` green.

## Two things worth a reviewer's eye

`_NON_SPECIALIST_META_AGENTS` carries no `# source:` citation, deliberately.
An earlier revision cited `~/.claude/agents/dispatch.md` "in this repo";
that file ships in no repository, so the citation was unverifiable by
anyone else — the §8 failure mode in its own right. It is now recorded as
what it is, a convention of the consumer environment whose consequence is
pinned by tests. Filtering a reserved name is also logged now, because the
entire defect class here is silent inactivity.

`agent_briefing.py` was already over the local 300-line cap before this work
(452 lines) and the fix took it to 476. Rather than defer it, keyword
extraction, the PG connect/query pair and the stderr logger move to sibling
modules; the file is back to 297 lines, so #401 closes by construction.

## Out of scope, filed not swallowed

A full-suite run under `pytest-randomly` surfaced one order-dependent
failure in `tests_py/benchmarks/test_lib_init_no_psycopg.py`, invisible in
deterministic order and absent when the directory runs alone. It is outside
this change's blast radius and is filed with its measurements as #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01263uv1QqR8TVzw2jXYUrXn