### PR TITLE
fix(errors): stop masking query-level errors as 'database_not_connected'

### DIFF
--- a/.craftsmanship-baseline.json
+++ b/.craftsmanship-baseline.json
@@ -5520,11 +5520,6 @@
     {
       "file": "mcp_server/tool_error_handler.py",
       "kind": "method-size",
-      "detail": "_classify_error"
-    },
-    {
-      "file": "mcp_server/tool_error_handler.py",
-      "kind": "method-size",
       "detail": "safe_handler"
     },
     {

--- a/mcp_server/tool_error_handler.py
+++ b/mcp_server/tool_error_handler.py
@@ -106,18 +106,35 @@ def _classify_error(exc: Exception) -> tuple[str, str]:
     ):
         return "missing_extension", _EXTENSION_GUIDE
 
+    # Connection/auth failures ONLY — each phrase below is unambiguous about a
+    # server that is unreachable, still starting, or refusing credentials.
+    #
+    # Deliberately NOT here (issue: SQLite query errors masked as
+    # "PostgreSQL not connected"): the exception CLASS name "operationalerror",
+    # a bare "does not exist", a bare "role", and a bare "timeout". Those match
+    # ordinary query-level failures — a FTS5 "syntax error", "no such table",
+    # a column that "does not exist", a statement/lock "timeout" — none of
+    # which are connection problems. On the SQLite backend they are never
+    # connection problems, yet the base class ``sqlite3.OperationalError`` set
+    # ``type(exc).__name__.lower() == "operationalerror"`` and every one of
+    # them got the PostgreSQL ``brew install`` guide, burying the real error
+    # (a FTS5 syntax error in get_causal_chain surfaced exactly this way).
+    # An error that is genuinely a create-db/create-role setup step is still
+    # fully actionable from its own honest ``OperationalError: ... FATAL:
+    # database "cortex" does not exist`` text, which the fall-through returns.
     if any(
         kw in exc_lower
         for kw in [
             "connection refused",
             "could not connect",
+            "could not translate host name",
             "no such host",
             "connection reset",
-            "does not exist",
-            "operationalerror",
-            "role",
-            "password authentication",
-            "timeout",
+            "server closed the connection",
+            "the database system is starting up",
+            "password authentication failed",
+            "connection timed out",
+            "timeout expired",  # psycopg connect-timeout wording
         ]
     ):
         return "database_not_connected", _DB_SETUP_GUIDE

--- a/mcp_server/tool_error_handler.py
+++ b/mcp_server/tool_error_handler.py
@@ -80,6 +80,41 @@ _EXTENSION_GUIDE = (
     "Then restart Claude Code."
 )
 
+_MISSING_EXTENSION_PHRASES = [
+    'type "vector" does not exist',
+    "extension",
+    "pg_trgm",
+]
+
+# Connection/auth failures ONLY — each phrase below is unambiguous about a
+# server that is unreachable, still starting, or refusing credentials.
+#
+# Deliberately NOT here (issue: SQLite query errors masked as
+# "PostgreSQL not connected"): the exception CLASS name "operationalerror",
+# a bare "does not exist", a bare "role", and a bare "timeout". Those match
+# ordinary query-level failures — a FTS5 "syntax error", "no such table",
+# a column that "does not exist", a statement/lock "timeout" — none of
+# which are connection problems. On the SQLite backend they are never
+# connection problems, yet the base class ``sqlite3.OperationalError`` set
+# ``type(exc).__name__.lower() == "operationalerror"`` and every one of
+# them got the PostgreSQL ``brew install`` guide, burying the real error
+# (a FTS5 syntax error in get_causal_chain surfaced exactly this way).
+# An error that is genuinely a create-db/create-role setup step is still
+# fully actionable from its own honest ``OperationalError: ... FATAL:
+# database "cortex" does not exist`` text, which the fall-through returns.
+_CONNECTION_FAILURE_PHRASES = [
+    "connection refused",
+    "could not connect",
+    "could not translate host name",
+    "no such host",
+    "connection reset",
+    "server closed the connection",
+    "the database system is starting up",
+    "password authentication failed",
+    "connection timed out",
+    "timeout expired",  # psycopg connect-timeout wording
+]
+
 
 def _classify_error(exc: Exception) -> tuple[str, str]:
     """Classify an exception into a user-friendly category and message."""
