### PR TITLE
chore(marketplace): bump hypermnesia-mcp-viz pin to 3.1.0 (cortex-viz#130)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,10 +62,10 @@
       "source": {
         "source": "github",
         "repo": "cdeust/cortex-viz",
-        "sha": "1c1940e278979f35cdecea6146d7fb5f749907e9"
+        "sha": "064e6d1f77bc36e47fd15fbf07969233bda4c32c"
       },
       "description": "Canonical Claude Code publication for the standalone Hypermnesia MCP Viz server — a live neural-graph galaxy of every project, file, symbol, memory, discussion and wiki page, plus a per-session execution trace, a consolidation kanban, and a curated knowledge/wiki browser. Read-only bridge over Cortex's shared PostgreSQL store and the ~/.claude artifacts; it renders, it never remembers. Restores the open_visualization and get_methodology_graph tools removed from Cortex; launch with /cortex-visualize.",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
       "source": {
         "source": "github",
         "repo": "cdeust/cortex-viz",
-        "sha": "064e6d1f77bc36e47fd15fbf07969233bda4c32c"
+        "sha": "c3576cf60e302cc88dc3ea33949d543d3f778d78"
       },
       "description": "Canonical Claude Code publication for the standalone Hypermnesia MCP Viz server — a live neural-graph galaxy of every project, file, symbol, memory, discussion and wiki page, plus a per-session execution trace, a consolidation kanban, and a curated knowledge/wiki browser. Read-only bridge over Cortex's shared PostgreSQL store and the ~/.claude artifacts; it renders, it never remembers. Restores the open_visualization and get_methodology_graph tools removed from Cortex; launch with /cortex-visualize.",
       "version": "3.1.0",


### PR DESCRIPTION
## Summary

- `cdeust/cortex-viz` has cut a 3.1.0 release: cdeust/cortex-viz#130, CI green. Four `feat` commits (trace streaming #111, wiki graph endpoint #120, static export #122, per-domain static export #123) landed after the 3.0.0 breaking-rename release with no further breaking change — SemVer minor, not a re-use of `3.0.0`.
- Bumps this repo's `hypermnesia-mcp-viz` marketplace entry `version` to `3.1.0` and its `source.sha` pin.
- This is exactly the step the workflow header on `cortex-viz`'s `Release.yaml` (and `docs/RELEASING.md` step 6) calls out as historically skipped: **six zetetic-team-subagents releases and two visualization releases reached zero installs because the marketplace pin was never bumped** (Cortex #179). A green tag build on `cortex-viz` alone does not ship this plugin to anyone — this pin is the last mile.

## Blocked / provisional — do not merge yet

I do not own this repository this session and am not merging here. Also:

- `cdeust/cortex-viz#130` is **not yet merged** (its own repo etiquette requires the owner's go-ahead, not self-merge). The `sha` in this diff is the **current tip of `cortex-viz@chore/release-3.1.0`** (`064e6d1f77bc36e47fd15fbf07969233bda4c32c`), not a tagged release commit — no `v3.1.0` tag exists yet on `cortex-viz`.
- Once `cortex-viz#130` merges (prior PRs on that repo were squash-merged, so the sha reaching `main` will likely differ from the one in this diff), the merge commit should be tagged `v3.1.0` and the tag pushed to trigger the PyPI/GitHub-release workflow. **This PR's `sha` must be re-pointed to that tag commit before merging** — do not merge this PR with the current provisional sha.

## Test plan
- [x] `.claude-plugin/marketplace.json` still valid JSON
- [ ] `sha` re-pointed to the actual `v3.1.0` tag commit once `cortex-viz#130` merges and is tagged
- [ ] This repo's own CI (if any gate exists on marketplace.json) green

Generated with Claude Code