### PR TITLE
fix(benchmarks): validate energy harness float32 outputs and carbon units

### DIFF
--- a/benchmarks/energy/README.md
+++ b/benchmarks/energy/README.md
@@ -1,0 +1,130 @@
+# Embedding energy harness
+
+W0-2 repairs the float32 equivalence gate and makes carbon inputs explicit.
+The automated fixtures exercise arithmetic and failure paths; they do **not**
+measure device energy or establish an energy improvement.
+
+## Run
+
+Run from an interactive macOS terminal, after supplying your sourced protocol
+and carbon factors. These environment variables intentionally have no example
+carbon values:
+
+```sh
+benchmarks/energy/run.sh \
+  --duration-seconds "$ENERGY_PHASE_SECONDS" \
+  --repetitions "$ENERGY_REPETITIONS" \
+  --carbon-intensity "$ENERGY_INTENSITY_G_PER_KWH" \
+  --embodied "$ENERGY_EMBODIED_G_PER_SECOND"
+```
+
+`--carbon-intensity` and `--embodied` are mandatory, finite and nonnegative.
+The runner validates them, and the protocol, before any `sudo` or model import.
+`--validate-only` performs just that validation. `--batch-size` defaults to the
+batch from the review's W3-2 probe; `--sample-rate-ms` defaults to the system
+powermetrics manual's sampling interval. Both are configurable experimental
+protocol choices. Choose phases long enough to contain sensor samples.
+
+`run.sh` owns sensor authorization and cleanup; it replaces the duplicate
+AppleScript sensor launcher previously embedded in Python. Only powermetrics
+runs elevated. `ENERGY_PYTHON` can select a Python interpreter; otherwise the
+runner uses the repository's `.venv/bin/python`. The Python entry point can use
+an already running stream via `--external-power-file`; without it, it directs
+the operator to `run.sh`. An unavailable neural model is an explicit error.
+The harness does not change the model's cache location.
+
+## Units and equivalence
+
+`I = --carbon-intensity` is the electricity region's intensity in gCO2eq/kWh.
+`--embodied` is an **already allocated emission rate** in gCO2eq/s, not the total
+device footprint. Derive it from sourced lifecycle emissions divided by expected
+life in seconds, multiplied by the resource share reserved for this workload.
+Record the region, observation period, lifecycle assessment, expected lifetime
+and reservation assumptions alongside your run. The harness records input
+values and units but does not verify their provenance.
+
+For each measured phase, with `t` its actual elapsed seconds and `N` its actual
+model input token count:
+
+```text
+M_phase [gCO2eq] = embodied_rate [gCO2eq/s] * t [s]
+O_phase [gCO2eq] = (energy_j / 3600000) [kWh] * I [gCO2eq/kWh]
+carbon per 1000 tokens = (O_phase + M_phase) * 1000 / N
+joules per 1000 tokens = energy_j * 1000 / N
+```
+
+The model's `tokenize` method supplies `attention_mask`; summing it counts
+non-padding tokens after truncation, including special tokens. The harness
+reconstructs every completed input batch and counts tokens **after all timed
+phases**. It never estimates tokens from characters. Scalar and batch phases
+use the same deterministic text generator; their LRU cache is cleared before
+each phase so the probe cannot warm scalar inputs into cache hits.
+
+Equivalence decodes `encode`/`encode_batch` blobs using
+`np.frombuffer(blob, dtype=np.float32)`. Empty, malformed, nonfinite, mismatched
+outputs and errors above `np.finfo(np.float32).eps` are refused before phases.
+The tolerance is absolute (`rtol=0`) and deliberately strict. NumPy supplies its
+floating-point definition; this is **not** a universal bound on model inference
+error. The probe validates the selected batch, device and run only. A fixture
+at `0.5` and its next float32 value toward `1` demonstrates why comparing byte
+values was incorrect.
+
+## Measurement boundary and artifacts
+
+`raw_system_energy_j` covers the sensor's combined **CPU+GPU+ANE** estimate.
+It is neither wall-plug energy nor a complete device/application SCI score.
+Memory, storage, screen, power supply losses, model warm-up and token counting
+are excluded. Carbon uses raw energy; idle-subtracted energy is a separate
+diagnostic and retains negative values so idle noise remains visible.
+
+The phase energy estimate is mean sampled watts multiplied by elapsed seconds;
+samples are assigned by their end timestamps. Finite sampling introduces phase
+boundary error. CPU-only samples are refused. An incomplete final sample may
+be ignored only when its timestamp is after every measured phase, with an
+explicit warning; malformed samples inside phases are refused.
+
+Successful runs preserve `results.json`, `MANIFEST.json` (commit and source
+hashes) and the exact analyzed `powermetrics.txt` snapshot under
+`benchmarks/results/energy/`. The snapshot is taken while the external sensor
+is running. On failure, the shell reports the retained raw temporary file;
+it never stores a model there. Sensor stop failures return nonzero and do not
+wait indefinitely for a sensor that could not be signalled.
+
+Stopping sends `SIGINT` directly to the existing sudo parent, which relays it
+to powermetrics under macOS's normal sudoers/PAM process model. This requires
+no new sudo invocation, so an expired authentication ticket does not prevent
+cleanup. A nonstandard sudo policy that replaces its parent with the root
+command may deny the signal; the runner then reports failure without waiting.
+
+## Primary sources
+
+- [Green Software Foundation SCI specification](https://sci.greensoftware.foundation/):
+  operational emissions `O=E*I`, embodied allocation `M=TE*TS*RS`, functional units.
+- [NumPy frombuffer](https://numpy.org/doc/stable/reference/generated/numpy.frombuffer.html),
+  [finfo](https://numpy.org/doc/stable/reference/generated/numpy.finfo.html), and
+  [allclose](https://numpy.org/doc/stable/reference/generated/numpy.allclose.html):
+  byte interpretation, machine epsilon and explicit tolerance semantics.
+- [SentenceTransformer.tokenize](https://www.sbert.net/docs/package_reference/sentence_transformer/SentenceTransformer.html#sentence_transformers.SentenceTransformer.tokenize)
+  and [Hugging Face tokenizer attention masks](https://huggingface.co/docs/transformers/main_classes/tokenizer):
+  actual model preprocessing and non-padding token masks.
+- [NIST SP 811 chapter 4](https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-4-two-classes-si-units-and-si-prefixes)
+  and [chapter 5](https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-5-units-outside-si):
+  watt/joule, kilo/milli prefixes and seconds per hour.
+- Local macOS `powermetrics(1)`, `/usr/share/man/man1/powermetrics.1`, consulted
+  2026-09-06: sample-rate default, continuous sampling, flushing and stop signals.
+- Local macOS `sudo(8)` 1.9.17p2, `/usr/share/man/man8/sudo.8`, sections
+  "Process model" and "Signal handling", and [Apple kill(2)](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kill.2.html):
+  user-generated signal relay and real/effective UID permission checks.
+- Protocol/acceptance: `tasks/codex-green-remediation-plan.md`, W0-2 and W3-2.
+
+## Fixture verification
+
+```sh
+.venv/bin/pytest tests_py/benchmarks/test_energy_*.py
+.venv/bin/ruff check benchmarks/energy tests_py/benchmarks/test_energy_*.py
+.venv/bin/ruff format --check benchmarks/energy tests_py/benchmarks/test_energy_*.py
+```
+
+The shell tests use a fake sudo executable for validation and a simulated
+sensor under a PTY for successful and failing workload cleanup. No test starts
+powermetrics, invokes real sudo or downloads/loads model weights.

--- a/benchmarks/energy/measurement.py
+++ b/benchmarks/energy/measurement.py
@@ -1,0 +1,244 @@
+"""Power samples, explicit carbon arithmetic, and reproducible report artifacts.
+
+The SCI equation is used only for the disclosed CPU+GPU+ANE boundary, which is
+not a complete device/application SCI assessment. See README.md for sources.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import statistics
+import subprocess
+import warnings
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+import numpy as np
+
+from benchmarks.energy.workload import Phase
+
+
+REPO = Path(__file__).resolve().parent.parent.parent
+# source: W0-2 functional unit in tasks/codex-green-remediation-plan.md.
+TOKENS_PER_UNIT = 1000
+# source: NIST SP 811 ch. 4 (W = J/s, kilo = 10^3), ch. 5 (h = 3600 s).
+JOULES_PER_KWH = 3_600_000
+# source: NIST SP 811 ch. 4, milli = 10^-3.
+MILLIWATTS_PER_WATT = 1000
+COMBINED_POWER_RE = re.compile(
+    r"Combined Power \(CPU \+ GPU \+ ANE\):\s*([0-9.]+)\s*mW"
+)
+SAMPLE_RE = re.compile(
+    r"\*\*\* Sampled system activity \(([^)]+)\).*?\*\*\*\n"
+    r"(.*?)(?=\n\*\*\* Sampled system activity|\Z)",
+    re.DOTALL,
+)
+
+
+@dataclass
+class MeasuredPhase:
+    phase: Phase
+    samples: int
+    mean_system_power_w: float
+    idle_power_w: float
+
+    @property
+    def raw_system_energy_j(self) -> float:
+        # source: NIST SP 811 ch. 4, W = J/s; sampled mean power approximation.
+        return self.mean_system_power_w * self.phase.elapsed_s
+
+    @property
+    def dynamic_energy_j(self) -> float:
+        # Keep negative differences visible; they indicate idle/noise sensitivity.
+        return (self.mean_system_power_w - self.idle_power_w) * self.phase.elapsed_s
+
+
+def parse_power_samples(
+    text: str, phase_end: float | None = None
+) -> list[tuple[float, float]]:
+    samples = []
+    blocks = SAMPLE_RE.findall(text)
+    for index, (timestamp, body) in enumerate(blocks):
+        sampled_at = parsedate_to_datetime(timestamp).timestamp()
+        match = COMBINED_POWER_RE.search(body)
+        if (
+            match is None
+            and index == len(blocks) - 1
+            and phase_end is not None
+            and sampled_at > phase_end
+        ):
+            warnings.warn(
+                "Incomplete final power sample outside measured phases ignored; "
+                "raw snapshot preserved",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            continue
+        if match is None:
+            raise ValueError("sample lacks Combined Power (CPU + GPU + ANE)")
+        watts = float(match.group(1)) / MILLIWATTS_PER_WATT
+        if not math.isfinite(watts):
+            raise ValueError("non-finite power sample")
+        samples.append((sampled_at, watts))
+    if not samples:
+        raise ValueError("no combined CPU+GPU+ANE power samples")
+    return samples
+
+
+def _mean_power(phase: Phase, samples: list[tuple[float, float]]) -> tuple[int, float]:
+    values = [
+        watts
+        for timestamp, watts in samples
+        if phase.wall_start <= timestamp <= phase.wall_end
+    ]
+    if not values:
+        raise RuntimeError(f"no power samples in phase {phase.condition}")
+    return len(values), statistics.fmean(values)
+
+
+def apply_power_samples(
+    phases: list[Phase], samples: list[tuple[float, float]]
+) -> list[MeasuredPhase]:
+    power = [_mean_power(phase, samples) for phase in phases]
+    idle_by_rep = {
+        phase.repetition: mean
+        for phase, (_, mean) in zip(phases, power, strict=True)
+        if phase.condition == "idle"
+    }
+    return [
+        MeasuredPhase(phase, count, mean, idle_by_rep[phase.repetition])
+        for phase, (count, mean) in zip(phases, power, strict=True)
+        if phase.condition != "idle"
+    ]
+
+
+def carbon_per_1k_tokens(
+    energy_j: float, tokens: int, intensity: float, embodied_g: float
+) -> float:
+    if tokens <= 0:
+        raise ValueError("token count must be positive")
+    if any(not math.isfinite(x) or x < 0 for x in (energy_j, intensity, embodied_g)):
+        raise ValueError("energy and carbon inputs must be finite and nonnegative")
+    # source: https://sci.greensoftware.foundation/ : O = E*I, SCI = (O+M)/R.
+    operational_g = energy_j / JOULES_PER_KWH * intensity
+    return (operational_g + embodied_g) * TOKENS_PER_UNIT / tokens
+
+
+def summarize(
+    rows: list[MeasuredPhase], mode: str, args: argparse.Namespace
+) -> dict[str, float]:
+    selected = [row for row in rows if row.phase.condition == mode]
+    per_text = [row.raw_system_energy_j / row.phase.operations for row in selected]
+    per_tokens = [
+        row.raw_system_energy_j * TOKENS_PER_UNIT / row.phase.tokens for row in selected
+    ]
+    carbon = [
+        carbon_per_1k_tokens(
+            row.raw_system_energy_j,
+            row.phase.tokens,
+            args.carbon_intensity,
+            args.embodied * row.phase.elapsed_s,
+        )
+        for row in selected
+    ]
+    return {
+        "repetitions": len(selected),
+        "operations_total": sum(row.phase.operations for row in selected),
+        "tokens_total": sum(row.phase.tokens for row in selected),
+        "energy_j_per_text_mean": statistics.fmean(per_text),
+        "energy_j_per_text_stdev": statistics.stdev(per_text),
+        "energy_j_per_1k_tokens_mean": statistics.fmean(per_tokens),
+        "carbon_gco2eq_per_1k_tokens_mean": statistics.fmean(carbon),
+        "idle_subtracted_j_per_text_mean": statistics.fmean(
+            row.dynamic_energy_j / row.phase.operations for row in selected
+        ),
+        "texts_per_second_mean": statistics.fmean(
+            row.phase.operations / row.phase.elapsed_s for row in selected
+        ),
+    }
+
+
+def _report_row(row: MeasuredPhase, args: argparse.Namespace) -> dict[str, object]:
+    return {
+        **asdict(row.phase),
+        "samples": row.samples,
+        "mean_system_power_w": row.mean_system_power_w,
+        "idle_power_w": row.idle_power_w,
+        "raw_system_energy_j": row.raw_system_energy_j,
+        "dynamic_energy_j": row.dynamic_energy_j,
+        "embodied_gco2eq": args.embodied * row.phase.elapsed_s,
+        "carbon_gco2eq_per_1k_tokens": carbon_per_1k_tokens(
+            row.raw_system_energy_j,
+            row.phase.tokens,
+            args.carbon_intensity,
+            args.embodied * row.phase.elapsed_s,
+        ),
+    }
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "git_commit": subprocess.check_output(
+            ["git", "-C", str(REPO), "rev-parse", "HEAD"], text=True
+        ).strip(),
+        "source_sha256": {
+            path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in sorted(Path(__file__).parent.iterdir())
+            if path.is_file()
+        },
+        "host": subprocess.check_output(["uname", "-a"], text=True).strip(),
+        "raw_measurement": "powermetrics.txt",
+        "limitations": [
+            "System CPU+GPU+ANE estimates, not process-isolated or device-total energy",
+            "Excludes memory, storage, display, supply losses, model load and counting",
+            "Mean power uses sample end timestamps within each phase; boundary error",
+            "Operator-supplied I and allocated embodied rate are not verified here",
+            "Float32 tolerance validates this probe only, not all inputs/devices",
+        ],
+    }
+
+
+def write_report(
+    args: argparse.Namespace,
+    results: tuple[list[MeasuredPhase], dict[str, dict[str, float]]],
+    evidence: tuple[bytes, float],
+) -> dict[str, object]:
+    rows, summary = results
+    raw_power, delta = evidence
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    out_dir = REPO / "benchmarks" / "results" / "energy" / stamp
+    out_dir.mkdir(parents=True, exist_ok=False)
+    result = {
+        "functional_units": ["one embedded text", "1000 model input tokens"],
+        "token_definition": (
+            "attention_mask sum after truncation; special tokens included"
+        ),
+        "boundary": "CPU+GPU+ANE power during local inference phases",
+        "duration_seconds": args.duration_seconds,
+        "repetitions": args.repetitions,
+        "batch_size": args.batch_size,
+        "sample_rate_ms": args.sample_rate_ms,
+        "carbon_intensity_gco2eq_per_kwh": args.carbon_intensity,
+        "embodied_rate_gco2eq_per_second": args.embodied,
+        "carbon_formula": (
+            "((energy_j / 3600000) * I + embodied_rate * elapsed_s) * 1000 / tokens"
+        ),
+        "max_abs_output_delta_scalar_vs_batch": delta,
+        "equivalence_atol": float(np.finfo(np.float32).eps),
+        "equivalence_rtol": 0,
+        "rows": [_report_row(row, args) for row in rows],
+        "summary": summary,
+    }
+    (out_dir / "powermetrics.txt").write_bytes(raw_power)
+    for name, payload in (("results.json", result), ("MANIFEST.json", _manifest())):
+        (out_dir / name).write_text(
+            json.dumps(payload, indent=2, allow_nan=False) + "\n"
+        )
+    return {"result_dir": str(out_dir), "summary": summary}

--- a/benchmarks/energy/run.sh
+++ b/benchmarks/energy/run.sh
@@ -1,0 +1,92 @@
+#!/bin/zsh
+# One privileged sensor; Python validation and inference remain unprivileged.
+set -euo pipefail
+unsetopt BG_NICE
+
+SCRIPT_DIR=${0:A:h}
+REPO_DIR=${SCRIPT_DIR:h:h}
+BENCH_PY=${ENERGY_PYTHON:-${REPO_DIR}/.venv/bin/python}
+ENERGY_POWER_FILE=""
+ENERGY_METER_PID=""
+
+if [[ ! -x ${BENCH_PY} ]]; then
+  print -u2 "Missing benchmark interpreter: ${BENCH_PY}"
+  exit 2
+fi
+for ENERGY_ARG in "$@"; do
+  if [[ ${ENERGY_ARG} == --help || ${ENERGY_ARG} == -h ]]; then
+    exec "${BENCH_PY}" "${SCRIPT_DIR}/run_embedding_energy.py" --help
+  fi
+done
+# Required carbon flags and every numeric argument are checked before sudo.
+ENERGY_SAMPLE_RATE_MS=$("${BENCH_PY}" "${SCRIPT_DIR}/run_embedding_energy.py" "$@" --validate-only)
+for ENERGY_ARG in "$@"; do
+  if [[ ${ENERGY_ARG} == --validate-only ]]; then
+    print "${ENERGY_SAMPLE_RATE_MS}"
+    exit 0
+  fi
+  if [[ ${ENERGY_ARG} == --external-power-file* ]]; then
+    print -u2 "Use run_embedding_energy.py directly for --external-power-file."
+    exit 2
+  fi
+done
+if [[ ! -t 0 ]]; then
+  print -u2 "Run from an interactive terminal so macOS can read the sudo password."
+  exit 2
+fi
+
+stop_meter() {
+  if [[ -z ${ENERGY_METER_PID} ]]; then
+    return
+  fi
+  if kill -0 "${ENERGY_METER_PID}" 2>/dev/null; then
+    # source: macOS sudo(8), Signal handling: user-sent SIGINT is relayed
+    # to the command. Signal the existing sudo parent; no fresh ticket needed.
+    if ! kill -INT "${ENERGY_METER_PID}"; then
+      print -u2 "Failed to stop sensor ${ENERGY_METER_PID}; refusing to wait indefinitely."
+      return 1
+    fi
+  fi
+  local ENERGY_WAIT_STATUS=0
+  wait "${ENERGY_METER_PID}" || ENERGY_WAIT_STATUS=$?
+  # source: zsh exit status for SIGINT is 128 + signal 2; powermetrics(1)
+  # specifies SIGINT as its normal stop-sampling-and-exit signal.
+  if (( ENERGY_WAIT_STATUS != 0 && ENERGY_WAIT_STATUS != 130 )); then
+    print -u2 "Sensor exited with status ${ENERGY_WAIT_STATUS}."
+    return ${ENERGY_WAIT_STATUS}
+  fi
+  ENERGY_METER_PID=""
+}
+
+cleanup() {
+  local ENERGY_EXIT_STATUS=$?
+  trap - EXIT INT TERM
+  stop_meter || ENERGY_EXIT_STATUS=$?
+  if [[ -n ${ENERGY_POWER_FILE} ]]; then
+    if (( ENERGY_EXIT_STATUS == 0 )); then
+      rm -f "${ENERGY_POWER_FILE}"
+    else
+      print -u2 "Raw sensor output preserved at ${ENERGY_POWER_FILE}."
+    fi
+  fi
+  exit ${ENERGY_EXIT_STATUS}
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+print "Authorizing the macOS energy sensor (Cortex remains non-root)..."
+sudo -v
+ENERGY_POWER_FILE=$(mktemp /private/tmp/cortex-energy.XXXXXX.txt)
+# source: powermetrics(1): 0 samples means continuous capture; buffer-size 1
+# flushes each sample. The EXIT trap stops the sensor after the Python run.
+sudo -n /usr/bin/powermetrics \
+  --samplers cpu_power,gpu_power,ane_power \
+  --sample-rate "${ENERGY_SAMPLE_RATE_MS}" --sample-count 0 --buffer-size 1 \
+  --output-file "${ENERGY_POWER_FILE}" &
+ENERGY_METER_PID=$!
+
+"${BENCH_PY}" "${SCRIPT_DIR}/run_embedding_energy.py" "$@" \
+  --external-power-file "${ENERGY_POWER_FILE}"
+stop_meter
+print "Energy benchmark complete; raw samples are in the result directory."

--- a/benchmarks/energy/run_embedding_energy.py
+++ b/benchmarks/energy/run_embedding_energy.py
@@ -1,0 +1,96 @@
+"""Validate the energy protocol before importing optional model dependencies.
+
+Use run.sh to authorize and manage the sensor, or supply an existing sensor
+stream with --external-power-file. This process never requests privileges.
+The model/workload imports are deliberately deferred until CLI validation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent.parent
+# source: tasks/codex-green-remediation-plan.md W3-2's scalar/batch(32) probe.
+DEFAULT_BATCH_SIZE = 32
+# source: macOS powermetrics(1), --sample-rate default, /usr/share/man/man1/.
+DEFAULT_SAMPLE_RATE_MS = 5000
+# source: sample standard deviation requires two independent observations.
+MIN_REPETITIONS = 2
+
+
+def _nonnegative_float(value: str) -> float:
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        raise argparse.ArgumentTypeError("must be finite and nonnegative")
+    return number
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--duration-seconds", type=_nonnegative_float, required=True)
+    parser.add_argument("--repetitions", type=int, required=True)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--sample-rate-ms", type=int, default=DEFAULT_SAMPLE_RATE_MS)
+    parser.add_argument("--external-power-file", type=Path)
+    parser.add_argument("--validate-only", action="store_true")
+    parser.add_argument(
+        "--carbon-intensity",
+        type=_nonnegative_float,
+        required=True,
+        help="region-specific electricity intensity I, in gCO2eq/kWh; no default",
+    )
+    parser.add_argument(
+        "--embodied",
+        type=_nonnegative_float,
+        required=True,
+        help="allocated embodied emission rate, gCO2eq/s; M = rate * phase seconds",
+    )
+    args = parser.parse_args(argv)
+    if args.duration_seconds <= 0 or args.repetitions < MIN_REPETITIONS:
+        parser.error("duration must be positive and repetitions >= 2")
+    if args.batch_size <= 0 or args.sample_rate_ms <= 0:
+        parser.error("batch-size and sample-rate-ms must be positive")
+    if not args.validate_only and args.external_power_file is None:
+        parser.error(
+            "--external-power-file is required; use run.sh to start the sensor"
+        )
+    return args
+
+
+def _run(args: argparse.Namespace) -> dict[str, object]:
+    # Direct script invocation must resolve the sibling benchmarks package.
+    if str(REPO) not in sys.path:
+        sys.path.insert(0, str(REPO))
+    # Deferred: these modules require NumPy and the optional embedding stack.
+    from benchmarks.energy import measurement, workload  # noqa: PLC0415
+
+    workload.wait_for_stream(args)
+    engine = workload.load_engine()
+    max_abs_delta = workload.verify_equivalence(engine, args.batch_size)
+    phases = workload.run_phases(engine, args)
+    raw_power = args.external_power_file.read_bytes()
+    samples = measurement.parse_power_samples(
+        raw_power.decode("utf-8"), max(phase.wall_end for phase in phases)
+    )
+    rows = measurement.apply_power_samples(phases, samples)
+    summary = {
+        mode: measurement.summarize(rows, mode, args) for mode in ("scalar", "batch")
+    }
+    return measurement.write_report(args, (rows, summary), (raw_power, max_abs_delta))
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    if args.validate_only:
+        print(args.sample_rate_ms)
+        return
+    print(json.dumps(_run(args), indent=2, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/energy/workload.py
+++ b/benchmarks/energy/workload.py
@@ -1,0 +1,172 @@
+"""Neural inference, float32 equivalence, and actual model-token accounting."""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from mcp_server.infrastructure.embedding_engine import EmbeddingEngine
+
+
+class Encoder(Protocol):
+    def encode(self, text: str) -> bytes | None: ...
+
+    def encode_batch(self, texts: list[str]) -> list[bytes | None]: ...
+
+
+class TokenizingModel(Protocol):
+    def tokenize(self, texts: list[str]) -> dict[str, object]: ...
+
+
+class SummableMask(Protocol):
+    def sum(self) -> SummableMask: ...
+
+    def item(self) -> int: ...
+
+
+@dataclass
+class Phase:
+    condition: str
+    repetition: int
+    wall_start: float
+    wall_end: float
+    elapsed_s: float
+    operations: int
+    tokens: int = 0
+
+
+def texts(round_id: int, count: int) -> list[str]:
+    return [
+        f"Cortex energy benchmark unique memory {round_id}:{i}; "
+        "batch-equivalence probe."
+        for i in range(count)
+    ]
+
+
+def _float32_row(blob: bytes | None) -> NDArray[np.float32]:
+    if not blob:
+        raise ValueError("missing or empty embedding output")
+    # source: numpy.frombuffer docs; engine.encode serializes native float32.
+    row = np.frombuffer(blob, dtype=np.float32)
+    if not np.isfinite(row).all():
+        raise ValueError("non-finite embedding output")
+    return row
+
+
+def verify_equivalence(engine: Encoder, batch_size: int) -> float:
+    probes = texts(0, batch_size)
+    scalar = [engine.encode(text) for text in probes]
+    batched = engine.encode_batch(probes)
+    if len(batched) != len(scalar):
+        raise ValueError("scalar/batch output count mismatch")
+    # source: numpy.finfo documents eps as spacing above 1. No model-wide claim:
+    # this strict absolute error budget is checked for this run's probe only.
+    tolerance = float(np.finfo(np.float32).eps)
+    max_delta = 0.0
+    for scalar_blob, batch_blob in zip(scalar, batched, strict=True):
+        left, right = _float32_row(scalar_blob), _float32_row(batch_blob)
+        if left.shape != right.shape:
+            raise ValueError("scalar/batch embedding shape mismatch")
+        delta = float(np.max(np.abs(left.astype(np.float64) - right)))
+        max_delta = max(max_delta, delta)
+        # source: numpy.allclose; explicit atol and zero rtol avoid its defaults.
+        if not np.allclose(left, right, rtol=0, atol=tolerance, equal_nan=False):
+            raise ValueError(
+                f"scalar/batch float32 mismatch: max_abs_delta={delta}, "
+                f"atol={tolerance}"
+            )
+    return max_delta
+
+
+def count_tokens(model: TokenizingModel, values: list[str]) -> int:
+    # source: SentenceTransformer.tokenize returns attention_mask; its sum counts
+    # non-padding tokens after the model's truncation, including special tokens.
+    mask = cast(SummableMask, model.tokenize(values)["attention_mask"])
+    count = int(mask.sum().item())
+    if count <= 0:
+        raise ValueError("tokenizer returned no active tokens")
+    return count
+
+
+def load_engine() -> EmbeddingEngine:
+    # Optional model dependency is loaded only after required CLI arguments pass.
+    from mcp_server.infrastructure.embedding_engine import (  # noqa: PLC0415
+        EmbeddingEngine,
+    )
+
+    engine = EmbeddingEngine()
+    engine.encode("Cortex energy benchmark model warm-up")
+    if engine.mode != "neural":
+        raise RuntimeError(
+            "energy benchmark requires the neural model; fallback refused"
+        )
+    return engine
+
+
+def _timed_workload(engine: Encoder, mode: str, args: argparse.Namespace) -> int:
+    if mode == "idle":
+        time.sleep(args.duration_seconds)
+        return 0
+    deadline = time.perf_counter() + args.duration_seconds
+    round_id = 0
+    while time.perf_counter() < deadline:
+        values = texts(round_id, args.batch_size)
+        if mode == "scalar":
+            for value in values:
+                engine.encode(value)
+        else:
+            engine.encode_batch(values)
+        round_id += 1
+    return round_id * args.batch_size
+
+
+def _measure_phase(
+    engine: EmbeddingEngine, mode: str, args: argparse.Namespace, repetition: int
+) -> Phase:
+    # The probe and earlier phases must not turn scalar inference into LRU hits.
+    engine._cache.clear()
+    wall_start, perf_start = time.time(), time.perf_counter()
+    operations = _timed_workload(engine, mode, args)
+    elapsed = time.perf_counter() - perf_start
+    phase = Phase(mode, repetition, wall_start, time.time(), elapsed, operations)
+    if engine.mode != "neural":
+        raise RuntimeError("neural model unavailable after phase; fallback refused")
+    if mode != "idle" and operations == 0:
+        raise RuntimeError("phase completed no embedding work")
+    return phase
+
+
+def run_phases(engine: EmbeddingEngine, args: argparse.Namespace) -> list[Phase]:
+    phases = []
+    for repetition in range(args.repetitions):
+        # source: original protocol: alternate the two inference conditions.
+        modes = ("scalar", "batch")
+        order = modes if repetition % len(modes) == 0 else tuple(reversed(modes))
+        for condition in ("idle", *order):
+            phases.append(_measure_phase(engine, condition, args, repetition))
+    model = cast(TokenizingModel, engine._model)
+    # Tokenize after ALL timed phases: counting does not inflate measured energy.
+    for phase in phases:
+        phase.tokens = sum(
+            count_tokens(model, texts(round_id, args.batch_size))
+            for round_id in range(phase.operations // args.batch_size)
+        )
+    return phases
+
+
+def wait_for_stream(args: argparse.Namespace) -> None:
+    # One phase duration is the caller's readiness budget; no invented timeout.
+    deadline = time.monotonic() + args.duration_seconds
+    # source: SI milli prefix: 1000 ms/s (NIST SP 811, chapter 4).
+    interval = args.sample_rate_ms / 1000
+    while time.monotonic() < deadline:
+        if "*** Sampled system activity" in args.external_power_file.read_text():
+            return
+        time.sleep(min(interval, max(0.0, deadline - time.monotonic())))
+    raise RuntimeError("external powermetrics stream did not become ready")

--- a/tests_py/benchmarks/test_energy_cli.py
+++ b/tests_py/benchmarks/test_energy_cli.py
@@ -1,0 +1,113 @@
+"""CLI validation must precede optional imports, stream access and sudo."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from benchmarks.energy import run_embedding_energy as cli
+
+
+SCRIPT = Path(cli.__file__)
+PROTOCOL = ["--duration-seconds", "1", "--repetitions", "2"]
+# Synthetic CLI inputs only, not measured or recommended carbon factors.
+CARBON = ["--carbon-intensity", "1", "--embodied", "1"]
+
+
+@pytest.mark.parametrize(
+    ("provided", "missing"),
+    [
+        ([], ["--carbon-intensity", "--embodied"]),
+        (["--carbon-intensity", "1"], ["--embodied"]),
+        (["--embodied", "1"], ["--carbon-intensity"]),
+    ],
+)
+def test_missing_carbon_fails_before_optional_imports(provided, missing):
+    # -S excludes site-packages: even NumPy import would fail before argparse.
+    result = subprocess.run(
+        [sys.executable, "-S", str(SCRIPT), *PROTOCOL, *provided],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert all(option in result.stderr for option in missing)
+    assert "ModuleNotFoundError" not in result.stderr
+    assert "--external-power-file is required" not in result.stderr
+
+
+@pytest.mark.parametrize("flag", ["--carbon-intensity", "--embodied"])
+@pytest.mark.parametrize("value", ["nan", "inf", "-1"])
+def test_invalid_carbon_refused_before_run(flag, value, monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_run", lambda args: pytest.fail("ran workload"))
+    with pytest.raises(SystemExit) as error:
+        cli.main([*PROTOCOL, *CARBON, flag, value])
+    assert error.value.code != 0
+    assert flag in capsys.readouterr().err
+
+
+def test_validate_only_needs_no_stream_or_model(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_run", lambda args: pytest.fail("ran workload"))
+    cli.main([*PROTOCOL, *CARBON, "--validate-only"])
+    assert capsys.readouterr().out.strip() == str(cli.DEFAULT_SAMPLE_RATE_MS)
+
+
+def test_valid_carbon_without_stream_points_to_runner(capsys):
+    with pytest.raises(SystemExit) as error:
+        cli.main([*PROTOCOL, *CARBON])
+    assert error.value.code != 0
+    assert "--external-power-file is required; use run.sh" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("flag", "value"),
+    [
+        ("--duration-seconds", "0"),
+        ("--repetitions", "1"),
+        ("--batch-size", "0"),
+        ("--sample-rate-ms", "0"),
+    ],
+)
+def test_invalid_protocol_refused(flag, value):
+    with pytest.raises(SystemExit) as error:
+        cli.main([*PROTOCOL, *CARBON, flag, value, "--validate-only"])
+    assert error.value.code != 0
+
+
+@pytest.mark.skipif(shutil.which("zsh") is None, reason="runner requires macOS/zsh")
+@pytest.mark.parametrize(
+    ("provided", "expected"),
+    [
+        ([], "--carbon-intensity"),
+        (["--carbon-intensity", "1"], "--embodied"),
+        (["--embodied", "1"], "--carbon-intensity"),
+        ([*CARBON, "--validate-only"], None),
+    ],
+)
+def test_shell_validates_before_sudo(provided, expected, tmp_path):
+    marker = tmp_path / "sudo-called"
+    fake_sudo = tmp_path / "sudo"
+    fake_sudo.write_text('#!/bin/sh\ntouch "$ENERGY_SUDO_MARKER"\nexit 99\n')
+    fake_sudo.chmod(0o755)
+    env = {
+        **os.environ,
+        "ENERGY_PYTHON": sys.executable,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "ENERGY_SUDO_MARKER": str(marker),
+    }
+    result = subprocess.run(
+        [shutil.which("zsh"), str(SCRIPT.with_name("run.sh")), *PROTOCOL, *provided],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert not marker.exists()
+    if expected is None:
+        assert result.returncode == 0, result.stderr
+    else:
+        assert result.returncode != 0
+        assert expected in result.stderr

--- a/tests_py/benchmarks/test_energy_measurement.py
+++ b/tests_py/benchmarks/test_energy_measurement.py
@@ -1,0 +1,115 @@
+"""Algebraic fixtures for energy/carbon units; no physical measurement occurs."""
+
+from argparse import Namespace
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks.energy import measurement
+from benchmarks.energy.workload import Phase
+
+
+def test_carbon_formula_per_thousand_tokens():
+    # Synthetic unit check: 1 kWh, I=2 g/kWh, M=3 g, 2000 tokens -> 2.5 g/1k.
+    assert measurement.carbon_per_1k_tokens(3_600_000, 2000, 2, 3) == 2.5
+    assert measurement.carbon_per_1k_tokens(3_600_000, 1000, 2, 3) == 5
+
+
+@pytest.mark.parametrize("tokens", [0, -1])
+def test_carbon_formula_refuses_invalid_denominator(tokens):
+    with pytest.raises(ValueError, match="token count"):
+        measurement.carbon_per_1k_tokens(1, tokens, 1, 1)
+
+
+@pytest.mark.parametrize("value", [-1, float("inf"), float("nan")])
+@pytest.mark.parametrize("position", [0, 2, 3])
+def test_carbon_formula_refuses_invalid_inputs(value, position):
+    args = [1, 1, 1, 1]
+    args[position] = value
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        measurement.carbon_per_1k_tokens(*args)
+
+
+def test_summary_uses_actual_token_counts_and_embodied_phase_duration():
+    args = Namespace(carbon_intensity=2, embodied=3)
+    phase = Phase("scalar", 0, 0, 2, 2, 4, tokens=2000)
+    row = measurement.MeasuredPhase(phase, 1, 1_800_000, 0)
+    summary = measurement.summarize([row, row], "scalar", args)
+    assert summary["tokens_total"] == 4000
+    assert summary["energy_j_per_1k_tokens_mean"] == 1_800_000
+    # One kWh * 2 g/kWh + (3 g/s * 2 s) = 8 g for 2000 tokens.
+    assert summary["carbon_gco2eq_per_1k_tokens_mean"] == 4
+
+
+def test_power_parser_requires_combined_boundary():
+    text = (
+        "*** Sampled system activity (Sun, 06 Sep 2026 12:00:00 +0000) ***\n"
+        "Combined Power (CPU + GPU + ANE): 2000 mW\n"
+    )
+    samples = measurement.parse_power_samples(text)
+    assert len(samples) == 1
+    assert samples[0][1] == 2
+    with pytest.raises(ValueError, match="lacks Combined Power"):
+        measurement.parse_power_samples(
+            text.replace("Combined Power (CPU + GPU + ANE)", "CPU Power")
+        )
+    with pytest.raises(ValueError, match="no combined"):
+        measurement.parse_power_samples("")
+
+
+def test_power_samples_are_applied_to_corresponding_idle_phase():
+    idle = Phase("idle", 0, 0, 1, 1, 0)
+    scalar = Phase("scalar", 0, 2, 4, 2, 4, tokens=10)
+    rows = measurement.apply_power_samples([idle, scalar], [(0.5, 2), (3, 1)])
+    assert rows[0].raw_system_energy_j == 2
+    assert rows[0].idle_power_w == 2
+    assert rows[0].dynamic_energy_j == -2  # No silent clamp of idle noise.
+    with pytest.raises(RuntimeError, match="no power samples in phase scalar"):
+        measurement.apply_power_samples([idle, scalar], [(0.5, 2)])
+
+
+def test_only_incomplete_final_sample_outside_phases_is_ignored():
+    complete = (
+        "*** Sampled system activity (Sun, 06 Sep 2026 12:00:00 +0000) ***\n"
+        "Combined Power (CPU + GPU + ANE): 2000 mW\n"
+    )
+    partial = (
+        "\n*** Sampled system activity (Sun, 06 Sep 2026 12:00:01 +0000) ***\n"
+        "CPU Power: 1000 mW\n"
+    )
+    expected = measurement.parse_power_samples(complete)
+    phase_end = expected[0][0]
+    with pytest.warns(RuntimeWarning, match="outside measured phases"):
+        assert (
+            measurement.parse_power_samples(complete + partial, phase_end) == expected
+        )
+    with pytest.raises(ValueError, match="lacks Combined Power"):
+        measurement.parse_power_samples(complete + partial, phase_end + 1)
+    with pytest.raises(ValueError, match="lacks Combined Power"):
+        measurement.parse_power_samples(partial + complete, phase_end)
+
+
+def test_report_preserves_raw_power_and_explicit_units(tmp_path, monkeypatch):
+    monkeypatch.setattr(measurement, "REPO", tmp_path)
+    monkeypatch.setattr(measurement, "_manifest", lambda: {"fixture": True})
+    args = Namespace(
+        carbon_intensity=2,
+        embodied=3,
+        duration_seconds=2,
+        repetitions=2,
+        batch_size=4,
+        sample_rate_ms=1,
+    )
+    phase = Phase("scalar", 0, 0, 2, 2, 4, tokens=2000)
+    row = measurement.MeasuredPhase(phase, 1, 1_800_000, 0)
+    raw = b"synthetic raw sensor fixture\n"
+    result = measurement.write_report(args, ([row], {}), (raw, 0))
+    output = Path(result["result_dir"])
+    assert (output / "powermetrics.txt").read_bytes() == raw
+    data = json.loads((output / "results.json").read_text())
+    assert data["carbon_intensity_gco2eq_per_kwh"] == 2
+    assert data["embodied_rate_gco2eq_per_second"] == 3
+    assert data["rows"][0]["embodied_gco2eq"] == 6
+    assert data["rows"][0]["carbon_gco2eq_per_1k_tokens"] == 4
+    assert "1000 model input tokens" in data["functional_units"]

--- a/tests_py/benchmarks/test_energy_runner.py
+++ b/tests_py/benchmarks/test_energy_runner.py
@@ -1,0 +1,161 @@
+"""Run the real shell lifecycle with an unprivileged, synthetic sensor.
+
+The fake sudo accepts authorization/start, but rejects a later sudo kill as an
+expired ticket would. FIFO synchronization avoids model/sensor timing assumptions.
+"""
+
+import json
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+RUNNER = Path(__file__).resolve().parents[2] / "benchmarks" / "energy" / "run.sh"
+FAKE_SUDO = """
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+
+args = sys.argv[1:]
+with Path(os.environ["ENERGY_SUDO_LOG"]).open("a") as log:
+    log.write(json.dumps(args) + "\\n")
+if args == ["-v"]:
+    sys.exit(0)
+if args[:2] == ["-n", "kill"]:
+    sys.exit("sudo: a password is required")
+if args[:2] != ["-n", "/usr/bin/powermetrics"]:
+    sys.exit("unexpected fake sudo invocation")
+
+def stop_sensor(signum, frame):
+    Path(os.environ["ENERGY_STOPPED"]).write_text("SIGINT received")
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, stop_sensor)
+Path(os.environ["ENERGY_SENSOR_PID"]).write_text(str(os.getpid()))
+output = Path(args[args.index("--output-file") + 1])
+output.write_text("synthetic raw sensor output\\n")
+with Path(os.environ["ENERGY_READY"]).open("w") as ready:
+    ready.write("ready")
+while True:
+    signal.pause()
+"""
+FAKE_WORKLOAD = """
+import os
+from pathlib import Path
+import sys
+
+if "--validate-only" in sys.argv:
+    print(1)
+    sys.exit(0)
+with Path(os.environ["ENERGY_READY"]).open() as ready:
+    assert ready.read() == "ready"
+power = Path(sys.argv[sys.argv.index("--external-power-file") + 1])
+Path(os.environ["ENERGY_SNAPSHOT"]).write_bytes(power.read_bytes())
+sys.exit(int(os.environ["ENERGY_WORKLOAD_STATUS"]))
+"""
+FAKE_MKTEMP = """
+import os
+from pathlib import Path
+
+path = Path(os.environ["ENERGY_RAW"])
+path.touch()
+print(path)
+"""
+
+
+def _executable(path, source):
+    path.write_text(f"#!{sys.executable}\n" + textwrap.dedent(source))
+    path.chmod(0o755)
+
+
+def _environment(tmp_path, workload_status):
+    for name, source in (
+        ("sudo", FAKE_SUDO),
+        ("workload", FAKE_WORKLOAD),
+        ("mktemp", FAKE_MKTEMP),
+    ):
+        _executable(tmp_path / name, source)
+    os.mkfifo(tmp_path / "ready")
+    return {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "ENERGY_PYTHON": str(tmp_path / "workload"),
+        "ENERGY_SUDO_LOG": str(tmp_path / "sudo.log"),
+        "ENERGY_STOPPED": str(tmp_path / "stopped"),
+        "ENERGY_SENSOR_PID": str(tmp_path / "sensor.pid"),
+        "ENERGY_READY": str(tmp_path / "ready"),
+        "ENERGY_SNAPSHOT": str(tmp_path / "snapshot.txt"),
+        "ENERGY_RAW": str(tmp_path / "raw.txt"),
+        "ENERGY_WORKLOAD_STATUS": str(workload_status),
+    }
+
+
+def _remove_test_process_group(pid):
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return  # Successful runs have already reaped the sensor and exited.
+
+
+@contextmanager
+def _run_shell(env):
+    master, slave = os.openpty()
+    args = [shutil.which("zsh"), str(RUNNER)]
+    process = subprocess.Popen(
+        args,
+        env=env,
+        stdin=slave,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        # Test-only hang protection; no benchmark timing assertion uses this limit.
+        stdout, stderr = process.communicate(timeout=10)
+        yield subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+    finally:
+        _remove_test_process_group(process.pid)
+        process.wait()
+        os.close(slave)
+        os.close(master)
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or shutil.which("zsh") is None,
+    reason="sensor runner requires POSIX PTY and zsh",
+)
+@pytest.mark.parametrize("workload_status", [0, 7])
+def test_runner_stops_sensor_without_reauthenticating(tmp_path, workload_status):
+    with _run_shell(_environment(tmp_path, workload_status)) as result:
+        assert result.returncode == workload_status, result.stderr
+        assert (tmp_path / "stopped").read_text() == "SIGINT received"
+        calls = [
+            json.loads(line)
+            for line in (tmp_path / "sudo.log").read_text().splitlines()
+        ]
+        assert len(calls) == 2  # Only initial authorization and sensor startup.
+        assert calls[0] == ["-v"]
+        assert calls[1][:2] == ["-n", "/usr/bin/powermetrics"]
+        # Assert before fixture cleanup: cleanup must not hide an orphaned sensor.
+        with pytest.raises(ProcessLookupError):
+            os.kill(int((tmp_path / "sensor.pid").read_text()), 0)
+        assert (
+            tmp_path / "snapshot.txt"
+        ).read_text() == "synthetic raw sensor output\n"
+        if workload_status:
+            assert "Raw sensor output preserved" in result.stderr
+            assert (tmp_path / "raw.txt").read_bytes() == (
+                tmp_path / "snapshot.txt"
+            ).read_bytes()
+        else:
+            assert not (tmp_path / "raw.txt").exists()

--- a/tests_py/benchmarks/test_energy_workload.py
+++ b/tests_py/benchmarks/test_energy_workload.py
@@ -1,0 +1,176 @@
+"""Energy harness contracts with deterministic float32/token-mask fixtures.
+
+All numbers here describe synthetic fixtures; none is a host energy measurement.
+"""
+
+from argparse import Namespace
+from types import SimpleNamespace
+import sys
+
+import numpy as np
+import pytest
+
+from benchmarks.energy import workload
+
+
+class FixtureEncoder:
+    def __init__(self, scalar, batch):
+        self.scalar = scalar
+        self.batch = batch
+
+    def encode(self, text):
+        return self.scalar
+
+    def encode_batch(self, values):
+        return [self.batch] * len(values)
+
+
+def test_float32_equivalence_accepts_different_bytes():
+    scalar = np.array([0.5], dtype=np.float32)
+    batch = np.nextafter(scalar, np.float32(1))
+    assert scalar.tobytes() != batch.tobytes()
+    # Before W0-2 the same fixture returned the byte difference 1.0.
+    assert (
+        max(abs(a - b) for a, b in zip(scalar.tobytes(), batch.tobytes(), strict=True))
+        == 1
+    )
+    delta = workload.verify_equivalence(
+        FixtureEncoder(scalar.tobytes(), batch.tobytes()), 4
+    )
+    assert delta == float(batch[0]) - float(scalar[0])
+    assert 0 < delta <= np.finfo(np.float32).eps
+
+
+def test_float32_equivalence_rejects_real_difference():
+    engine = FixtureEncoder(
+        np.array([0.5], dtype=np.float32).tobytes(),
+        np.array([0.75], dtype=np.float32).tobytes(),
+    )
+    with pytest.raises(ValueError, match="float32 mismatch"):
+        workload.verify_equivalence(engine, 4)
+
+
+@pytest.mark.parametrize(
+    ("batch", "message"),
+    [
+        (None, "missing"),
+        (b"", "empty"),
+        (b"abc", "multiple"),
+        (np.array([float("nan")], dtype=np.float32).tobytes(), "non-finite"),
+        (np.array([float("inf")], dtype=np.float32).tobytes(), "non-finite"),
+        (np.array([0.5, 0.5], dtype=np.float32).tobytes(), "shape mismatch"),
+    ],
+)
+def test_float32_equivalence_refuses_invalid_outputs(batch, message):
+    engine = FixtureEncoder(np.array([0.5], dtype=np.float32).tobytes(), batch)
+    with pytest.raises(ValueError, match=message):
+        workload.verify_equivalence(engine, 4)
+
+
+def test_float32_equivalence_refuses_output_count_mismatch(monkeypatch):
+    engine = FixtureEncoder(np.array([0.5], dtype=np.float32).tobytes(), None)
+    monkeypatch.setattr(engine, "encode_batch", lambda values: [])
+    with pytest.raises(ValueError, match="count mismatch"):
+        workload.verify_equivalence(engine, 4)
+
+
+class FixtureTokenizer:
+    def __init__(self):
+        self.calls = []
+
+    def tokenize(self, values):
+        self.calls.append(values)
+        # Already truncated model input: three active tokens, two active, padding.
+        return {"attention_mask": np.array([[1, 1, 1, 0], [1, 1, 0, 0]])}
+
+
+def test_token_count_uses_model_attention_mask():
+    model = FixtureTokenizer()
+    values = ["é", "a much longer input whose character count is irrelevant"]
+    assert workload.count_tokens(model, values) == 5
+    assert model.calls == [values]
+
+
+def test_token_count_refuses_empty_mask():
+    model = SimpleNamespace(
+        tokenize=lambda values: {"attention_mask": np.zeros((1, 1))}
+    )
+    with pytest.raises(ValueError, match="no active tokens"):
+        workload.count_tokens(model, ["input"])
+
+
+def test_phases_count_exact_completed_batches_outside_measurement(monkeypatch):
+    model = FixtureTokenizer()
+
+    def measure(engine, mode, args, repetition):
+        assert not model.calls, "token counting must follow all timed phases"
+        return workload.Phase(mode, repetition, 0, 1, 1, 0 if mode == "idle" else 4)
+
+    monkeypatch.setattr(workload, "_measure_phase", measure)
+    args = Namespace(repetitions=2, batch_size=2)
+    phases = workload.run_phases(SimpleNamespace(_model=model), args)
+    assert [phase.condition for phase in phases] == [
+        "idle",
+        "scalar",
+        "batch",
+        "idle",
+        "batch",
+        "scalar",
+    ]
+    assert [phase.tokens for phase in phases] == [0, 10, 10, 0, 10, 10]
+    assert model.calls == [workload.texts(i, 2) for _ in range(4) for i in range(2)]
+
+
+@pytest.mark.parametrize("mode", ["scalar", "batch"])
+def test_timed_workload_counts_completed_texts(mode, monkeypatch):
+    ticks = iter([0, 0, 2])
+    monkeypatch.setattr(workload.time, "perf_counter", lambda: next(ticks))
+    calls = []
+    engine = SimpleNamespace(encode=calls.append, encode_batch=calls.extend)
+    args = Namespace(duration_seconds=1, batch_size=4)
+    assert workload._timed_workload(engine, mode, args) == 4
+    assert calls == workload.texts(0, 4)
+
+
+def test_load_engine_refuses_algorithmic_fallback(monkeypatch):
+    engine = SimpleNamespace(encode=lambda text: None, mode="fallback")
+    module = SimpleNamespace(EmbeddingEngine=lambda: engine)
+    monkeypatch.setitem(
+        sys.modules, "mcp_server.infrastructure.embedding_engine", module
+    )
+    with pytest.raises(RuntimeError, match="fallback refused"):
+        workload.load_engine()
+
+
+def test_phase_clears_warm_cache_and_refuses_fallback(monkeypatch):
+    engine = SimpleNamespace(_cache={"warm": b"embedding"}, mode="fallback")
+    monkeypatch.setattr(workload, "_timed_workload", lambda *args: 1)
+    with pytest.raises(RuntimeError, match="fallback refused"):
+        workload._measure_phase(engine, "scalar", Namespace(), 0)
+    assert engine._cache == {}
+
+
+def test_phase_refuses_no_completed_work(monkeypatch):
+    engine = SimpleNamespace(_cache={}, mode="neural")
+    monkeypatch.setattr(workload, "_timed_workload", lambda *args: 0)
+    with pytest.raises(RuntimeError, match="no embedding work"):
+        workload._measure_phase(engine, "scalar", Namespace(), 0)
+
+
+def test_stream_timeout_is_explicit(tmp_path, monkeypatch):
+    path = tmp_path / "power.txt"
+    path.write_text("")
+    ticks = iter([0, 0, 0, 2])
+    monkeypatch.setattr(workload.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(workload.time, "sleep", lambda duration: None)
+    args = Namespace(duration_seconds=1, sample_rate_ms=1, external_power_file=path)
+    with pytest.raises(RuntimeError, match="stream did not become ready"):
+        workload.wait_for_stream(args)
+
+
+def test_stream_file_error_is_not_swallowed(tmp_path):
+    args = Namespace(
+        duration_seconds=1, sample_rate_ms=1, external_power_file=tmp_path / "missing"
+    )
+    with pytest.raises(FileNotFoundError):
+        workload.wait_for_stream(args)


### PR DESCRIPTION
## Symptôme

W0-2 / ⚪8 : le harnais comparait les valeurs des octets sérialisés au lieu des
composantes float32 et ne produisait pas de résultat carbone par 1 000 tokens.
Cette PR est empilée sur #468 ; aucune fusion n'est effectuée par Codex.

## Cause racine

Contrat de représentation et unités manquants : `EmbeddingEngine` renvoie des
blobs float32, et le calcul carbone doit recevoir explicitement ses facteurs.
Les deux chemins d'orchestration du capteur rendaient aussi son cycle de vie
plus difficile à vérifier.

## Changement

Le runner valide les arguments avant modèle ou sudo. `--carbon-intensity`
(gCO2eq/kWh) et `--embodied` (taux déjà alloué, gCO2eq/s) sont obligatoires.
L'équivalence décode les blobs avec `numpy.frombuffer(dtype=float32)` et refuse
les sorties invalides ou au-delà de la tolérance explicitée. Le dénominateur
vient des vrais masques d'attention du tokenizer, comptés hors phases mesurées.

`run.sh` orchestre seul l'autorisation et le capteur ; la charge Python reste
non privilégiée. Le rapport archive les octets effectivement analysés, les
unités, les paramètres, le commit et les hashes sources. Le README décrit la
frontière CPU+GPU+ANE et les limites de l'estimation.

## Preuve

Sur le même fixture float32 `[0.5]` puis `nextafter(..., 1)` :

| Contrôle | Avant | Après |
|---|---:|---:|
| Différence rapportée | 1.0 (octets) | 5.960464477539063e-08 (float32) |
| Tolérance explicite | absente | 1.1920928955078125e-07, rtol=0 |

La version initiale non suivie a été conservée localement pour reproduire ce
contre-exemple (SHA256 du script initial :
`231e2fe24b11464ccc9c9f8dbf1ac75dfd863c5ca22c063f50ee39dbcf70cc6b`).
Il s'agit d'un test arithmétique, pas d'une mesure d'énergie.

```sh
.venv/bin/python -S benchmarks/energy/run_embedding_energy.py \
  --duration-seconds 20 --repetitions 2 --validate-only
# exit 2 : the following arguments are required: --carbon-intensity, --embodied
```

La désactivation des site-packages (`-S`) prouve que ce refus ne dépend pas du
chargement de NumPy ou du modèle. Les tests du shell utilisent un faux sudo
et un faux capteur, sans mesure physique ni demande de mot de passe.

Validation finale du diff commité `c16b84e9`, le 2026-09-06 sur macOS ARM64,
Python 3.13.7 : verrouillage, Ruff (1 412 fichiers), craftsmanship et Pyright
(zéro diagnostic) passent. Couche : **145 passed** en 32,55 s. Suite complète :
**7 547 passed, 221 skipped, 123 subtests passed** en 148,43 s.
Charge avant : 3,00 pour 10 cœurs ; disque libre avant/après : 66 GiB.

CI complète **verte** au même SHA :
[run 34034623118](https://github.com/cdeust/Cortex/actions/runs/34034623118).
Déclenchement `workflow_dispatch` nécessaire car la base de cette PR est la
branche W0-1 et l'ancien filtre de branches ne couvrait que `main`.

Les commandes de gates sont celles du contrat : synchronisation verrouillée
dev+sqlite+lint, Ruff check/format, craftsmanship, environnement Pyright prescrit
par CONTRIBUTING, Pyright, tests de `tests_py/benchmarks/`, puis suite complète.
PostgreSQL est explicitement inaccessible à localhost:1 ; les données de test
sont jetables. Logs : `/private/tmp/cortex-green-w0-2-final-gates.log`.

## Conformité

- Périmètre W0-2 : harnais autorisé par le propriétaire et tests associés.
- Caps : nouveaux modules et fonctions sous les limites ; baseline inchangée.
- Aucun import de production modifié, aucun modèle sous `/tmp`.
- Aucun fallback silencieux : paramètres, modèle, équivalence et capteur sont
  contrôlés et les erreurs sont explicites.
- Constantes physiques et équations sourcées dans le code et le README ; aucun
  facteur carbone par défaut et aucun gain énergétique prétendu.
- Aucune base de production, aucune opération de maintenance ou fusion.

## Candidats issues

Une validation physique du protocole reste à effectuer avec les facteurs et
la durée choisis par le propriétaire. La puissance CPU+GPU+ANE n'est pas la
consommation totale de la machine. La tolérance du probe n'est pas une borne
universelle d'erreur de l'inférence sur tous appareils et textes.

## Runbook

Le propriétaire fournit les facteurs sourcés et lance `benchmarks/energy/run.sh`
depuis un terminal interactif, selon le README. Lui seul saisit son mot de passe
pour autoriser le capteur macOS. Aucune mesure physique n'a été lancée par cette PR.
