### PR TITLE
ci: execute pytest once on the coverage leg (W1-3)

### DIFF
--- a/.github/actions/test-suite/action.yml
+++ b/.github/actions/test-suite/action.yml
@@ -257,26 +257,21 @@ runs:
         HF_HUB_OFFLINE: "1"
         TRANSFORMERS_OFFLINE: "1"
         CORTEX_RERANKER_OFFLINE: "1"
-      run: pytest --tb=short -q
-
-    # The four steps below are CI-only: they run on the single matrix leg
-    # the ci.yml caller marks run-extended-checks: true (Python 3.12).
-    # release.yml never sets run-extended-checks — its test job is a
-    # pass/fail gate before publishing, not the leg that owns coverage, the
-    # MCP host contract check, or the advertised-test-count/badge check.
-    - name: Run tests with coverage
-      if: inputs.run-extended-checks == 'true'
-      shell: bash
-      env:
-        HF_HUB_OFFLINE: "1"
-        TRANSFORMERS_OFFLINE: "1"
-        CORTEX_RERANKER_OFFLINE: "1"
+        RUN_EXTENDED_CHECKS: ${{ inputs.run-extended-checks }}
       # --cov-fail-under is the statement-coverage floor (issue #196
       # criterion 4): seeded at the number this job itself achieved
       # (82.02% — 30,229 of 36,854 statements, run 30316539703,
       # coverage.py 7.15.2) so the figure can only ratchet up, never
       # silently fall back. Raise the floor when coverage rises.
-      run: pytest --cov=mcp_server --cov-report=xml --cov-report=term-missing --cov-fail-under=82
+      # W1-3: collect coverage during this same suite execution on the
+      # extended leg, preserving both reports and the existing floor.
+      run: |
+        set -euo pipefail
+        pytest_args=(--tb=short -q)
+        if [ "$RUN_EXTENDED_CHECKS" = "true" ]; then
+          pytest_args+=(--cov=mcp_server --cov-report=xml --cov-report=term-missing --cov-fail-under=82)
+        fi
+        pytest "${pytest_args[@]}"
 
     # Match the primary Claude and additive Codex client identities against
     # a real, explicitly configured PostgreSQL instance. Explicit targets
@@ -300,6 +295,8 @@ runs:
     # without collecting the suite, so it is checked in the job that already
     # has the suite installed. `--collect-only` re-collects (~seconds) rather
     # than parsing the run above, so the number is the collector's own.
+    # W1-3 retains this separate assertion: it executes no tests and keeps
+    # the advertised count and badge independent of coverage/run summaries.
     - name: Check advertised test count
       if: inputs.run-extended-checks == 'true'
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@
 #
 # Scope note: `open-pull-requests-limit` is deliberately low. The point is a
 # steady trickle that gets reviewed, not a queue nobody reads.
+# Group compatible version updates within each ecosystem/directory; major
+# updates retain individual PRs so unrelated breaking changes are not bundled.
+# source: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups
 version: 2
 updates:
   # Keeps the SHA pins in .github/workflows fresh. Dependabot rewrites the SHA
@@ -18,6 +21,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "ci"
 
