### PR TITLE
fix(telemetry): measure response bytes and retrieval work (W0-1)

### DIFF
--- a/.craftsmanship-baseline.json
+++ b/.craftsmanship-baseline.json
@@ -2808,11 +2808,6 @@
       "detail": "pathlib"
     },
     {
-      "file": "mcp_server/core/telemetry.py",
-      "kind": "method-size",
-      "detail": "record"
-    },
-    {
       "file": "mcp_server/core/thermodynamics.py",
       "kind": "file-size",
       "detail": "exceeds 300-line cap"

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -54,6 +54,22 @@ reports **local** performance statistics only, and every recorded sample is
 appended to a local, no-egress JSONL file
 (`~/.claude/methodology/telemetry.jsonl`).
 
+`CORTEX_CLAUDE_DIR` redirects that file to the selected configuration root.
+Samples contain operation names, durations, byte counts, result counts and
+completion status, without prompt or response content. `query_methodology`,
+`session_start` and `auto_recall` are included. `tier` records the retrieval
+route actually executed (`pg` for the current memory-store pipeline, or the
+legacy dispatch tier); it is null when no retrieval route ran.
+`reranked_count` counts passages successfully processed by the reranker,
+including candidates later filtered out of the response.
+For MCP calls, `bytes_out` measures the SDK's final UTF-8 text payload, including
+error messages and excluding the transport envelope and structured-content
+duplicate. Direct handler calls measure their serialized response (zero when
+they raise without returning a response). Hook `bytes_out` measures stdout
+after encoding and newline conversion. A silent hook records zero bytes.
+Hook `ok` describes normal completion or exit code zero; it does not certify
+that every optional retrieval source was available.
+
 The only outbound network activity is:
 
 1. **One-time model download.** On first use, the open-source embedding model

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -64,6 +64,7 @@ from mcp_server import (
     tool_registry_wiki,
 )
 from mcp_server.core import telemetry
+from mcp_server.telemetry_middleware import TelemetryMiddleware
 from mcp_server.tool_profile_middleware import ToolProfileMiddleware
 from mcp_server.core.wiki_axis_registry import configure_default_wiki_root
 from mcp_server.core.wiki_classifier import configure_user_rules_provider
@@ -120,7 +121,7 @@ mcp = MCPServer(
     # started in (issue #177 criterion 3). FULL keeps the historical onboarding
     # line ("Call query_methodology…").
     instructions=tool_profiles.instructions(ACTIVE_PROFILE),
-    middleware=[ToolProfileMiddleware(ACTIVE_PROFILE)],
+    middleware=[TelemetryMiddleware(), ToolProfileMiddleware(ACTIVE_PROFILE)],
 )
 
 # ── Tool Registration ──────────────────────────────────────────────────────

--- a/mcp_server/core/pg_recall_stages.py
+++ b/mcp_server/core/pg_recall_stages.py
@@ -15,6 +15,7 @@ one object rather than passed as 8-13 positional parameters
 
 from __future__ import annotations
 
+from mcp_server.shared.telemetry_context import set_retrieval_tier
 from mcp_server.core.pg_recall_context import RecallContext, fetch_and_triage
 from mcp_server.core.pg_recall_signals import (
     _get_active_goal,
@@ -235,6 +236,7 @@ def run_recall_pipeline(ctx: RecallContext) -> list[dict]:
     pg_recall_context.py's ``RecallContext``/``fetch_and_triage`` for the
     per-parameter rationale and citations.
     """
+    set_retrieval_tier("pg")
     top_k = ctx.top_k
     candidates, ctx, early_return = fetch_and_triage(ctx)
     if early_return:

--- a/mcp_server/core/reranker.py
+++ b/mcp_server/core/reranker.py
@@ -43,6 +43,7 @@ from mcp_server.core.reranker_scoring import (
     _compute_retrieval_confidence,
 )
 from mcp_server.observability import silent_failure
+from mcp_server.shared.telemetry_context import count_reranked
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +193,7 @@ def rerank_results(
             for i, (mid, _) in enumerate(candidates)
         ]
         results = ranker.rerank(RerankRequest(query=query, passages=passages))
+        count_reranked(len(passages))
         ce_scores = {r["id"]: r["score"] for r in results}
         return _blend_scores(
             candidates, ce_scores, alpha, adaptive=adaptive, apply_platt=apply_platt

--- a/mcp_server/core/retrieval_dispatch.py
+++ b/mcp_server/core/retrieval_dispatch.py
@@ -17,6 +17,7 @@ from mcp_server.core.query_decomposition import decompose_query
 from mcp_server.core.query_intent import QueryIntent
 from mcp_server.core.reranker import rerank_results
 from mcp_server.observability import silent_failure
+from mcp_server.shared.telemetry_context import set_retrieval_tier
 
 # ── Tier Classification ──────────────────────────────────────────────────
 
@@ -237,6 +238,7 @@ def dispatch_retrieval(
     """Run 3-tier retrieval dispatch. Returns (results, tier_name)."""
     intent = intent_info.get("intent", QueryIntent.GENERAL)
     tier = classify_tier(intent)
+    set_retrieval_tier(tier)
     weights = compute_signal_weights(
         tier,
         intent_info.get("weights", {}),

--- a/mcp_server/core/telemetry.py
+++ b/mcp_server/core/telemetry.py
@@ -39,11 +39,9 @@ Layer:
 Contract (record):
   precondition: ``op`` is a non-empty string; ``latency_ms`` >= 0;
                 byte / count fields are non-negative ints.
-  postcondition: counters[op] is updated atomically; one JSONL line is
-                appended on success or silently dropped on OSError; the
-                registered exporter (if any) is invoked with the same
-                sample and any exception it raises is swallowed; no
-                exception escapes to the handler.
+  postcondition: a sample is published immediately, or captured until the
+                MCP response exists. Publication updates counters atomically
+                and writes JSONL/exporter best-effort, without failing callers.
 """
 
 from __future__ import annotations
@@ -53,8 +51,14 @@ import logging
 import os
 import threading
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, TypedDict, runtime_checkable
+
+from mcp_server.shared.telemetry_context import retrieval_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +70,7 @@ class TelemetryExporter(Protocol):
     Contract:
       - ``export`` receives the same dict shape written to the JSONL log
         (``ts``, ``op``, ``latency_ms``, ``bytes_in``, ``bytes_out``,
-        ``result_count``, ``ok``).
+        ``result_count``, ``ok``, ``tier``, ``reranked_count``).
       - ``export`` MUST NOT raise for control flow that reaches the
         caller -- ``record()`` catches any exception defensively, but a
         well-behaved implementation handles its own I/O errors.
@@ -93,16 +97,60 @@ def set_exporter(exporter: TelemetryExporter | None) -> None:
     _exporter = exporter
 
 
-_LOG_PATH = Path.home() / ".claude" / "methodology" / "telemetry.jsonl"
+# source: infrastructure/config.py — CORTEX_CLAUDE_DIR isolates all local data.
+# Existing filesystem ownership in this module is unchanged; no infrastructure
+# import is introduced into core to resolve the same configuration root.
+_root_override = os.environ.get("CORTEX_CLAUDE_DIR", "").strip()
+_LOG_PATH = (
+    (Path(_root_override).expanduser() if _root_override else Path.home() / ".claude")
+    / "methodology"
+    / "telemetry.jsonl"
+)
 try:
     _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 except OSError:
-    # Directory creation may fail under sandbox; record() is still
-    # safe -- the OSError on open() will be swallowed there too.
-    pass
+    logger.warning("Cannot create telemetry directory: %s", _LOG_PATH.parent)
 
 _lock = threading.Lock()
 _counters: dict[str, dict[str, float | int]] = {}
+
+
+class TelemetrySample(TypedDict):
+    """One operation, finalized with the concrete MCP response when available."""
+
+    ts: float
+    op: str
+    latency_ms: float
+    bytes_in: int
+    bytes_out: int
+    result_count: int
+    ok: bool
+    tier: str | None
+    reranked_count: int
+
+
+@dataclass
+class _Capture:
+    samples: list[TelemetrySample] = field(default_factory=list)
+    closed: bool = False
+
+
+_capture: ContextVar[_Capture | None] = ContextVar("telemetry_capture", default=None)
+
+
+@contextmanager
+def capture_records() -> Iterator[list[TelemetrySample]]:
+    """Defer publication; copied worker contexts publish directly after closure."""
+    captured = _Capture()
+    token = _capture.set(captured)
+    try:
+        yield captured.samples
+    finally:
+        # asyncio.to_thread copies context; a cancelled caller can finish first.
+        # Lock closure against late worker appends so no sample is stranded.
+        with _lock:
+            captured.closed = True
+        _capture.reset(token)
 
 
 def _disabled() -> bool:
@@ -119,18 +167,34 @@ def record(
     result_count: int = 0,
     ok: bool = True,
 ) -> None:
-    """Record one operation.
-
-    ``op`` is the canonical handler name, e.g. ``recall``, ``remember``,
-    ``forget``, ``recall_hierarchical``. Cheap by design: one dict
-    update + one short JSONL line. Target overhead < 1 ms (smoke-tested).
-    """
+    """Capture one operation, or publish immediately outside an MCP request."""
     if _disabled():
         return
-    record_line: dict[str, Any]
+    retrieval = retrieval_metrics()
+    sample: TelemetrySample = {
+        "ts": time.time(),
+        "op": op,
+        "latency_ms": latency_ms,
+        "bytes_in": bytes_in,
+        "bytes_out": bytes_out,
+        "result_count": result_count,
+        "ok": ok,
+        "tier": retrieval.tier,
+        "reranked_count": retrieval.reranked_count,
+    }
+    captured = _capture.get()
+    with _lock:
+        if captured is not None and not captured.closed:
+            captured.samples.append(sample)
+            return
+    publish_record(sample)
+
+
+def _update_counters(sample: TelemetrySample) -> None:
+    """Keep full-precision latency in counters, as before JSONL rounding."""
     with _lock:
         c = _counters.setdefault(
-            op,
+            sample["op"],
             {
                 "count": 0,
                 "ok": 0,
@@ -143,32 +207,26 @@ def record(
             },
         )
         c["count"] += 1
-        c["ok" if ok else "fail"] += 1
-        c["bytes_in"] += bytes_in
-        c["bytes_out"] += bytes_out
-        c["result_count"] += result_count
-        c["latency_ms_sum"] += latency_ms
-        if latency_ms > c["latency_ms_max"]:
-            c["latency_ms_max"] = latency_ms
-        record_line = {
-            "ts": time.time(),
-            "op": op,
-            "latency_ms": round(latency_ms, 3),
-            "bytes_in": bytes_in,
-            "bytes_out": bytes_out,
-            "result_count": result_count,
-            "ok": ok,
-        }
-    # JSONL append is best-effort: a full disk or permission error must
-    # never break the handler. The in-memory counters are already updated.
+        c["ok" if sample["ok"] else "fail"] += 1
+        c["bytes_in"] += sample["bytes_in"]
+        c["bytes_out"] += sample["bytes_out"]
+        c["result_count"] += sample["result_count"]
+        c["latency_ms_sum"] += sample["latency_ms"]
+        c["latency_ms_max"] = max(c["latency_ms_max"], sample["latency_ms"])
+
+
+def publish_record(sample: TelemetrySample) -> None:
+    """Publish one finalized sample to counters, JSONL and the optional exporter."""
+    if _disabled():
+        return
+    _update_counters(sample)
+    # source: existing JSONL contract rounds latency_ms to three decimal places.
+    record_line = {**sample, "latency_ms": round(sample["latency_ms"], 3)}
     try:
-        with _LOG_PATH.open("a") as f:
+        with _LOG_PATH.open("a", encoding="utf-8") as f:
             f.write(json.dumps(record_line) + "\n")
     except OSError:
-        pass
-    # Optional external export (issue #122): best-effort, never breaks the
-    # caller. Reads the module-level reference once so a concurrent
-    # set_exporter(None) mid-call degrades to a no-op rather than racing.
+        logger.warning("Cannot append telemetry sample: %s", _LOG_PATH, exc_info=True)
     exporter = _exporter
     if exporter is not None:
         try:
@@ -189,6 +247,9 @@ _READ_OPS = {
     "navigate_memory",
     "get_causal_chain",
     "drill_down",
+    "query_methodology",
+    "session_start",
+    "auto_recall",
 }
 _WRITE_OPS = {"remember", "forget", "validate_memory", "rate_memory"}
 

--- a/mcp_server/handlers/_telemetry_wrap.py
+++ b/mcp_server/handlers/_telemetry_wrap.py
@@ -1,9 +1,9 @@
 """Telemetry wrapping helper for handler entry points.
 
 Wrap a handler's ``handler(args)`` coroutine with this and the call is
-timed + recorded against the telemetry counters. Negligible overhead
-(<1ms measured): one ``perf_counter`` pair, one JSON-len, one dispatch
-to ``telemetry.record``.
+timed + recorded against the telemetry counters. Response byte volume uses
+the SDK's UTF-8 text-content serialization, after JSON-native normalization;
+it excludes the MCP transport envelope and structured-content duplication.
 
 Usage:
 
@@ -16,20 +16,40 @@ Usage:
 from __future__ import annotations
 
 import json
+import logging
 import time
 from typing import Any, Awaitable, Callable
 
+from pydantic_core import to_json
+
 from mcp_server.core import telemetry
+from mcp_server.shared.json_native import to_json_native
+from mcp_server.shared.telemetry_context import operation_metrics
 
 HandlerFn = Callable[[dict[str, Any] | None], Awaitable[dict[str, Any]]]
+logger = logging.getLogger(__name__)
 
 
 def _safe_json_len(args: dict[str, Any] | None) -> int:
     if not args:
         return 0
     try:
-        return len(json.dumps(args, default=str))
+        return len(json.dumps(args, default=str).encode("utf-8"))
     except (TypeError, ValueError):
+        logger.warning("Cannot serialize telemetry input", exc_info=True)
+        return 0
+
+
+def _response_bytes(result: dict[str, Any] | None) -> int:
+    """UTF-8 bytes of the MCP text response, excluding the transport envelope."""
+    if result is None:
+        return 0
+    try:
+        # source: MCP SDK utilities/func_metadata.py::_convert_to_content;
+        # safe_handler normalizes JSON-native values before SDK serialization.
+        return len(to_json(to_json_native(result), fallback=str, indent=2))
+    except (TypeError, ValueError):
+        logger.warning("Cannot serialize telemetry output", exc_info=True)
         return 0
 
 
@@ -55,32 +75,31 @@ def instrument(
     precondition: ``fn`` is an async callable accepting a single
                   ``args`` dict and returning a dict.
     postcondition: every call to the returned wrapper records exactly
-                   one telemetry sample (op, latency_ms, bytes_in,
-                   result_count, ok) and re-raises any exception
+                   one telemetry sample (op, latency_ms, bytes_in/out,
+                   result_count, retrieval work, ok) and re-raises any exception
                    unchanged after marking ok=False.
     """
 
     async def wrapped(args: dict[str, Any] | None = None) -> dict[str, Any]:
         t0 = time.perf_counter()
         ok = True
-        result: dict[str, Any] = {}
-        try:
-            result = await fn(args)
-            # The assignment above is not redundant: `result` also feeds
-            # `finally`'s `_result_count(result, ...)` telemetry sample.
-            # Inlining this into `return await fn(args)` would leave
-            # `result` at its pre-declared `{}` for that read.
-            return result  # noqa: RET504 — read by finally's telemetry sample
-        except Exception:
-            ok = False
-            raise
-        finally:
-            telemetry.record(
-                op,
-                latency_ms=(time.perf_counter() - t0) * 1000.0,
-                bytes_in=_safe_json_len(args),
-                result_count=_result_count(result, result_count_key),
-                ok=ok,
-            )
+        result: dict[str, Any] | None = None
+        with operation_metrics():
+            try:
+                result = await fn(args)
+                return result  # noqa: RET504 — read by finally's telemetry sample
+            except BaseException:
+                ok = False
+                raise
+            finally:
+                telemetry.record(
+                    op,
+                    # source: SI prefix milli; perf_counter returns seconds.
+                    latency_ms=(time.perf_counter() - t0) * 1000.0,
+                    bytes_in=_safe_json_len(args),
+                    bytes_out=_response_bytes(result),
+                    result_count=_result_count(result, result_count_key),
+                    ok=ok,
+                )
 
     return wrapped

--- a/mcp_server/handlers/query_methodology.py
+++ b/mcp_server/handlers/query_methodology.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+from functools import partial
 from typing import Any
 
 from mcp_server.core.context_generator import generate_context
@@ -17,6 +18,7 @@ from mcp_server.core.prospective import check_trigger
 from mcp_server.core.response_budget import ListTarget, TextTarget, bound_payload
 from mcp_server.infrastructure.profile_store import load_profiles
 from mcp_server.handlers._tool_meta import READ_ONLY
+from mcp_server.handlers._telemetry_wrap import instrument
 from mcp_server.infrastructure.memory_config import get_memory_settings
 from mcp_server.infrastructure.memory_store import get_shared_store
 
@@ -292,6 +294,7 @@ def _bounded(resp: dict) -> dict:
     )
 
 
+@partial(instrument, "query_methodology", result_count_key="hotMemories")
 async def handler(args: dict | None = None) -> dict:
     args = args or {}
     cwd = args.get("cwd", "")

--- a/mcp_server/hooks/_telemetry.py
+++ b/mcp_server/hooks/_telemetry.py
@@ -1,0 +1,140 @@
+"""Observe a hook's emitted UTF-8 text and process-level completion.
+
+The stream forwards writes immediately: injection text, receipt markers and
+print's trailing newlines stay unchanged. ``ok`` describes normal completion
+or exit code zero, including the hooks' intentionally tolerated degradations.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import logging
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, redirect_stdout
+from functools import wraps
+from typing import TYPE_CHECKING, BinaryIO, Protocol, TextIO, runtime_checkable
+
+from mcp_server.core import telemetry
+from mcp_server.shared.telemetry_context import operation_metrics
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from _typeshed import ReadableBuffer
+
+
+class _CountingOutput:
+    """Count unencoded test/custom text streams that have no binary buffer."""
+
+    def __init__(self, stream: TextIO) -> None:
+        self._stream = stream
+        self.bytes_out = 0
+
+    def write(self, text: str) -> int:
+        written = self._stream.write(text)
+        # source: UTF-8 encoding of the text accepted by TextIO.write.
+        self.bytes_out += len(text[:written].encode("utf-8"))
+        return written
+
+    def flush(self) -> None:
+        self._stream.flush()
+
+
+@runtime_checkable
+class _BufferedOutput(Protocol):
+    """Text streams exposing the binary destination after newline/encoding."""
+
+    @property
+    def buffer(self) -> BinaryIO: ...
+
+    def flush(self) -> None: ...
+
+
+class _CountingBuffer:
+    """Count bytes accepted after TextIOWrapper encoding and newline conversion."""
+
+    def __init__(self, buffer: BinaryIO) -> None:
+        self.write_original = buffer.write
+        self.bytes_out = 0
+
+    def write(self, data: ReadableBuffer) -> int:
+        written = self.write_original(data)
+        self.bytes_out += written
+        return written
+
+
+@contextmanager
+def _observe_output() -> Iterator[_CountingOutput | _CountingBuffer]:
+    """Observe the existing encoder; do not reconstruct its newline policy."""
+    stream = sys.stdout
+    if not isinstance(stream, _BufferedOutput):
+        output = _CountingOutput(stream)
+        with redirect_stdout(output):
+            yield output
+        return
+    # Flush pre-existing text before attaching the counter to this operation.
+    stream.flush()
+    counter = _CountingBuffer(stream.buffer)
+    stream.buffer.write = counter.write
+    failed = False
+    try:
+        yield counter
+    except BaseException:
+        failed = True
+        raise
+    finally:
+        try:
+            # TextIOWrapper may defer encoding until flush; count that output
+            # before restoring the original binary write method.
+            _flush_output(stream, failed)
+        finally:
+            stream.buffer.write = counter.write_original
+
+
+def _flush_output(stream: _BufferedOutput, failed: bool) -> None:
+    """A broken output stream must not replace an already-raised hook error."""
+    try:
+        stream.flush()
+    except (OSError, ValueError):
+        if not failed:
+            raise
+        logger.warning("Cannot flush failed hook output", exc_info=True)
+
+
+def _run_observed(op: str, hook: Callable[[], None]) -> None:
+    """Record once, preserving stdout, exceptions and the hook's exit code."""
+    started = time.perf_counter()
+    ok = False
+    output: _CountingOutput | _CountingBuffer = _CountingOutput(sys.stdout)
+    with operation_metrics():
+        try:
+            with _observe_output() as observed:
+                output = observed
+                hook()
+            ok = True
+        except SystemExit as exc:
+            # source: Python sys.exit: None and zero signal successful exit.
+            ok = exc.code is None or exc.code == 0
+            raise
+        finally:
+            telemetry.record(
+                op,
+                # source: SI conversion, one second equals 1000 milliseconds.
+                latency_ms=(time.perf_counter() - started) * 1000,
+                bytes_out=output.bytes_out,
+                ok=ok,
+            )
+
+
+def observe_hook(op: str) -> Callable[[Callable[[], None]], Callable[[], None]]:
+    """Decorate a CLI main, giving each hook invocation its own metrics."""
+
+    def decorate(hook: Callable[[], None]) -> Callable[[], None]:
+        @wraps(hook)
+        def observed() -> None:
+            _run_observed(op, hook)
+
+        return observed
+
+    return decorate

--- a/mcp_server/hooks/auto_recall.py
+++ b/mcp_server/hooks/auto_recall.py
@@ -77,6 +77,7 @@ from mcp_server.handlers.injection_receipts import (
     receipt_marker,
     session_id_from_transcript,
 )
+from mcp_server.hooks._telemetry import observe_hook
 from mcp_server.shared.freshness import provenance_suffix
 
 _LOG_PREFIX = "[cortex-auto-recall]"
@@ -453,6 +454,7 @@ def process_event(event: dict[str, Any]) -> None:
     sys.exit(0)
 
 
+@observe_hook("auto_recall")
 def main() -> None:
     """Entry point — read JSON event from stdin."""
     if sys.stdin.isatty():

--- a/mcp_server/hooks/session_start.py
+++ b/mcp_server/hooks/session_start.py
@@ -30,6 +30,7 @@ from mcp_server.handlers.injection_receipts import (
     receipt_marker,
     session_id_from_transcript,
 )
+from mcp_server.hooks._telemetry import observe_hook
 from mcp_server.shared.freshness import provenance_suffix
 from mcp_server.shared.platform import python_executable
 import sqlite3
@@ -1188,6 +1189,7 @@ def _sqlite_context(event: dict) -> None:
     _print_external_sources()
 
 
+@observe_hook("session_start")
 def main() -> None:
     """Entry point — print context block to stdout."""
 

--- a/mcp_server/shared/telemetry_context.py
+++ b/mcp_server/shared/telemetry_context.py
@@ -1,0 +1,57 @@
+"""Request-local retrieval measurements; no changes to ranking or responses.
+
+ContextVar scopes measurements to the current async task/thread. Reset tokens
+also preserve the outer operation when an instrumented handler calls another.
+Source: Python contextvars documentation, ContextVar.set/reset and asyncio support.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+
+@dataclass
+class RetrievalMetrics:
+    """Actual dispatch route and passages successfully scored by the model."""
+
+    tier: str | None = None
+    reranked_count: int = 0
+
+
+_metrics: ContextVar[RetrievalMetrics | None] = ContextVar(
+    "cortex_retrieval_metrics", default=None
+)
+
+
+@contextmanager
+def operation_metrics() -> Iterator[RetrievalMetrics]:
+    """Start an independent operation and restore its caller on every exit."""
+    current = RetrievalMetrics()
+    token = _metrics.set(current)
+    try:
+        yield current
+    finally:
+        _metrics.reset(token)
+
+
+def retrieval_metrics() -> RetrievalMetrics:
+    """Return recorded work, or an empty measurement outside an operation."""
+    current = _metrics.get()
+    return current if current is not None else RetrievalMetrics()
+
+
+def set_retrieval_tier(tier: str) -> None:
+    """Record the route actually executed, rather than inferring from intent."""
+    current = _metrics.get()
+    if current is not None:
+        current.tier = tier
+
+
+def count_reranked(count: int) -> None:
+    """Count successful model work; skipped/failed inference contributes zero."""
+    current = _metrics.get()
+    if current is not None:
+        current.reranked_count += count

--- a/mcp_server/telemetry_middleware.py
+++ b/mcp_server/telemetry_middleware.py
@@ -1,0 +1,83 @@
+"""Finalize existing operation samples from the MCP SDK's actual text response.
+
+The SDK converts handler exceptions to TextContent inside call_next. Measuring
+here includes those errors without reconstructing SDK messages or changing tool
+results. Source: mcp 2.0.0 MCPServer._handle_call_tool and ServerMiddleware.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict, cast
+
+from mcp.types import CallToolResult, TextContent
+from typing_extensions import NotRequired
+
+from mcp_server.core import telemetry
+
+if TYPE_CHECKING:
+    from mcp.server.context import CallNext, HandlerResult, ServerRequestContext
+
+
+class _ContentBlock(TypedDict):
+    type: str
+    text: NotRequired[str]
+
+
+class _ToolResponse(TypedDict):
+    content: list[_ContentBlock]
+    isError: NotRequired[bool]
+
+
+def _response_measurement(result: HandlerResult) -> tuple[int, bool] | None:
+    """Support both SDK result shapes without serializing the transport envelope."""
+    if isinstance(result, CallToolResult):
+        text = (
+            block.text for block in result.content if isinstance(block, TextContent)
+        )
+        return sum(len(value.encode("utf-8")) for value in text), not result.is_error
+    if isinstance(result, dict) and "content" in result:
+        response = cast("_ToolResponse", result)
+        text = (
+            block.get("text", "")
+            for block in response["content"]
+            if block["type"] == "text"
+        )
+        return sum(len(value.encode("utf-8")) for value in text), not response.get(
+            "isError", False
+        )
+    return None
+
+
+def _finalize_response(
+    samples: list[telemetry.TelemetrySample], name: str, result: HandlerResult
+) -> None:
+    """Update the outer operation only; nested handler samples retain their scope."""
+    measurement = _response_measurement(result)
+    if measurement is None:
+        return
+    for sample in reversed(samples):
+        if sample["op"] == name:
+            sample["bytes_out"], sample["ok"] = measurement
+            return
+
+
+class TelemetryMiddleware:
+    """Publish existing handler samples exactly once, after SDK conversion."""
+
+    async def __call__(
+        self, ctx: ServerRequestContext[object, object], call_next: CallNext
+    ) -> HandlerResult:
+        if ctx.method != "tools/call":
+            return await call_next(ctx)
+        name = (ctx.params or {}).get("name")
+        result = None
+        samples: list[telemetry.TelemetrySample] = []
+        try:
+            with telemetry.capture_records() as samples:
+                result = await call_next(ctx)
+        finally:
+            if isinstance(name, str):
+                _finalize_response(samples, name, result)
+            for sample in samples:
+                telemetry.publish_record(sample)
+        return result

--- a/tests_py/core/test_retrieval_telemetry.py
+++ b/tests_py/core/test_retrieval_telemetry.py
@@ -1,0 +1,71 @@
+"""W0-1: count model work without changing results or leaking across calls."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import Mock
+
+from mcp_server.core import reranker, retrieval_dispatch
+from mcp_server.shared.telemetry_context import (
+    count_reranked,
+    operation_metrics,
+    retrieval_metrics,
+    set_retrieval_tier,
+)
+
+
+def test_metrics_are_nested_and_task_local():
+    async def collect(tier, count):
+        with operation_metrics() as measured:
+            set_retrieval_tier(tier)
+            count_reranked(count)
+            await asyncio.sleep(0)
+            with operation_metrics() as nested:
+                assert nested.tier is None
+                count_reranked(1)
+            assert retrieval_metrics() is measured
+            return measured.tier, measured.reranked_count
+
+    async def run():
+        return await asyncio.gather(collect("simple", 2), collect("deep", 3))
+
+    assert asyncio.run(run()) == [("simple", 2), ("deep", 3)]
+    assert retrieval_metrics().reranked_count == 0
+    assert retrieval_metrics().tier is None
+
+
+def test_successful_reranking_counts_input_and_preserves_result(monkeypatch):
+    model = Mock()
+    model.rerank.return_value = [{"id": 0, "score": 0.9}, {"id": 1, "score": 0.8}]
+    monkeypatch.setattr(reranker, "_ensure_reranker", lambda: model)
+    candidates = [(1, 0.7), (2, 0.6)]
+    content = {1: "first", 2: "second"}
+    uninstrumented = reranker.rerank_results("query", candidates, content)
+    with operation_metrics() as measured:
+        instrumented = reranker.rerank_results("query", candidates, content)
+    assert instrumented == uninstrumented
+    assert measured.reranked_count == len(model.rerank.call_args.args[0].passages)
+
+
+def test_skipped_or_failed_model_is_not_counted(monkeypatch, caplog):
+    monkeypatch.setattr(reranker, "_ensure_reranker", lambda: None)
+    with operation_metrics() as measured:
+        assert reranker.rerank_results("q", [(1, 0.5)], {}) == [(1, 0.5)]
+        assert measured.reranked_count == 0
+    model = Mock()
+    model.rerank.side_effect = RuntimeError("fixture inference failure")
+    monkeypatch.setattr(reranker, "_ensure_reranker", lambda: model)
+    with operation_metrics() as measured:
+        assert reranker.rerank_results("q", [(1, 0.5)], {}) == [(1, 0.5)]
+        assert measured.reranked_count == 0
+    assert "fixture inference failure" in caplog.text
+
+
+def test_legacy_dispatch_records_executed_tier_without_changing_output(monkeypatch):
+    monkeypatch.setattr(retrieval_dispatch, "rerank_results", lambda q, p, c: p)
+    args = ("q", {"vector": [(1, 0.5)]}, {"intent": "general"}, {1: "text"})
+    original = retrieval_dispatch.dispatch_retrieval(*args)
+    with operation_metrics() as measured:
+        observed = retrieval_dispatch.dispatch_retrieval(*args)
+    assert observed == original
+    assert measured.tier == observed[1]

--- a/tests_py/core/test_telemetry_isolation.py
+++ b/tests_py/core/test_telemetry_isolation.py
@@ -1,0 +1,29 @@
+"""The telemetry log follows the same disposable root as every other store."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def test_fresh_process_respects_configuration_root(tmp_path):
+    isolated = tmp_path / "claude"
+    script = (
+        "from mcp_server.core import telemetry; "
+        "telemetry.record('fixture', latency_ms=0); "
+        "print(telemetry.summary()['log_path'])"
+    )
+    env = dict(os.environ, CORTEX_CLAUDE_DIR=str(isolated))
+    env.pop("CORTEX_TELEMETRY_DISABLED", None)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    expected = isolated / "methodology" / "telemetry.jsonl"
+    assert result.stdout.strip() == str(expected)
+    assert json.loads(expected.read_text())["op"] == "fixture"

--- a/tests_py/handlers/test_telemetry_response.py
+++ b/tests_py/handlers/test_telemetry_response.py
@@ -1,0 +1,98 @@
+"""W0-1: response bytes and request-scoped retrieval work are observable."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from pydantic_core import to_json
+
+from mcp_server.core import telemetry
+from mcp_server.handlers._telemetry_wrap import instrument
+from mcp_server.handlers import recall, remember
+from mcp_server.shared.telemetry_context import count_reranked, set_retrieval_tier
+
+
+@pytest.fixture
+def telemetry_log(tmp_path, monkeypatch):
+    path = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", path)
+    monkeypatch.delenv("CORTEX_TELEMETRY_DISABLED", raising=False)
+    telemetry.reset()
+    yield path
+    telemetry.reset()
+
+
+def test_public_recall_remember_record_response_bytes(telemetry_log):
+    """Even empty-query / rejected-write responses carry serialized output."""
+    responses = [asyncio.run(recall.handler({})), asyncio.run(remember.handler({}))]
+    samples = [json.loads(line) for line in telemetry_log.read_text().splitlines()]
+    assert [sample["op"] for sample in samples] == ["recall", "remember"]
+    for sample, response in zip(samples, responses, strict=True):
+        assert sample["bytes_out"] == len(to_json(response, fallback=str, indent=2))
+        assert sample["bytes_out"] > 0
+        assert sample["tier"] is None
+        assert sample["reranked_count"] == 0
+
+
+def test_wrapper_preserves_result_and_records_failure(telemetry_log):
+    async def fail(args):
+        raise ValueError("fixture failure")
+
+    with pytest.raises(ValueError, match="fixture failure"):
+        asyncio.run(instrument("fixture", fail)({"query": "café"}))
+    sample = json.loads(telemetry_log.read_text())
+    assert sample["ok"] is False
+    assert sample["bytes_out"] == 0
+    assert sample["bytes_in"] == len(json.dumps({"query": "café"}).encode("utf-8"))
+
+
+def test_unicode_response_matches_sdk_and_records_retrieval_work(telemetry_log):
+    response = {"memories": [{"id": 1, "content": "café 🧠"}]}
+
+    async def retrieve(args):
+        set_retrieval_tier("pg")
+        count_reranked(2)
+        return response
+
+    assert asyncio.run(instrument("recall", retrieve)({})) is response
+    sample = json.loads(telemetry_log.read_text())
+    assert sample["bytes_out"] == len(to_json(response, fallback=str, indent=2))
+    assert sample["bytes_out"] > len(to_json(response, indent=2).decode("utf-8"))
+    assert sample["tier"] == "pg"
+    assert sample["reranked_count"] == 2
+
+
+def test_cancelled_handler_records_failure_and_restores_metrics(telemetry_log):
+    async def cancel(args):
+        set_retrieval_tier("deep")
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(instrument("recall", cancel)({}))
+    asyncio.run(recall.handler({}))
+    samples = [json.loads(line) for line in telemetry_log.read_text().splitlines()]
+    assert samples[0]["ok"] is False
+    assert samples[0]["tier"] == "deep"
+    assert samples[1]["tier"] is None
+
+
+def test_real_store_round_trip_records_nonempty_response_sizes(telemetry_log):
+    content = "We decided to verify UTF-8 telemetry with an isolated SQLite store."
+    stored = asyncio.run(remember.handler({"content": content, "force": True}))
+    assert stored["stored"] is True
+    telemetry_log.write_text("")
+    recalled = asyncio.run(recall.handler({"query": "UTF-8 telemetry"}))
+    written = asyncio.run(
+        remember.handler({"content": "Follow-up decision", "force": True})
+    )
+    assert recalled["count"] > 0
+    assert written["stored"] is True
+    samples = [json.loads(line) for line in telemetry_log.read_text().splitlines()]
+    assert [sample["op"] for sample in samples] == ["recall", "remember"]
+    for sample, response in zip(samples, [recalled, written], strict=True):
+        assert sample["bytes_out"] == len(to_json(response, fallback=str, indent=2))
+        assert sample["bytes_out"] > 0
+        assert "tier" in sample and "reranked_count" in sample
+    assert samples[0]["tier"] == "pg"

--- a/tests_py/hooks/test_hook_telemetry.py
+++ b/tests_py/hooks/test_hook_telemetry.py
@@ -1,0 +1,289 @@
+"""Hook telemetry measures emitted text without changing CLI behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from mcp_server.core import telemetry
+from mcp_server.handlers import query_methodology
+from mcp_server.hooks import _telemetry, auto_recall, session_start
+from mcp_server.shared.telemetry_context import (
+    count_reranked,
+    operation_metrics,
+    retrieval_metrics,
+    set_retrieval_tier,
+)
+
+
+@pytest.fixture(autouse=True)
+def telemetry_log(tmp_path, monkeypatch):
+    path = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", path)
+    monkeypatch.delenv("CORTEX_TELEMETRY_DISABLED", raising=False)
+    telemetry.set_exporter(None)
+    telemetry.reset()
+    yield path
+    telemetry.set_exporter(None)
+    telemetry.reset()
+
+
+def _sample(path):
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    return json.loads(lines[0])
+
+
+def test_counting_output_counts_only_text_accepted_by_stream():
+    accepted = []
+    flushed = []
+
+    def partial_write(text):
+        accepted.append(text[:1])
+        return 1
+
+    stream = SimpleNamespace(write=partial_write, flush=lambda: flushed.append(True))
+    output = _telemetry._CountingOutput(stream)
+    assert output.write("été") == 1
+    output.flush()
+    assert accepted == ["é"]
+    assert output.bytes_out == len("é".encode("utf-8"))
+    assert flushed == [True]
+
+
+def test_counting_output_preserves_write_failures():
+    stream = io.StringIO()
+    stream.close()
+    output = _telemetry._CountingOutput(stream)
+    with pytest.raises(ValueError, match="closed file"):
+        output.write("mémoire")
+    assert output.bytes_out == 0
+
+
+def test_observer_measures_complete_utf8_output_and_duration(
+    telemetry_log, monkeypatch, capsys
+):
+    clock = iter((5.0, 5.25))
+    monkeypatch.setattr(_telemetry.time, "perf_counter", lambda: next(clock))
+    original_stdout = sys.stdout
+
+    @_telemetry.observe_hook("session_start")
+    def hook():
+        print("Décision 🧠", end=" ", flush=True)
+        print("⟦rcpt:7⟧")
+        print("\nSources externes : mémoire")
+        print("diagnostic", file=sys.stderr)
+
+    hook()
+    assert sys.stdout is original_stdout
+    out, err = capsys.readouterr()
+    assert out == "Décision 🧠 ⟦rcpt:7⟧\n\nSources externes : mémoire\n"
+    assert err == "diagnostic\n"
+    sample = _sample(telemetry_log)
+    assert sample["bytes_out"] == len(out.encode("utf-8"))
+    assert sample["latency_ms"] == 250.0
+    assert sample["ok"] is True
+
+
+@pytest.mark.parametrize("code", [None, 0, 1, "failure"])
+def test_exit_code_is_preserved_and_recorded(code, telemetry_log, capsys):
+    original_stdout = sys.stdout
+    failure = SystemExit(code)
+
+    @_telemetry.observe_hook("auto_recall")
+    def hook():
+        print("déjà émis")
+        raise failure
+
+    with pytest.raises(SystemExit) as caught:
+        hook()
+    assert caught.value is failure
+    assert sys.stdout is original_stdout
+    sample = _sample(telemetry_log)
+    assert sample["ok"] is (code is None or code == 0)
+    assert sample["bytes_out"] == len(capsys.readouterr().out.encode("utf-8"))
+
+
+def test_exception_records_partial_output_and_remains_visible(telemetry_log, capsys):
+    original_stdout = sys.stdout
+    failure = RuntimeError("hook failed")
+
+    @_telemetry.observe_hook("session_start")
+    def hook():
+        print("émission partielle")
+        raise failure
+
+    with pytest.raises(RuntimeError) as caught:
+        hook()
+    assert caught.value is failure
+    assert sys.stdout is original_stdout
+    sample = _sample(telemetry_log)
+    assert sample["ok"] is False
+    assert sample["bytes_out"] == len(capsys.readouterr().out.encode("utf-8"))
+
+
+def test_metrics_are_isolated_and_recorded_before_context_exit(telemetry_log):
+    @_telemetry.observe_hook("auto_recall")
+    def hook():
+        assert retrieval_metrics().tier is None
+        assert retrieval_metrics().reranked_count == 0
+        set_retrieval_tier("hook")
+        count_reranked(2)
+
+    with operation_metrics():
+        set_retrieval_tier("outer")
+        count_reranked(3)
+        hook()
+        assert retrieval_metrics().tier == "outer"
+        assert retrieval_metrics().reranked_count == 3
+    sample = _sample(telemetry_log)
+    assert sample["tier"] == "hook"
+    assert sample["reranked_count"] == 2
+    assert sample["bytes_out"] == 0
+    assert sample["ok"] is True
+
+
+def test_disabled_telemetry_preserves_output(telemetry_log, monkeypatch, capsys):
+    monkeypatch.setenv("CORTEX_TELEMETRY_DISABLED", "1")
+
+    @_telemetry.observe_hook("auto_recall")
+    def hook():
+        print("mémoire")
+
+    hook()
+    assert capsys.readouterr().out == "mémoire\n"
+    assert not telemetry_log.exists()
+    assert telemetry.snapshot() == {}
+
+
+def test_log_write_failure_does_not_break_hook(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(telemetry, "_LOG_PATH", tmp_path)
+
+    @_telemetry.observe_hook("auto_recall")
+    def hook():
+        print("mémoire")
+
+    hook()
+    assert capsys.readouterr().out == "mémoire\n"
+    assert telemetry.snapshot()["auto_recall"]["ok"] == 1
+
+
+def _patch_session_main(monkeypatch):
+    for name in (
+        "_refresh_session_registry",
+        "_auto_wire_pipeline",
+        "_maybe_background_reanalyze",
+        "_maybe_background_consolidate",
+    ):
+        monkeypatch.setattr(session_start, name, lambda *args: None)
+    values = {
+        "_read_event": {},
+        "_backend_is_sqlite": False,
+        "_connect_pg": SimpleNamespace(close=lambda: None),
+        "_count_memories": 1,
+        "_fetch_anchors": [{"id": 1, "content": "Décision 🧠"}],
+        "_fetch_hot_memories": [],
+        "_fetch_team_decisions": [],
+        "_fetch_checkpoint": None,
+        "_count_pending_curations": 0,
+        "_fetch_grooming_staleness": [],
+        "_emit_banner_receipt": 7,
+        "_has_sentence_transformers": True,
+        "_detect_external_sources": [],
+    }
+    for name, value in values.items():
+        monkeypatch.setattr(session_start, name, lambda *args, value=value: value)
+
+
+def test_session_main_counts_banner_receipt_and_external_sources(
+    telemetry_log, monkeypatch, capsys
+):
+    _patch_session_main(monkeypatch)
+    monkeypatch.setattr(
+        session_start,
+        "_detect_external_sources",
+        lambda: [{"name": "Mémoire externe", "path": "/fixture/été", "count": 1}],
+    )
+
+    session_start.main()
+
+    out = capsys.readouterr().out
+    assert "Décision 🧠" in out
+    assert "⟦rcpt:7⟧" in out
+    assert "Mémoire externe" in out
+    sample = _sample(telemetry_log)
+    assert sample["op"] == "session_start"
+    assert sample["bytes_out"] == len(out.encode("utf-8"))
+    assert sample["ok"] is True
+
+
+def _patch_auto_main(monkeypatch):
+    monkeypatch.setattr(
+        sys, "stdin", io.StringIO('{"prompt":"remember this decision"}')
+    )
+    monkeypatch.setattr(auto_recall, "_refresh_session_registry", lambda event: None)
+    monkeypatch.setattr(auto_recall, "_backend_is_sqlite", lambda: False)
+    monkeypatch.setattr(
+        auto_recall, "_connect", lambda: SimpleNamespace(close=lambda: None)
+    )
+    monkeypatch.setattr(
+        auto_recall,
+        "_recall_memories",
+        lambda conn, query: [{"id": 1, "content": "Décision 🧠"}],
+    )
+    monkeypatch.setattr(auto_recall, "emit_hook_receipt", lambda *args, **kwargs: 9)
+
+
+def test_isolated_session_records_all_context_operations(
+    telemetry_log, monkeypatch, capsys
+):
+    monkeypatch.setattr(query_methodology, "load_profiles", lambda: {})
+    monkeypatch.setattr(query_methodology, "_try_get_memory_store", lambda: None)
+    monkeypatch.setattr(query_methodology, "_bounded", lambda response: response)
+    response = asyncio.run(
+        query_methodology.handler({"cwd": str(telemetry_log.parent)})
+    )
+    assert response["coldStart"] is True
+    _patch_session_main(monkeypatch)
+    session_start.main()
+    banner = capsys.readouterr().out
+    _patch_auto_main(monkeypatch)
+    with pytest.raises(SystemExit) as caught:
+        auto_recall.main()
+    assert caught.value.code == 0
+    out = capsys.readouterr().out
+    assert "Décision 🧠" in out
+    assert "⟦rcpt:9⟧" in out
+    samples = [json.loads(line) for line in telemetry_log.read_text().splitlines()]
+    assert [sample["op"] for sample in samples] == [
+        "query_methodology",
+        "session_start",
+        "auto_recall",
+    ]
+    assert samples[0]["bytes_out"] > 0
+    assert samples[1]["bytes_out"] == len(banner.encode("utf-8")) > 0
+    assert samples[2]["bytes_out"] == len(out.encode("utf-8")) > 0
+    assert all(sample["ok"] for sample in samples)
+
+
+@pytest.mark.parametrize("raw", ["", "{bad json", '{"prompt":"ok"}'])
+def test_auto_recall_main_silent_exits_are_recorded(
+    raw, telemetry_log, monkeypatch, capsys
+):
+    monkeypatch.setattr(sys, "stdin", io.StringIO(raw))
+    monkeypatch.setattr(auto_recall, "_refresh_session_registry", lambda event: None)
+
+    with pytest.raises(SystemExit) as caught:
+        auto_recall.main()
+
+    assert caught.value.code == 0
+    assert capsys.readouterr().out == ""
+    sample = _sample(telemetry_log)
+    assert sample["op"] == "auto_recall"
+    assert sample["bytes_out"] == 0
+    assert sample["ok"] is True

--- a/tests_py/hooks/test_hook_telemetry_bytes.py
+++ b/tests_py/hooks/test_hook_telemetry_bytes.py
@@ -1,0 +1,88 @@
+"""Count actual stdout bytes after encoding, errors policy, and CRLF expansion."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+
+import pytest
+
+from mcp_server.core import telemetry
+from mcp_server.hooks._telemetry import observe_hook
+
+
+@pytest.mark.parametrize("newline", [None, "\r\n", ""])
+def test_observer_counts_binary_output_after_text_transformations(
+    newline, tmp_path, monkeypatch
+):
+    log = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", log)
+    sink = io.BytesIO()
+    stream = io.TextIOWrapper(sink, encoding="utf-8", errors="replace", newline=newline)
+    monkeypatch.setattr(sys, "stdout", stream)
+    original_write = sink.write
+    stream.write("previous output\n")
+
+    @observe_hook("session_start")
+    def emit():
+        print("café\n\ud800")
+
+    emit()
+    # source: TextIOWrapper newline=None translates LF to os.linesep.
+    translated = os.linesep if newline is None else newline or "\n"
+    expected = "café\n?\n".replace("\n", translated).encode("utf-8")
+    sample = json.loads(log.read_text())
+    assert sink.getvalue().endswith(expected)
+    assert sample["bytes_out"] == len(expected)
+    assert sample["ok"] is True
+    assert sys.stdout is stream
+    assert sink.write == original_write
+    stream.detach()
+
+
+def test_flush_failure_does_not_replace_original_exception(
+    tmp_path, monkeypatch, caplog
+):
+    log = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", log)
+    stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-8")
+    monkeypatch.setattr(sys, "stdout", stream)
+    failure = RuntimeError("original failure")
+
+    @observe_hook("auto_recall")
+    def emit():
+        print("partial output")
+        stream.close()
+        raise failure
+
+    with pytest.raises(RuntimeError) as caught:
+        emit()
+    assert caught.value is failure
+    assert "Cannot flush failed hook output" in caplog.text
+    assert json.loads(log.read_text())["ok"] is False
+
+
+def test_binary_stdout_is_restored_after_hook_exception(tmp_path, monkeypatch):
+    log = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", log)
+    sink = io.BytesIO()
+    stream = io.TextIOWrapper(sink, encoding="utf-8", newline="\r\n")
+    monkeypatch.setattr(sys, "stdout", stream)
+    original_write = sink.write
+    failure = RuntimeError("original failure")
+
+    @observe_hook("auto_recall")
+    def emit():
+        print("déjà émis")
+        raise failure
+
+    with pytest.raises(RuntimeError) as caught:
+        emit()
+    sample = json.loads(log.read_text())
+    assert caught.value is failure
+    assert sample["bytes_out"] == len(sink.getvalue()) > 0
+    assert sample["ok"] is False
+    assert sink.write == original_write
+    stream.detach()

--- a/tests_py/test_telemetry_middleware.py
+++ b/tests_py/test_telemetry_middleware.py
@@ -1,0 +1,162 @@
+"""Measure real MCP success/error TextContent once, including worker offload."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextvars import copy_context
+from types import SimpleNamespace
+
+import pytest
+from mcp import Client
+from mcp.server.mcpserver import MCPServer
+from mcp.types import CallToolResult, TextContent
+from pydantic import BaseModel
+
+from mcp_server.core import telemetry
+from mcp_server.handlers._telemetry_wrap import instrument
+from mcp_server.shared.telemetry_context import count_reranked, set_retrieval_tier
+from mcp_server.telemetry_middleware import TelemetryMiddleware
+from mcp_server.tool_error_handler import safe_handler
+
+
+@pytest.fixture
+def telemetry_log(tmp_path, monkeypatch):
+    path = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", path)
+    monkeypatch.delenv("CORTEX_TELEMETRY_DISABLED", raising=False)
+    telemetry.set_exporter(None)
+    telemetry.reset()
+    yield path
+    telemetry.reset()
+    telemetry.set_exporter(None)
+
+
+def _samples(path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def _server(*, fail=False, invalid_output=False, measured=True):
+    server = MCPServer(name="telemetry-fixture", middleware=[TelemetryMiddleware()])
+
+    async def handler(args):
+        set_retrieval_tier("pg")
+        count_reranked(2)
+        if fail:
+            raise ValueError("échec de fixture 🧠")
+        return {"message": "café 🧠"}
+
+    observed = instrument("fixture", handler) if measured else handler
+
+    @server.tool(name="fixture")
+    async def fixture() -> dict[str, str]:
+        return await safe_handler(observed, {})
+
+    if invalid_output:
+        tool = server._tool_manager.get_tool("fixture")
+        assert tool is not None
+
+        # The SDK validates this model after the instrumented handler returns.
+        class RequiredOutput(BaseModel):
+            required_field: int
+
+        tool.fn_metadata.output_model = RequiredOutput
+    return server
+
+
+def _call(server):
+    async def run():
+        async with Client(server) as client:
+            return await client.call_tool("fixture", {})
+
+    return asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    "fail,invalid_output", [(False, False), (True, False), (False, True)]
+)
+def test_sdk_text_response_is_counted_exactly_once(fail, invalid_output, telemetry_log):
+    result = _call(_server(fail=fail, invalid_output=invalid_output))
+    samples = _samples(telemetry_log)
+    assert len(samples) == 1
+    sample = samples[0]
+    text = [block.text for block in result.content if isinstance(block, TextContent)]
+    assert sample["bytes_out"] == sum(len(value.encode("utf-8")) for value in text) > 0
+    assert sample["ok"] is (not result.is_error)
+    assert result.is_error is (fail or invalid_output)
+    if fail:
+        assert "échec de fixture 🧠" in "".join(text)
+    elif not invalid_output:
+        assert json.loads("".join(text)) == {"message": "café 🧠"}
+    assert sample["tier"] == "pg"
+    assert sample["reranked_count"] == 2
+    counters = telemetry.snapshot()["fixture"]
+    assert counters["count"] == 1
+    assert counters["bytes_out"] == sample["bytes_out"]
+    assert counters["fail"] == int(result.is_error)
+
+
+def test_uninstrumented_sdk_tool_creates_no_sample(telemetry_log):
+    result = _call(_server(measured=False))
+    assert not result.is_error
+    assert not telemetry_log.exists()
+    assert telemetry.snapshot() == {}
+
+
+@pytest.mark.parametrize("as_dict", [False, True])
+def test_middleware_preserves_response_and_nested_operation(as_dict, telemetry_log):
+    response = CallToolResult(
+        content=[TextContent(type="text", text="réponse 🧠")], is_error=True
+    )
+    expected = response.model_dump(by_alias=True) if as_dict else response
+
+    async def call_next(ctx):
+        telemetry.record("nested", latency_ms=1, bytes_out=5)
+        telemetry.record("fixture", latency_ms=2, bytes_out=0)
+        assert telemetry.snapshot() == {}
+        assert not telemetry_log.exists()
+        return expected
+
+    context = SimpleNamespace(method="tools/call", params={"name": "fixture"})
+    result = asyncio.run(TelemetryMiddleware()(context, call_next))
+    assert result is expected
+    nested, outer = _samples(telemetry_log)
+    assert nested["bytes_out"] == 5
+    assert nested["ok"] is True
+    assert outer["bytes_out"] == len("réponse 🧠".encode("utf-8"))
+    assert outer["ok"] is False
+
+
+def test_missing_response_publishes_failure_without_swallowing_it(telemetry_log):
+    failure = RuntimeError("transport fixture failure")
+
+    async def call_next(ctx):
+        telemetry.record("fixture", latency_ms=1, ok=False)
+        raise failure
+
+    context = SimpleNamespace(method="tools/call", params={"name": "fixture"})
+    with pytest.raises(RuntimeError) as caught:
+        asyncio.run(TelemetryMiddleware()(context, call_next))
+    assert caught.value is failure
+    sample = _samples(telemetry_log)
+    assert len(sample) == 1
+    assert sample[0]["bytes_out"] == 0
+    assert sample[0]["ok"] is False
+
+
+def test_capture_restores_context_and_late_worker_can_publish(telemetry_log):
+    with telemetry.capture_records() as samples:
+        worker_context = copy_context()
+        telemetry.record("captured", latency_ms=1.23456)
+        assert telemetry.snapshot() == {}
+    assert not telemetry_log.exists()
+    telemetry.publish_record(samples[0])
+    worker_context.run(telemetry.record, "late_worker", latency_ms=2)
+    telemetry.record("direct", latency_ms=3)
+    assert [sample["op"] for sample in _samples(telemetry_log)] == [
+        "captured",
+        "late_worker",
+        "direct",
+    ]
+    assert len(samples) == 1
+    assert telemetry.snapshot()["captured"]["latency_ms_sum"] == 1.23456


### PR DESCRIPTION
## Symptôme

W0-1 / ⚪2 : les opérations instrumentées écrivaient `bytes_out=0`, tandis que
`query_methodology`, `session_start` et `auto_recall` étaient absents du journal.
Le chemin de récupération et le travail effectif du reranker n'étaient pas mesurés.

## Cause racine

Contrat de mesure incomplet : `_telemetry_wrap` n'envoyait pas la réponse au
compteur. Les erreurs et validations de sortie sont converties par le SDK après
le handler ; les compter dans le handler seul laisse encore des zéros faux.
Les hooks ne possédaient pas de frontière de mesure, et le chemin du journal
ignorait `CORTEX_CLAUDE_DIR`.

## Changement

- Mesurer le texte UTF-8 effectivement rendu par le SDK, succès comme erreur,
  dans un middleware de composition ; publier chaque échantillon une seule fois.
  Les appels directs aux handlers mesurent leur résultat sérialisé.
- Enregistrer les opérations manquantes. Les hooks comptent les octets après
  encodage et conversion des fins de ligne, sans reconstruire l'encodeur stdout.
- Transporter `tier` et `reranked_count` dans un contexte propre à l'opération,
  restauré après les appels imbriqués. Le compteur ne croît qu'après une inférence
  réussie ; il vaut zéro si le modèle est sauté ou échoue.
- Respecter `CORTEX_CLAUDE_DIR` pour le journal et signaler ses échecs d'écriture.
  Documenter la frontière de mesure et la signification des champs dans PRIVACY.md.

Les poids de récupération, les décisions du reranker et les réponses ne changent
pas. `tier=pg` nomme le pipeline actuellement exécuté, y compris avec son store
SQLite ; les anciennes routes conservent `simple` / `mixed` / `deep`. `tier=null`
signifie qu'aucune route instrumentée n'a été exécutée. Un hook silencieux et un
handler direct qui lève sans réponse gardent légitimement `bytes_out=0`.

## Preuve

Base : `10a0f38152d15625b58b4027ea86eb7705377ae7`.
Commit testé : `24f7a398abd3371d983421ae94ff177e2ecfb5c9` ; aucun rebase.
Checkout propre : `/private/tmp/cortex-green-w0-1-validation`, macOS arm64,
Python 3.12.11, versions installées depuis `uv.lock`.

Conditions relevées avant validation : `getconf NPROCESSORS_ONLN` → `10` ;
`uptime` → `load averages: 5.66 6.04 4.93` ; `df -h /` → `68Gi` disponibles.
Avant la suite complète : charge `5.65 5.44 5.19` ; `67Gi` disponibles après
préparation du checkout. Un seul travail lourd local à la fois.
Après validation : charge `6.84 6.33 5.62`, espace disponible `67Gi`.

Avant correction, le test du wrapper sur les handlers publics `recall({})` et
`remember({})` échouait sur la première assertion de volume : `bytes_out=0`
malgré une réponse non vide (`1 failed, 1 passed`). Après correction, les tests
comparent le volume à la sérialisation du SDK et au stdout effectivement écrit.

Signaux d'acceptation W0-1 présents dans les tests :

- `test_real_store_round_trip_records_nonempty_response_sizes` : vrai store
  SQLite jetable, rappel suivi d'une écriture, exactement les deux échantillons,
  `bytes_out>0`, `tier` et `reranked_count` présents.
- `test_isolated_session_records_all_context_operations` : session avec sources
  simulées, journal jetable contenant exactement `query_methodology`,
  `session_start`, `auto_recall` ; tailles du banner et de l'injection exactes.
- `test_sdk_text_response_is_counted_exactly_once` : vrai client/serveur SDK en
  mémoire, succès, exception et rejet du schéma de sortie ; volume, statut et
  compteurs concordent avec le résultat reçu.
- Tests de CRLF, UTF-8, remplacement des caractères invalides, exceptions,
  restauration de stdout, scopes concurrents/imbriqués et worker tardif.

Gates exécutées dans cet ordre :

```sh
uv sync --no-default-groups --extra dev --extra sqlite --group lint --locked
.venv/bin/ruff check && .venv/bin/ruff format --check
# All checks passed! ; 1403 files already formatted
.venv/bin/python scripts/check_craftsmanship.py
# Craftsmanship gate: OK
uv sync --no-default-groups --extra dev --extra postgresql --extra sqlite \
  --extra codebase --extra otel --group typecheck --group lint --locked
.venv/bin/python -m pyright mcp_server/
# 0 errors, 0 warnings, 0 informations
```

Environnement des commandes pytest ci-dessous :

```sh
export CORTEX_TEST_DATABASE_URL=postgresql://localhost:1/cortex_green_isolated
export CORTEX_MEMORY_STORE_BACKEND=sqlite DATABASE_URL=
export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 CORTEX_RERANKER_OFFLINE=1
.venv/bin/python -m pytest tests_py/core/ tests_py/shared/ tests_py/handlers/ \
  tests_py/hooks/ tests_py/test_telemetry_middleware.py -q --tb=short
# 5566 passed, 67 skipped, 3 warnings in 110.32s
.venv/bin/python -m pytest -q --tb=short
# 7490 passed, 221 skipped, 3 warnings, 123 subtests passed in 143.13s
```

PostgreSQL est volontairement inaccessible : les tests qui le requièrent sont
signalés comme sautés, pas comme validés. La suite redirige tous ses chemins de
données vers des arbres jetables. Aucun score de qualité de rappel ni gain
énergétique n'est revendiqué par cette PR d'instrumentation.

## Conformité

- §1.1 : PASS — branche dédiée `fix/green-telemetry`, commit conventionnel, une PR W0-1 ;
  fusion laissée au propriétaire.
- §1.2 : PASS — gates locales ci-dessus ; baseline diminuée de la seule entrée
  `method-size: record`, rendue inutile par l'extraction des étapes de publication.
- §1.3 : PASS — nouveaux modules sous les caps, nouveaux imports conformes aux couches ;
  les sources de la sérialisation et des conversions sont nommées dans le code.
  La dette historique conservée est détaillée ci-dessous.
- §1.4 : PASS — échecs de journalisation observables, aucun cache de modèle sous `/tmp`,
  aucun shim ni mécanisme retiré.
- §1.5 : PASS — données exclusivement jetables ; pas de changement d'algorithme de
  lecture/écriture ni de revendication de floors. L'acceptation spécifique W0-1
  est démontrée par les tests ci-dessus.
- §1.6 : PASS — charge vérifiée avant les travaux lourds ; exécutions locales sérialisées.
- §1.7 : PASS — aucune opération sur les données de production.
- §1.8 : PASS — aucune issue ouverte ; dette rencontrée listée ci-dessous.
- §1.9 : PASS — nombres issus des sorties des commandes ou de l'identifiant ⚪2 du contrat.
- §1.10 : PASS — porte binaire de confiance du reranker inchangée.

## Candidats issues

- `core/telemetry.py` conserve ses imports historiques `os` et `pathlib`, déjà
  présents dans la baseline de la base. Cette PR corrige la résolution du chemin
  existant sans introduire de nouvel import de couche ; extraire tout le sink
  demanderait une tâche distincte.
- Les fichiers historiques `query_methodology.py`, `session_start.py`,
  `auto_recall.py` et certaines fonctions de récupération dépassent déjà les caps.
  Le diff ajoute leurs points d'observation sans absorber leur refonte générale.
- Le harnais local non suivi `benchmarks/energy/` présente des erreurs Ruff
  préexistantes ; il n'entre pas dans W0-1. La décision du propriétaire pour W0-2
  reste nécessaire. Le checkout isolé vérifie l'intégralité des fichiers de la PR.
- La protection GitHub de `main` liste encore des jobs individuels, contrairement
  au check agrégé décrit par CONTRIBUTING.md ; traitement prévu par W1-2.

## Runbook

Aucune migration, purge ou opération de maintenance sur la production.
Après fusion, redémarrer l'hôte MCP pour charger l'instrumentation.
