### PR TITLE
fix(hooks): bound checkpoint fields in the session-start banner

### DIFF
--- a/mcp_server/hooks/session_start.py
+++ b/mcp_server/hooks/session_start.py
@@ -556,23 +556,31 @@ def _auto_backfill() -> int:
 
 
 def _format_checkpoint_section(checkpoint: dict) -> list[str]:
-    """Format the checkpoint into markdown lines."""
+    """Format the checkpoint into markdown lines.
+
+    Every field is passed through ``_short()`` — the same per-item cap
+    already applied to anchors/team-decisions/hot memories below. Before
+    this, checkpoint fields were the one banner section written raw: a
+    long ``current_task`` or a verbose ``next_steps``/``active_errors``/
+    ``open_questions`` entry could inflate this per-turn-repeated banner
+    with no bound, unlike every other section in this file.
+    """
     lines = ["### Last Session State"]
-    lines.append(f"**Task:** {checkpoint['current_task']}")
+    lines.append(f"**Task:** {_short(str(checkpoint['current_task']))}")
     if checkpoint.get("directory"):
         lines.append(f"**Directory:** `{checkpoint['directory']}`")
     if checkpoint.get("next_steps"):
         lines.append("**Next steps:**")
         for step in checkpoint["next_steps"][:3]:
-            lines.append(f"- {step}")
+            lines.append(f"- {_short(str(step))}")
     if checkpoint.get("active_errors"):
         lines.append("**Active errors:**")
         for err in checkpoint["active_errors"][:2]:
-            lines.append(f"- {err}")
+            lines.append(f"- {_short(str(err))}")
     if checkpoint.get("open_questions"):
         lines.append("**Open questions:**")
         for q in checkpoint["open_questions"][:2]:
-            lines.append(f"- {q}")
+            lines.append(f"- {_short(str(q))}")
     lines.append("")
     return lines
 

--- a/tests_py/hooks/test_session_start.py
+++ b/tests_py/hooks/test_session_start.py
@@ -347,6 +347,26 @@ def test_build_context_empty_inputs_yield_empty_banner():
     assert hook._build_context([], [], None) == ""
 
 
+def test_checkpoint_section_truncates_long_fields_like_every_other_section():
+    """Checkpoint fields must respect the same _short() cap already applied
+    to anchors/team-decisions/hot memories — otherwise this is the one
+    section of the per-turn-repeated banner that can grow unbounded."""
+    long_task = "x" * 500
+    cp = {
+        "current_task": long_task,
+        "next_steps": ["y" * 500],
+        "open_questions": [],
+        "active_errors": [],
+        "key_decisions": [],
+        "directory": "",
+    }
+    lines = hook._format_checkpoint_section(cp)
+    text = "\n".join(lines)
+    assert long_task not in text
+    assert "y" * 500 not in text
+    assert "..." in text
+
+
 def test_build_context_renders_all_sections_and_receipt_marker():
     anchors = [{"id": 1, "content": "anchored fact", "domain": "", "is_global": False}]
     hot = [{"id": 2, "content": "hot fact", "domain": "cortex", "heat": 0.9}]


### PR DESCRIPTION
## What

\`_format_checkpoint_section\` in the SessionStart hook was the one banner
section writing raw, untruncated text (\`current_task\`, \`next_steps\`,
\`active_errors\`, \`open_questions\`) while every other section (anchors,
team decisions, hot memories) already goes through the file's own
\`_short()\` cap (120 chars). Since this banner is re-injected and
refacturé on every turn of a Claude Code session, an unbounded checkpoint
field had no ceiling on per-turn cost.

## Why now

Prompted by a green-software-engineering discussion (Boris Cherny /
Claude Code's own JIT tool-loading pattern, Green Software Foundation
energy-efficiency principles, Codex CLI's 5,000-token bounded MEMORY.md
precedent). The `SessionStart` hook is declared in
`.claude-plugin/plugin.json` — exclusive to Claude Code; other MCP
harnesses (Codex, Cursor, Gemini CLI, Cline) never execute it and only
ever reach Cortex through `recall`/`query_methodology`/`unified_search`,
so they were already fully on-demand. This change touches only the one
non-cross-platform piece.

## Change

Wrap the four checkpoint fields in \`_short(str(...))\` — \`str()\` is
defensive since \`_parse_json_list\` does not guarantee string list
elements.

## Retrieval-scoring blast radius

This diff touches only markdown-formatting code in the SessionStart
hook. It does not import, call, or modify \`recall\`, \`query_methodology\`,
\`unified_search\`, WRRF fusion (\`pg_recall.py\`/\`retrieval_dispatch.py\`),
reranking (\`reranker*.py\`), or any scoring module — confirmed by reading
the diff (2 files: the hook and its test) and by \`_format_checkpoint_section\`
having no dependency on the retrieval pipeline. No retrieval-scoring
benchmark run is required for this specific diff; see PR discussion for
the before-merge verification requested.

## Local checks at this commit

\`\`\`
uv run pytest tests_py/hooks/test_session_start.py -q   -> 75 passed
uv run ruff check / format --check                       -> OK
python scripts/check_craftsmanship.py                     -> OK
pyright mcp_server/hooks/session_start.py                 -> 2 pre-existing psycopg import errors, unrelated to this diff's lines
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4uZ6ryUEiVZjtgjgpBgCc