### PR TITLE
feat(remediation): wire change_impact output into the remediation loop

### DIFF
--- a/mcp_server/core/change_remediation.py
+++ b/mcp_server/core/change_remediation.py
@@ -24,11 +24,41 @@ scope code-derived rows, reused here — not a new classification signal.
 from __future__ import annotations
 
 from enum import Enum
+from typing import Protocol
 
 
 class Remediation(str, Enum):
     REINGEST = "reingest"
     FLAG_STALE = "flag_stale"
+
+
+class _ImpactMatch(Protocol):
+    """The subset of ``core.change_impact_matcher.ImpactMatch`` this needs.
+
+    Duck-typed (not imported) so this policy module stays a leaf.
+    """
+
+    memory_id: int
+    matched_files: list[str]
+
+
+def build_impacted(
+    matches: list[_ImpactMatch], memory_by_id: dict[int, dict]
+) -> list[dict]:
+    """Glue ``change_impact`` output onto ``remediate_impacted`` input.
+
+    ``change_impact`` yields one ``ImpactMatch`` per impacted memory, whose
+    ``matched_files`` is exactly the subset of that memory's file references the
+    commit changed. Attach it to the memory dict as ``changed_refs`` — the shape
+    ``handlers/consolidation/change_remediation_pass.remediate_impacted``
+    consumes. Matches with no known memory are dropped.
+    """
+    impacted: list[dict] = []
+    for m in matches:
+        mem = memory_by_id.get(m.memory_id)
+        if mem is not None:
+            impacted.append({**mem, "changed_refs": list(m.matched_files)})
+    return impacted
 
 
 def is_code_derived(memory: dict) -> bool:

--- a/mcp_server/handlers/consolidation/change_remediation_pass.py
+++ b/mcp_server/handlers/consolidation/change_remediation_pass.py
@@ -21,7 +21,11 @@ from __future__ import annotations
 import logging
 from typing import Callable, Protocol
 
