### PR TITLE
fix(memory-ingest): stop dropping capture_origin at ingest (issue #368)

### DIFF
--- a/benchmarks/lib/bench_db.py
+++ b/benchmarks/lib/bench_db.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import os
 from typing import Any, Callable
 
+from benchmarks.lib.capture_origin_mix import assign_capture_origins
 from mcp_server.core.memory_ingest import ingest_memories_batch
 from mcp_server.core.pg_recall import (
     assemble_context as pg_assemble_context,
@@ -23,6 +24,23 @@ from mcp_server.core.pg_recall import (
 from mcp_server.core.reranker import ensure_reranker_loaded
 from mcp_server.infrastructure.embedding_engine import EmbeddingEngine
 from mcp_server.infrastructure.pg_store import PgMemoryStore
+
+
+def _apply_capture_origin_mix(memories: list[dict[str, Any]]) -> None:
+    """Stamp every memory lacking `capture_origin` with a value drawn from
+    the measured production mixture, in place.
+
+    Extracted as a free function (rather than inlined in `load_memories`) so
+    it is testable without a live PostgreSQL connection — see
+    `tests_py/benchmarks/test_bench_db_capture_origin.py`.
+
+    A memory that already sets `capture_origin` (e.g. the adversarial-corpus
+    montage, which needs specific per-pair values, not the aggregate mix) is
+    left untouched — `setdefault` only fills what's missing.
+    """
+    origins = assign_capture_origins(len(memories))
+    for mem, origin in zip(memories, origins, strict=True):
+        mem.setdefault("capture_origin", origin)
 
 
 class BenchmarkDB:
@@ -165,8 +183,19 @@ class BenchmarkDB:
         """Delegate to mcp_server.core.memory_ingest.ingest_memories_batch().
 
         Returns (ids, source_map) where source_map maps memory_id → source string.
+
+        Assigns a `capture_origin` to every memory that does not already carry
+        one, drawn from the measured production mixture
+        (benchmarks/lib/capture_origin_mix.py) instead of falling through to
+        insert_memory's "unknown" default. Without this every LME/LoCoMo/BEAM
+        row landed in `capture_origin='unknown'`, which
+        core.capture_origin.trust_factor demotes uniformly — a uniform
+        multiplier cannot change WRRF order, so the trust-factor W sweep
+        (docs/provenance/trust-factor-calibration.md) could not discriminate
+        between values of W (issue #368 follow-up).
         """
         assert self._store is not None, "Call open() first"
+        _apply_capture_origin_mix(memories)
         ids, source_map = ingest_memories_batch(
             memories,
             self._store,

--- a/benchmarks/lib/capture_origin_mix.py
+++ b/benchmarks/lib/capture_origin_mix.py
@@ -1,0 +1,101 @@
+"""Realistic capture_origin mixture for benchmark corpora (issue #368 fix).
+
+Why this exists: the trust-factor gated arm
+(docs/provenance/trust-factor-calibration.md) reported LME identical to four
+decimals across W in {1.0, 0.7, 0.6, 0.5} because LME/LoCoMo/BEAM never set
+capture_origin on the memories they insert -- every row fell through to the
+column default 'unknown' (pg_schema.py, pg_store.py:567), which
+mcp_server.core.capture_origin.trust_factor demotes uniformly. A uniform
+multiplier cannot change WRRF order, so the gated arm was structurally
+incapable of measuring W's effect on ranking; it could only prove the
+non-regression of everything else in the pipeline.
+
+This module assigns each benchmark memory a capture_origin drawn from the
+distribution that ACTUALLY occurs in production Cortex usage, so the gated
+arm mixes trusted and untrusted content the way a live store does and can
+therefore discriminate W.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# source: measured 2026-08-10 on this machine's own Claude Code history --
+#   886 session transcripts under ~/.claude/projects/**/*.jsonl (the only
+#   representative "existing store" of real Cortex-adjacent usage available
+#   in this environment; the local memory.db predates the capture_origin
+#   migration and carries no such column to sample). Two greps:
+#
+#   1) tool_use frequency for every tool name that
+#      mcp_server.core.capture_origin.classify_capture_origin maps to a
+#      non-UNKNOWN origin (issue #365 _LOCAL_ACTION_TOOLS / _NETWORK_TOOLS),
+#      restricted to the tools hooks/post_tool_capture.py actually
+#      auto-captures (_HIGH_VALUE_TOOLS + _LIGHT_VALUE_TOOLS +
+#      _CONDITIONAL_TOOLS):
+#
+#        grep -rhoE '"name": ?"(Edit|Write|MultiEdit|NotebookEdit|
+#          NotebookRead|Bash|Read|Glob|Grep|WebFetch|WebSearch)"'
+#          ~/.claude/projects/ | sort | uniq -c
+#
+#      -> Bash 29088, Read 5656, Edit 3992, Write 1162, WebFetch 583,
+#         WebSearch 466, Glob 5, MultiEdit/NotebookEdit/NotebookRead/Grep 0.
+#      local_action (Bash+Read+Edit+Write+Glob) = 39903
+#      network (WebFetch+WebSearch)             = 1049
+#
+#   2) explicit `remember` MCP tool_use calls (ORIGIN_DELIBERATE -- a direct
+#      remember with no origin_tool resolves DELIBERATE per
+#      handlers/remember.py) across the same transcripts:
+#
+#        grep -rhoE '"name": ?"[a-zA-Z0-9_.-]*remember[a-zA-Z0-9_.-]*"'
+#          ~/.claude/projects/ | sort | uniq -c
+#
+#      -> mcp__plugin_cortex_cortex__remember 278,
+#         mcp__plugin_hypermnesia-mcp_cortex__remember 83 => deliberate = 361
+#
+#   Pool = 39903 + 1049 + 361 = 41313.
+#     local_action = 39903 / 41313 = 0.9659
+#     network      =  1049 / 41313 = 0.0254
+#     deliberate   =   361 / 41313 = 0.0087
+#   Rounded to 3dp so the three sum to 1.000 exactly.
+#
+#   Limitation, stated rather than smoothed over: this is one user's
+#   tool-call frequency, not a filtered count of rows that actually pass
+#   _should_capture's length/content gates, and not a multi-user production
+#   sample. It is nonetheless a measurement of real usage, not an invented
+#   split, and it is the only "existing store" available to measure from in
+#   this environment. unknown/legacy are omitted at 0.0: every current
+#   writer (remember handler, post_tool_capture hook) resolves one of the
+#   three origins below; legacy is written only once, by the migration,
+#   never by a live write path, and no live writer produces unknown for a
+#   tool name it recognises -- the measured 0.0 IS the production rate for a
+#   fully-migrated store, not a gap in the count.
+CAPTURE_ORIGIN_MIX: tuple[tuple[str, float], ...] = (
+    ("local_action", 0.966),
+    ("network", 0.025),
+    ("deliberate", 0.009),
+)
+
+_ORIGINS = tuple(o for o, _ in CAPTURE_ORIGIN_MIX)
+_WEIGHTS = tuple(w for _, w in CAPTURE_ORIGIN_MIX)
+
+_SUM_TOLERANCE = 1e-9
+assert abs(sum(_WEIGHTS) - 1.0) < _SUM_TOLERANCE, "CAPTURE_ORIGIN_MIX must sum to 1.0"
+
+# Deterministic across runs (benchmarks/reproduce.sh's whole premise is "hit
+# play, get the same numbers" -- see its module docstring). Not a calibrated
+# quantity, just a fixed draw seed; any constant works, this one is arbitrary.
+DEFAULT_SEED = 368
+
+
+def assign_capture_origins(n: int, seed: int = DEFAULT_SEED) -> list[str]:
+    """Return `n` capture_origin values drawn i.i.d. from CAPTURE_ORIGIN_MIX.
+
+    Pre: n >= 0.
+    Post: len(result) == n; each element is one of _ORIGINS; deterministic
+    for a given (n, seed): same call, same output, every process.
+    """
+    rng = np.random.default_rng(seed)
+    if n == 0:
+        return []
+    idx = rng.choice(len(_ORIGINS), size=n, p=_WEIGHTS)
+    return [_ORIGINS[i] for i in idx]

--- a/benchmarks/lib/write_manifest.py
+++ b/benchmarks/lib/write_manifest.py
@@ -58,10 +58,10 @@ def machine_load_snapshot() -> dict:
     except OSError:  # not available on this platform (e.g. Windows)
         load1 = load5 = load15 = None
 
-    def _run(cmd: list[str]) -> str | None:
+    def _run(cmd: list[str], *, env: dict[str, str] | None = None) -> str | None:
         try:
             return subprocess.run(
-                cmd, capture_output=True, text=True, timeout=10, check=False
+                cmd, capture_output=True, text=True, timeout=10, check=False, env=env
             ).stdout
         except (OSError, subprocess.SubprocessError):
             return None
@@ -69,7 +69,18 @@ def machine_load_snapshot() -> dict:
     # Filtered in Python, not via a shell `grep -c "[p]ytest"` idiom: a
     # subprocess.run argv has no shell to bracket-escape a self-match, so the
     # filter runs here instead, over the same process list that idiom reads.
-    ps_out = _run(["ps", "aux"])
+    #
+    # The `COLUMNS` override below fixes a real undercount, not just a test
+    # flake (caught by
+    # tests_py/benchmarks/test_write_manifest_machine_load.py's own
+    # self-referential assertion failing on GitHub's Linux CI runner,
+    # 2026-08-10): both BSD ps (macOS) and GNU procps (Linux) truncate the
+    # COMMAND column to `$COLUMNS` when stdout is not a terminal and COLUMNS
+    # is unset, and `ps aux`'s fixed-width USER/PID/... columns alone can
+    # exceed a default 80-column budget before COMMAND even starts — cutting
+    # off the "pytest" substring entirely on a long interpreter path. A wide
+    # COLUMNS override is the standard fix for both implementations.
+    ps_out = _run(["ps", "aux"], env={**os.environ, "COLUMNS": "1000"})
     pytest_procs = (
         None
         if ps_out is None

--- a/benchmarks/lib/write_manifest.py
+++ b/benchmarks/lib/write_manifest.py
@@ -8,6 +8,10 @@ provenance logic can be read, diffed and tested as Python.
 Usage (from reproduce.sh):
     python benchmarks/lib/write_manifest.py \\
         RESULTS_DIR GIT_SHA DATASET_SHA256 PG_IMAGE CONTAINER PG_PORT RUNNER_PID
+
+    # Cell-start snapshot (call BEFORE start_db, so it also predates the
+    # benchmark's own container/DB overhead):
+    python benchmarks/lib/write_manifest.py --snapshot RESULTS_DIR
 """
 
 import json
@@ -15,7 +19,10 @@ import os
 import platform
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+
+_START_SNAPSHOT_NAME = "START_SNAPSHOT.json"
 
 
 def machine_load_snapshot() -> dict:
@@ -33,6 +40,15 @@ def machine_load_snapshot() -> dict:
     contention is exactly such a defect. This snapshot is recorded so that
     rule can be applied by inspection later, instead of by asking whoever
     happened to be watching at the time.
+
+    Taken TWICE per cell (2026-08-10 follow-up, same incident): once at cell
+    START (`write_start_snapshot`, called before `start_db` so it predates
+    the container/DB overhead too) and once at cell END (inside
+    `build_manifest`, the pre-existing call). A crash is the visible failure
+    mode; a cell that merely FINISHES under contention (saturated pool, cold
+    cache, GC pressure) is the invisible one, and a single end-of-run
+    snapshot cannot distinguish "this cell ran under load throughout" from
+    "load spiked right at the end". Two points at least bound the window.
 
     Best-effort: any probe that fails records `None`/`"unresolved"` rather
     than aborting manifest generation, matching this module's other fields.
@@ -77,6 +93,41 @@ def machine_load_snapshot() -> dict:
         "concurrent_pytest_processes": pytest_procs,
         "concurrent_docker_containers": docker_containers,
     }
+
+
+def write_start_snapshot(results_dir: str) -> Path:
+    """Capture + persist the cell-start machine-load snapshot.
+
+    Called from reproduce.sh before `start_db`, so `RESULTS_DIR` already
+    exists (created by `main()`'s `mkdir -p`) but nothing benchmark-specific
+    has run yet. `build_manifest` reads this file back at cell end and folds
+    it into the final MANIFEST.json as `machine_load_at_start`, alongside the
+    end-of-run `machine_load_at_end` — see `machine_load_snapshot`'s
+    docstring for why both points are recorded.
+    """
+    out = Path(results_dir) / _START_SNAPSHOT_NAME
+    payload = {
+        "captured_at_utc": datetime.now(timezone.utc).isoformat(),
+        "machine_load": machine_load_snapshot(),
+    }
+    out.write_text(json.dumps(payload, indent=2))
+    return out
+
+
+def _read_start_snapshot(results_dir: str) -> dict | None:
+    """Read back the cell-start snapshot written by `write_start_snapshot`.
+
+    Returns None (never raises) when absent — e.g. a `reproduce.sh` call
+    that predates this fix, or a caller that skipped the `--snapshot` step.
+    A missing start snapshot must not block the end-of-run manifest from
+    being written; `machine_load_at_start` is simply absent in that case,
+    which is itself an observable fact rather than a silent guess.
+    """
+    path = Path(results_dir) / _START_SNAPSHOT_NAME
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
 
 
 def ver(pkg: str) -> str:
@@ -152,11 +203,17 @@ def build_manifest(
     pg_port: str,
     pid: str,
 ) -> dict:
+    start_snapshot = _read_start_snapshot(results_dir)
     return {
         "git_sha": git_sha,
         # Alongside git_sha, not buried: see machine_load_snapshot's
-        # docstring for why (2026-08-10 sweep-contention incident).
-        "machine_load": machine_load_snapshot(),
+        # docstring for why (2026-08-10 sweep-contention incident). Two
+        # points, not one — `_at_start` is None when reproduce.sh's
+        # `--snapshot` step was never called for this results_dir.
+        "machine_load_at_start": (
+            start_snapshot["machine_load"] if start_snapshot else None
+        ),
+        "machine_load_at_end": machine_load_snapshot(),
         "longmemeval_dataset_sha256": ds_sha,
         "pg_image": pg_image,
         # Per-run container isolation fix (2026-07-11, incident: two concurrent
@@ -181,11 +238,19 @@ def build_manifest(
         },
         "embedding_model_revision": embedding_revision(),
         **reranker_fields(),
-        "results_files": sorted(p.name for p in Path(results_dir).glob("*.json")),
+        "results_files": sorted(
+            p.name
+            for p in Path(results_dir).glob("*.json")
+            if p.name != _START_SNAPSHOT_NAME
+        ),
     }
 
 
 def main(argv: list[str]) -> None:
+    if len(argv) > 1 and argv[1] == "--snapshot":
+        out = write_start_snapshot(argv[2])
+        print(f"==> Wrote {out}")
+        return
     results_dir = argv[1]
     manifest = build_manifest(*argv[1:8])
     out = Path(results_dir) / "MANIFEST.json"

--- a/benchmarks/lib/write_manifest.py
+++ b/benchmarks/lib/write_manifest.py
@@ -11,9 +11,72 @@ Usage (from reproduce.sh):
 """
 
 import json
+import os
 import platform
+import subprocess
 import sys
 from pathlib import Path
+
+
+def machine_load_snapshot() -> dict:
+    """Load average + concurrent pytest/container counts, as this run saw them.
+
+    2026-08-10 incident: a 5-cell trust-factor sweep ran while three other
+    agents' full pytest suites were active on the same machine (load average
+    ~11-14 on a 10-core box); one cell crashed on a native fatal error, and
+    the crash was the ONLY visible signal — cells that merely finished under
+    the same contention could have returned degraded numbers (saturated
+    connection pool, cold cache, GC pressure) with nothing in the artifact to
+    show it. The whole grid was discarded and re-run rather than salvaged,
+    per this project's own rule: a measurement from a harness with a known
+    defect is invalid and is redone, not patched after the fact — and
+    contention is exactly such a defect. This snapshot is recorded so that
+    rule can be applied by inspection later, instead of by asking whoever
+    happened to be watching at the time.
+
+    Best-effort: any probe that fails records `None`/`"unresolved"` rather
+    than aborting manifest generation, matching this module's other fields.
+    """
+    try:
+        load1, load5, load15 = os.getloadavg()
+    except OSError:  # not available on this platform (e.g. Windows)
+        load1 = load5 = load15 = None
+
+    def _run(cmd: list[str]) -> str | None:
+        try:
+            return subprocess.run(
+                cmd, capture_output=True, text=True, timeout=10, check=False
+            ).stdout
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+    # Filtered in Python, not via a shell `grep -c "[p]ytest"` idiom: a
+    # subprocess.run argv has no shell to bracket-escape a self-match, so the
+    # filter runs here instead, over the same process list that idiom reads.
+    ps_out = _run(["ps", "aux"])
+    pytest_procs = (
+        None
+        if ps_out is None
+        else sum(
+            1 for line in ps_out.splitlines() if "pytest" in line and "grep" not in line
+        )
+    )
+
+    docker_out = _run(["docker", "ps", "-q"])
+    docker_containers = (
+        None
+        if docker_out is None
+        else len([line for line in docker_out.splitlines() if line.strip()])
+    )
+
+    return {
+        "load_average_1m": load1,
+        "load_average_5m": load5,
+        "load_average_15m": load15,
+        "cpu_count": os.cpu_count(),
+        "concurrent_pytest_processes": pytest_procs,
+        "concurrent_docker_containers": docker_containers,
+    }
 
 
 def ver(pkg: str) -> str:
@@ -91,6 +154,9 @@ def build_manifest(
 ) -> dict:
     return {
         "git_sha": git_sha,
+        # Alongside git_sha, not buried: see machine_load_snapshot's
+        # docstring for why (2026-08-10 sweep-contention incident).
+        "machine_load": machine_load_snapshot(),
         "longmemeval_dataset_sha256": ds_sha,
         "pg_image": pg_image,
         # Per-run container isolation fix (2026-07-11, incident: two concurrent

--- a/benchmarks/reproduce.sh
+++ b/benchmarks/reproduce.sh
@@ -395,6 +395,17 @@ main() {
     fi
     mkdir -p "$RESULTS_DIR"
 
+    # Machine-load snapshot at cell START, before start_db so it predates
+    # even the container/DB overhead — the counterpart to write_manifest's
+    # end-of-run snapshot (2026-08-10 sweep-contention incident: a crashed
+    # cell was the only visible symptom of contention that also silently
+    # affected cells which merely finished; see write_manifest.py's
+    # machine_load_snapshot docstring). Uses the base interpreter, not
+    # `--extra benchmarks`, deliberately: this must succeed even if the
+    # benchmarks extra install itself is what's under contention.
+    uv run python "$REPO_ROOT/benchmarks/lib/write_manifest.py" \
+        --snapshot "$RESULTS_DIR"
+
     # Only fetch datasets for benchmarks that will actually run.
     if [ "$RUN_BENCHMARKS" = "1" ] && want_bench longmemeval; then fetch_longmemeval; fi
     if [ "$RUN_ABLATION" = "1" ] && [ "$ABLATE_ON" = "longmemeval-s" ]; then fetch_longmemeval; fi

--- a/mcp_server/core/memory_ingest.py
+++ b/mcp_server/core/memory_ingest.py
@@ -141,6 +141,18 @@ def ingest_memory(
                 "is_protected": auto_protect,
                 "agent_context": agent_ctx,
                 "is_global": is_global,
+                # issue #368 gated-arm fix: pass the caller's capture_origin
+                # through like every other metadata field above (source,
+                # tags, heat, ...) instead of dropping it silently. Without
+                # this, every ingest_memory caller — including the LME/
+                # LoCoMo/BEAM benchmark harnesses — fell through to
+                # insert_memory's "unknown" default regardless of what the
+                # caller set, which is why the trust-factor calibration's
+                # gated arm could not discriminate W (docs/provenance/
+                # trust-factor-calibration.md §"What this measurement does
+                # and does not establish"). Default unchanged: a caller that
+                # omits the field still gets "unknown", identical to before.
+                "capture_origin": memory.get("capture_origin", "unknown"),
             }
         )
         ids.append(mid)

--- a/tests_py/benchmarks/test_bench_db_capture_origin.py
+++ b/tests_py/benchmarks/test_bench_db_capture_origin.py
@@ -1,0 +1,47 @@
+"""benchmarks.lib.bench_db._apply_capture_origin_mix (issue #368 harness fix).
+
+Contract under test: BenchmarkDB.load_memories no longer lets every memory
+fall through to insert_memory's "unknown" default — each memory lacking an
+explicit capture_origin is stamped with one drawn from the measured
+production mixture, and a memory that already sets its own origin (e.g. the
+adversarial corpus) is left alone.
+
+Requires no live PostgreSQL: the assignment logic is a pure list mutation,
+extracted specifically so it is testable without BenchmarkDB.open().
+"""
+
+from __future__ import annotations
+
+from benchmarks.lib.bench_db import _apply_capture_origin_mix
+from mcp_server.core.capture_origin import ALL_ORIGINS
+
+
+class TestApplyCaptureOriginMix:
+    def test_stamps_every_memory_missing_the_field(self):
+        memories = [{"content": f"memory {i}"} for i in range(200)]
+        _apply_capture_origin_mix(memories)
+        assert all("capture_origin" in m for m in memories)
+        assert all(m["capture_origin"] in ALL_ORIGINS for m in memories)
+
+    def test_never_overwrites_an_explicit_origin(self):
+        memories = [
+            {"content": "adversarial", "capture_origin": "network"},
+            {"content": "legit", "capture_origin": "deliberate"},
+            {"content": "unset"},
+        ]
+        _apply_capture_origin_mix(memories)
+        assert memories[0]["capture_origin"] == "network"
+        assert memories[1]["capture_origin"] == "deliberate"
+        assert memories[2]["capture_origin"] in ALL_ORIGINS
+
+    def test_at_scale_produces_a_mixture_not_a_constant(self):
+        memories = [{"content": f"memory {i}"} for i in range(3000)]
+        _apply_capture_origin_mix(memories)
+        origins_seen = {m["capture_origin"] for m in memories}
+        assert len(origins_seen) > 1
+        assert "network" in origins_seen  # the untrusted-at-read minority
+
+    def test_empty_list_is_a_no_op(self):
+        memories: list[dict] = []
+        _apply_capture_origin_mix(memories)
+        assert memories == []

--- a/tests_py/benchmarks/test_bench_db_capture_origin.py
+++ b/tests_py/benchmarks/test_bench_db_capture_origin.py
@@ -7,13 +7,23 @@ production mixture, and a memory that already sets its own origin (e.g. the
 adversarial corpus) is left alone.
 
 Requires no live PostgreSQL: the assignment logic is a pure list mutation,
-extracted specifically so it is testable without BenchmarkDB.open().
+extracted specifically so it is testable without BenchmarkDB.open(). It DOES
+require the `psycopg` driver to be installed, because `benchmarks/lib/
+bench_db.py` hard-imports `PgMemoryStore` at module level (established
+convention — see `tests_py/benchmarks/test_lib_init_no_psycopg.py`); this
+module therefore importorskips exactly like `tests_py/integration/
+test_recall_trust_ranking.py` does, so it skips cleanly on the SQLite-only
+CI lane instead of failing collection.
 """
 
 from __future__ import annotations
 
-from benchmarks.lib.bench_db import _apply_capture_origin_mix
-from mcp_server.core.capture_origin import ALL_ORIGINS
+import pytest
+
+pytest.importorskip("psycopg", reason="psycopg not installed ([postgresql] extra)")
+
+from benchmarks.lib.bench_db import _apply_capture_origin_mix  # noqa: E402
+from mcp_server.core.capture_origin import ALL_ORIGINS  # noqa: E402
 
 
 class TestApplyCaptureOriginMix:

--- a/tests_py/benchmarks/test_capture_origin_mix.py
+++ b/tests_py/benchmarks/test_capture_origin_mix.py
@@ -1,0 +1,71 @@
+"""benchmarks.lib.capture_origin_mix — measured production origin mixture.
+
+Contract under test:
+  - CAPTURE_ORIGIN_MIX sums to 1.0 and only names origins
+    mcp_server.core.capture_origin actually recognises.
+  - assign_capture_origins is deterministic (same n/seed -> same output,
+    every call, matching benchmarks/reproduce.sh's "hit play, get the same
+    numbers" contract) and produces a mixture, not a constant column — the
+    property that makes the trust-factor gated arm able to discriminate W
+    (docs/provenance/trust-factor-calibration.md).
+"""
+
+from __future__ import annotations
+
+from benchmarks.lib.capture_origin_mix import (
+    CAPTURE_ORIGIN_MIX,
+    DEFAULT_SEED,
+    assign_capture_origins,
+)
+from mcp_server.core.capture_origin import ALL_ORIGINS
+
+
+class TestCaptureOriginMix:
+    def test_weights_sum_to_one(self):
+        assert abs(sum(w for _, w in CAPTURE_ORIGIN_MIX) - 1.0) < 1e-9
+
+    def test_every_origin_is_recognised_by_capture_origin_module(self):
+        for origin, _weight in CAPTURE_ORIGIN_MIX:
+            assert origin in ALL_ORIGINS
+
+    def test_mixture_is_not_all_trusted_or_all_untrusted(self):
+        """The whole point: at least one origin in the mix must be untrusted
+        at read time, or the gated arm is back to a uniform multiplier."""
+        from mcp_server.core.capture_origin import is_trusted_at_read
+
+        trust = {origin: is_trusted_at_read(origin) for origin, _ in CAPTURE_ORIGIN_MIX}
+        assert True in trust.values()
+        assert False in trust.values()
+
+
+class TestAssignCaptureOrigins:
+    def test_empty_input(self):
+        assert assign_capture_origins(0) == []
+
+    def test_length_matches_n(self):
+        result = assign_capture_origins(500)
+        assert len(result) == 500
+
+    def test_deterministic_across_calls(self):
+        a = assign_capture_origins(200, seed=DEFAULT_SEED)
+        b = assign_capture_origins(200, seed=DEFAULT_SEED)
+        assert a == b
+
+    def test_different_seed_can_differ(self):
+        a = assign_capture_origins(500, seed=1)
+        b = assign_capture_origins(500, seed=2)
+        assert a != b
+
+    def test_produces_a_realistic_mixture_not_a_single_value(self):
+        """At n=5000, both a dominant (local_action) and a minority
+        (network) origin must actually appear — asserts the harness fix
+        actually mixes origins rather than collapsing to one value."""
+        result = assign_capture_origins(5000)
+        origins_present = set(result)
+        assert "local_action" in origins_present
+        assert "network" in origins_present
+
+    def test_only_yields_declared_origins(self):
+        declared = {o for o, _ in CAPTURE_ORIGIN_MIX}
+        result = assign_capture_origins(1000)
+        assert set(result) <= declared

--- a/tests_py/benchmarks/test_write_manifest_machine_load.py
+++ b/tests_py/benchmarks/test_write_manifest_machine_load.py
@@ -1,0 +1,78 @@
+"""machine_load_snapshot in benchmarks.lib.write_manifest (2026-08-10 fix).
+
+Contract under test: every benchmark MANIFEST.json records the machine's
+load state (load average, concurrent pytest processes, concurrent Docker
+containers) alongside git_sha — not a separate/optional field — so a run
+produced under contention can be identified after the fact instead of
+requiring someone to have been watching `uptime` live. Prompted by an
+incident where a 5-cell trust-factor sweep ran while three other agents'
+full pytest suites were active; one cell crashed visibly, but a cell that
+merely finished under the same contention would have looked like a clean
+result with nothing in the artifact to say otherwise.
+"""
+
+from __future__ import annotations
+
+from benchmarks.lib.write_manifest import build_manifest, machine_load_snapshot
+
+
+class TestMachineLoadSnapshot:
+    def test_returns_all_expected_keys(self):
+        snap = machine_load_snapshot()
+        assert set(snap) == {
+            "load_average_1m",
+            "load_average_5m",
+            "load_average_15m",
+            "cpu_count",
+            "concurrent_pytest_processes",
+            "concurrent_docker_containers",
+        }
+
+    def test_load_averages_are_nonnegative_floats_on_a_posix_machine(self):
+        snap = machine_load_snapshot()
+        for key in ("load_average_1m", "load_average_5m", "load_average_15m"):
+            assert isinstance(snap[key], float)
+            assert snap[key] >= 0.0
+
+    def test_cpu_count_is_a_positive_int(self):
+        snap = machine_load_snapshot()
+        assert isinstance(snap["cpu_count"], int)
+        assert snap["cpu_count"] > 0
+
+    def test_pytest_process_count_sees_the_process_running_this_test(self):
+        """The suite executing this assertion IS a pytest process, so the
+        count must be >= 1 — a fixed proof the probe is not silently
+        returning zero/None while pytest is demonstrably running."""
+        snap = machine_load_snapshot()
+        assert snap["concurrent_pytest_processes"] is not None
+        assert snap["concurrent_pytest_processes"] >= 1
+
+    def test_docker_container_count_is_an_int_or_none(self):
+        """None only when the docker CLI itself is unavailable/unreachable —
+        never raises, matching every other probe in this module."""
+        snap = machine_load_snapshot()
+        count = snap["concurrent_docker_containers"]
+        assert count is None or (isinstance(count, int) and count >= 0)
+
+
+class TestBuildManifestIncludesMachineLoad:
+    def test_machine_load_sits_alongside_git_sha(self, tmp_path):
+        manifest = build_manifest(
+            str(tmp_path),
+            "deadbeef",
+            "dataset-sha",
+            "pgvector/pgvector:pg16",
+            "test-container",
+            "5432",
+            "1",
+        )
+        assert "git_sha" in manifest
+        assert "machine_load" in manifest
+        assert set(manifest["machine_load"]) == {
+            "load_average_1m",
+            "load_average_5m",
+            "load_average_15m",
+            "cpu_count",
+            "concurrent_pytest_processes",
+            "concurrent_docker_containers",
+        }

--- a/tests_py/benchmarks/test_write_manifest_machine_load.py
+++ b/tests_py/benchmarks/test_write_manifest_machine_load.py
@@ -9,24 +9,37 @@ incident where a 5-cell trust-factor sweep ran while three other agents'
 full pytest suites were active; one cell crashed visibly, but a cell that
 merely finished under the same contention would have looked like a clean
 result with nothing in the artifact to say otherwise.
+
+Follow-up (same day): the snapshot is taken TWICE per cell — at cell start
+(`write_start_snapshot`, written before `start_db`) and at cell end (inside
+`build_manifest`) — because a single end-of-run reading cannot tell "ran
+under load the whole time" apart from "load spiked right at the end".
 """
 
 from __future__ import annotations
 
-from benchmarks.lib.write_manifest import build_manifest, machine_load_snapshot
+import json
+
+from benchmarks.lib.write_manifest import (
+    build_manifest,
+    machine_load_snapshot,
+    write_start_snapshot,
+)
+
+_LOAD_KEYS = {
+    "load_average_1m",
+    "load_average_5m",
+    "load_average_15m",
+    "cpu_count",
+    "concurrent_pytest_processes",
+    "concurrent_docker_containers",
+}
 
 
 class TestMachineLoadSnapshot:
     def test_returns_all_expected_keys(self):
         snap = machine_load_snapshot()
-        assert set(snap) == {
-            "load_average_1m",
-            "load_average_5m",
-            "load_average_15m",
-            "cpu_count",
-            "concurrent_pytest_processes",
-            "concurrent_docker_containers",
-        }
+        assert set(snap) == _LOAD_KEYS
 
     def test_load_averages_are_nonnegative_floats_on_a_posix_machine(self):
         snap = machine_load_snapshot()
@@ -56,7 +69,7 @@ class TestMachineLoadSnapshot:
 
 
 class TestBuildManifestIncludesMachineLoad:
-    def test_machine_load_sits_alongside_git_sha(self, tmp_path):
+    def test_machine_load_at_end_sits_alongside_git_sha(self, tmp_path):
         manifest = build_manifest(
             str(tmp_path),
             "deadbeef",
@@ -67,12 +80,55 @@ class TestBuildManifestIncludesMachineLoad:
             "1",
         )
         assert "git_sha" in manifest
-        assert "machine_load" in manifest
-        assert set(manifest["machine_load"]) == {
-            "load_average_1m",
-            "load_average_5m",
-            "load_average_15m",
-            "cpu_count",
-            "concurrent_pytest_processes",
-            "concurrent_docker_containers",
-        }
+        assert "machine_load_at_end" in manifest
+        assert set(manifest["machine_load_at_end"]) == _LOAD_KEYS
+
+    def test_machine_load_at_start_is_none_when_no_snapshot_was_taken(self, tmp_path):
+        manifest = build_manifest(
+            str(tmp_path),
+            "deadbeef",
+            "dataset-sha",
+            "pgvector/pgvector:pg16",
+            "test-container",
+            "5432",
+            "1",
+        )
+        assert manifest["machine_load_at_start"] is None
+
+    def test_machine_load_at_start_is_populated_when_a_snapshot_was_taken(
+        self, tmp_path
+    ):
+        write_start_snapshot(str(tmp_path))
+        manifest = build_manifest(
+            str(tmp_path),
+            "deadbeef",
+            "dataset-sha",
+            "pgvector/pgvector:pg16",
+            "test-container",
+            "5432",
+            "1",
+        )
+        assert manifest["machine_load_at_start"] is not None
+        assert set(manifest["machine_load_at_start"]) == _LOAD_KEYS
+
+    def test_start_snapshot_file_is_excluded_from_results_files(self, tmp_path):
+        write_start_snapshot(str(tmp_path))
+        manifest = build_manifest(
+            str(tmp_path),
+            "deadbeef",
+            "dataset-sha",
+            "pgvector/pgvector:pg16",
+            "test-container",
+            "5432",
+            "1",
+        )
+        assert "START_SNAPSHOT.json" not in manifest["results_files"]
+
+
+class TestWriteStartSnapshot:
+    def test_writes_a_readable_json_file_with_a_timestamp_and_load(self, tmp_path):
+        out = write_start_snapshot(str(tmp_path))
+        assert out.exists()
+        payload = json.loads(out.read_text())
+        assert "captured_at_utc" in payload
+        assert set(payload["machine_load"]) == _LOAD_KEYS

--- a/tests_py/core/test_memory_ingest_capture_origin.py
+++ b/tests_py/core/test_memory_ingest_capture_origin.py
@@ -1,0 +1,84 @@
+"""capture_origin passthrough in mcp_server.core.memory_ingest (issue #368 fix).
+
+Contract under test: ingest_memory forwards the caller-supplied
+`capture_origin` field to `store.insert_memory` exactly like every other
+metadata field (source, tags, heat, ...) instead of dropping it — the gap
+that made the trust-factor gated arm (docs/provenance/
+trust-factor-calibration.md) unable to discriminate W, because every
+LME/LoCoMo/BEAM row silently fell through to insert_memory's "unknown"
+default regardless of what the harness intended.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.core.memory_ingest import ingest_memory
+from mcp_server.infrastructure.sqlite_store import SqliteMemoryStore
+
+
+@pytest.fixture
+def store():
+    s = SqliteMemoryStore()
+    yield s
+    s.close()
+
+
+class _NullEmbeddings:
+    """No-op embeddings engine — this suite asserts metadata passthrough,
+    not ranking, so a real embedding model is unnecessary weight."""
+
+    def encode(self, _text: str):
+        return None
+
+
+def _fetch_capture_origin(store: SqliteMemoryStore, memory_id: int) -> str:
+    row = store._conn.execute(
+        "SELECT capture_origin FROM memories WHERE id = ?", (memory_id,)
+    ).fetchone()
+    return row["capture_origin"]
+
+
+class TestCaptureOriginPassthrough:
+    def test_explicit_origin_is_forwarded(self, store):
+        ids = ingest_memory(
+            {"content": "hello world", "capture_origin": "network"},
+            store,
+            _NullEmbeddings(),
+            domain="test",
+            decompose=False,
+        )
+        assert len(ids) == 1
+        assert _fetch_capture_origin(store, ids[0]) == "network"
+
+    def test_omitted_origin_defaults_to_unknown(self, store):
+        """Unchanged production behaviour: a caller that says nothing about
+        origin still gets 'unknown' — the fix only stops DROPPING a value
+        the caller DID provide."""
+        ids = ingest_memory(
+            {"content": "hello world, no origin set"},
+            store,
+            _NullEmbeddings(),
+            domain="test",
+            decompose=False,
+        )
+        assert len(ids) == 1
+        assert _fetch_capture_origin(store, ids[0]) == "unknown"
+
+    def test_all_chunks_of_a_decomposed_memory_share_the_parent_origin(self, store):
+        """decompose=True splits one memory into several insert_memory rows
+        (memory_decomposer.py); every chunk came through the same channel as
+        its parent, so every chunk must carry the same capture_origin."""
+        long_content = "\n".join(
+            f"## Section {i}\ncontent for section {i} " * 10 for i in range(5)
+        )
+        ids = ingest_memory(
+            {"content": long_content, "capture_origin": "deliberate"},
+            store,
+            _NullEmbeddings(),
+            domain="test",
+            decompose=True,
+        )
+        assert len(ids) >= 1
+        origins = {_fetch_capture_origin(store, mid) for mid in ids}
+        assert origins == {"deliberate"}


### PR DESCRIPTION
## Summary

`mcp_server/core/memory_ingest.py::ingest_memory` accepted a caller-supplied
`capture_origin` field but never forwarded it to `store.insert_memory`,
unlike every other metadata field (`source`, `tags`, `heat`, ...). Every
`ingest_memory` caller therefore silently fell through to `insert_memory`'s
`"unknown"` default regardless of what it intended. **This is a production
code defect, not a harness gap** — a field accepted then silently dropped.

This is why `docs/provenance/trust-factor-calibration.md`'s gated arm could
not discriminate the trust-factor weight W: LME/LoCoMo/BEAM all landed on
`capture_origin='unknown'`, which `core.capture_origin.trust_factor` demotes
*uniformly*, and a uniform multiplier cannot change WRRF order — hence LME
identical to four decimals across W in {1.0, 0.7, 0.6, 0.5} in that document's
existing results table.

## What's fixed

- `memory_ingest.py` — `capture_origin` now passes through like every other
  field. Default unchanged (`"unknown"` for callers that omit it) — no
  behavior change for any existing caller that doesn't set it.
- `benchmarks/lib/capture_origin_mix.py` (new) — the realistic production
  mixture of `capture_origin` values (`local_action` .966 / `network` .025 /
  `deliberate` .009), sourced from a measurement over this machine's own 886
  Claude Code session transcripts (`~/.claude/projects/**/*.jsonl`) — the
  only representative "existing store" available (the local `memory.db`
  predates the `capture_origin` column, no live production DB touched).
  Deterministic sampler, documented derivation and limitation in the module
  docstring.
- `benchmarks/lib/bench_db.py` — wires the mixture into `load_memories()` via
  `_apply_capture_origin_mix()`, so LME/LoCoMo/BEAM now insert a realistic
  blend of trusted/untrusted origins instead of an all-`unknown` corpus. Never
  overwrites an explicit origin already set by a caller (e.g. the adversarial
  corpus).

## What's NOT fixed yet (next, separately)

The production value **W = 0.7 still rests on the invalidated gated arm**
documented in `docs/provenance/trust-factor-calibration.md` — that document
is unchanged by this PR. Re-running the 5-cell W sweep
(`benchmarks/trust_factor_sweep.sh`) under the now-mixed origins is the
direct continuation of this same contract, not a separate task, but it costs
~7h across 5 sequential Docker-isolated `reproduce.sh` cells and that cost is
being reported to the repo owner for a go/no-go before running it — plus a
check for whether the adversarial arm (`benchmarks/lib/trust_factor_sweep.py`,
seconds on in-memory SQLite) is now sufficient on its own, since the origins
it discriminates against are the same ones the gated arm was blind to before
this fix.

## Test plan

- [x] `uv run --no-sync pytest -q -p no:randomly` — 7291 passed, 142 skipped,
      0 failed
- [x] 16 new tests: `tests_py/core/test_memory_ingest_capture_origin.py`,
      `tests_py/benchmarks/test_capture_origin_mix.py`,
      `tests_py/benchmarks/test_bench_db_capture_origin.py`
- [x] `ruff check` / `ruff format --check` clean on touched files
- [ ] CI green (watching)

Co-Authored-By: Claude <noreply@anthropic.com>