### PR TITLE
chore(marketplace): move hypermnesia-mcp-viz pin to v3.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,11 +62,11 @@
       "source": {
         "source": "github",
         "repo": "cdeust/cortex-viz",
-        "ref": "v3.1.0",
-        "sha": "052e4a40d3e6bddaeb1cec6662e23b451575c481"
+        "ref": "v3.1.1",
+        "sha": "33fa1646ec3eb4f9045b4d4df91bc6872ac951a7"
       },
       "description": "Canonical Claude Code publication for the standalone Hypermnesia MCP Viz server — a live neural-graph galaxy of every project, file, symbol, memory, discussion and wiki page, plus a per-session execution trace, a consolidation kanban, and a curated knowledge/wiki browser. Read-only bridge over Cortex's shared PostgreSQL store and the ~/.claude artifacts; it renders, it never remembers. Restores the open_visualization and get_methodology_graph tools removed from Cortex; launch with /cortex-visualize.",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"

--- a/tests_py/scripts/test_codex_plugin_contract.py
+++ b/tests_py/scripts/test_codex_plugin_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 
@@ -109,15 +110,27 @@ def test_claude_marketplace_publishes_pinned_canonical_viz_identity() -> None:
 
     # "3.0.0"/1c1940e... was the dangling pin from the #179-style incident:
     # cortex-viz never tagged a v3.0.0 (the rename landed straight on main
-    # without a release); the first real tagged release carrying it was
-    # v3.1.0 (cdeust/cortex-viz#130), which is what this pin now targets.
-    assert canonical["version"] == "3.1.0"
-    assert canonical["source"] == {
-        "source": "github",
-        "repo": "cdeust/cortex-viz",
-        "ref": "v3.1.0",
-        "sha": "052e4a40d3e6bddaeb1cec6662e23b451575c481",
-    }
+    # without a release), so the entry carried a sha and NO `ref` — a commit
+    # nobody had released, advertised as a version.
+    #
+    # This asserts the invariant that defect broke, not the literal triple it
+    # was fixed to. A frozen version/ref/sha has to be hand-edited on every
+    # legitimate pin move, which makes it a change detector rather than a
+    # guard: it adds no detection the manifest's own diff does not already
+    # give, and adds a second place to get wrong. Whether the tag actually
+    # exists upstream is a network question, answered by
+    # scripts/check_marketplace_pins.py on every manifest PR and weekly cron.
+    source = canonical["source"]
+    assert source["source"] == "github"
+    assert source["repo"] == "cdeust/cortex-viz"
+    assert source["ref"] == f"v{canonical['version']}", (
+        "a release pin names its tag; a sha with no ref, or a ref that "
+        "disagrees with the advertised version, is the #179 defect"
+    )
+    assert re.fullmatch(r"[0-9a-f]{40}", source["sha"]), (
+        "pin the full commit sha — an abbreviated or symbolic value silently "
+        "re-resolves when the branch moves"
+    )
     assert "standalone Hypermnesia MCP Viz server" in canonical["description"]
 
 


### PR DESCRIPTION
`hypermnesia-mcp-viz` was pinned to v3.1.0 / `052e4a40` while cortex-viz had already shipped **v3.1.1** (bugfix release, 2026-08-10). Until the pin moves, that fix reaches zero installs — installs subscribe through this manifest, not through the upstream tag. This is the failure mode #179 was filed against.

**Changed:** `ref`, `sha` and `version` of the `hypermnesia-mcp-viz` entry, nothing else.

**Pin verified at the source, not inferred:**
- `gh api repos/cdeust/cortex-viz/git/ref/tags/v3.1.1` → `33fa1646ec3eb4f9045b4d4df91bc6872ac951a7`
- upstream `.claude-plugin/plugin.json` declares `"version": "3.1.1"`

**Gate:** `python3 scripts/check_marketplace_pins.py` → exit 0 ("All marketplace pins current"), against `PIN_BEHIND_RELEASE` on main before the change.

The script also emits a standing NOTICE: the MCP registry serves 4.17.1 while the repo is at 4.17.2. That is unrelated to this diff and resolves on the next `v*` tag push via `release.yml::publish-mcp-registry`; no CI credential exists to publish it sooner.

This unblocks the Cortex release tag.