@@ -96,47 +131,10 @@ def _classify_error(exc: Exception) -> tuple[str, str]:
     if "explicit database_url unreachable" in exc_lower:
         return "explicit_database_url_unreachable", str(exc)
 
-    if any(
-        kw in exc_lower
-        for kw in [
-            'type "vector" does not exist',
-            "extension",
-            "pg_trgm",
-        ]
-    ):
+    if any(kw in exc_lower for kw in _MISSING_EXTENSION_PHRASES):
         return "missing_extension", _EXTENSION_GUIDE
 
-    # Connection/auth failures ONLY — each phrase below is unambiguous about a
-    # server that is unreachable, still starting, or refusing credentials.
-    #
-    # Deliberately NOT here (issue: SQLite query errors masked as
-    # "PostgreSQL not connected"): the exception CLASS name "operationalerror",
-    # a bare "does not exist", a bare "role", and a bare "timeout". Those match
-    # ordinary query-level failures — a FTS5 "syntax error", "no such table",
-    # a column that "does not exist", a statement/lock "timeout" — none of
-    # which are connection problems. On the SQLite backend they are never
-    # connection problems, yet the base class ``sqlite3.OperationalError`` set
-    # ``type(exc).__name__.lower() == "operationalerror"`` and every one of
-    # them got the PostgreSQL ``brew install`` guide, burying the real error
-    # (a FTS5 syntax error in get_causal_chain surfaced exactly this way).
-    # An error that is genuinely a create-db/create-role setup step is still
-    # fully actionable from its own honest ``OperationalError: ... FATAL:
-    # database "cortex" does not exist`` text, which the fall-through returns.
-    if any(
-        kw in exc_lower
-        for kw in [
-            "connection refused",
-            "could not connect",
-            "could not translate host name",
-            "no such host",
-            "connection reset",
-            "server closed the connection",
-            "the database system is starting up",
-            "password authentication failed",
-            "connection timed out",
-            "timeout expired",  # psycopg connect-timeout wording
-        ]
-    ):
+    if any(kw in exc_lower for kw in _CONNECTION_FAILURE_PHRASES):
         return "database_not_connected", _DB_SETUP_GUIDE
 
     return type(exc).__name__, str(exc)

--- a/tests_py/server/test_tool_error_handler_classification.py
+++ b/tests_py/server/test_tool_error_handler_classification.py
@@ -69,6 +69,66 @@ class TestGenericClassification:
         assert message == "some unrelated application error"
 
 
