### PR TITLE
ci: limit runtime image builds to Docker changes and weekly validation (W1-4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  schedule:
+    # source: W1-4 in tasks/codex-green-remediation-plan.md requires weekly
+    # builds; reuse fuzz.yml's Monday 04:17 UTC window as a config choice.
+    - cron: "17 4 * * 1"
 
 permissions:
   contents: read
@@ -64,7 +68,7 @@ jobs:
   # installed unconditionally inside the action rather than passed in.
   test:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     # Bound a hung leg instead of inheriting GitHub's 360-minute default:
@@ -104,7 +108,7 @@ jobs:
 
   test-sqlite:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (SQLite backend)
     runs-on: ubuntu-latest
 
@@ -246,7 +250,7 @@ jobs:
 
   mcp-host-config:
     needs: [changes, lint]
-    if: (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    if: github.event_name != 'schedule' && ((github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false))
     name: Validate MCP host configurations
     # The pinned Claude package requires its postinstall to select the native
     # validator. Never execute install scripts from a lockfile modified by an
@@ -327,7 +331,7 @@ jobs:
 
   test-windows:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Windows, SQLite backend)
     runs-on: windows-latest
 
@@ -451,7 +455,7 @@ jobs:
   # (`--storage-selection sqlite` is the default).
   release-deps:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Release dependency set (requirements/release.txt)
     runs-on: ubuntu-latest
     steps:
@@ -647,7 +651,7 @@ jobs:
   # in .craftsmanship-baseline.json) does not retroactively block.
   craftsmanship:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Craftsmanship Gate
     runs-on: ubuntu-latest
     steps:
@@ -672,7 +676,7 @@ jobs:
 
   typecheck:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Type Check
     runs-on: ubuntu-latest
     steps:
@@ -730,7 +734,7 @@ jobs:
 
   build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Build Package
     runs-on: ubuntu-latest
     steps:
@@ -762,7 +766,7 @@ jobs:
   # the image still builds, and its hash-pinned installs still resolve.
   docker-runtime-build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (runtime image)
     runs-on: ubuntu-latest
     steps:
@@ -789,11 +793,13 @@ jobs:
           tags: cortex-runtime:ci
           load: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # source: https://docs.docker.com/build/cache/backends/#cache-mode
+          # min exports image layers; intermediate build layers are omitted.
+          cache-to: type=gha,mode=min
 
   devcontainer-build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (devcontainer image)
     runs-on: ubuntu-latest
     steps:
@@ -816,7 +822,9 @@ jobs:
           tags: cortex-devcontainer:ci
           load: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # source: https://docs.docker.com/build/cache/backends/#cache-mode
+          # min exports image layers; intermediate build layers are omitted.
+          cache-to: type=gha,mode=min
 
   docker-smoke:
     needs: [changes, lint]

--- a/scripts/check_ci_gate_results.py
+++ b/scripts/check_ci_gate_results.py
@@ -1,11 +1,12 @@
 """Fail CI Green unless every job succeeded or has a verified skip reason.
 
-The policy mirrors ci.yml: non-PR runs execute the full matrix; code,
-dependency or workflow changes do so on PRs. Docker changes also run Docker
-jobs. The vendor CLI job skips fork PRs because it executes npm postinstall.
-Missing classifications and unknown jobs fail closed.
+The policy mirrors ci.yml: code, dependency or workflow PR changes run code
+jobs and Docker smoke. Pushes and dispatches also run those jobs; schedules
+run smoke but skip code jobs. Runtime/devcontainer builds require Docker
+changes, a schedule or a dispatch. The vendor CLI job skips fork PRs because
+it executes npm postinstall. Missing classifications and unknown jobs fail closed.
 
-Source: tasks/codex-green-remediation-plan.md W1-2 and ci.yml job predicates.
+Source: tasks/codex-green-remediation-plan.md W1-2/W1-4 and ci.yml predicates.
 GitHub's needs context exposes result and outputs for direct dependencies:
 https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context
 """
@@ -30,13 +31,13 @@ CODE_JOBS = frozenset(
         "build",
     }
 )
-DOCKER_JOBS = frozenset({"docker-runtime-build", "devcontainer-build", "docker-smoke"})
+DOCKER_BUILD_JOBS = frozenset({"docker-runtime-build", "devcontainer-build"})
 ALWAYS_JOBS = frozenset({"changes", "lint"})
-CONDITIONAL_JOBS = CODE_JOBS | DOCKER_JOBS
+CONDITIONAL_JOBS = CODE_JOBS | DOCKER_BUILD_JOBS | {"docker-smoke"}
 EXPECTED_JOBS = ALWAYS_JOBS | CONDITIONAL_JOBS
 # source: .github/workflows/ci.yml changes.outputs and on triggers.
 FILTERS = frozenset({"code", "docs", "docker", "workflows", "deps"})