@@ -28,6 +35,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -36,6 +47,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -44,6 +59,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -67,6 +86,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "deps"
     ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -15,6 +14,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+      docker: ${{ steps.filter.outputs.docker }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      deps: ${{ steps.filter.outputs.deps }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Verify pull request file-list completeness
+        if: github.event_name == 'pull_request'
+        run: python3 scripts/check_ci_file_count.py
+      # Classify each file independently. Unknown paths conservatively count
+      # as code; a docs file cannot hide code changed in the same PR.
+      # source: https://github.com/dorny/paths-filter/tree/v4.0.1#usage
+      # `every` applies all code exclusions to each file, not to the PR.
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - '**'
+              - '!{*.md,docs/**/*.md,tasks/**/*.md,Dockerfile,.dockerignore,docker/**,.devcontainer/**,.github/**,pyproject.toml,uv.lock,requirements/**,**/package.json,**/package-lock.json}'
+            docs:
+              - '{*.md,docs/**/*.md,tasks/**/*.md}'
+            docker:
+              - '{Dockerfile,.dockerignore,docker/**,.devcontainer/**}'
+            workflows:
+              - '.github/**'
+            deps:
+              - '{pyproject.toml,uv.lock,requirements/**,**/package.json,**/package-lock.json}'
+
   # Uses the composite action at .github/actions/test-suite/action.yml for
   # the step-level rationale, including why the shared unit is a composite
   # action and not a reusable workflow: a job delegating via `uses:` reports
@@ -26,6 +63,8 @@ jobs:
   # `requirements/ci-postgresql.txt` and tree-sitter grammars are now
   # installed unconditionally inside the action rather than passed in.
   test:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     # Bound a hung leg instead of inheriting GitHub's 360-minute default:
@@ -64,6 +103,8 @@ jobs:
           run-extended-checks: ${{ matrix.python-version == '3.12' }}
 
   test-sqlite:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (SQLite backend)
     runs-on: ubuntu-latest
 
@@ -204,12 +245,13 @@ jobs:
         run: python scripts/verify_mcp_hosts.py -- hypermnesia-mcp
 
   mcp-host-config:
+    needs: [changes, lint]
+    if: (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     name: Validate MCP host configurations
     # The pinned Claude package requires its postinstall to select the native
     # validator. Never execute install scripts from a lockfile modified by an
     # untrusted fork; same-repository PRs and main/workflow_dispatch remain
     # covered by this vendor-parser contract.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -284,6 +326,8 @@ jobs:
               -- "${plugin_command[@]}"
 
   test-windows:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (Windows, SQLite backend)
     runs-on: windows-latest
 
@@ -406,6 +450,8 @@ jobs:
   # under this narrower dependency set, with no PostgreSQL service needed
   # (`--storage-selection sqlite` is the default).
   release-deps:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Release dependency set (requirements/release.txt)
     runs-on: ubuntu-latest
     steps:
@@ -600,6 +646,8 @@ jobs:
   # scripts/craftsmanship_baseline.py for why pre-existing debt (recorded
   # in .craftsmanship-baseline.json) does not retroactively block.
   craftsmanship:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Craftsmanship Gate
     runs-on: ubuntu-latest
     steps:
@@ -623,6 +671,8 @@ jobs:
         run: python scripts/check_craftsmanship.py
 
   typecheck:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Type Check
     runs-on: ubuntu-latest
     steps:
@@ -679,6 +729,8 @@ jobs:
         run: .venv/bin/python -m pyright mcp_server/
 
   build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Build Package
     runs-on: ubuntu-latest
     steps:
@@ -709,6 +761,8 @@ jobs:
   # separate services. The claim here is narrow and worth making on its own:
   # the image still builds, and its hash-pinned installs still resolve.
   docker-runtime-build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Build (runtime image)
     runs-on: ubuntu-latest
     steps:
@@ -738,6 +792,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   devcontainer-build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Build (devcontainer image)
     runs-on: ubuntu-latest
     steps:
@@ -763,6 +819,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   docker-smoke:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Smoke (bare-container DB-less contract)
     runs-on: ubuntu-latest
     # BLOCKING: this job asserts the exact contract that silently broke for
@@ -807,8 +865,9 @@ jobs:
         env:
           CORTEX_SMOKE_IMAGE: cortex-smoke:local
 
-  # The one status check branch protection on `main` names. Everything else
-  # in this workflow is reached through its `needs:` list, so renaming a job,
+  # The aggregate required check for this workflow. CodeQL remains an
+  # independent required check outside ci.yml. Everything else here is reached
+  # through its `needs:` list, so renaming a job,
   # resizing the matrix, or delegating steps to a reusable workflow (which
   # rewrites check names to "<caller> / <callee>", issue #336) no longer
   # touches the protection settings — the contract is this file, in git,
@@ -827,6 +886,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
+      - changes
       - test
       - test-sqlite
       - mcp-host-config
@@ -840,30 +900,15 @@ jobs:
       - devcontainer-build
       - docker-smoke
     steps:
-      - name: Require every job above to have succeeded
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Require successful jobs or justified skips
         env:
           NEEDS: ${{ toJSON(needs) }}
-          # Jobs permitted to report `skipped`, with the reason. ONLY jobs
-          # carrying a job-level `if:` belong here; anything else that skips
-          # is a gap, not an exemption.
-          #   mcp-host-config — `if: github.event_name != 'pull_request' ||
-          #   github.event.pull_request.head.repo.fork == false`: a fork PR
-          #   has no access to the secrets it needs, so it cannot run there.
-          ALLOWED_SKIPS: mcp-host-config
-        run: |
-          set -euo pipefail
-          echo "$NEEDS"
-          failed=$(printf '%s' "$NEEDS" | jq -r --arg allowed "$ALLOWED_SKIPS" '
-            ($allowed | split(",") | map(ltrimstr(" ") | rtrimstr(" "))) as $ok
-            | to_entries[]
-            | select(.value.result != "success")
-            | select(.value.result != "skipped" or ([.key] | inside($ok) | not))
-            | "\(.key)=\(.value.result)"')
-          if [ -n "$failed" ]; then
-            echo "::error::CI Green refuses the merge — $(echo "$failed" | tr '\n' ' ')"
-            exit 1
-          fi
-          echo "every required job succeeded"
+          # Path skips are valid only for irrelevant PRs. mcp-host-config
+          # additionally skips fork PRs to avoid untrusted npm postinstall.
+          # The checker verifies these reasons against this run's inputs.
+          ALLOWED_SKIPS: test,test-sqlite,mcp-host-config,test-windows,release-deps,craftsmanship,typecheck,build,docker-runtime-build,devcontainer-build,docker-smoke
+        run: python3 scripts/check_ci_gate_results.py
 
   # The tag-as-output half of issue #392: a green push to `main` tags the
   # exact SHA that just passed CI Green, instead of a human hand-picking

--- a/scripts/check_ci_file_count.py
+++ b/scripts/check_ci_file_count.py
@@ -1,0 +1,40 @@
+"""Refuse PR path classification when GitHub's file list may be incomplete."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+
+
+# source: https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
+# The REST endpoint used by dorny/paths-filter returns at most 3000 files.
+API_FILE_LIMIT = 3000
+
+
+def check(count: object) -> str | None:
+    if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+        return "pull_request.changed_files must be a nonnegative integer"
+    if count > API_FILE_LIMIT:
+        return (
+            f"PR changes {count} files, exceeding GitHub's {API_FILE_LIMIT}-file "
+            "API limit; refusing incomplete classification. Split the PR."
+        )
+    return None
+
+
+def main() -> int:
+    try:
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        failure = check(event["pull_request"].get("changed_files"))
+    except (KeyError, OSError, ValueError, TypeError, AttributeError) as error:
+        failure = f"cannot validate pull request file count: {error}"
+    if failure:
+        print(f"::error::{failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_ci_gate_complete.py
+++ b/scripts/check_ci_gate_complete.py
@@ -1,54 +1,12 @@
-"""CI-gate completeness: every ci.yml job must be behind the aggregate gate.
+"""Static CI-gate coverage and prerequisite checks without YAML dependencies.
 
-Branch protection on ``main`` names required status checks as strings, in
-GitHub settings — outside git, invisible in review, and unversioned. Naming
-individual jobs there makes the contract break on every rename: extracting
-the test steps into a reusable workflow (issue #336) renamed the four matrix
-legs to ``Test (Python X.Y) / Test (Python X.Y)``, so the four bare contexts
-``main`` required were never reported again and a fully green PR sat BLOCKED
-(PR #387, run 31250898534). Renaming the contexts fixes that one PR and
-leaves the next rename to rediscover it.
+Every job must be a direct CI Green dependency or declare a conditional
+post-merge exemption. Every conditional gated job belongs to ALLOWED_SKIPS;
+the runtime checker independently verifies the reason for each actual skip.
+CI Green must always run to report failures and rejected skips.
 
-So protection names ONE ci.yml context — ``CI Green`` — and the real list
-lives here, in git, where a diff shows it. That moves the failure mode: the
-gate is only as good as its ``needs:`` list, and a job added later that
-nobody adds to it is silently ungated. That is what this script refuses.
-
-It also refuses the second escape hatch. The gate treats any result other
-than ``success`` as failure, EXCEPT for jobs named in its ``ALLOWED_SKIPS``
-env — because a job carrying a job-level ``if:`` legitimately reports
-``skipped``. An unlisted conditional would therefore let a job skip its way
-past the gate, so every job with an ``if:`` must be declared, and every
-declared exemption must correspond to a job that actually has one (a stale
-exemption is a hole nobody is watching).
-
-A third case exists that ``needs:``/``ALLOWED_SKIPS`` cannot express:
-``release-gate`` (issue #392) runs ONLY on a push to ``main`` — after the PR
-it belongs to has already merged. There is nothing for it to gate: it cannot
-block a PR that is already closed, and putting it in ``ci-green.needs`` would
-make the branch-protection context depend on a job that never runs on a PR
-in the first place, permanently blocking every PR. Such a job declares itself
-with a ``# ci-gate-exempt: <reason>`` marker line in its body instead of
-appearing in ``needs:``. The marker is not a blank check: it is refused
-unless the job ALSO carries a job-level ``if:`` — an exempt job with no
-condition would run ungated on every push and PR, which is exactly the hole
-this script exists to close.
-
-Checks, all of them fatal:
-
-1. the gate job exists;
-2. every other ci.yml job appears in the gate's ``needs:`` OR carries a
-   ``# ci-gate-exempt:`` marker;
-3. every name in ``needs:`` is a real job;
-4. every job carrying a job-level ``if:`` and not exempt is listed in
-   ``ALLOWED_SKIPS``;
-5. every name in ``ALLOWED_SKIPS`` is a job that carries an ``if:``;
-6. every ``# ci-gate-exempt:`` job carries a job-level ``if:`` — an exemption
-   with no condition is not a narrower gate, it is no gate.
-
-Static only — regex over the workflow text, no PyYAML. The Lint job installs
-ruff and nothing else, and this script runs there alongside
-``check_doc_claims.py``, which is static for the same reason.
+Source: tasks/codex-green-remediation-plan.md W1-2 and GitHub workflow syntax:
+https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds
 """
 
 from __future__ import annotations
@@ -60,12 +18,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
-# The single job branch protection points at. Renaming it is a protection
-# change, not a refactor — hence a named constant rather than a literal.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+from check_ci_gate_results import check_policy  # noqa: E402
+
+# The aggregate context for this workflow. Renaming it requires updating
+# branch protection, hence a named constant rather than a literal.
 GATE_JOB = "ci-green"
 
 _JOB_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
 _JOB_IF_RE = re.compile(r"^    if:\s*(\S.*)$")
+_NEEDS_INLINE_RE = re.compile(r"^    needs:\s*\[([^]]*)\]\s*$")
 _NEEDS_BLOCK_RE = re.compile(r"^    needs:\s*$")
 _NEEDS_ITEM_RE = re.compile(r"^      - ([A-Za-z0-9_-]+)\s*$")
 _ALLOWED_SKIPS_RE = re.compile(r"^\s*ALLOWED_SKIPS:\s*(\S.*?)\s*$")
@@ -114,6 +78,10 @@ def _parse_needs(body: list[str]) -> list[str]:
     collecting = False
 
     for line in body:
+        inline = _NEEDS_INLINE_RE.match(line)
+        if inline:
+            needs.extend(name.strip() for name in inline.group(1).split(","))
+            continue
         if _NEEDS_BLOCK_RE.match(line):
             collecting = True
             continue
@@ -205,7 +173,7 @@ def _check_allowed_skips(
 ) -> list[str]:
     """Checks 4 and 5: ALLOWED_SKIPS and the set of conditional jobs agree.
 
-    Exempt jobs never appear in ``needs:``, so ci-green's jq never evaluates
+    Exempt jobs never appear in ``needs:``, so CI Green never evaluates
     their result — ALLOWED_SKIPS governs skip results INSIDE the gate only,
     and does not apply to a job structurally outside it.
     """
@@ -242,6 +210,32 @@ def _check_exempt_jobs_are_conditional(
     ]
 
 
+def _check_gate_execution(bodies: dict[str, list[str]], needs: list[str]) -> list[str]:
+    conditions = [
+        match.group(1) for line in bodies[GATE_JOB] if (match := _JOB_IF_RE.match(line))
+    ]
+    if conditions != ["always()"]:
+        return [f"{GATE_JOB} must have exactly 'if: always()'"]
+    if len(needs) != len(set(needs)) or GATE_JOB in needs:
+        return [f"{GATE_JOB}.needs has a duplicate or self dependency"]
+    return []
+
+
+def check_runtime_contract(text: str) -> list[str]:
+    """Check production workflow policy and lint-before-matrix dependencies."""
+    _, needs, allowed, _ = parse_workflow(text)
+    failures = check_policy(needs, allowed)
+    bodies = _job_bodies(text)
+    for job in allowed:
+        if set(_parse_needs(bodies.get(job, []))) != {"changes", "lint"}:
+            failures.append(f"{job} must depend on exactly changes and lint")
+    for job in ("changes", "lint"):
+        body = bodies.get(job, [])
+        if _parse_needs(body) or any(_JOB_IF_RE.match(line) for line in body):
+            failures.append(f"{job} must always run without prerequisites")
+    return failures
+
+
 def check(text: str) -> list[str]:
     """Return the list of failures; empty means the gate is complete."""
     jobs, needs, allowed_skips, exempt = parse_workflow(text)
@@ -257,7 +251,8 @@ def check(text: str) -> list[str]:
         ]
 
     return (
-        _check_every_job_is_gated(jobs, set(needs) | exempt)
+        _check_gate_execution(_job_bodies(text), needs)
+        + _check_every_job_is_gated(jobs, set(needs) | exempt)
         + _check_needs_are_real_jobs(jobs, needs)
         + _check_allowed_skips(jobs, allowed_skips, exempt)
         + _check_exempt_jobs_are_conditional(jobs, exempt)
@@ -269,7 +264,8 @@ def main() -> int:
         print(f"FAIL: {CI_WORKFLOW} not found", file=sys.stderr)
         return 1
 
-    failures = check(CI_WORKFLOW.read_text(encoding="utf-8"))
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+    failures = check(text) + check_runtime_contract(text)
     if failures:
         print("CI gate completeness: FAIL", file=sys.stderr)
         for failure in failures:

--- a/scripts/check_ci_gate_results.py
+++ b/scripts/check_ci_gate_results.py
@@ -1,0 +1,130 @@
+"""Fail CI Green unless every job succeeded or has a verified skip reason.
+
+The policy mirrors ci.yml: non-PR runs execute the full matrix; code,
+dependency or workflow changes do so on PRs. Docker changes also run Docker
+jobs. The vendor CLI job skips fork PRs because it executes npm postinstall.
+Missing classifications and unknown jobs fail closed.
+
+Source: tasks/codex-green-remediation-plan.md W1-2 and ci.yml job predicates.
+GitHub's needs context exposes result and outputs for direct dependencies:
+https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# source: .github/workflows/ci.yml, jobs gated by changes and lint.
+CODE_JOBS = frozenset(
+    {
+        "test",
+        "test-sqlite",
+        "mcp-host-config",
+        "test-windows",
+        "release-deps",
+        "craftsmanship",
+        "typecheck",
+        "build",
+    }
+)
+DOCKER_JOBS = frozenset({"docker-runtime-build", "devcontainer-build", "docker-smoke"})
+ALWAYS_JOBS = frozenset({"changes", "lint"})
+CONDITIONAL_JOBS = CODE_JOBS | DOCKER_JOBS
+EXPECTED_JOBS = ALWAYS_JOBS | CONDITIONAL_JOBS
+# source: .github/workflows/ci.yml changes.outputs and on triggers.
+FILTERS = frozenset({"code", "docs", "docker", "workflows", "deps"})
+EVENTS = frozenset({"pull_request", "push", "workflow_dispatch"})
+
+
+def check_policy(needs: list[str], allowed: list[str]) -> list[str]:
+    """Keep the workflow and the executable skip policy in exact agreement."""
+    failures = []
+    if set(needs) != EXPECTED_JOBS:
+        failures.append("CI Green needs do not match the runtime job policy")
+    if set(allowed) != CONDITIONAL_JOBS:
+        failures.append("ALLOWED_SKIPS does not match the runtime skip policy")
+    return failures
+
+
+def _classifications(needs: dict) -> dict[str, bool]:
+    outputs = needs["changes"].get("outputs")
+    if not isinstance(outputs, dict) or set(outputs) != FILTERS:
+        raise ValueError("changes must provide exactly the five path outputs")
+    if any(value not in ("true", "false") for value in outputs.values()):
+        raise ValueError("changes outputs must be the strings 'true' or 'false'")
+    return {name: value == "true" for name, value in outputs.items()}
+
+
+def _is_fork(event_name: str, event: dict) -> bool:
+    if event_name != "pull_request":
+        return False
+    try:
+        fork = event["pull_request"]["head"]["repo"]["fork"]
+    except (KeyError, TypeError) as error:
+        raise ValueError("pull_request event is missing head.repo.fork") from error
+    if not isinstance(fork, bool):
+        raise ValueError("pull_request head.repo.fork must be a boolean")
+    return fork
+
+
+def _required_jobs(flags: dict[str, bool], event_name: str, fork: bool) -> set[str]:
+    full = event_name != "pull_request" or any(
+        flags[name] for name in ("code", "deps", "workflows")
+    )
+    required = set(ALWAYS_JOBS)
+    if full:
+        required.update(CODE_JOBS)
+    if full or flags["docker"]:
+        required.update(DOCKER_JOBS)
+    if fork:
+        required.discard("mcp-host-config")
+    return required
+
+
+def check(needs: dict, event_name: str, event: dict) -> list[str]:
+    """Evaluate actual results, never treating an allowlist as a skip reason."""
+    if not isinstance(needs, dict) or set(needs) != EXPECTED_JOBS:
+        return ["needs must contain exactly the expected CI jobs"]
+    if event_name not in EVENTS or not isinstance(event, dict):
+        return ["missing or unsupported GitHub event context"]
+    if any(not isinstance(value, dict) for value in needs.values()):
+        return ["every needs entry must be a job result object"]
+    try:
+        flags = _classifications(needs)
+        required = _required_jobs(flags, event_name, _is_fork(event_name, event))
+    except ValueError as error:
+        return [str(error)]
+    failures = []
+    for job, value in sorted(needs.items()):
+        result = value.get("result")
+        if result == "success":
+            continue
+        if result == "skipped" and job not in required:
+            continue
+        failures.append(f"{job}={result!r} (success required or invalid result)")
+    return failures
+
+
+def main() -> int:
+    try:
+        allowed = os.environ["ALLOWED_SKIPS"].split(",")
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        needs = json.loads(os.environ["NEEDS"])
+        failures = check(needs, os.environ["GITHUB_EVENT_NAME"], event)
+        if set(allowed) != CONDITIONAL_JOBS:
+            failures.append("ALLOWED_SKIPS does not match the runtime skip policy")
+    except (KeyError, OSError, ValueError) as error:
+        failures = [f"cannot read CI gate inputs: {error}"]
+    if failures:
+        for failure in failures:
+            print(f"::error::CI Green: {failure}", file=sys.stderr)
+        return 1
+    print("CI Green: all required jobs succeeded; every skip is justified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_py/scripts/test_check_ci_file_count.py
+++ b/tests_py/scripts/test_check_ci_file_count.py
@@ -1,0 +1,43 @@
+"""Guard against GitHub silently truncating a pull request's changed files."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from scripts.check_ci_file_count import check
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_ci_file_count.py"
+
+
+class FileCountTests(unittest.TestCase):
+    def test_complete_api_range_is_accepted(self):
+        for count in (0, 1, 3000):
+            with self.subTest(count=count):
+                self.assertIsNone(check(count))
+
+    def test_truncated_api_range_is_refused(self):
+        self.assertIn("3000-file API limit", check(3001))
+
+    def test_missing_or_invalid_count_is_refused(self):
+        for count in (None, True, False, -1, "1", 1.0, {}):
+            with self.subTest(count=count):
+                self.assertIn("nonnegative integer", check(count))
+
+    def test_cli_refuses_truncation_with_a_diagnostic(self):
+        with tempfile.TemporaryDirectory() as directory:
+            event = Path(directory) / "event.json"
+            event.write_text(json.dumps({"pull_request": {"changed_files": 3001}}))
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                env={**os.environ, "GITHUB_EVENT_PATH": str(event)},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("refusing incomplete classification", result.stderr)

--- a/tests_py/scripts/test_check_ci_gate_complete.py
+++ b/tests_py/scripts/test_check_ci_gate_complete.py
@@ -114,6 +114,18 @@ class RefusesIncompleteGate(unittest.TestCase):
         )
         self.assertIn("'lint'", self._only_failure(workflow))
 
+    def test_gate_must_always_run(self) -> None:
+        for condition in ("", "    if: success()\n"):
+            workflow = _COMPLETE.replace("    if: always()\n", condition)
+            self.assertIn("always()", self._only_failure(workflow))
+
+    def test_duplicate_or_self_needs_fail(self) -> None:
+        for job in ("lint", "ci-green"):
+            workflow = _COMPLETE.replace(
+                "      - lint\n", f"      - lint\n      - {job}\n"
+            )
+            self.assertIn("dependency", self._only_failure(workflow))
+
 
 _WITH_EXEMPT_JOB = _workflow(
     """  lint:
@@ -199,6 +211,30 @@ class RepositoryWorkflowIsGated(unittest.TestCase):
             gate.check(gate.CI_WORKFLOW.read_text(encoding="utf-8")),
             [],
         )
+
+    def test_runtime_policy_matches_live_workflow(self) -> None:
+        self.assertEqual(gate.check_runtime_contract(gate.CI_WORKFLOW.read_text()), [])
+
+    def test_costly_jobs_must_wait_for_lint_and_changes(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        for prerequisites in ("[changes]", "[lint]", "[changes, lint, test]"):
+            changed = workflow.replace("[changes, lint]", prerequisites, 1)
+            failures = gate.check_runtime_contract(changed)
+            self.assertTrue(any("depend on exactly" in f for f in failures))
+
+    def test_lint_and_changes_cannot_be_conditional(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        for job in ("changes", "lint"):
+            changed = workflow.replace(f"  {job}:\n", f"  {job}:\n    if: false\n")
+            self.assertTrue(gate.check_runtime_contract(changed))
+
+    def test_new_skip_needs_an_executable_policy(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        workflow = workflow.replace(
+            "ALLOWED_SKIPS: test,", "ALLOWED_SKIPS: unknown-job,test,"
+        )
+        failures = gate.check_runtime_contract(workflow)
+        self.assertTrue(any("runtime skip policy" in f for f in failures))
 
 
 if __name__ == "__main__":

--- a/tests_py/scripts/test_check_ci_gate_results.py
+++ b/tests_py/scripts/test_check_ci_gate_results.py
@@ -1,0 +1,164 @@
+"""CI Green must fail closed without importing application code or its DB."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import check_ci_gate_results as gate
+
+
+def _event(fork: bool = False) -> dict:
+    return {"pull_request": {"head": {"repo": {"fork": fork}}}}
+
+
+def _needs(*changed: str) -> dict:
+    needs = {job: {"result": "success", "outputs": {}} for job in gate.EXPECTED_JOBS}
+    needs["changes"]["outputs"] = {
+        name: "true" if name in changed else "false" for name in gate.FILTERS
+    }
+    return needs
+
+
+def _skip(needs: dict, jobs: frozenset[str]) -> dict:
+    for job in jobs:
+        needs[job]["result"] = "skipped"
+    return needs
+
+
+class JustifiedSkips(unittest.TestCase):
+    def test_docs_only_runs_only_changes_and_lint(self) -> None:
+        needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+        self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+
+    def test_docker_only_requires_docker_jobs(self) -> None:
+        needs = _skip(_needs("docker"), gate.CODE_JOBS)
+        self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+        for job in gate.DOCKER_JOBS:
+            with self.subTest(job=job):
+                needs[job]["result"] = "skipped"
+                self.assertTrue(gate.check(needs, "pull_request", _event()))
+                needs[job]["result"] = "success"
+
+    def test_code_deps_workflows_require_every_job(self) -> None:
+        for changed in (("code",), ("docs", "code"), ("deps",), ("workflows",)):
+            needs = _needs(*changed)
+            self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+            for job in gate.CONDITIONAL_JOBS:
+                with self.subTest(changed=changed, job=job):
+                    needs[job]["result"] = "skipped"
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+                    needs[job]["result"] = "success"
+
+    def test_non_pr_runs_require_full_matrix_even_for_docs(self) -> None:
+        for event_name in ("push", "workflow_dispatch"):
+            needs = _needs("docs")
+            self.assertEqual(gate.check(needs, event_name, {}), [])
+            needs["test"]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, event_name, {}))
+
+    def test_fork_guard_applies_only_to_vendor_cli_job(self) -> None:
+        needs = _needs("code")
+        needs["mcp-host-config"]["result"] = "skipped"
+        self.assertEqual(gate.check(needs, "pull_request", _event(True)), [])
+        self.assertTrue(gate.check(needs, "pull_request", _event(False)))
+        needs["test"]["result"] = "skipped"
+        self.assertTrue(gate.check(needs, "pull_request", _event(True)))
+
+
+class FailClosed(unittest.TestCase):
+    def test_failures_cancellation_and_invalid_results_never_pass(self) -> None:
+        for result in ("failure", "cancelled", "pending", "", None):
+            for job in gate.EXPECTED_JOBS:
+                with self.subTest(result=result, job=job):
+                    needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+                    needs[job]["result"] = result
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_lint_failure_rejects_skipped_matrix(self) -> None:
+        needs = _skip(_needs("code"), gate.CONDITIONAL_JOBS)
+        needs["lint"]["result"] = "failure"
+        failures = gate.check(needs, "pull_request", _event())
+        self.assertTrue(any("lint=" in failure for failure in failures))
+
+    def test_changes_and_lint_may_never_skip(self) -> None:
+        for job in gate.ALWAYS_JOBS:
+            needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_and_unexpected_jobs_fail(self) -> None:
+        for job in gate.EXPECTED_JOBS:
+            needs = _needs("docs")
+            del needs[job]
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+        needs = _needs("docs")
+        needs["unwatched"] = {"result": "success"}
+        self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_and_invalid_classifications_fail(self) -> None:
+        for output in gate.FILTERS:
+            for value in (True, False, "", "TRUE", None, [], {}):
+                with self.subTest(output=output, value=value):
+                    needs = _needs("docs")
+                    needs["changes"]["outputs"][output] = value
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+            needs = _needs("docs")
+            del needs["changes"]["outputs"][output]
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_invalid_job_objects_and_output_objects_fail(self) -> None:
+        for value in (None, [], "success"):
+            needs = _needs("docs")
+            needs["changes"] = value
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+            needs = _needs("docs")
+            needs["changes"]["outputs"] = value
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_or_invalid_fork_context_fails(self) -> None:
+        for event in ({}, {"pull_request": None}, _event("false")):
+            self.assertTrue(gate.check(_needs("docs"), "pull_request", event))
+
+    def test_unsupported_event_context_fails(self) -> None:
+        self.assertTrue(gate.check(_needs("docs"), "", {}))
+        self.assertTrue(gate.check(_needs("docs"), "push", []))
+
+
+class ExecutableContract(unittest.TestCase):
+    def _run(self, needs: str) -> subprocess.CompletedProcess:
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = Path(directory) / "event.json"
+            event_path.write_text(json.dumps(_event()), encoding="utf-8")
+            env = {
+                **os.environ,
+                "NEEDS": needs,
+                "GITHUB_EVENT_PATH": str(event_path),
+                "GITHUB_EVENT_NAME": "pull_request",
+                "ALLOWED_SKIPS": ",".join(sorted(gate.CONDITIONAL_JOBS)),
+            }
+            return subprocess.run(
+                [sys.executable, str(Path(gate.__file__))],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_docs_only_cli_succeeds(self) -> None:
+        result = self._run(json.dumps(_skip(_needs("docs"), gate.CONDITIONAL_JOBS)))
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_malformed_json_cli_fails_with_diagnostic(self) -> None:
+        result = self._run("{bad json")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot read CI gate inputs", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Symptôme

W1-3 / F14 : la jambe Python 3.12 exécutait toute la suite deux fois,
dont une seconde fois pour produire la couverture. PR empilée sur #471.

## Cause racine

Deux étapes pytest distinctes étaient actives quand `run-extended-checks`
valait `true`.

## Changement

Une seule invocation pytest construit ses arguments dans un tableau Bash.
La jambe étendue conserve les rapports XML/terminal et le seuil existant de
82 %, sourcé dans le workflow. Les autres jambes gardent leurs arguments.
Le contrôle du contrat MCP, la collecte sans exécution servant au compteur
de tests, le badge et l'upload de couverture restent actifs.

## Preuve

Au commit `03e884a3`, gates locaux ordonnés verts : Ruff 1 416 fichiers,
craftsmanship et Pyright zéro diagnostic ; tests scripts 825 passed,
5 skipped, 280 subtests ; suite complète 7 572 passed, 221 skipped,
280 subtests en 145,65 s. Les skips PostgreSQL locaux sont explicites
(endpoint isolé indisponible localhost:1), aucune base de production utilisée.
Charge initiale 3,32 / 10 cœurs, 66 GiB libres avant/après.

Six sondes Bash contre l'action réelle vérifient une seule invocation,
les arguments avec/sans couverture, les entrées non booléennes et la
propagation d'un échec pytest. Log local :
`/private/tmp/cortex-green-w1-3-gates.log`.

```sh
uv sync --locked --no-default-groups --extra dev --extra sqlite --group lint
.venv/bin/ruff check
.venv/bin/ruff format --check
.venv/bin/python scripts/check_craftsmanship.py
uv sync --locked --no-default-groups --extra dev --extra postgresql --extra sqlite --extra codebase --extra otel --group typecheck --group lint
.venv/bin/python -m pyright mcp_server/
export CORTEX_TEST_DATABASE_URL=postgresql://localhost:1/cortex_green_isolated
export CORTEX_MEMORY_STORE_BACKEND=sqlite DATABASE_URL=
export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 CORTEX_RERANKER_OFFLINE=1
.venv/bin/python -m pytest tests_py/scripts/ -q --tb=short
.venv/bin/python -m pytest -q --tb=short
```

Deux runs après au même SHA `03e884a3` sont verts :
[34037347199](https://github.com/cdeust/Cortex/actions/runs/34037347199) et
[34038092818](https://github.com/cdeust/Cortex/actions/runs/34038092818).

| Mesure | Python 3.12 | Médiane des autres jambes |
|---|---:|---:|
| Avant, run34035713474 | 1 097 s | 535 s |
| Avant, run34036866480 | 1 104 s | 515 s |
| Après, run34037347199 | 656 s | 491 s |
| Après, run34038092818 | 663 s | 545 s |

La moyenne Python 3.12 passe de 1 100,5 s à 659,5 s : **441 s de moins**
(40,07 %), sur ces deux observations avant/après. Ce n'est pas une mesure
d'énergie ; charge/cache du runner ne sont pas contrôlés expérimentalement.
Chaque run après produit `coverage-report` (84 673 octets), atteint **85,34 %**
de couverture et valide le compteur/badge (**badges OK, 5 contrôlés**).
Les logs montrent une seule invocation pytest avec couverture.
Archives locales : `/private/tmp/cortex-green-w1-3-after{1,2}-jobs.jsonl`,
`cortex-green-w1-3-after1-python312.log`, `cortex-green-w1-3-after2.log`.

## Conformité

Un seul fichier modifié, aucune baseline ajoutée, aucun import ou mécanisme
mémoire modifié. Le seuil et les contrôles existants sont conservés.
La collecte `--collect-only` ne lance aucun test.

## Candidats issues

La durée relative Python 3.12 / autres jambes dépend aussi de l'instrumentation
de couverture et des caches ; les deux mesures seront publiées sans attribuer
toute variation au changement.

## Runbook

Le propriétaire décide de la fusion. Aucune opération de production.