+class TestQueryErrorsAreNotMaskedAsDbNotConnected:
+    """Regression: SQLite query-level OperationalErrors were classified as
+    'database_not_connected' (PostgreSQL setup guide) because the exception
+    CLASS name is 'OperationalError' and the old keyword list matched
+    'operationalerror'. A FTS5 syntax error in get_causal_chain surfaced this
+    way — the real error was buried under a 'brew install postgresql' guide,
+    doubly wrong on the SQLite backend. Query errors must fall through to
+    their honest '<Type>: <message>'."""
+
+    def test_fts5_syntax_error_not_masked(self):
+        import sqlite3
+
+        exc = sqlite3.OperationalError('fts5: syntax error near ""__main__""')
+        error_type, message = _classify_error(exc)
+        assert error_type == "OperationalError"
+        assert "fts5: syntax error" in message
+
+    def test_no_such_table_not_masked(self):
+        import sqlite3
+
+        exc = sqlite3.OperationalError("no such table: memories")
+        error_type, message = _classify_error(exc)
+        assert error_type == "OperationalError"
+        assert "no such table" in message
+
+    def test_column_does_not_exist_not_masked(self):
+        # bare "does not exist" used to route a query bug to the DB guide.
+        exc = Exception('column "heat" does not exist')
+        error_type, _ = _classify_error(exc)
+        assert error_type == "Exception"
+
+    def test_word_containing_role_not_masked(self):
+        # bare "role" matched substrings like "control"/"payroll" — gone.
+        exc = ValueError("invalid role assignment in access control policy")
+        error_type, _ = _classify_error(exc)
+        assert error_type == "ValueError"
+
+    def test_statement_timeout_not_masked(self):
+        # a lock/statement timeout is not a connection failure.
+        import sqlite3
+
+        exc = sqlite3.OperationalError("database is locked")
+        error_type, _ = _classify_error(exc)
+        assert error_type == "OperationalError"
+
+    def test_genuine_connection_failures_still_classified(self):
+        for msg in [
+            "connection refused",
+            "could not connect to server",
+            "could not translate host name",
+            "server closed the connection unexpectedly",
+            "the database system is starting up",
+            "password authentication failed for user",
+            "connection timed out",
+        ]:
+            error_type, message = _classify_error(RuntimeError(msg))
+            assert error_type == "database_not_connected", msg
+            assert "PostgreSQL" in message
+
+
 class TestSafeHandlerErrorPath:
     """safe_handler must raise ToolError, not return an error dict, and
     must log the underlying exception (with traceback) before

--- a/tests_py/server/test_tool_error_handler_classification.py
+++ b/tests_py/server/test_tool_error_handler_classification.py
@@ -119,10 +119,13 @@ class TestQueryErrorsAreNotMaskedAsDbNotConnected:
             "connection refused",
             "could not connect to server",
             "could not translate host name",
+            "no such host",
+            "connection reset",
             "server closed the connection unexpectedly",
             "the database system is starting up",
             "password authentication failed for user",
             "connection timed out",
+            "timeout expired",
         ]:
             error_type, message = _classify_error(RuntimeError(msg))
             assert error_type == "database_not_connected", msg


### PR DESCRIPTION
## What

`_classify_error` routed exceptions to the PostgreSQL setup guide (`database_not_connected`) when their text matched any of `"operationalerror"`, `"role"`, `"does not exist"`, or a bare `"timeout"`. Those substrings match ordinary **query-level** failures, not connection failures.

The worst offender: `sqlite3.OperationalError`'s class name is literally `OperationalError`, so `type(exc).__name__.lower() == "operationalerror"`. **Every** SQLite query error — a FTS5 `syntax error`, `no such table`, `database is locked` — matched and was handed a `brew install postgresql@17` guide. On the SQLite backend that guide is doubly wrong, and it *buried the real error*.

This is how it was found: while running the harness-comparison benchmark on a real SQLite store, a FTS5 syntax error in `get_causal_chain` (fixed in #447) came back to the client as "Cortex could not connect to PostgreSQL" — sending diagnosis in exactly the wrong direction.

The other keywords were similarly broad: `"role"` matched `control`/`payroll`/`role-based`; `"does not exist"` matched `column "x" does not exist` (a query/schema bug); bare `"timeout"` matched statement/lock timeouts.

## Fix

Tighten the `database_not_connected` bucket to unambiguous connection/auth phrases only:

```
connection refused · could not connect · could not translate host name ·
no such host · connection reset · server closed the connection ·
the database system is starting up · password authentication failed ·
connection timed out · timeout expired
```

Genuine create-db/create-role first-run conditions stay fully actionable from their own honest `OperationalError: ... FATAL: database "cortex" does not exist` text, which the fall-through (`type(exc).__name__, str(exc)`) returns verbatim — precision over hand-holding, so a real bug is never masked.

## Tests

Added `TestQueryErrorsAreNotMaskedAsDbNotConnected`: FTS5 syntax error, `no such table`, `column "x" does not exist`, a `role` substring in unrelated text, and a locked-db error all fall through to `<Type>: <message>`; a companion test asserts the seven genuine connection failures still get the setup guide. The pre-existing `test_generic_connection_refused_still_classified_as_db_not_connected` continues to pass unchanged.

Gates: `ruff check` ✓ · `ruff format --check` ✓ · craftsmanship gate ✓ · `pytest tests_py/server/test_tool_error_handler_classification.py` → 13 passed.

Pairs with #447 (the FTS5 crash this bug was hiding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017fnomaXS71hgxMw2zr7HGR)_