-EVENTS = frozenset({"pull_request", "push", "workflow_dispatch"})
+EVENTS = frozenset({"pull_request", "push", "workflow_dispatch", "schedule"})
 
 
 def check_policy(needs: list[str], allowed: list[str]) -> list[str]:
@@ -75,10 +76,12 @@ def _required_jobs(flags: dict[str, bool], event_name: str, fork: bool) -> set[s
         flags[name] for name in ("code", "deps", "workflows")
     )
     required = set(ALWAYS_JOBS)
-    if full:
+    if full and event_name != "schedule":
         required.update(CODE_JOBS)
     if full or flags["docker"]:
-        required.update(DOCKER_JOBS)
+        required.add("docker-smoke")
+    if flags["docker"] or event_name in ("schedule", "workflow_dispatch"):
+        required.update(DOCKER_BUILD_JOBS)
     if fork:
         required.discard("mcp-host-config")
     return required

--- a/tests_py/scripts/test_check_ci_gate_results.py
+++ b/tests_py/scripts/test_check_ci_gate_results.py
@@ -39,23 +39,23 @@ class JustifiedSkips(unittest.TestCase):
     def test_docker_only_requires_docker_jobs(self) -> None:
         needs = _skip(_needs("docker"), gate.CODE_JOBS)
         self.assertEqual(gate.check(needs, "pull_request", _event()), [])
-        for job in gate.DOCKER_JOBS:
+        for job in gate.DOCKER_BUILD_JOBS | {"docker-smoke"}:
             with self.subTest(job=job):
                 needs[job]["result"] = "skipped"
                 self.assertTrue(gate.check(needs, "pull_request", _event()))
                 needs[job]["result"] = "success"
 
-    def test_code_deps_workflows_require_every_job(self) -> None:
+    def test_code_deps_workflows_require_code_and_smoke(self) -> None:
         for changed in (("code",), ("docs", "code"), ("deps",), ("workflows",)):
-            needs = _needs(*changed)
+            needs = _skip(_needs(*changed), gate.DOCKER_BUILD_JOBS)
             self.assertEqual(gate.check(needs, "pull_request", _event()), [])
-            for job in gate.CONDITIONAL_JOBS:
+            for job in gate.CODE_JOBS | {"docker-smoke"}:
                 with self.subTest(changed=changed, job=job):
                     needs[job]["result"] = "skipped"
                     self.assertTrue(gate.check(needs, "pull_request", _event()))
                     needs[job]["result"] = "success"
 
-    def test_non_pr_runs_require_full_matrix_even_for_docs(self) -> None:
+    def test_push_and_dispatch_require_code_even_for_docs(self) -> None:
         for event_name in ("push", "workflow_dispatch"):
             needs = _needs("docs")
             self.assertEqual(gate.check(needs, event_name, {}), [])
@@ -69,6 +69,48 @@ class JustifiedSkips(unittest.TestCase):
         self.assertTrue(gate.check(needs, "pull_request", _event(False)))
         needs["test"]["result"] = "skipped"
         self.assertTrue(gate.check(needs, "pull_request", _event(True)))
+
+
+class DockerBuildPolicy(unittest.TestCase):
+    def test_push_without_docker_changes_skips_only_docker_builds(self) -> None:
+        for changed in (("docs",), ("code",), ("workflows",), ("deps",), ()):
+            needs = _skip(_needs(*changed), gate.DOCKER_BUILD_JOBS)
+            self.assertEqual(gate.check(needs, "push", {}), [])
+            needs["docker-smoke"]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "push", {}))
+
+    def test_push_with_docker_changes_requires_every_job(self) -> None:
+        needs = _needs("docker")
+        self.assertEqual(gate.check(needs, "push", {}), [])
+        for job in gate.CONDITIONAL_JOBS:
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "push", {}))
+            needs[job]["result"] = "success"
+
+    def test_dispatch_requires_builds_even_without_docker_changes(self) -> None:
+        needs = _needs("docs")
+        self.assertEqual(gate.check(needs, "workflow_dispatch", {}), [])
+        for job in gate.DOCKER_BUILD_JOBS:
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "workflow_dispatch", {}))
+            needs[job]["result"] = "success"
+
+    def test_schedule_skips_code_jobs_regardless_of_changed_paths(self) -> None:
+        for changed in ((), ("code",), ("docker",), ("docs",)):
+            needs = _skip(_needs(*changed), gate.CODE_JOBS)
+            self.assertEqual(gate.check(needs, "schedule", {}), [])
+            for job in gate.DOCKER_BUILD_JOBS | {"docker-smoke"} | gate.ALWAYS_JOBS:
+                with self.subTest(changed=changed, job=job):
+                    needs[job]["result"] = "skipped"
+                    self.assertTrue(gate.check(needs, "schedule", {}))
+                    needs[job]["result"] = "success"
+
+    def test_schedule_rejects_failed_and_cancelled_jobs_even_if_optional(self) -> None:
+        for job in gate.EXPECTED_JOBS:
+            for result in ("failure", "cancelled"):
+                needs = _skip(_needs("docs"), gate.CODE_JOBS)
+                needs[job]["result"] = result
+                self.assertTrue(gate.check(needs, "schedule", {}))
 
 
 class FailClosed(unittest.TestCase):