-from mcp_server.core.change_remediation import Remediation, classify_remediation
+from mcp_server.core.change_remediation import (
+    Remediation,
+    build_impacted,
+    classify_remediation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -56,3 +60,20 @@ def remediate_impacted(
     counts["reingest_paths"] = len(reingest_paths)
     logger.info("change remediation: %s", counts)
     return counts
+
+
+def remediate_from_impact(
+    matches: list,
+    memory_by_id: dict[int, dict],
+    store: _RemediationStore,
+    reingest_fn: ReingestFn,
+) -> dict[str, int]:
+    """Drive remediation straight from ``change_impact``'s match output.
+
+    ``matches`` is the ``ImpactMatch`` list from ``handlers/change_impact.py``
+    (each carrying ``memory_id`` + the changed ``matched_files``); ``memory_by_id``
+    resolves those ids to memory dicts. This is the one composition the caller
+    needs — supply the real ``reingest_fn`` (an incremental ``codebase_analyze``
+    over the changed paths), validated against AP + a real codebase.
+    """
+    return remediate_impacted(build_impacted(matches, memory_by_id), store, reingest_fn)

--- a/tests_py/core/test_change_remediation.py
+++ b/tests_py/core/test_change_remediation.py
@@ -2,11 +2,35 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from mcp_server.core.change_remediation import (
     Remediation,
+    build_impacted,
     classify_remediation,
     is_code_derived,
 )
+
+
+@dataclass
+class _Match:
+    memory_id: int
+    matched_files: list[str]
+
+
+def test_build_impacted_attaches_changed_refs() -> None:
+    matches = [_Match(1, ["src/a.py", "src/b.py"]), _Match(2, ["src/c.py"])]
+    memory_by_id = {1: {"id": 1, "content": "x"}, 2: {"id": 2, "content": "y"}}
+    impacted = build_impacted(matches, memory_by_id)
+    assert impacted[0]["changed_refs"] == ["src/a.py", "src/b.py"]
+    assert impacted[0]["content"] == "x"  # memory fields preserved
+    assert impacted[1]["changed_refs"] == ["src/c.py"]
+
+
+def test_build_impacted_drops_unknown_memory() -> None:
+    matches = [_Match(1, ["src/a.py"]), _Match(99, ["src/z.py"])]
+    impacted = build_impacted(matches, {1: {"id": 1}})
+    assert [m["id"] for m in impacted] == [1]  # id 99 has no memory → dropped
 
 
 def test_code_derived_by_agent_context() -> None:

--- a/tests_py/handlers/consolidation/test_change_remediation_pass.py
+++ b/tests_py/handlers/consolidation/test_change_remediation_pass.py
@@ -7,9 +7,20 @@ hand-authored→flag-stale split, path dedup, and the no-op case.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from mcp_server.handlers.consolidation.change_remediation_pass import (
+    remediate_from_impact,
     remediate_impacted,
 )
+
+
+@dataclass
+class _Match:
+    """Stand-in for change_impact_matcher.ImpactMatch (duck-typed)."""
+
+    memory_id: int
+    matched_files: list[str]
 
 
 class _FakeStore:
@@ -71,3 +82,21 @@ def test_empty_impacted_is_noop() -> None:
     assert counts == {"reingest_memories": 0, "flagged_stale": 0, "reingest_paths": 0}
     assert calls == []
     assert store.marked == []
+
+
+def test_remediate_from_impact_glues_change_impact_output() -> None:
+    # ImpactMatches straight from change_impact: id 1 code-derived → reingest its
+    # changed file; id 2 hand-authored → flag; id 9 has no memory row → dropped.
+    matches = [_Match(1, ["src/a.py"]), _Match(2, ["src/a.py"]), _Match(9, ["x.py"])]
+    memory_by_id = {
+        1: {"id": 1, "agent_context": "codebase"},
+        2: {"id": 2, "agent_context": "", "tags": ["lesson"]},
+    }
+    store = _FakeStore()
+    calls, reingest = _recorder()
+
+    counts = remediate_from_impact(matches, memory_by_id, store, reingest)
+
+    assert counts == {"reingest_memories": 1, "flagged_stale": 1, "reingest_paths": 1}
+    assert calls == [["src/a.py"]]  # only the code-derived memory's changed ref
+    assert store.marked == [(2, True)]  # only the hand-authored memory flagged


### PR DESCRIPTION
## Summary

Stacked on #444. That PR shipped the remediation **policy + orchestrator** but deliberately left the composition (diff → impacted memories → remediate) to the caller, noting it "needs AP." It turns out the AP is **`ai-architect-mcp-codebase`**, which Cortex already reaches through `ap_bridge` (`detect_changes` / `get_impact` / `ingest_codebase`), and `change_impact.py` already turns a commit diff into `ImpactMatch` rows whose `matched_files` **are** the subset of each memory's refs that changed. So the only missing piece was pure glue — now added and unit-tested:

- **`core/change_remediation.py`** — `build_impacted(matches, memory_by_id)` attaches each `ImpactMatch.matched_files` to its memory dict as `changed_refs`, the exact shape `remediate_impacted` consumes. Duck-typed on the match (`memory_id` + `matched_files`) so the policy module stays a leaf.
- **`change_remediation_pass.py`** — `remediate_from_impact(matches, memory_by_id, store, reingest_fn)` = `build_impacted` → `remediate_impacted`. The one call a caller needs.

So the full loop is now expressible end to end: `change_impact` (diff → matches) → `remediate_from_impact` → code-derived memories re-ingested (supersede), hand-authored ones flagged.

## Honest boundary

This closes the **logic** gap and it's fully unit-tested. What it does **not** do is run itself: the caller still supplies the real `reingest_fn` (an incremental `codebase_analyze` over the changed paths) and invokes it from the commit path, and that end-to-end behavior is only truly validated against a live AP + a real codebase — same boundary #444 drew. I'm not claiming CI proves the live re-ingest; CI proves the composition logic.

## Type of change

- [x] New feature (non-breaking; pure glue + a convenience composition)
- [x] Audit-finding closure (partial — cdeust/fleet-watch#110, diff→remediate composition)

## Test plan

All 10 change-remediation tests pass locally (ran directly); full suite in CI.
- `test_change_remediation.py`: `build_impacted` attaches `changed_refs` and preserves memory fields; drops matches with no known memory.
- `test_change_remediation_pass.py`: `remediate_from_impact` splits code-derived→reingest vs hand-authored→flag straight from raw `ImpactMatch` input.
- `ruff` + craftsmanship gate clean; **no numeric constants introduced** (the `# source:` lesson from #443 stays applied).

- [ ] All existing tests pass — deferred to CI.
- [x] New tests for new behavior.
- [x] Mutation check: not attaching `matched_files`, not dropping unknown-id matches, or bypassing `remediate_impacted`'s split are all caught.

## Coding-standards compliance

- [x] §2.2 Layer direction: `build_impacted` is pure `core/` (leaf; duck-typed, no matcher import); composition stays in the handler layer.
- [x] §4.1 / §4.2 sizes within limits · §4.4 ≤4 params · §8 no numeric constants.

## Breaking changes

None. New pure function + one convenience wrapper; nothing invoked automatically.

## Reviewer checklist

- [ ] CHANGELOG.md — not touched; reviewer preference.
- [x] No secrets / PII in the diff.
- [ ] CI passes on the latest commit — pending.

---
_Generated by [Claude Code](https://claude.ai/code/session_017fnomaXS71hgxMw2zr7HGR)_