### PR TITLE
ci: bound the test job with timeout-minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,16 @@ jobs:
     # timeout-less `requests.get` until pytest-timeout fired, and only that
     # per-test guard, not the job, ever bounded the suite.
     # source: measured 2026-09-03 over the last 12 green `main` runs of this
-    # workflow (gh run list --status success): the slowest leg, Test (Python
-    # 3.12, the only one running the extended checks), took 15-22 min
-    # (max 22 min 32 s at e8ae24c8, run 31411417950); the other three legs
-    # took 7-11 min (max 10 min 59 s, Python 3.11, run 33678125783). 45 min is
-    # about twice that measured maximum, so a slow runner still passes while a
-    # stalled job is cut within one ordinary run's wall time.
-    timeout-minutes: 45
+    # workflow (gh run list --status success, runs 31417063954 to
+    # 33688337476, 48 legs, started_at to completed_at per job): Test (Python
+    # 3.12, the only leg running the extended checks) took 15-20 min (max
+    # 19 min 36 s, run 32747742631); the other three legs took 8-11 min in 11
+    # of the 12 runs, but in run 33688337476 (c5ec018a) Python 3.10 took
+    # 15 min 06 s and Python 3.13 took 27 min 17 s, the slowest green leg in
+    # the window. 60 min is about twice that maximum (60 / 27.3 = 2.2), so a
+    # slow runner still passes while a stalled job is cut within one ordinary
+    # run's wall time.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
     # source: measured 2026-09-03 over the last 12 green `main` runs of this
     # workflow (gh run list --status success): the slowest leg, Test (Python
     # 3.12, the only one running the extended checks), took 15-22 min
-    # (max 22 min at e8ae24c8); the other three legs took 7-10 min. 45 min is
+    # (max 22 min 32 s at e8ae24c8, run 31411417950); the other three legs
+    # took 7-11 min (max 10 min 59 s, Python 3.11, run 33678125783). 45 min is
     # about twice that measured maximum, so a slow runner still passes while a
     # stalled job is cut within one ordinary run's wall time.
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,17 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # Bound a hung leg instead of inheriting GitHub's 360-minute default:
+    # release run 30741657854 (v4.17.0, CHANGELOG 4.17.1) sat in FlashRank's
+    # timeout-less `requests.get` until pytest-timeout fired, and only that
+    # per-test guard, not the job, ever bounded the suite.
+    # source: measured 2026-09-03 over the last 12 green `main` runs of this
+    # workflow (gh run list --status success): the slowest leg, Test (Python
+    # 3.12, the only one running the extended checks), took 15-22 min
+    # (max 22 min at e8ae24c8); the other three legs took 7-10 min. 45 min is
+    # about twice that measured maximum, so a slow runner still passes while a
+    # stalled job is cut within one ordinary run's wall time.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Adds `timeout-minutes: 60` to the `test` job of `.github/workflows/ci.yml`, which previously inherited GitHub's 360-minute default.

## Why

A hung leg holds the whole workflow for hours. The precedent is release run 30741657854 (v4.17.0): FlashRank's timeout-less `requests.get` stalled in `sock.connect` until pytest-timeout killed the suite, and nothing bounded the job itself (CHANGELOG 4.17.1). Since issue #392 the release path is gated through this very job (`ci-green` -> `test` -> `release-gate`), so bounding it bounds the release path too.

## Source of the constant

Measured 2026-09-03 over the last 12 green `main` runs of this workflow (`gh run list --workflow ci.yml --branch main --status success --limit 12`, runs 31417063954 to 33688337476), 48 `Test (Python x.y)` jobs, duration = `completed_at - started_at` from `gh api repos/cdeust/Cortex/actions/runs/<id>/jobs`:

| Leg | Duration over the 12 runs |
|---|---|
| Test (Python 3.12), runs the extended checks | 15 to 20 min (max 19 min 36 s, run 32747742631) |
| Test (Python 3.10) | 8 to 10 min in 11 runs; 15 min 06 s in run 33688337476 |
| Test (Python 3.11) | 8 to 11 min (max 10 min 59 s, run 33678125783) |
| Test (Python 3.13) | 8 to 10 min in 11 runs; **27 min 17 s** in run 33688337476 |

The slowest green leg in the window is therefore Python 3.13 at 27 min 17 s (run 33688337476, c5ec018a), not the 3.12 leg. The constant follows the same rule as before, about twice the measured maximum so a slow runner still passes while a stalled job is cut within one ordinary run's wall time: 60 / 27.3 = 2.2. The earlier 45 would have been 1.65x a single passing observation, too thin a margin to keep the stated rule honest.

## Not in this PR

The sibling jobs of ci.yml (`test-sqlite`, `test-windows`, `lint`, `craftsmanship`, `typecheck`, `build`, the Docker jobs) still inherit the 360-minute default. Pre-existing, unworsened by this diff, left for a separate change. `release.yml` has no test job of its own since #392, so there is nothing to bound there.

## Review

- c660d95f: fresh-context review APPROVE, with two prose corrections to this description.
- 018a40ed: fresh-context review REQUEST_CHANGES: the comment's "other three legs took 7-11 min" and "3.12 is the slowest leg" were false for the claimed 12-run window (run 33688337476 has 3.13 at 27 min 17 s), and 45 / 27.3 = 1.65, not "about twice". Fixed by the following commit, which re-measures all 48 legs and moves the constant to 60 so the stated rule holds.
- e1597938: fresh-context review APPROVE (48 legs, window, maxima and ratio re-derived via gh api; one cosmetic note on the 8-min floor, true minimum 7 min 38 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