### PR DESCRIPTION
## Symptôme

W1-4 / F13 : runtime et devcontainer étaient construits sur chaque PR sans
être exécutés. PR empilée sur #475.

## Cause racine

Ces deux validations de construction partageaient le déclenchement des tests
courants ; leur cache exportait aussi les couches intermédiaires.

## Changement

Runtime/devcontainer sont requis pour un changement Docker, le lancement
manuel et le rendez-vous hebdomadaire (lundi 04:17 UTC, fenêtre existante de
fuzz réutilisée). Le run hebdomadaire exécute ces builds et le smoke Docker,
avec classification/lint/agrégateur ; il n'ajoute pas une matrice Python.
Le smoke conserve son prédicat existant. L'agrégateur vérifie ces raisons de skip.

Les deux exports BuildKit passent à `mode=min`, qui conserve les couches de
l'image finale plutôt que toutes les étapes intermédiaires, conformément à la
[documentation Docker](https://docs.docker.com/build/cache/backends/#cache-mode).

## Preuve

Gates locaux ordonnés verts : Ruff 1 416 fichiers, craftsmanship, Pyright zéro
diagnostic ; couche scripts 830 passed, 5 skipped, 292 subtests ; suite
complète 7 577 passed, 221 skipped, 292 subtests en 147,15 s.
Les skips PostgreSQL locaux sont explicites (localhost:1 indisponible). Charge initiale 2,19 / 10 cœurs,
66 GiB disponibles. Actionlint et `scripts/check_ci_gate_complete.py` verts.
Les cas ciblés couvrent push, PR Docker/code/docs, dispatch, schedule,
échecs et annulations des jobs optionnels.

```sh
uv sync --locked --no-default-groups --extra dev --extra sqlite --group lint
.venv/bin/ruff check
.venv/bin/ruff format --check
.venv/bin/python scripts/check_craftsmanship.py
uv sync --locked --no-default-groups --extra dev --extra postgresql --extra sqlite --extra codebase --extra otel --group typecheck --group lint
.venv/bin/python -m pyright mcp_server/
export CORTEX_TEST_DATABASE_URL=postgresql://localhost:1/cortex_green_isolated
export CORTEX_MEMORY_STORE_BACKEND=sqlite DATABASE_URL=
export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 CORTEX_RERANKER_OFFLINE=1
.venv/bin/python -m pytest tests_py/scripts/ -q --tb=short
.venv/bin/python -m pytest -q --tb=short

```

Log : `/private/tmp/cortex-green-w1-4-gates.log`.
Inventaire avant du 2026-09-06 : 182 caches, **12 529 799 262 octets**, relevés
par `gh api repos/cdeust/Cortex/actions/caches --paginate`.

L'acceptation PR sans Docker est prouvée par le [run 34037578794](https://github.com/cdeust/Cortex/actions/runs/34037578794), entièrement vert : runtime/devcontainer ignorés, smoke exécuté avec succès. Le vrai déclenchement
hebdomadaire et la taille des caches après une semaine nécessitent la fusion
par le propriétaire puis l'observation ; ils restent explicitement en attente.

## Conformité

Trois fichiers, aucune baseline ajoutée. Pas de modification des couches
mémoire. Données de test isolées et modèles hors ligne. Aucun cache existant
supprimé. Pas de fusion, d'issue, ni d'opération de production.

## Candidats issues

Le seuil total de cache dépend aussi des caches HF/pip et des autres workflows.
`mode=min` seul ne prouve pas un total inférieur à 10 Go après une semaine.

## Runbook

Après fusion décidée par le propriétaire, vérifier le run planifié puis relever
`gh api repos/cdeust/Cortex/actions/caches --paginate` après sept jours.
Conserver les durées et la somme des `size_in_bytes` comme preuve d'acceptation.
