### PR TITLE
docs: import the global agent rules into CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,6 @@
+@~/.claude/rules/model-behavior.md
+@~/.claude/rules/coding-standards.md
+
 # Cortex — Persistent Memory MCP Server
 
 Persistent memory and cognitive profiling MCP server for Claude Code.


### PR DESCRIPTION
`CLAUDE.md` existed here but wired in no global rules, so a session working on Cortex loaded neither `~/.claude/rules/model-behavior.md` nor `~/.claude/rules/coding-standards.md`.

Two lines at the top, using `@path` import syntax — a prose mention loads nothing. The existing content is untouched.

Why it matters concretely: `model-behavior.md` carries per-model guidance that is *opposite* between Opus 5 and Fable 5 on delegation and self-verification, so a session applying the wrong one actively degrades output.