### PR TITLE
ci: set measured timeouts and cancel superseded PR runs (W1-7)

### DIFF
--- a/.github/actions/test-suite/action.yml
+++ b/.github/actions/test-suite/action.yml
@@ -257,26 +257,21 @@ runs:
         HF_HUB_OFFLINE: "1"
         TRANSFORMERS_OFFLINE: "1"
         CORTEX_RERANKER_OFFLINE: "1"
-      run: pytest --tb=short -q
-
-    # The four steps below are CI-only: they run on the single matrix leg
-    # the ci.yml caller marks run-extended-checks: true (Python 3.12).
-    # release.yml never sets run-extended-checks — its test job is a
-    # pass/fail gate before publishing, not the leg that owns coverage, the
-    # MCP host contract check, or the advertised-test-count/badge check.
-    - name: Run tests with coverage
-      if: inputs.run-extended-checks == 'true'
-      shell: bash
-      env:
-        HF_HUB_OFFLINE: "1"
-        TRANSFORMERS_OFFLINE: "1"
-        CORTEX_RERANKER_OFFLINE: "1"
+        RUN_EXTENDED_CHECKS: ${{ inputs.run-extended-checks }}
       # --cov-fail-under is the statement-coverage floor (issue #196
       # criterion 4): seeded at the number this job itself achieved
       # (82.02% — 30,229 of 36,854 statements, run 30316539703,
       # coverage.py 7.15.2) so the figure can only ratchet up, never
       # silently fall back. Raise the floor when coverage rises.
-      run: pytest --cov=mcp_server --cov-report=xml --cov-report=term-missing --cov-fail-under=82
+      # W1-3: collect coverage during this same suite execution on the
+      # extended leg, preserving both reports and the existing floor.
+      run: |
+        set -euo pipefail
+        pytest_args=(--tb=short -q)
+        if [ "$RUN_EXTENDED_CHECKS" = "true" ]; then
+          pytest_args+=(--cov=mcp_server --cov-report=xml --cov-report=term-missing --cov-fail-under=82)
+        fi
+        pytest "${pytest_args[@]}"
 
     # Match the primary Claude and additive Codex client identities against
     # a real, explicitly configured PostgreSQL instance. Explicit targets
@@ -300,6 +295,8 @@ runs:
     # without collecting the suite, so it is checked in the job that already
     # has the suite installed. `--collect-only` re-collects (~seconds) rather
     # than parsing the run above, so the number is the collector's own.
+    # W1-3 retains this separate assertion: it executes no tests and keeps
+    # the advertised count and badge independent of coverage/run summaries.
     - name: Check advertised test count
       if: inputs.run-extended-checks == 'true'
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@
 #
 # Scope note: `open-pull-requests-limit` is deliberately low. The point is a
 # steady trickle that gets reviewed, not a queue nobody reads.
+# Group compatible version updates within each ecosystem/directory; major
+# updates retain individual PRs so unrelated breaking changes are not bundled.
+# source: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups
 version: 2
 updates:
   # Keeps the SHA pins in .github/workflows fresh. Dependabot rewrites the SHA
@@ -18,6 +21,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "ci"
 
@@ -28,6 +35,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -36,6 +47,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -44,6 +59,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -67,6 +86,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "deps"
     ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
             # source: run 34046091095 (2026-09-06), max 1197s; ceil(2 * 1197 / 60).
             timeout-minutes: 40
           - python-version: "3.13"
-            # source: run 33951959734 (2026-09-05), max 577s; ceil(2 * 577 / 60).
-            timeout-minutes: 20
+            # source: run 33688337476 (2026-09-02), max 1637s; ceil(2 * 1637 / 60).
+            timeout-minutes: 55
 
     steps:
       # A local `uses: ./...` is resolved from the checked-out tree, so the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -15,6 +14,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+      docker: ${{ steps.filter.outputs.docker }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      deps: ${{ steps.filter.outputs.deps }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Verify pull request file-list completeness
+        if: github.event_name == 'pull_request'
+        run: python3 scripts/check_ci_file_count.py
+      # Classify each file independently. Unknown paths conservatively count
+      # as code; a docs file cannot hide code changed in the same PR.
+      # source: https://github.com/dorny/paths-filter/tree/v4.0.1#usage
+      # `every` applies all code exclusions to each file, not to the PR.
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - '**'
+              - '!{*.md,docs/**/*.md,tasks/**/*.md,Dockerfile,.dockerignore,docker/**,.devcontainer/**,.github/**,pyproject.toml,uv.lock,requirements/**,**/package.json,**/package-lock.json}'
+            docs:
+              - '{*.md,docs/**/*.md,tasks/**/*.md}'
+            docker:
+              - '{Dockerfile,.dockerignore,docker/**,.devcontainer/**}'
+            workflows:
+              - '.github/**'
+            deps:
+              - '{pyproject.toml,uv.lock,requirements/**,**/package.json,**/package-lock.json}'
+
   # Uses the composite action at .github/actions/test-suite/action.yml for
   # the step-level rationale, including why the shared unit is a composite
   # action and not a reusable workflow: a job delegating via `uses:` reports
@@ -26,6 +63,8 @@ jobs:
   # `requirements/ci-postgresql.txt` and tree-sitter grammars are now
   # installed unconditionally inside the action rather than passed in.
   test:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     # Bound a hung leg instead of inheriting GitHub's 360-minute default:
@@ -64,6 +103,8 @@ jobs:
           run-extended-checks: ${{ matrix.python-version == '3.12' }}
 
   test-sqlite:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (SQLite backend)
     runs-on: ubuntu-latest
 
@@ -204,12 +245,13 @@ jobs:
         run: python scripts/verify_mcp_hosts.py -- hypermnesia-mcp
 
   mcp-host-config:
+    needs: [changes, lint]
+    if: (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     name: Validate MCP host configurations
     # The pinned Claude package requires its postinstall to select the native
     # validator. Never execute install scripts from a lockfile modified by an
     # untrusted fork; same-repository PRs and main/workflow_dispatch remain
     # covered by this vendor-parser contract.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -284,6 +326,8 @@ jobs:
               -- "${plugin_command[@]}"
 
   test-windows:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (Windows, SQLite backend)
     runs-on: windows-latest
 
@@ -406,6 +450,8 @@ jobs:
   # under this narrower dependency set, with no PostgreSQL service needed
   # (`--storage-selection sqlite` is the default).
   release-deps:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Release dependency set (requirements/release.txt)
     runs-on: ubuntu-latest
     steps:
@@ -600,6 +646,8 @@ jobs:
   # scripts/craftsmanship_baseline.py for why pre-existing debt (recorded
   # in .craftsmanship-baseline.json) does not retroactively block.
   craftsmanship:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Craftsmanship Gate
     runs-on: ubuntu-latest
     steps:
@@ -623,6 +671,8 @@ jobs:
         run: python scripts/check_craftsmanship.py
 
   typecheck:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Type Check
     runs-on: ubuntu-latest
     steps:
@@ -679,6 +729,8 @@ jobs:
         run: .venv/bin/python -m pyright mcp_server/
 
   build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Build Package
     runs-on: ubuntu-latest
     steps:
@@ -709,6 +761,8 @@ jobs:
   # separate services. The claim here is narrow and worth making on its own:
   # the image still builds, and its hash-pinned installs still resolve.
   docker-runtime-build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Build (runtime image)
     runs-on: ubuntu-latest
     steps:
@@ -738,6 +792,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   devcontainer-build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Build (devcontainer image)
     runs-on: ubuntu-latest
     steps:
@@ -763,6 +819,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   docker-smoke:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Smoke (bare-container DB-less contract)
     runs-on: ubuntu-latest
     # BLOCKING: this job asserts the exact contract that silently broke for
@@ -807,8 +865,9 @@ jobs:
         env:
           CORTEX_SMOKE_IMAGE: cortex-smoke:local
 
-  # The one status check branch protection on `main` names. Everything else
-  # in this workflow is reached through its `needs:` list, so renaming a job,
+  # The aggregate required check for this workflow. CodeQL remains an
+  # independent required check outside ci.yml. Everything else here is reached
+  # through its `needs:` list, so renaming a job,
   # resizing the matrix, or delegating steps to a reusable workflow (which
   # rewrites check names to "<caller> / <callee>", issue #336) no longer
   # touches the protection settings — the contract is this file, in git,
@@ -827,6 +886,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
+      - changes
       - test
       - test-sqlite
       - mcp-host-config
@@ -840,30 +900,15 @@ jobs:
       - devcontainer-build
       - docker-smoke
     steps:
-      - name: Require every job above to have succeeded
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Require successful jobs or justified skips
         env:
           NEEDS: ${{ toJSON(needs) }}
-          # Jobs permitted to report `skipped`, with the reason. ONLY jobs
-          # carrying a job-level `if:` belong here; anything else that skips
-          # is a gap, not an exemption.
-          #   mcp-host-config — `if: github.event_name != 'pull_request' ||
-          #   github.event.pull_request.head.repo.fork == false`: a fork PR
-          #   has no access to the secrets it needs, so it cannot run there.
-          ALLOWED_SKIPS: mcp-host-config
-        run: |
-          set -euo pipefail
-          echo "$NEEDS"
-          failed=$(printf '%s' "$NEEDS" | jq -r --arg allowed "$ALLOWED_SKIPS" '
-            ($allowed | split(",") | map(ltrimstr(" ") | rtrimstr(" "))) as $ok
-            | to_entries[]
-            | select(.value.result != "success")
-            | select(.value.result != "skipped" or ([.key] | inside($ok) | not))
-            | "\(.key)=\(.value.result)"')
-          if [ -n "$failed" ]; then
-            echo "::error::CI Green refuses the merge — $(echo "$failed" | tr '\n' ' ')"
-            exit 1
-          fi
-          echo "every required job succeeded"
+          # Path skips are valid only for irrelevant PRs. mcp-host-config
+          # additionally skips fork PRs to avoid untrusted npm postinstall.
+          # The checker verifies these reasons against this run's inputs.
+          ALLOWED_SKIPS: test,test-sqlite,mcp-host-config,test-windows,release-deps,craftsmanship,typecheck,build,docker-runtime-build,devcontainer-build,docker-smoke
+        run: python3 scripts/check_ci_gate_results.py
 
   # The tag-as-output half of issue #392: a green push to `main` tags the
   # exact SHA that just passed CI Green, instead of a human hand-picking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  schedule:
+    # source: W1-4 in tasks/codex-green-remediation-plan.md requires weekly
+    # builds; reuse fuzz.yml's Monday 04:17 UTC window as a config choice.
+    - cron: "17 4 * * 1"
 
 permissions:
   contents: read
@@ -64,7 +68,7 @@ jobs:
   # installed unconditionally inside the action rather than passed in.
   test:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     # Bound a hung leg instead of inheriting GitHub's 360-minute default:
@@ -104,7 +108,7 @@ jobs:
 
   test-sqlite:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (SQLite backend)
     runs-on: ubuntu-latest
 
@@ -246,7 +250,7 @@ jobs:
 
   mcp-host-config:
     needs: [changes, lint]
-    if: (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    if: github.event_name != 'schedule' && ((github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false))
     name: Validate MCP host configurations
     # The pinned Claude package requires its postinstall to select the native
     # validator. Never execute install scripts from a lockfile modified by an
@@ -327,7 +331,7 @@ jobs:
 
   test-windows:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Windows, SQLite backend)
     runs-on: windows-latest
 
@@ -451,7 +455,7 @@ jobs:
   # (`--storage-selection sqlite` is the default).
   release-deps:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Release dependency set (requirements/release.txt)
     runs-on: ubuntu-latest
     steps:
@@ -647,7 +651,7 @@ jobs:
   # in .craftsmanship-baseline.json) does not retroactively block.
   craftsmanship:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Craftsmanship Gate
     runs-on: ubuntu-latest
     steps:
@@ -672,7 +676,7 @@ jobs:
 
   typecheck:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Type Check
     runs-on: ubuntu-latest
     steps:
@@ -730,7 +734,7 @@ jobs:
 
   build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Build Package
     runs-on: ubuntu-latest
     steps:
@@ -762,7 +766,7 @@ jobs:
   # the image still builds, and its hash-pinned installs still resolve.
   docker-runtime-build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (runtime image)
     runs-on: ubuntu-latest
     steps:
@@ -789,11 +793,13 @@ jobs:
           tags: cortex-runtime:ci
           load: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # source: https://docs.docker.com/build/cache/backends/#cache-mode
+          # min exports image layers; intermediate build layers are omitted.
+          cache-to: type=gha,mode=min
 
   devcontainer-build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (devcontainer image)
     runs-on: ubuntu-latest
     steps:
@@ -816,7 +822,9 @@ jobs:
           tags: cortex-devcontainer:ci
           load: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # source: https://docs.docker.com/build/cache/backends/#cache-mode
+          # min exports image layers; intermediate build layers are omitted.
+          cache-to: type=gha,mode=min
 
   docker-smoke:
     needs: [changes, lint]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,12 +698,6 @@ jobs:
       - name: Build sdist and wheel
         run: python -m build
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: dist
-          path: dist/
-
   # The two images below had NO CI build at all until this change, so a
   # regression in either was invisible until someone built it by hand. That
   # is not hypothetical: docker/Dockerfile copied a python3.12 site-packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    # source: W1-7 review runs 33990473565, 33951959734, 33951905125,
-    # 33806380625; each matrix limit is twice that leg's maximum elapsed time.
+    # source: W1-7 review and successful W2 runs cited per matrix leg.
+    # Each limit is ceil(twice that leg's maximum elapsed seconds / 60).
     timeout-minutes: ${{ matrix.timeout-minutes }}
     strategy:
       fail-fast: false
@@ -82,14 +82,14 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         include:
           - python-version: "3.10"
-            # source: run 33951959734 (2026-09-05), max 545s; ceil(2 * 545 / 60).
-            timeout-minutes: 19
+            # source: run 34047249647 (2026-09-06), max 980s; ceil(2 * 980 / 60).
+            timeout-minutes: 33
           - python-version: "3.11"
             # source: run 33806380625 (2026-09-03), max 1931s; ceil(2 * 1931 / 60).
             timeout-minutes: 65
           - python-version: "3.12"
-            # source: run 33951959734 (2026-09-05), max 1143s; ceil(2 * 1143 / 60).
-            timeout-minutes: 39
+            # source: run 34046091095 (2026-09-06), max 1197s; ceil(2 * 1197 / 60).
+            timeout-minutes: 40
           - python-version: "3.13"
             # source: run 33951959734 (2026-09-05), max 577s; ceil(2 * 577 / 60).
             timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
   changes:
     name: Changed paths
     runs-on: ubuntu-latest
+    # source: run 34035713474 (2026-09-06), max 9s; ceil(2 * 9 / 60).
+    timeout-minutes: 1
     permissions:
       contents: read
       pull-requests: read
@@ -71,25 +73,26 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    # Bound a hung leg instead of inheriting GitHub's 360-minute default:
-    # release run 30741657854 (v4.17.0, CHANGELOG 4.17.1) sat in FlashRank's
-    # timeout-less `requests.get` until pytest-timeout fired, and only that
-    # per-test guard, not the job, ever bounded the suite.
-    # source: measured 2026-09-03 over the last 12 green `main` runs of this
-    # workflow (gh run list --status success, runs 31417063954 to
-    # 33688337476, 48 legs, started_at to completed_at per job): Test (Python
-    # 3.12, the only leg running the extended checks) took 15-20 min (max
-    # 19 min 36 s, run 32747742631); the other three legs took 8-11 min in 11
-    # of the 12 runs, but in run 33688337476 (c5ec018a) Python 3.10 took
-    # 15 min 06 s and Python 3.13 took 27 min 17 s, the slowest green leg in
-    # the window. 60 min is about twice that maximum (60 / 27.3 = 2.2), so a
-    # slow runner still passes while a stalled job is cut within one ordinary
-    # run's wall time.
-    timeout-minutes: 60
+    # source: W1-7 review runs 33990473565, 33951959734, 33951905125,
+    # 33806380625; each matrix limit is twice that leg's maximum elapsed time.
+    timeout-minutes: ${{ matrix.timeout-minutes }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          - python-version: "3.10"
+            # source: run 33951959734 (2026-09-05), max 545s; ceil(2 * 545 / 60).
+            timeout-minutes: 19
+          - python-version: "3.11"
+            # source: run 33806380625 (2026-09-03), max 1931s; ceil(2 * 1931 / 60).
+            timeout-minutes: 65
+          - python-version: "3.12"
+            # source: run 33951959734 (2026-09-05), max 1143s; ceil(2 * 1143 / 60).
+            timeout-minutes: 39
+          - python-version: "3.13"
+            # source: run 33951959734 (2026-09-05), max 577s; ceil(2 * 577 / 60).
+            timeout-minutes: 20
 
     steps:
       # A local `uses: ./...` is resolved from the checked-out tree, so the
@@ -111,6 +114,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (SQLite backend)
     runs-on: ubuntu-latest
+    # source: run 33806380625 (2026-09-03), max 292s; ceil(2 * 292 / 60).
+    timeout-minutes: 10
 
     # Force the SQLite fallback path — no PostgreSQL installed or started.
     # The conftest detects PG-unreachable and sets CORTEX_MEMORY_STORE_BACKEND=sqlite
@@ -257,6 +262,8 @@ jobs:
     # untrusted fork; same-repository PRs and main/workflow_dispatch remain
     # covered by this vendor-parser contract.
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 61s; ceil(2 * 61 / 60).
+    timeout-minutes: 3
     permissions:
       contents: read
 
@@ -341,6 +348,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Windows, SQLite backend)
     runs-on: windows-latest
+    # source: run 33990473565 (2026-09-05), max 426s; ceil(2 * 426 / 60).
+    timeout-minutes: 15
 
     # Real NT proof for the cross-platform fixes (fcntl→msvcrt, sys.executable,
     # NTFS exec bits, $HOME override, path separators). We use the SQLite
@@ -467,6 +476,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Release dependency set (requirements/release.txt)
     runs-on: ubuntu-latest
+    # source: run 33806380625 (2026-09-03), max 109s; ceil(2 * 109 / 60).
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -513,6 +524,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 17s; ceil(2 * 17 / 60).
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -683,6 +696,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Craftsmanship Gate
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 9s; ceil(2 * 9 / 60).
+    timeout-minutes: 1
     steps:
       # fetch-depth: 0 so `origin/main` — the diff base the gate compares
       # the PR's changed files against — is resolvable locally, not just
@@ -708,6 +723,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Type Check
     runs-on: ubuntu-latest
+    # source: run 33990473565 (2026-09-05), max 94s; ceil(2 * 94 / 60).
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -770,6 +787,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Build Package
     runs-on: ubuntu-latest
+    # source: run 33951905125 (2026-09-05), max 19s; ceil(2 * 19 / 60).
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -804,6 +823,8 @@ jobs:
     if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (runtime image)
     runs-on: ubuntu-latest
+    # source: run 33951905125 (2026-09-05), max 514s; ceil(2 * 514 / 60).
+    timeout-minutes: 18
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -837,6 +858,8 @@ jobs:
     if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (devcontainer image)
     runs-on: ubuntu-latest
+    # source: run 33951905125 (2026-09-05), max 349s; ceil(2 * 349 / 60).
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -866,6 +889,8 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Smoke (bare-container DB-less contract)
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 369s; ceil(2 * 369 / 60).
+    timeout-minutes: 13
     # BLOCKING: this job asserts the exact contract that silently broke for
     # two months (fix/bare-container-contract, commit 5d71069c) — third-party
     # registry indexers (Glama et al.) `docker build` the bare repo, then
@@ -928,6 +953,8 @@ jobs:
     name: CI Green
     if: always()
     runs-on: ubuntu-latest
+    # source: run 33806380625 (2026-09-03), max 4s; ceil(2 * 4 / 60).
+    timeout-minutes: 1
     needs:
       - changes
       - test
@@ -973,6 +1000,8 @@ jobs:
     # has already merged — see the job comment above.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # source: run 33990473565 (2026-09-05), max 12s; ceil(2 * 12 / 60).
+    timeout-minutes: 1
     # `contents: read`, NOT write, and that is deliberate. The tag is pushed
     # with the RELEASE_TAG_SSH_KEY deploy key (persisted by the checkout step
     # below), never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,10 @@ jobs:
           # @anthropic-ai/claude-code 2.1.220 declares Node >=22; Node 24 is
           # the repository's existing release-toolchain pin.
           node-version: "24"
+          # source: https://github.com/actions/setup-node/tree/v7.0.0#caching-global-packages-data
+          # Cache downloads, not node_modules.
+          cache: npm
+          cache-dependency-path: tests_js/mcp-host-clis/package-lock.json
 
       - name: Install uv (pinned)
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -329,6 +333,9 @@ jobs:
               --storage-selection auto \
               -- "${plugin_command[@]}"
 
+  # source: https://github.com/actions/setup-python/tree/v7.0.0#caching-packages-dependencies
+  # pip caches below hash each job's exact exported constraints. Requirement
+  # installs still use --require-hashes; no installed environment is restored.
   test-windows:
     needs: [changes, lint]
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
@@ -350,6 +357,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/ci-sqlite-min.txt
 
       - name: Cache HuggingFace models
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -465,6 +474,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/release.txt
 
       - name: Cache HuggingFace models
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -509,6 +520,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/lint.txt
 
       - name: Install ruff
         # Pinned: ruff's formatter output changes across minor versions
@@ -624,12 +637,28 @@ jobs:
       # curl|bash), matching this repo's supply-chain-hardening stance (release.yml).
       # source: https://github.com/rhysd/actionlint/releases/tag/v1.7.12,
       # actionlint_1.7.12_checksums.txt, linux_amd64 entry, verified 2026-07-29.
+      # Cache only the release archive; verify its checksum on every run.
+      # source: https://github.com/actions/cache/tree/v6.1.0#usage
+      - name: Cache actionlint archive
+        id: actionlint-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/cortex-actionlint/actionlint_1.7.12_linux_amd64.tar.gz
+          key: ${{ runner.os }}-${{ runner.arch }}-actionlint-1.7.12-8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+
       - name: Install actionlint (pinned, checksum-verified)
+        env:
+          CACHE_HIT: ${{ steps.actionlint-cache.outputs.cache-hit }}
+          ACTIONLINT_CACHE_DIR: ${{ runner.temp }}/cortex-actionlint
         run: |
           set -euxo pipefail
           VERSION="1.7.12"
           ARCHIVE="actionlint_${VERSION}_linux_amd64.tar.gz"
-          curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/${ARCHIVE}"
+          mkdir -p "$ACTIONLINT_CACHE_DIR"
+          cd "$ACTIONLINT_CACHE_DIR"
+          if [ "$CACHE_HIT" != "true" ]; then
+            curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/${ARCHIVE}"
+          fi
           echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  ${ARCHIVE}" | sha256sum -c -
           tar -xzf "${ARCHIVE}" actionlint
           sudo install -m 0755 actionlint /usr/local/bin/actionlint
@@ -686,6 +715,10 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements/ci-typecheck.txt
+            requirements/typecheck-tool.txt
 
       # Pyright resolves third-party imports from ./.venv (pinned in
       # pyrightconfig.json: venvPath="."/venv=".venv"). The full stub set MUST
@@ -744,6 +777,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/packaging.txt
 
       - name: Install build tools
         # --no-deps: the file is the complete, uv-resolved dependency graph

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,11 +34,18 @@ on:
 
 permissions: read-all
 
+# source: W1-7 in tasks/codex-green-remediation-plan.md; superseded PR checks.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pr-batch:
     name: Fuzz (PR batch)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # source: run 34030977934 (2026-09-06), max 363s; ceil(2 * 363 / 60).
+    timeout-minutes: 13
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +74,8 @@ jobs:
     name: Fuzz (scheduled batch)
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # source: run 33384194242 (2026-08-31), max 1144s; ceil(2 * 1144 / 60).
+    timeout-minutes: 39
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -30,10 +30,17 @@ on:
 permissions:
   contents: read
 
+# source: W1-7 in tasks/codex-green-remediation-plan.md; superseded PR checks.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   scan:
     name: HOL plugin scan
     runs-on: ubuntu-latest
+    # source: run 34030977899 (2026-09-06), max 59s; ceil(2 * 59 / 60).
+    timeout-minutes: 2
     permissions:
       contents: read
       security-events: write   # SARIF upload to code scanning

--- a/.github/workflows/marketplace-pins.yml
+++ b/.github/workflows/marketplace-pins.yml
@@ -30,6 +30,8 @@ jobs:
   check-pins:
     name: pins current vs latest releases
     runs-on: ubuntu-latest
+    # source: run 33723724819 (2026-09-03), max 13s; ceil(2 * 13 / 60).
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check marketplace pins

--- a/.github/workflows/mcp-toplist-badge.yml
+++ b/.github/workflows/mcp-toplist-badge.yml
@@ -27,6 +27,8 @@ jobs:
   refresh:
     name: refresh rank badge from upstream
     runs-on: ubuntu-latest
+    # source: run 30692957797 (2026-08-01), max 32s; ceil(2 * 32 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
     # form; this one was the exception.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 39s; ceil(2 * 39 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write  # create the release + attach auto-generated notes
     steps:
@@ -134,6 +136,8 @@ jobs:
     # thing they all used to wait on) is gone (issue #392).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 33725153709 (2026-09-03), max 31s; ceil(2 * 31 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write       # upload attested wheel/sdist + checksums to release
       id-token: write       # OIDC token Sigstore exchanges for a signing cert
@@ -218,6 +222,8 @@ jobs:
     # nothing (see `build`'s identical comment for why there is no `needs:`).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 32s; ceil(2 * 32 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write       # upload SBOM + checksum to the release
       id-token: write       # OIDC for attestation
@@ -288,6 +294,8 @@ jobs:
     # identical comment for why there is no `needs:`).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 25s; ceil(2 * 25 / 60).
+    timeout-minutes: 1
     permissions:
       contents: write       # upload bundle + checksum + server.json to release
       id-token: write       # OIDC token Sigstore exchanges for a signing cert
@@ -398,6 +406,8 @@ jobs:
     # tag-only contract survives a future edit to `build`'s condition.
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 33809450915 (2026-09-03), max 23s; ceil(2 * 23 / 60).
+    timeout-minutes: 1
     # OIDC Trusted Publishing — no stored secret. Verified by PyPI against
     # the trusted-publisher entry for (cdeust/Cortex, release.yml,
     # environment=pypi). This is the same entry that published <= 3.14.7.
@@ -471,6 +481,8 @@ jobs:
     needs: publish-pypi
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 14s; ceil(2 * 14 / 60).
+    timeout-minutes: 1
     permissions:
       id-token: write   # OIDC — mcp-publisher login github-oidc
       contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,6 +37,8 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    # source: run 33806380608 (2026-09-03), max 40s; ceil(2 * 40 / 60).
+    timeout-minutes: 2
     permissions:
       security-events: write   # upload SARIF to code scanning
       id-token: write          # publish signed results to the OpenSSF API

--- a/.github/workflows/upstream-identity.yml
+++ b/.github/workflows/upstream-identity.yml
@@ -27,10 +27,17 @@ on:
 permissions:
   contents: read
 
+# source: W1-7 in tasks/codex-green-remediation-plan.md; superseded PR checks.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   contract:
     name: agree with the upstream identity contract
     runs-on: ubuntu-latest
+    # source: run 34034615566 (2026-09-06), max 9s; ceil(2 * 9 / 60).
+    timeout-minutes: 1
     env:
       CONTRACT_URL: https://raw.githubusercontent.com/cdeust/ai-architect-mcp-codebase/37728cc5747cebe39ea9d4011b7424de90f0a57b/mcp-contract.json
     steps:

--- a/benchmarks/energy/README.md
+++ b/benchmarks/energy/README.md
@@ -1,0 +1,130 @@
+# Embedding energy harness
+
+W0-2 repairs the float32 equivalence gate and makes carbon inputs explicit.
+The automated fixtures exercise arithmetic and failure paths; they do **not**
+measure device energy or establish an energy improvement.
+
+## Run
+
+Run from an interactive macOS terminal, after supplying your sourced protocol
+and carbon factors. These environment variables intentionally have no example
+carbon values:
+
+```sh
+benchmarks/energy/run.sh \
+  --duration-seconds "$ENERGY_PHASE_SECONDS" \
+  --repetitions "$ENERGY_REPETITIONS" \
+  --carbon-intensity "$ENERGY_INTENSITY_G_PER_KWH" \
+  --embodied "$ENERGY_EMBODIED_G_PER_SECOND"
+```
+
+`--carbon-intensity` and `--embodied` are mandatory, finite and nonnegative.
+The runner validates them, and the protocol, before any `sudo` or model import.
+`--validate-only` performs just that validation. `--batch-size` defaults to the
+batch from the review's W3-2 probe; `--sample-rate-ms` defaults to the system
+powermetrics manual's sampling interval. Both are configurable experimental
+protocol choices. Choose phases long enough to contain sensor samples.
+
+`run.sh` owns sensor authorization and cleanup; it replaces the duplicate
+AppleScript sensor launcher previously embedded in Python. Only powermetrics
+runs elevated. `ENERGY_PYTHON` can select a Python interpreter; otherwise the
+runner uses the repository's `.venv/bin/python`. The Python entry point can use
+an already running stream via `--external-power-file`; without it, it directs
+the operator to `run.sh`. An unavailable neural model is an explicit error.
+The harness does not change the model's cache location.
+
+## Units and equivalence
+
+`I = --carbon-intensity` is the electricity region's intensity in gCO2eq/kWh.
+`--embodied` is an **already allocated emission rate** in gCO2eq/s, not the total
+device footprint. Derive it from sourced lifecycle emissions divided by expected
+life in seconds, multiplied by the resource share reserved for this workload.
+Record the region, observation period, lifecycle assessment, expected lifetime
+and reservation assumptions alongside your run. The harness records input
+values and units but does not verify their provenance.
+
+For each measured phase, with `t` its actual elapsed seconds and `N` its actual
+model input token count:
+
+```text
+M_phase [gCO2eq] = embodied_rate [gCO2eq/s] * t [s]
+O_phase [gCO2eq] = (energy_j / 3600000) [kWh] * I [gCO2eq/kWh]
+carbon per 1000 tokens = (O_phase + M_phase) * 1000 / N
+joules per 1000 tokens = energy_j * 1000 / N
+```
+
+The model's `tokenize` method supplies `attention_mask`; summing it counts
+non-padding tokens after truncation, including special tokens. The harness
+reconstructs every completed input batch and counts tokens **after all timed
+phases**. It never estimates tokens from characters. Scalar and batch phases
+use the same deterministic text generator; their LRU cache is cleared before
+each phase so the probe cannot warm scalar inputs into cache hits.
+
+Equivalence decodes `encode`/`encode_batch` blobs using
+`np.frombuffer(blob, dtype=np.float32)`. Empty, malformed, nonfinite, mismatched
+outputs and errors above `np.finfo(np.float32).eps` are refused before phases.
+The tolerance is absolute (`rtol=0`) and deliberately strict. NumPy supplies its
+floating-point definition; this is **not** a universal bound on model inference
+error. The probe validates the selected batch, device and run only. A fixture
+at `0.5` and its next float32 value toward `1` demonstrates why comparing byte
+values was incorrect.
+
+## Measurement boundary and artifacts
+
+`raw_system_energy_j` covers the sensor's combined **CPU+GPU+ANE** estimate.
+It is neither wall-plug energy nor a complete device/application SCI score.
+Memory, storage, screen, power supply losses, model warm-up and token counting
+are excluded. Carbon uses raw energy; idle-subtracted energy is a separate
+diagnostic and retains negative values so idle noise remains visible.
+
+The phase energy estimate is mean sampled watts multiplied by elapsed seconds;
+samples are assigned by their end timestamps. Finite sampling introduces phase
+boundary error. CPU-only samples are refused. An incomplete final sample may
+be ignored only when its timestamp is after every measured phase, with an
+explicit warning; malformed samples inside phases are refused.
+
+Successful runs preserve `results.json`, `MANIFEST.json` (commit and source
+hashes) and the exact analyzed `powermetrics.txt` snapshot under
+`benchmarks/results/energy/`. The snapshot is taken while the external sensor
+is running. On failure, the shell reports the retained raw temporary file;
+it never stores a model there. Sensor stop failures return nonzero and do not
+wait indefinitely for a sensor that could not be signalled.
+
+Stopping sends `SIGINT` directly to the existing sudo parent, which relays it
+to powermetrics under macOS's normal sudoers/PAM process model. This requires
+no new sudo invocation, so an expired authentication ticket does not prevent
+cleanup. A nonstandard sudo policy that replaces its parent with the root
+command may deny the signal; the runner then reports failure without waiting.
+
+## Primary sources
+
+- [Green Software Foundation SCI specification](https://sci.greensoftware.foundation/):
+  operational emissions `O=E*I`, embodied allocation `M=TE*TS*RS`, functional units.
+- [NumPy frombuffer](https://numpy.org/doc/stable/reference/generated/numpy.frombuffer.html),
+  [finfo](https://numpy.org/doc/stable/reference/generated/numpy.finfo.html), and
+  [allclose](https://numpy.org/doc/stable/reference/generated/numpy.allclose.html):
+  byte interpretation, machine epsilon and explicit tolerance semantics.
+- [SentenceTransformer.tokenize](https://www.sbert.net/docs/package_reference/sentence_transformer/SentenceTransformer.html#sentence_transformers.SentenceTransformer.tokenize)
+  and [Hugging Face tokenizer attention masks](https://huggingface.co/docs/transformers/main_classes/tokenizer):
+  actual model preprocessing and non-padding token masks.
+- [NIST SP 811 chapter 4](https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-4-two-classes-si-units-and-si-prefixes)
+  and [chapter 5](https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-5-units-outside-si):
+  watt/joule, kilo/milli prefixes and seconds per hour.
+- Local macOS `powermetrics(1)`, `/usr/share/man/man1/powermetrics.1`, consulted
+  2026-09-06: sample-rate default, continuous sampling, flushing and stop signals.
+- Local macOS `sudo(8)` 1.9.17p2, `/usr/share/man/man8/sudo.8`, sections
+  "Process model" and "Signal handling", and [Apple kill(2)](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kill.2.html):
+  user-generated signal relay and real/effective UID permission checks.
+- Protocol/acceptance: `tasks/codex-green-remediation-plan.md`, W0-2 and W3-2.
+
+## Fixture verification
+
+```sh
+.venv/bin/pytest tests_py/benchmarks/test_energy_*.py
+.venv/bin/ruff check benchmarks/energy tests_py/benchmarks/test_energy_*.py
+.venv/bin/ruff format --check benchmarks/energy tests_py/benchmarks/test_energy_*.py
+```
+
+The shell tests use a fake sudo executable for validation and a simulated
+sensor under a PTY for successful and failing workload cleanup. No test starts
+powermetrics, invokes real sudo or downloads/loads model weights.

--- a/benchmarks/energy/measurement.py
+++ b/benchmarks/energy/measurement.py
@@ -1,0 +1,244 @@
+"""Power samples, explicit carbon arithmetic, and reproducible report artifacts.
+
+The SCI equation is used only for the disclosed CPU+GPU+ANE boundary, which is
+not a complete device/application SCI assessment. See README.md for sources.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import statistics
+import subprocess
+import warnings
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+import numpy as np
+
+from benchmarks.energy.workload import Phase
+
+
+REPO = Path(__file__).resolve().parent.parent.parent
+# source: W0-2 functional unit in tasks/codex-green-remediation-plan.md.
+TOKENS_PER_UNIT = 1000
+# source: NIST SP 811 ch. 4 (W = J/s, kilo = 10^3), ch. 5 (h = 3600 s).
+JOULES_PER_KWH = 3_600_000
+# source: NIST SP 811 ch. 4, milli = 10^-3.
+MILLIWATTS_PER_WATT = 1000
+COMBINED_POWER_RE = re.compile(
+    r"Combined Power \(CPU \+ GPU \+ ANE\):\s*([0-9.]+)\s*mW"
+)
+SAMPLE_RE = re.compile(
+    r"\*\*\* Sampled system activity \(([^)]+)\).*?\*\*\*\n"
+    r"(.*?)(?=\n\*\*\* Sampled system activity|\Z)",
+    re.DOTALL,
+)
+
+
+@dataclass
+class MeasuredPhase:
+    phase: Phase
+    samples: int
+    mean_system_power_w: float
+    idle_power_w: float
+
+    @property
+    def raw_system_energy_j(self) -> float:
+        # source: NIST SP 811 ch. 4, W = J/s; sampled mean power approximation.
+        return self.mean_system_power_w * self.phase.elapsed_s
+
+    @property
+    def dynamic_energy_j(self) -> float:
+        # Keep negative differences visible; they indicate idle/noise sensitivity.
+        return (self.mean_system_power_w - self.idle_power_w) * self.phase.elapsed_s
+
+
+def parse_power_samples(
+    text: str, phase_end: float | None = None
+) -> list[tuple[float, float]]:
+    samples = []
+    blocks = SAMPLE_RE.findall(text)
+    for index, (timestamp, body) in enumerate(blocks):
+        sampled_at = parsedate_to_datetime(timestamp).timestamp()
+        match = COMBINED_POWER_RE.search(body)
+        if (
+            match is None
+            and index == len(blocks) - 1
+            and phase_end is not None
+            and sampled_at > phase_end
+        ):
+            warnings.warn(
+                "Incomplete final power sample outside measured phases ignored; "
+                "raw snapshot preserved",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            continue
+        if match is None:
+            raise ValueError("sample lacks Combined Power (CPU + GPU + ANE)")
+        watts = float(match.group(1)) / MILLIWATTS_PER_WATT
+        if not math.isfinite(watts):
+            raise ValueError("non-finite power sample")
+        samples.append((sampled_at, watts))
+    if not samples:
+        raise ValueError("no combined CPU+GPU+ANE power samples")
+    return samples
+
+
+def _mean_power(phase: Phase, samples: list[tuple[float, float]]) -> tuple[int, float]:
+    values = [
+        watts
+        for timestamp, watts in samples
+        if phase.wall_start <= timestamp <= phase.wall_end
+    ]
+    if not values:
+        raise RuntimeError(f"no power samples in phase {phase.condition}")
+    return len(values), statistics.fmean(values)
+
+
+def apply_power_samples(
+    phases: list[Phase], samples: list[tuple[float, float]]
+) -> list[MeasuredPhase]:
+    power = [_mean_power(phase, samples) for phase in phases]
+    idle_by_rep = {
+        phase.repetition: mean
+        for phase, (_, mean) in zip(phases, power, strict=True)
+        if phase.condition == "idle"
+    }
+    return [
+        MeasuredPhase(phase, count, mean, idle_by_rep[phase.repetition])
+        for phase, (count, mean) in zip(phases, power, strict=True)
+        if phase.condition != "idle"
+    ]
+
+
+def carbon_per_1k_tokens(
+    energy_j: float, tokens: int, intensity: float, embodied_g: float
+) -> float:
+    if tokens <= 0:
+        raise ValueError("token count must be positive")
+    if any(not math.isfinite(x) or x < 0 for x in (energy_j, intensity, embodied_g)):
+        raise ValueError("energy and carbon inputs must be finite and nonnegative")
+    # source: https://sci.greensoftware.foundation/ : O = E*I, SCI = (O+M)/R.
+    operational_g = energy_j / JOULES_PER_KWH * intensity
+    return (operational_g + embodied_g) * TOKENS_PER_UNIT / tokens
+
+
+def summarize(
+    rows: list[MeasuredPhase], mode: str, args: argparse.Namespace
+) -> dict[str, float]:
+    selected = [row for row in rows if row.phase.condition == mode]
+    per_text = [row.raw_system_energy_j / row.phase.operations for row in selected]
+    per_tokens = [
+        row.raw_system_energy_j * TOKENS_PER_UNIT / row.phase.tokens for row in selected
+    ]
+    carbon = [
+        carbon_per_1k_tokens(
+            row.raw_system_energy_j,
+            row.phase.tokens,
+            args.carbon_intensity,
+            args.embodied * row.phase.elapsed_s,
+        )
+        for row in selected
+    ]
+    return {
+        "repetitions": len(selected),
+        "operations_total": sum(row.phase.operations for row in selected),
+        "tokens_total": sum(row.phase.tokens for row in selected),
+        "energy_j_per_text_mean": statistics.fmean(per_text),
+        "energy_j_per_text_stdev": statistics.stdev(per_text),
+        "energy_j_per_1k_tokens_mean": statistics.fmean(per_tokens),
+        "carbon_gco2eq_per_1k_tokens_mean": statistics.fmean(carbon),
+        "idle_subtracted_j_per_text_mean": statistics.fmean(
+            row.dynamic_energy_j / row.phase.operations for row in selected
+        ),
+        "texts_per_second_mean": statistics.fmean(
+            row.phase.operations / row.phase.elapsed_s for row in selected
+        ),
+    }
+
+
+def _report_row(row: MeasuredPhase, args: argparse.Namespace) -> dict[str, object]:
+    return {
+        **asdict(row.phase),
+        "samples": row.samples,
+        "mean_system_power_w": row.mean_system_power_w,
+        "idle_power_w": row.idle_power_w,
+        "raw_system_energy_j": row.raw_system_energy_j,
+        "dynamic_energy_j": row.dynamic_energy_j,
+        "embodied_gco2eq": args.embodied * row.phase.elapsed_s,
+        "carbon_gco2eq_per_1k_tokens": carbon_per_1k_tokens(
+            row.raw_system_energy_j,
+            row.phase.tokens,
+            args.carbon_intensity,
+            args.embodied * row.phase.elapsed_s,
+        ),
+    }
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "git_commit": subprocess.check_output(
+            ["git", "-C", str(REPO), "rev-parse", "HEAD"], text=True
+        ).strip(),
+        "source_sha256": {
+            path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in sorted(Path(__file__).parent.iterdir())
+            if path.is_file()
+        },
+        "host": subprocess.check_output(["uname", "-a"], text=True).strip(),
+        "raw_measurement": "powermetrics.txt",
+        "limitations": [
+            "System CPU+GPU+ANE estimates, not process-isolated or device-total energy",
+            "Excludes memory, storage, display, supply losses, model load and counting",
+            "Mean power uses sample end timestamps within each phase; boundary error",
+            "Operator-supplied I and allocated embodied rate are not verified here",
+            "Float32 tolerance validates this probe only, not all inputs/devices",
+        ],
+    }
+
+
+def write_report(
+    args: argparse.Namespace,
+    results: tuple[list[MeasuredPhase], dict[str, dict[str, float]]],
+    evidence: tuple[bytes, float],
+) -> dict[str, object]:
+    rows, summary = results
+    raw_power, delta = evidence
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    out_dir = REPO / "benchmarks" / "results" / "energy" / stamp
+    out_dir.mkdir(parents=True, exist_ok=False)
+    result = {
+        "functional_units": ["one embedded text", "1000 model input tokens"],
+        "token_definition": (
+            "attention_mask sum after truncation; special tokens included"
+        ),
+        "boundary": "CPU+GPU+ANE power during local inference phases",
+        "duration_seconds": args.duration_seconds,
+        "repetitions": args.repetitions,
+        "batch_size": args.batch_size,
+        "sample_rate_ms": args.sample_rate_ms,
+        "carbon_intensity_gco2eq_per_kwh": args.carbon_intensity,
+        "embodied_rate_gco2eq_per_second": args.embodied,
+        "carbon_formula": (
+            "((energy_j / 3600000) * I + embodied_rate * elapsed_s) * 1000 / tokens"
+        ),
+        "max_abs_output_delta_scalar_vs_batch": delta,
+        "equivalence_atol": float(np.finfo(np.float32).eps),
+        "equivalence_rtol": 0,
+        "rows": [_report_row(row, args) for row in rows],
+        "summary": summary,
+    }
+    (out_dir / "powermetrics.txt").write_bytes(raw_power)
+    for name, payload in (("results.json", result), ("MANIFEST.json", _manifest())):
+        (out_dir / name).write_text(
+            json.dumps(payload, indent=2, allow_nan=False) + "\n"
+        )
+    return {"result_dir": str(out_dir), "summary": summary}

--- a/benchmarks/energy/run.sh
+++ b/benchmarks/energy/run.sh
@@ -1,0 +1,92 @@
+#!/bin/zsh
+# One privileged sensor; Python validation and inference remain unprivileged.
+set -euo pipefail
+unsetopt BG_NICE
+
+SCRIPT_DIR=${0:A:h}
+REPO_DIR=${SCRIPT_DIR:h:h}
+BENCH_PY=${ENERGY_PYTHON:-${REPO_DIR}/.venv/bin/python}
+ENERGY_POWER_FILE=""
+ENERGY_METER_PID=""
+
+if [[ ! -x ${BENCH_PY} ]]; then
+  print -u2 "Missing benchmark interpreter: ${BENCH_PY}"
+  exit 2
+fi
+for ENERGY_ARG in "$@"; do
+  if [[ ${ENERGY_ARG} == --help || ${ENERGY_ARG} == -h ]]; then
+    exec "${BENCH_PY}" "${SCRIPT_DIR}/run_embedding_energy.py" --help
+  fi
+done
+# Required carbon flags and every numeric argument are checked before sudo.
+ENERGY_SAMPLE_RATE_MS=$("${BENCH_PY}" "${SCRIPT_DIR}/run_embedding_energy.py" "$@" --validate-only)
+for ENERGY_ARG in "$@"; do
+  if [[ ${ENERGY_ARG} == --validate-only ]]; then
+    print "${ENERGY_SAMPLE_RATE_MS}"
+    exit 0
+  fi
+  if [[ ${ENERGY_ARG} == --external-power-file* ]]; then
+    print -u2 "Use run_embedding_energy.py directly for --external-power-file."
+    exit 2
+  fi
+done
+if [[ ! -t 0 ]]; then
+  print -u2 "Run from an interactive terminal so macOS can read the sudo password."
+  exit 2
+fi
+
+stop_meter() {
+  if [[ -z ${ENERGY_METER_PID} ]]; then
+    return
+  fi
+  if kill -0 "${ENERGY_METER_PID}" 2>/dev/null; then
+    # source: macOS sudo(8), Signal handling: user-sent SIGINT is relayed
+    # to the command. Signal the existing sudo parent; no fresh ticket needed.
+    if ! kill -INT "${ENERGY_METER_PID}"; then
+      print -u2 "Failed to stop sensor ${ENERGY_METER_PID}; refusing to wait indefinitely."
+      return 1
+    fi
+  fi
+  local ENERGY_WAIT_STATUS=0
+  wait "${ENERGY_METER_PID}" || ENERGY_WAIT_STATUS=$?
+  # source: zsh exit status for SIGINT is 128 + signal 2; powermetrics(1)
+  # specifies SIGINT as its normal stop-sampling-and-exit signal.
+  if (( ENERGY_WAIT_STATUS != 0 && ENERGY_WAIT_STATUS != 130 )); then
+    print -u2 "Sensor exited with status ${ENERGY_WAIT_STATUS}."
+    return ${ENERGY_WAIT_STATUS}
+  fi
+  ENERGY_METER_PID=""
+}
+
+cleanup() {
+  local ENERGY_EXIT_STATUS=$?
+  trap - EXIT INT TERM
+  stop_meter || ENERGY_EXIT_STATUS=$?
+  if [[ -n ${ENERGY_POWER_FILE} ]]; then
+    if (( ENERGY_EXIT_STATUS == 0 )); then
+      rm -f "${ENERGY_POWER_FILE}"
+    else
+      print -u2 "Raw sensor output preserved at ${ENERGY_POWER_FILE}."
+    fi
+  fi
+  exit ${ENERGY_EXIT_STATUS}
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+print "Authorizing the macOS energy sensor (Cortex remains non-root)..."
+sudo -v
+ENERGY_POWER_FILE=$(mktemp /private/tmp/cortex-energy.XXXXXX.txt)
+# source: powermetrics(1): 0 samples means continuous capture; buffer-size 1
+# flushes each sample. The EXIT trap stops the sensor after the Python run.
+sudo -n /usr/bin/powermetrics \
+  --samplers cpu_power,gpu_power,ane_power \
+  --sample-rate "${ENERGY_SAMPLE_RATE_MS}" --sample-count 0 --buffer-size 1 \
+  --output-file "${ENERGY_POWER_FILE}" &
+ENERGY_METER_PID=$!
+
+"${BENCH_PY}" "${SCRIPT_DIR}/run_embedding_energy.py" "$@" \
+  --external-power-file "${ENERGY_POWER_FILE}"
+stop_meter
+print "Energy benchmark complete; raw samples are in the result directory."

--- a/benchmarks/energy/run_embedding_energy.py
+++ b/benchmarks/energy/run_embedding_energy.py
@@ -1,0 +1,96 @@
+"""Validate the energy protocol before importing optional model dependencies.
+
+Use run.sh to authorize and manage the sensor, or supply an existing sensor
+stream with --external-power-file. This process never requests privileges.
+The model/workload imports are deliberately deferred until CLI validation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent.parent
+# source: tasks/codex-green-remediation-plan.md W3-2's scalar/batch(32) probe.
+DEFAULT_BATCH_SIZE = 32
+# source: macOS powermetrics(1), --sample-rate default, /usr/share/man/man1/.
+DEFAULT_SAMPLE_RATE_MS = 5000
+# source: sample standard deviation requires two independent observations.
+MIN_REPETITIONS = 2
+
+
+def _nonnegative_float(value: str) -> float:
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        raise argparse.ArgumentTypeError("must be finite and nonnegative")
+    return number
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--duration-seconds", type=_nonnegative_float, required=True)
+    parser.add_argument("--repetitions", type=int, required=True)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--sample-rate-ms", type=int, default=DEFAULT_SAMPLE_RATE_MS)
+    parser.add_argument("--external-power-file", type=Path)
+    parser.add_argument("--validate-only", action="store_true")
+    parser.add_argument(
+        "--carbon-intensity",
+        type=_nonnegative_float,
+        required=True,
+        help="region-specific electricity intensity I, in gCO2eq/kWh; no default",
+    )
+    parser.add_argument(
+        "--embodied",
+        type=_nonnegative_float,
+        required=True,
+        help="allocated embodied emission rate, gCO2eq/s; M = rate * phase seconds",
+    )
+    args = parser.parse_args(argv)
+    if args.duration_seconds <= 0 or args.repetitions < MIN_REPETITIONS:
+        parser.error("duration must be positive and repetitions >= 2")
+    if args.batch_size <= 0 or args.sample_rate_ms <= 0:
+        parser.error("batch-size and sample-rate-ms must be positive")
+    if not args.validate_only and args.external_power_file is None:
+        parser.error(
+            "--external-power-file is required; use run.sh to start the sensor"
+        )
+    return args
+
+
+def _run(args: argparse.Namespace) -> dict[str, object]:
+    # Direct script invocation must resolve the sibling benchmarks package.
+    if str(REPO) not in sys.path:
+        sys.path.insert(0, str(REPO))
+    # Deferred: these modules require NumPy and the optional embedding stack.
+    from benchmarks.energy import measurement, workload  # noqa: PLC0415
+
+    workload.wait_for_stream(args)
+    engine = workload.load_engine()
+    max_abs_delta = workload.verify_equivalence(engine, args.batch_size)
+    phases = workload.run_phases(engine, args)
+    raw_power = args.external_power_file.read_bytes()
+    samples = measurement.parse_power_samples(
+        raw_power.decode("utf-8"), max(phase.wall_end for phase in phases)
+    )
+    rows = measurement.apply_power_samples(phases, samples)
+    summary = {
+        mode: measurement.summarize(rows, mode, args) for mode in ("scalar", "batch")
+    }
+    return measurement.write_report(args, (rows, summary), (raw_power, max_abs_delta))
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    if args.validate_only:
+        print(args.sample_rate_ms)
+        return
+    print(json.dumps(_run(args), indent=2, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/energy/workload.py
+++ b/benchmarks/energy/workload.py
@@ -1,0 +1,172 @@
+"""Neural inference, float32 equivalence, and actual model-token accounting."""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from mcp_server.infrastructure.embedding_engine import EmbeddingEngine
+
+
+class Encoder(Protocol):
+    def encode(self, text: str) -> bytes | None: ...
+
+    def encode_batch(self, texts: list[str]) -> list[bytes | None]: ...
+
+
+class TokenizingModel(Protocol):
+    def tokenize(self, texts: list[str]) -> dict[str, object]: ...
+
+
+class SummableMask(Protocol):
+    def sum(self) -> SummableMask: ...
+
+    def item(self) -> int: ...
+
+
+@dataclass
+class Phase:
+    condition: str
+    repetition: int
+    wall_start: float
+    wall_end: float
+    elapsed_s: float
+    operations: int
+    tokens: int = 0
+
+
+def texts(round_id: int, count: int) -> list[str]:
+    return [
+        f"Cortex energy benchmark unique memory {round_id}:{i}; "
+        "batch-equivalence probe."
+        for i in range(count)
+    ]
+
+
+def _float32_row(blob: bytes | None) -> NDArray[np.float32]:
+    if not blob:
+        raise ValueError("missing or empty embedding output")
+    # source: numpy.frombuffer docs; engine.encode serializes native float32.
+    row = np.frombuffer(blob, dtype=np.float32)
+    if not np.isfinite(row).all():
+        raise ValueError("non-finite embedding output")
+    return row
+
+
+def verify_equivalence(engine: Encoder, batch_size: int) -> float:
+    probes = texts(0, batch_size)
+    scalar = [engine.encode(text) for text in probes]
+    batched = engine.encode_batch(probes)
+    if len(batched) != len(scalar):
+        raise ValueError("scalar/batch output count mismatch")
+    # source: numpy.finfo documents eps as spacing above 1. No model-wide claim:
+    # this strict absolute error budget is checked for this run's probe only.
+    tolerance = float(np.finfo(np.float32).eps)
+    max_delta = 0.0
+    for scalar_blob, batch_blob in zip(scalar, batched, strict=True):
+        left, right = _float32_row(scalar_blob), _float32_row(batch_blob)
+        if left.shape != right.shape:
+            raise ValueError("scalar/batch embedding shape mismatch")
+        delta = float(np.max(np.abs(left.astype(np.float64) - right)))
+        max_delta = max(max_delta, delta)
+        # source: numpy.allclose; explicit atol and zero rtol avoid its defaults.
+        if not np.allclose(left, right, rtol=0, atol=tolerance, equal_nan=False):
+            raise ValueError(
+                f"scalar/batch float32 mismatch: max_abs_delta={delta}, "
+                f"atol={tolerance}"
+            )
+    return max_delta
+
+
+def count_tokens(model: TokenizingModel, values: list[str]) -> int:
+    # source: SentenceTransformer.tokenize returns attention_mask; its sum counts
+    # non-padding tokens after the model's truncation, including special tokens.
+    mask = cast(SummableMask, model.tokenize(values)["attention_mask"])
+    count = int(mask.sum().item())
+    if count <= 0:
+        raise ValueError("tokenizer returned no active tokens")
+    return count
+
+
+def load_engine() -> EmbeddingEngine:
+    # Optional model dependency is loaded only after required CLI arguments pass.
+    from mcp_server.infrastructure.embedding_engine import (  # noqa: PLC0415
+        EmbeddingEngine,
+    )
+
+    engine = EmbeddingEngine()
+    engine.encode("Cortex energy benchmark model warm-up")
+    if engine.mode != "neural":
+        raise RuntimeError(
+            "energy benchmark requires the neural model; fallback refused"
+        )
+    return engine
+
+
+def _timed_workload(engine: Encoder, mode: str, args: argparse.Namespace) -> int:
+    if mode == "idle":
+        time.sleep(args.duration_seconds)
+        return 0
+    deadline = time.perf_counter() + args.duration_seconds
+    round_id = 0
+    while time.perf_counter() < deadline:
+        values = texts(round_id, args.batch_size)
+        if mode == "scalar":
+            for value in values:
+                engine.encode(value)
+        else:
+            engine.encode_batch(values)
+        round_id += 1
+    return round_id * args.batch_size
+
+
+def _measure_phase(
+    engine: EmbeddingEngine, mode: str, args: argparse.Namespace, repetition: int
+) -> Phase:
+    # The probe and earlier phases must not turn scalar inference into LRU hits.
+    engine._cache.clear()
+    wall_start, perf_start = time.time(), time.perf_counter()
+    operations = _timed_workload(engine, mode, args)
+    elapsed = time.perf_counter() - perf_start
+    phase = Phase(mode, repetition, wall_start, time.time(), elapsed, operations)
+    if engine.mode != "neural":
+        raise RuntimeError("neural model unavailable after phase; fallback refused")
+    if mode != "idle" and operations == 0:
+        raise RuntimeError("phase completed no embedding work")
+    return phase
+
+
+def run_phases(engine: EmbeddingEngine, args: argparse.Namespace) -> list[Phase]:
+    phases = []
+    for repetition in range(args.repetitions):
+        # source: original protocol: alternate the two inference conditions.
+        modes = ("scalar", "batch")
+        order = modes if repetition % len(modes) == 0 else tuple(reversed(modes))
+        for condition in ("idle", *order):
+            phases.append(_measure_phase(engine, condition, args, repetition))
+    model = cast(TokenizingModel, engine._model)
+    # Tokenize after ALL timed phases: counting does not inflate measured energy.
+    for phase in phases:
+        phase.tokens = sum(
+            count_tokens(model, texts(round_id, args.batch_size))
+            for round_id in range(phase.operations // args.batch_size)
+        )
+    return phases
+
+
+def wait_for_stream(args: argparse.Namespace) -> None:
+    # One phase duration is the caller's readiness budget; no invented timeout.
+    deadline = time.monotonic() + args.duration_seconds
+    # source: SI milli prefix: 1000 ms/s (NIST SP 811, chapter 4).
+    interval = args.sample_rate_ms / 1000
+    while time.monotonic() < deadline:
+        if "*** Sampled system activity" in args.external_power_file.read_text():
+            return
+        time.sleep(min(interval, max(0.0, deadline - time.monotonic())))
+    raise RuntimeError("external powermetrics stream did not become ready")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,19 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["mcp_server"]
 
+# W1-6: benchmark output, media and paper bundles dominate the source archive;
+# retain application source, tests, fixtures and packaging inputs.
+# source: https://hatch.pypa.io/latest/config/build/#patterns
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/benchmarks/beam/variance/*.txt",
+    "/video/captures",
+    "/video/output",
+    "/docs/**/*.png",
+    "/docs/arxiv-*/**",
+    "/docs/campaigns/*.json",
+]
+
 # ── Resolver constraints ─────────────────────────────────────────────────
 #
 # This table is declared before the `[[tool.uv.index]]` / `[tool.uv.sources]`

--- a/scripts/check_ci_file_count.py
+++ b/scripts/check_ci_file_count.py
@@ -1,0 +1,40 @@
+"""Refuse PR path classification when GitHub's file list may be incomplete."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+
+
+# source: https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
+# The REST endpoint used by dorny/paths-filter returns at most 3000 files.
+API_FILE_LIMIT = 3000
+
+
+def check(count: object) -> str | None:
+    if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+        return "pull_request.changed_files must be a nonnegative integer"
+    if count > API_FILE_LIMIT:
+        return (
+            f"PR changes {count} files, exceeding GitHub's {API_FILE_LIMIT}-file "
+            "API limit; refusing incomplete classification. Split the PR."
+        )
+    return None
+
+
+def main() -> int:
+    try:
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        failure = check(event["pull_request"].get("changed_files"))
+    except (KeyError, OSError, ValueError, TypeError, AttributeError) as error:
+        failure = f"cannot validate pull request file count: {error}"
+    if failure:
+        print(f"::error::{failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_ci_gate_complete.py
+++ b/scripts/check_ci_gate_complete.py
@@ -1,54 +1,12 @@
-"""CI-gate completeness: every ci.yml job must be behind the aggregate gate.
+"""Static CI-gate coverage and prerequisite checks without YAML dependencies.
 
-Branch protection on ``main`` names required status checks as strings, in
-GitHub settings — outside git, invisible in review, and unversioned. Naming
-individual jobs there makes the contract break on every rename: extracting
-the test steps into a reusable workflow (issue #336) renamed the four matrix
-legs to ``Test (Python X.Y) / Test (Python X.Y)``, so the four bare contexts
-``main`` required were never reported again and a fully green PR sat BLOCKED
-(PR #387, run 31250898534). Renaming the contexts fixes that one PR and
-leaves the next rename to rediscover it.
+Every job must be a direct CI Green dependency or declare a conditional
+post-merge exemption. Every conditional gated job belongs to ALLOWED_SKIPS;
+the runtime checker independently verifies the reason for each actual skip.
+CI Green must always run to report failures and rejected skips.
 
-So protection names ONE ci.yml context — ``CI Green`` — and the real list
-lives here, in git, where a diff shows it. That moves the failure mode: the
-gate is only as good as its ``needs:`` list, and a job added later that
-nobody adds to it is silently ungated. That is what this script refuses.
-
-It also refuses the second escape hatch. The gate treats any result other
-than ``success`` as failure, EXCEPT for jobs named in its ``ALLOWED_SKIPS``
-env — because a job carrying a job-level ``if:`` legitimately reports
-``skipped``. An unlisted conditional would therefore let a job skip its way
-past the gate, so every job with an ``if:`` must be declared, and every
-declared exemption must correspond to a job that actually has one (a stale
-exemption is a hole nobody is watching).
-
-A third case exists that ``needs:``/``ALLOWED_SKIPS`` cannot express:
-``release-gate`` (issue #392) runs ONLY on a push to ``main`` — after the PR
-it belongs to has already merged. There is nothing for it to gate: it cannot
-block a PR that is already closed, and putting it in ``ci-green.needs`` would
-make the branch-protection context depend on a job that never runs on a PR
-in the first place, permanently blocking every PR. Such a job declares itself
-with a ``# ci-gate-exempt: <reason>`` marker line in its body instead of
-appearing in ``needs:``. The marker is not a blank check: it is refused
-unless the job ALSO carries a job-level ``if:`` — an exempt job with no
-condition would run ungated on every push and PR, which is exactly the hole
-this script exists to close.
-
-Checks, all of them fatal:
-
-1. the gate job exists;
-2. every other ci.yml job appears in the gate's ``needs:`` OR carries a
-   ``# ci-gate-exempt:`` marker;
-3. every name in ``needs:`` is a real job;
-4. every job carrying a job-level ``if:`` and not exempt is listed in
-   ``ALLOWED_SKIPS``;
-5. every name in ``ALLOWED_SKIPS`` is a job that carries an ``if:``;
-6. every ``# ci-gate-exempt:`` job carries a job-level ``if:`` — an exemption
-   with no condition is not a narrower gate, it is no gate.
-
-Static only — regex over the workflow text, no PyYAML. The Lint job installs
-ruff and nothing else, and this script runs there alongside
-``check_doc_claims.py``, which is static for the same reason.
+Source: tasks/codex-green-remediation-plan.md W1-2 and GitHub workflow syntax:
+https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds
 """
 
 from __future__ import annotations
@@ -60,12 +18,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
-# The single job branch protection points at. Renaming it is a protection
-# change, not a refactor — hence a named constant rather than a literal.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+from check_ci_gate_results import check_policy  # noqa: E402
+
+# The aggregate context for this workflow. Renaming it requires updating
+# branch protection, hence a named constant rather than a literal.
 GATE_JOB = "ci-green"
 
 _JOB_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
 _JOB_IF_RE = re.compile(r"^    if:\s*(\S.*)$")
+_NEEDS_INLINE_RE = re.compile(r"^    needs:\s*\[([^]]*)\]\s*$")
 _NEEDS_BLOCK_RE = re.compile(r"^    needs:\s*$")
 _NEEDS_ITEM_RE = re.compile(r"^      - ([A-Za-z0-9_-]+)\s*$")
 _ALLOWED_SKIPS_RE = re.compile(r"^\s*ALLOWED_SKIPS:\s*(\S.*?)\s*$")
@@ -114,6 +78,10 @@ def _parse_needs(body: list[str]) -> list[str]:
     collecting = False
 
     for line in body:
+        inline = _NEEDS_INLINE_RE.match(line)
+        if inline:
+            needs.extend(name.strip() for name in inline.group(1).split(","))
+            continue
         if _NEEDS_BLOCK_RE.match(line):
             collecting = True
             continue
@@ -205,7 +173,7 @@ def _check_allowed_skips(
 ) -> list[str]:
     """Checks 4 and 5: ALLOWED_SKIPS and the set of conditional jobs agree.
 
-    Exempt jobs never appear in ``needs:``, so ci-green's jq never evaluates
+    Exempt jobs never appear in ``needs:``, so CI Green never evaluates
     their result — ALLOWED_SKIPS governs skip results INSIDE the gate only,
     and does not apply to a job structurally outside it.
     """
@@ -242,6 +210,32 @@ def _check_exempt_jobs_are_conditional(
     ]
 
 
+def _check_gate_execution(bodies: dict[str, list[str]], needs: list[str]) -> list[str]:
+    conditions = [
+        match.group(1) for line in bodies[GATE_JOB] if (match := _JOB_IF_RE.match(line))
+    ]
+    if conditions != ["always()"]:
+        return [f"{GATE_JOB} must have exactly 'if: always()'"]
+    if len(needs) != len(set(needs)) or GATE_JOB in needs:
+        return [f"{GATE_JOB}.needs has a duplicate or self dependency"]
+    return []
+
+
+def check_runtime_contract(text: str) -> list[str]:
+    """Check production workflow policy and lint-before-matrix dependencies."""
+    _, needs, allowed, _ = parse_workflow(text)
+    failures = check_policy(needs, allowed)
+    bodies = _job_bodies(text)
+    for job in allowed:
+        if set(_parse_needs(bodies.get(job, []))) != {"changes", "lint"}:
+            failures.append(f"{job} must depend on exactly changes and lint")
+    for job in ("changes", "lint"):
+        body = bodies.get(job, [])
+        if _parse_needs(body) or any(_JOB_IF_RE.match(line) for line in body):
+            failures.append(f"{job} must always run without prerequisites")
+    return failures
+
+
 def check(text: str) -> list[str]:
     """Return the list of failures; empty means the gate is complete."""
     jobs, needs, allowed_skips, exempt = parse_workflow(text)
@@ -257,7 +251,8 @@ def check(text: str) -> list[str]:
         ]
 
     return (
-        _check_every_job_is_gated(jobs, set(needs) | exempt)
+        _check_gate_execution(_job_bodies(text), needs)
+        + _check_every_job_is_gated(jobs, set(needs) | exempt)
         + _check_needs_are_real_jobs(jobs, needs)
         + _check_allowed_skips(jobs, allowed_skips, exempt)
         + _check_exempt_jobs_are_conditional(jobs, exempt)
@@ -269,7 +264,8 @@ def main() -> int:
         print(f"FAIL: {CI_WORKFLOW} not found", file=sys.stderr)
         return 1
 
-    failures = check(CI_WORKFLOW.read_text(encoding="utf-8"))
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+    failures = check(text) + check_runtime_contract(text)
     if failures:
         print("CI gate completeness: FAIL", file=sys.stderr)
         for failure in failures:

--- a/scripts/check_ci_gate_results.py
+++ b/scripts/check_ci_gate_results.py
@@ -1,11 +1,12 @@
 """Fail CI Green unless every job succeeded or has a verified skip reason.
 
-The policy mirrors ci.yml: non-PR runs execute the full matrix; code,
-dependency or workflow changes do so on PRs. Docker changes also run Docker
-jobs. The vendor CLI job skips fork PRs because it executes npm postinstall.
-Missing classifications and unknown jobs fail closed.
+The policy mirrors ci.yml: code, dependency or workflow PR changes run code
+jobs and Docker smoke. Pushes and dispatches also run those jobs; schedules
+run smoke but skip code jobs. Runtime/devcontainer builds require Docker
+changes, a schedule or a dispatch. The vendor CLI job skips fork PRs because
+it executes npm postinstall. Missing classifications and unknown jobs fail closed.
 
-Source: tasks/codex-green-remediation-plan.md W1-2 and ci.yml job predicates.
+Source: tasks/codex-green-remediation-plan.md W1-2/W1-4 and ci.yml predicates.
 GitHub's needs context exposes result and outputs for direct dependencies:
 https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context
 """
@@ -30,13 +31,13 @@ CODE_JOBS = frozenset(
         "build",
     }
 )
-DOCKER_JOBS = frozenset({"docker-runtime-build", "devcontainer-build", "docker-smoke"})
+DOCKER_BUILD_JOBS = frozenset({"docker-runtime-build", "devcontainer-build"})
 ALWAYS_JOBS = frozenset({"changes", "lint"})
-CONDITIONAL_JOBS = CODE_JOBS | DOCKER_JOBS
+CONDITIONAL_JOBS = CODE_JOBS | DOCKER_BUILD_JOBS | {"docker-smoke"}
 EXPECTED_JOBS = ALWAYS_JOBS | CONDITIONAL_JOBS
 # source: .github/workflows/ci.yml changes.outputs and on triggers.
 FILTERS = frozenset({"code", "docs", "docker", "workflows", "deps"})
-EVENTS = frozenset({"pull_request", "push", "workflow_dispatch"})
+EVENTS = frozenset({"pull_request", "push", "workflow_dispatch", "schedule"})
 
 
 def check_policy(needs: list[str], allowed: list[str]) -> list[str]:
@@ -75,10 +76,12 @@ def _required_jobs(flags: dict[str, bool], event_name: str, fork: bool) -> set[s
         flags[name] for name in ("code", "deps", "workflows")
     )
     required = set(ALWAYS_JOBS)
-    if full:
+    if full and event_name != "schedule":
         required.update(CODE_JOBS)
     if full or flags["docker"]:
-        required.update(DOCKER_JOBS)
+        required.add("docker-smoke")
+    if flags["docker"] or event_name in ("schedule", "workflow_dispatch"):
+        required.update(DOCKER_BUILD_JOBS)
     if fork:
         required.discard("mcp-host-config")
     return required

--- a/scripts/check_ci_gate_results.py
+++ b/scripts/check_ci_gate_results.py
@@ -1,0 +1,130 @@
+"""Fail CI Green unless every job succeeded or has a verified skip reason.
+
+The policy mirrors ci.yml: non-PR runs execute the full matrix; code,
+dependency or workflow changes do so on PRs. Docker changes also run Docker
+jobs. The vendor CLI job skips fork PRs because it executes npm postinstall.
+Missing classifications and unknown jobs fail closed.
+
+Source: tasks/codex-green-remediation-plan.md W1-2 and ci.yml job predicates.
+GitHub's needs context exposes result and outputs for direct dependencies:
+https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# source: .github/workflows/ci.yml, jobs gated by changes and lint.
+CODE_JOBS = frozenset(
+    {
+        "test",
+        "test-sqlite",
+        "mcp-host-config",
+        "test-windows",
+        "release-deps",
+        "craftsmanship",
+        "typecheck",
+        "build",
+    }
+)
+DOCKER_JOBS = frozenset({"docker-runtime-build", "devcontainer-build", "docker-smoke"})
+ALWAYS_JOBS = frozenset({"changes", "lint"})
+CONDITIONAL_JOBS = CODE_JOBS | DOCKER_JOBS
+EXPECTED_JOBS = ALWAYS_JOBS | CONDITIONAL_JOBS
+# source: .github/workflows/ci.yml changes.outputs and on triggers.
+FILTERS = frozenset({"code", "docs", "docker", "workflows", "deps"})
+EVENTS = frozenset({"pull_request", "push", "workflow_dispatch"})
+
+
+def check_policy(needs: list[str], allowed: list[str]) -> list[str]:
+    """Keep the workflow and the executable skip policy in exact agreement."""
+    failures = []
+    if set(needs) != EXPECTED_JOBS:
+        failures.append("CI Green needs do not match the runtime job policy")
+    if set(allowed) != CONDITIONAL_JOBS:
+        failures.append("ALLOWED_SKIPS does not match the runtime skip policy")
+    return failures
+
+
+def _classifications(needs: dict) -> dict[str, bool]:
+    outputs = needs["changes"].get("outputs")
+    if not isinstance(outputs, dict) or set(outputs) != FILTERS:
+        raise ValueError("changes must provide exactly the five path outputs")
+    if any(value not in ("true", "false") for value in outputs.values()):
+        raise ValueError("changes outputs must be the strings 'true' or 'false'")
+    return {name: value == "true" for name, value in outputs.items()}
+
+
+def _is_fork(event_name: str, event: dict) -> bool:
+    if event_name != "pull_request":
+        return False
+    try:
+        fork = event["pull_request"]["head"]["repo"]["fork"]
+    except (KeyError, TypeError) as error:
+        raise ValueError("pull_request event is missing head.repo.fork") from error
+    if not isinstance(fork, bool):
+        raise ValueError("pull_request head.repo.fork must be a boolean")
+    return fork
+
+
+def _required_jobs(flags: dict[str, bool], event_name: str, fork: bool) -> set[str]:
+    full = event_name != "pull_request" or any(
+        flags[name] for name in ("code", "deps", "workflows")
+    )
+    required = set(ALWAYS_JOBS)
+    if full:
+        required.update(CODE_JOBS)
+    if full or flags["docker"]:
+        required.update(DOCKER_JOBS)
+    if fork:
+        required.discard("mcp-host-config")
+    return required
+
+
+def check(needs: dict, event_name: str, event: dict) -> list[str]:
+    """Evaluate actual results, never treating an allowlist as a skip reason."""
+    if not isinstance(needs, dict) or set(needs) != EXPECTED_JOBS:
+        return ["needs must contain exactly the expected CI jobs"]
+    if event_name not in EVENTS or not isinstance(event, dict):
+        return ["missing or unsupported GitHub event context"]
+    if any(not isinstance(value, dict) for value in needs.values()):
+        return ["every needs entry must be a job result object"]
+    try:
+        flags = _classifications(needs)
+        required = _required_jobs(flags, event_name, _is_fork(event_name, event))
+    except ValueError as error:
+        return [str(error)]
+    failures = []
+    for job, value in sorted(needs.items()):
+        result = value.get("result")
+        if result == "success":
+            continue
+        if result == "skipped" and job not in required:
+            continue
+        failures.append(f"{job}={result!r} (success required or invalid result)")
+    return failures
+
+
+def main() -> int:
+    try:
+        allowed = os.environ["ALLOWED_SKIPS"].split(",")
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        needs = json.loads(os.environ["NEEDS"])
+        failures = check(needs, os.environ["GITHUB_EVENT_NAME"], event)
+        if set(allowed) != CONDITIONAL_JOBS:
+            failures.append("ALLOWED_SKIPS does not match the runtime skip policy")
+    except (KeyError, OSError, ValueError) as error:
+        failures = [f"cannot read CI gate inputs: {error}"]
+    if failures:
+        for failure in failures:
+            print(f"::error::CI Green: {failure}", file=sys.stderr)
+        return 1
+    print("CI Green: all required jobs succeeded; every skip is justified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_py/benchmarks/test_energy_cli.py
+++ b/tests_py/benchmarks/test_energy_cli.py
@@ -1,0 +1,113 @@
+"""CLI validation must precede optional imports, stream access and sudo."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from benchmarks.energy import run_embedding_energy as cli
+
+
+SCRIPT = Path(cli.__file__)
+PROTOCOL = ["--duration-seconds", "1", "--repetitions", "2"]
+# Synthetic CLI inputs only, not measured or recommended carbon factors.
+CARBON = ["--carbon-intensity", "1", "--embodied", "1"]
+
+
+@pytest.mark.parametrize(
+    ("provided", "missing"),
+    [
+        ([], ["--carbon-intensity", "--embodied"]),
+        (["--carbon-intensity", "1"], ["--embodied"]),
+        (["--embodied", "1"], ["--carbon-intensity"]),
+    ],
+)
+def test_missing_carbon_fails_before_optional_imports(provided, missing):
+    # -S excludes site-packages: even NumPy import would fail before argparse.
+    result = subprocess.run(
+        [sys.executable, "-S", str(SCRIPT), *PROTOCOL, *provided],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert all(option in result.stderr for option in missing)
+    assert "ModuleNotFoundError" not in result.stderr
+    assert "--external-power-file is required" not in result.stderr
+
+
+@pytest.mark.parametrize("flag", ["--carbon-intensity", "--embodied"])
+@pytest.mark.parametrize("value", ["nan", "inf", "-1"])
+def test_invalid_carbon_refused_before_run(flag, value, monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_run", lambda args: pytest.fail("ran workload"))
+    with pytest.raises(SystemExit) as error:
+        cli.main([*PROTOCOL, *CARBON, flag, value])
+    assert error.value.code != 0
+    assert flag in capsys.readouterr().err
+
+
+def test_validate_only_needs_no_stream_or_model(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_run", lambda args: pytest.fail("ran workload"))
+    cli.main([*PROTOCOL, *CARBON, "--validate-only"])
+    assert capsys.readouterr().out.strip() == str(cli.DEFAULT_SAMPLE_RATE_MS)
+
+
+def test_valid_carbon_without_stream_points_to_runner(capsys):
+    with pytest.raises(SystemExit) as error:
+        cli.main([*PROTOCOL, *CARBON])
+    assert error.value.code != 0
+    assert "--external-power-file is required; use run.sh" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("flag", "value"),
+    [
+        ("--duration-seconds", "0"),
+        ("--repetitions", "1"),
+        ("--batch-size", "0"),
+        ("--sample-rate-ms", "0"),
+    ],
+)
+def test_invalid_protocol_refused(flag, value):
+    with pytest.raises(SystemExit) as error:
+        cli.main([*PROTOCOL, *CARBON, flag, value, "--validate-only"])
+    assert error.value.code != 0
+
+
+@pytest.mark.skipif(shutil.which("zsh") is None, reason="runner requires macOS/zsh")
+@pytest.mark.parametrize(
+    ("provided", "expected"),
+    [
+        ([], "--carbon-intensity"),
+        (["--carbon-intensity", "1"], "--embodied"),
+        (["--embodied", "1"], "--carbon-intensity"),
+        ([*CARBON, "--validate-only"], None),
+    ],
+)
+def test_shell_validates_before_sudo(provided, expected, tmp_path):
+    marker = tmp_path / "sudo-called"
+    fake_sudo = tmp_path / "sudo"
+    fake_sudo.write_text('#!/bin/sh\ntouch "$ENERGY_SUDO_MARKER"\nexit 99\n')
+    fake_sudo.chmod(0o755)
+    env = {
+        **os.environ,
+        "ENERGY_PYTHON": sys.executable,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "ENERGY_SUDO_MARKER": str(marker),
+    }
+    result = subprocess.run(
+        [shutil.which("zsh"), str(SCRIPT.with_name("run.sh")), *PROTOCOL, *provided],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert not marker.exists()
+    if expected is None:
+        assert result.returncode == 0, result.stderr
+    else:
+        assert result.returncode != 0
+        assert expected in result.stderr

--- a/tests_py/benchmarks/test_energy_measurement.py
+++ b/tests_py/benchmarks/test_energy_measurement.py
@@ -1,0 +1,115 @@
+"""Algebraic fixtures for energy/carbon units; no physical measurement occurs."""
+
+from argparse import Namespace
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks.energy import measurement
+from benchmarks.energy.workload import Phase
+
+
+def test_carbon_formula_per_thousand_tokens():
+    # Synthetic unit check: 1 kWh, I=2 g/kWh, M=3 g, 2000 tokens -> 2.5 g/1k.
+    assert measurement.carbon_per_1k_tokens(3_600_000, 2000, 2, 3) == 2.5
+    assert measurement.carbon_per_1k_tokens(3_600_000, 1000, 2, 3) == 5
+
+
+@pytest.mark.parametrize("tokens", [0, -1])
+def test_carbon_formula_refuses_invalid_denominator(tokens):
+    with pytest.raises(ValueError, match="token count"):
+        measurement.carbon_per_1k_tokens(1, tokens, 1, 1)
+
+
+@pytest.mark.parametrize("value", [-1, float("inf"), float("nan")])
+@pytest.mark.parametrize("position", [0, 2, 3])
+def test_carbon_formula_refuses_invalid_inputs(value, position):
+    args = [1, 1, 1, 1]
+    args[position] = value
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        measurement.carbon_per_1k_tokens(*args)
+
+
+def test_summary_uses_actual_token_counts_and_embodied_phase_duration():
+    args = Namespace(carbon_intensity=2, embodied=3)
+    phase = Phase("scalar", 0, 0, 2, 2, 4, tokens=2000)
+    row = measurement.MeasuredPhase(phase, 1, 1_800_000, 0)
+    summary = measurement.summarize([row, row], "scalar", args)
+    assert summary["tokens_total"] == 4000
+    assert summary["energy_j_per_1k_tokens_mean"] == 1_800_000
+    # One kWh * 2 g/kWh + (3 g/s * 2 s) = 8 g for 2000 tokens.
+    assert summary["carbon_gco2eq_per_1k_tokens_mean"] == 4
+
+
+def test_power_parser_requires_combined_boundary():
+    text = (
+        "*** Sampled system activity (Sun, 06 Sep 2026 12:00:00 +0000) ***\n"
+        "Combined Power (CPU + GPU + ANE): 2000 mW\n"
+    )
+    samples = measurement.parse_power_samples(text)
+    assert len(samples) == 1
+    assert samples[0][1] == 2
+    with pytest.raises(ValueError, match="lacks Combined Power"):
+        measurement.parse_power_samples(
+            text.replace("Combined Power (CPU + GPU + ANE)", "CPU Power")
+        )
+    with pytest.raises(ValueError, match="no combined"):
+        measurement.parse_power_samples("")
+
+
+def test_power_samples_are_applied_to_corresponding_idle_phase():
+    idle = Phase("idle", 0, 0, 1, 1, 0)
+    scalar = Phase("scalar", 0, 2, 4, 2, 4, tokens=10)
+    rows = measurement.apply_power_samples([idle, scalar], [(0.5, 2), (3, 1)])
+    assert rows[0].raw_system_energy_j == 2
+    assert rows[0].idle_power_w == 2
+    assert rows[0].dynamic_energy_j == -2  # No silent clamp of idle noise.
+    with pytest.raises(RuntimeError, match="no power samples in phase scalar"):
+        measurement.apply_power_samples([idle, scalar], [(0.5, 2)])
+
+
+def test_only_incomplete_final_sample_outside_phases_is_ignored():
+    complete = (
+        "*** Sampled system activity (Sun, 06 Sep 2026 12:00:00 +0000) ***\n"
+        "Combined Power (CPU + GPU + ANE): 2000 mW\n"
+    )
+    partial = (
+        "\n*** Sampled system activity (Sun, 06 Sep 2026 12:00:01 +0000) ***\n"
+        "CPU Power: 1000 mW\n"
+    )
+    expected = measurement.parse_power_samples(complete)
+    phase_end = expected[0][0]
+    with pytest.warns(RuntimeWarning, match="outside measured phases"):
+        assert (
+            measurement.parse_power_samples(complete + partial, phase_end) == expected
+        )
+    with pytest.raises(ValueError, match="lacks Combined Power"):
+        measurement.parse_power_samples(complete + partial, phase_end + 1)
+    with pytest.raises(ValueError, match="lacks Combined Power"):
+        measurement.parse_power_samples(partial + complete, phase_end)
+
+
+def test_report_preserves_raw_power_and_explicit_units(tmp_path, monkeypatch):
+    monkeypatch.setattr(measurement, "REPO", tmp_path)
+    monkeypatch.setattr(measurement, "_manifest", lambda: {"fixture": True})
+    args = Namespace(
+        carbon_intensity=2,
+        embodied=3,
+        duration_seconds=2,
+        repetitions=2,
+        batch_size=4,
+        sample_rate_ms=1,
+    )
+    phase = Phase("scalar", 0, 0, 2, 2, 4, tokens=2000)
+    row = measurement.MeasuredPhase(phase, 1, 1_800_000, 0)
+    raw = b"synthetic raw sensor fixture\n"
+    result = measurement.write_report(args, ([row], {}), (raw, 0))
+    output = Path(result["result_dir"])
+    assert (output / "powermetrics.txt").read_bytes() == raw
+    data = json.loads((output / "results.json").read_text())
+    assert data["carbon_intensity_gco2eq_per_kwh"] == 2
+    assert data["embodied_rate_gco2eq_per_second"] == 3
+    assert data["rows"][0]["embodied_gco2eq"] == 6
+    assert data["rows"][0]["carbon_gco2eq_per_1k_tokens"] == 4
+    assert "1000 model input tokens" in data["functional_units"]

--- a/tests_py/benchmarks/test_energy_runner.py
+++ b/tests_py/benchmarks/test_energy_runner.py
@@ -1,0 +1,161 @@
+"""Run the real shell lifecycle with an unprivileged, synthetic sensor.
+
+The fake sudo accepts authorization/start, but rejects a later sudo kill as an
+expired ticket would. FIFO synchronization avoids model/sensor timing assumptions.
+"""
+
+import json
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+RUNNER = Path(__file__).resolve().parents[2] / "benchmarks" / "energy" / "run.sh"
+FAKE_SUDO = """
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+
+args = sys.argv[1:]
+with Path(os.environ["ENERGY_SUDO_LOG"]).open("a") as log:
+    log.write(json.dumps(args) + "\\n")
+if args == ["-v"]:
+    sys.exit(0)
+if args[:2] == ["-n", "kill"]:
+    sys.exit("sudo: a password is required")
+if args[:2] != ["-n", "/usr/bin/powermetrics"]:
+    sys.exit("unexpected fake sudo invocation")
+
+def stop_sensor(signum, frame):
+    Path(os.environ["ENERGY_STOPPED"]).write_text("SIGINT received")
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, stop_sensor)
+Path(os.environ["ENERGY_SENSOR_PID"]).write_text(str(os.getpid()))
+output = Path(args[args.index("--output-file") + 1])
+output.write_text("synthetic raw sensor output\\n")
+with Path(os.environ["ENERGY_READY"]).open("w") as ready:
+    ready.write("ready")
+while True:
+    signal.pause()
+"""
+FAKE_WORKLOAD = """
+import os
+from pathlib import Path
+import sys
+
+if "--validate-only" in sys.argv:
+    print(1)
+    sys.exit(0)
+with Path(os.environ["ENERGY_READY"]).open() as ready:
+    assert ready.read() == "ready"
+power = Path(sys.argv[sys.argv.index("--external-power-file") + 1])
+Path(os.environ["ENERGY_SNAPSHOT"]).write_bytes(power.read_bytes())
+sys.exit(int(os.environ["ENERGY_WORKLOAD_STATUS"]))
+"""
+FAKE_MKTEMP = """
+import os
+from pathlib import Path
+
+path = Path(os.environ["ENERGY_RAW"])
+path.touch()
+print(path)
+"""
+
+
+def _executable(path, source):
+    path.write_text(f"#!{sys.executable}\n" + textwrap.dedent(source))
+    path.chmod(0o755)
+
+
+def _environment(tmp_path, workload_status):
+    for name, source in (
+        ("sudo", FAKE_SUDO),
+        ("workload", FAKE_WORKLOAD),
+        ("mktemp", FAKE_MKTEMP),
+    ):
+        _executable(tmp_path / name, source)
+    os.mkfifo(tmp_path / "ready")
+    return {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "ENERGY_PYTHON": str(tmp_path / "workload"),
+        "ENERGY_SUDO_LOG": str(tmp_path / "sudo.log"),
+        "ENERGY_STOPPED": str(tmp_path / "stopped"),
+        "ENERGY_SENSOR_PID": str(tmp_path / "sensor.pid"),
+        "ENERGY_READY": str(tmp_path / "ready"),
+        "ENERGY_SNAPSHOT": str(tmp_path / "snapshot.txt"),
+        "ENERGY_RAW": str(tmp_path / "raw.txt"),
+        "ENERGY_WORKLOAD_STATUS": str(workload_status),
+    }
+
+
+def _remove_test_process_group(pid):
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return  # Successful runs have already reaped the sensor and exited.
+
+
+@contextmanager
+def _run_shell(env):
+    master, slave = os.openpty()
+    args = [shutil.which("zsh"), str(RUNNER)]
+    process = subprocess.Popen(
+        args,
+        env=env,
+        stdin=slave,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        # Test-only hang protection; no benchmark timing assertion uses this limit.
+        stdout, stderr = process.communicate(timeout=10)
+        yield subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+    finally:
+        _remove_test_process_group(process.pid)
+        process.wait()
+        os.close(slave)
+        os.close(master)
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or shutil.which("zsh") is None,
+    reason="sensor runner requires POSIX PTY and zsh",
+)
+@pytest.mark.parametrize("workload_status", [0, 7])
+def test_runner_stops_sensor_without_reauthenticating(tmp_path, workload_status):
+    with _run_shell(_environment(tmp_path, workload_status)) as result:
+        assert result.returncode == workload_status, result.stderr
+        assert (tmp_path / "stopped").read_text() == "SIGINT received"
+        calls = [
+            json.loads(line)
+            for line in (tmp_path / "sudo.log").read_text().splitlines()
+        ]
+        assert len(calls) == 2  # Only initial authorization and sensor startup.
+        assert calls[0] == ["-v"]
+        assert calls[1][:2] == ["-n", "/usr/bin/powermetrics"]
+        # Assert before fixture cleanup: cleanup must not hide an orphaned sensor.
+        with pytest.raises(ProcessLookupError):
+            os.kill(int((tmp_path / "sensor.pid").read_text()), 0)
+        assert (
+            tmp_path / "snapshot.txt"
+        ).read_text() == "synthetic raw sensor output\n"
+        if workload_status:
+            assert "Raw sensor output preserved" in result.stderr
+            assert (tmp_path / "raw.txt").read_bytes() == (
+                tmp_path / "snapshot.txt"
+            ).read_bytes()
+        else:
+            assert not (tmp_path / "raw.txt").exists()

--- a/tests_py/benchmarks/test_energy_workload.py
+++ b/tests_py/benchmarks/test_energy_workload.py
@@ -1,0 +1,176 @@
+"""Energy harness contracts with deterministic float32/token-mask fixtures.
+
+All numbers here describe synthetic fixtures; none is a host energy measurement.
+"""
+
+from argparse import Namespace
+from types import SimpleNamespace
+import sys
+
+import numpy as np
+import pytest
+
+from benchmarks.energy import workload
+
+
+class FixtureEncoder:
+    def __init__(self, scalar, batch):
+        self.scalar = scalar
+        self.batch = batch
+
+    def encode(self, text):
+        return self.scalar
+
+    def encode_batch(self, values):
+        return [self.batch] * len(values)
+
+
+def test_float32_equivalence_accepts_different_bytes():
+    scalar = np.array([0.5], dtype=np.float32)
+    batch = np.nextafter(scalar, np.float32(1))
+    assert scalar.tobytes() != batch.tobytes()
+    # Before W0-2 the same fixture returned the byte difference 1.0.
+    assert (
+        max(abs(a - b) for a, b in zip(scalar.tobytes(), batch.tobytes(), strict=True))
+        == 1
+    )
+    delta = workload.verify_equivalence(
+        FixtureEncoder(scalar.tobytes(), batch.tobytes()), 4
+    )
+    assert delta == float(batch[0]) - float(scalar[0])
+    assert 0 < delta <= np.finfo(np.float32).eps
+
+
+def test_float32_equivalence_rejects_real_difference():
+    engine = FixtureEncoder(
+        np.array([0.5], dtype=np.float32).tobytes(),
+        np.array([0.75], dtype=np.float32).tobytes(),
+    )
+    with pytest.raises(ValueError, match="float32 mismatch"):
+        workload.verify_equivalence(engine, 4)
+
+
+@pytest.mark.parametrize(
+    ("batch", "message"),
+    [
+        (None, "missing"),
+        (b"", "empty"),
+        (b"abc", "multiple"),
+        (np.array([float("nan")], dtype=np.float32).tobytes(), "non-finite"),
+        (np.array([float("inf")], dtype=np.float32).tobytes(), "non-finite"),
+        (np.array([0.5, 0.5], dtype=np.float32).tobytes(), "shape mismatch"),
+    ],
+)
+def test_float32_equivalence_refuses_invalid_outputs(batch, message):
+    engine = FixtureEncoder(np.array([0.5], dtype=np.float32).tobytes(), batch)
+    with pytest.raises(ValueError, match=message):
+        workload.verify_equivalence(engine, 4)
+
+
+def test_float32_equivalence_refuses_output_count_mismatch(monkeypatch):
+    engine = FixtureEncoder(np.array([0.5], dtype=np.float32).tobytes(), None)
+    monkeypatch.setattr(engine, "encode_batch", lambda values: [])
+    with pytest.raises(ValueError, match="count mismatch"):
+        workload.verify_equivalence(engine, 4)
+
+
+class FixtureTokenizer:
+    def __init__(self):
+        self.calls = []
+
+    def tokenize(self, values):
+        self.calls.append(values)
+        # Already truncated model input: three active tokens, two active, padding.
+        return {"attention_mask": np.array([[1, 1, 1, 0], [1, 1, 0, 0]])}
+
+
+def test_token_count_uses_model_attention_mask():
+    model = FixtureTokenizer()
+    values = ["é", "a much longer input whose character count is irrelevant"]
+    assert workload.count_tokens(model, values) == 5
+    assert model.calls == [values]
+
+
+def test_token_count_refuses_empty_mask():
+    model = SimpleNamespace(
+        tokenize=lambda values: {"attention_mask": np.zeros((1, 1))}
+    )
+    with pytest.raises(ValueError, match="no active tokens"):
+        workload.count_tokens(model, ["input"])
+
+
+def test_phases_count_exact_completed_batches_outside_measurement(monkeypatch):
+    model = FixtureTokenizer()
+
+    def measure(engine, mode, args, repetition):
+        assert not model.calls, "token counting must follow all timed phases"
+        return workload.Phase(mode, repetition, 0, 1, 1, 0 if mode == "idle" else 4)
+
+    monkeypatch.setattr(workload, "_measure_phase", measure)
+    args = Namespace(repetitions=2, batch_size=2)
+    phases = workload.run_phases(SimpleNamespace(_model=model), args)
+    assert [phase.condition for phase in phases] == [
+        "idle",
+        "scalar",
+        "batch",
+        "idle",
+        "batch",
+        "scalar",
+    ]
+    assert [phase.tokens for phase in phases] == [0, 10, 10, 0, 10, 10]
+    assert model.calls == [workload.texts(i, 2) for _ in range(4) for i in range(2)]
+
+
+@pytest.mark.parametrize("mode", ["scalar", "batch"])
+def test_timed_workload_counts_completed_texts(mode, monkeypatch):
+    ticks = iter([0, 0, 2])
+    monkeypatch.setattr(workload.time, "perf_counter", lambda: next(ticks))
+    calls = []
+    engine = SimpleNamespace(encode=calls.append, encode_batch=calls.extend)
+    args = Namespace(duration_seconds=1, batch_size=4)
+    assert workload._timed_workload(engine, mode, args) == 4
+    assert calls == workload.texts(0, 4)
+
+
+def test_load_engine_refuses_algorithmic_fallback(monkeypatch):
+    engine = SimpleNamespace(encode=lambda text: None, mode="fallback")
+    module = SimpleNamespace(EmbeddingEngine=lambda: engine)
+    monkeypatch.setitem(
+        sys.modules, "mcp_server.infrastructure.embedding_engine", module
+    )
+    with pytest.raises(RuntimeError, match="fallback refused"):
+        workload.load_engine()
+
+
+def test_phase_clears_warm_cache_and_refuses_fallback(monkeypatch):
+    engine = SimpleNamespace(_cache={"warm": b"embedding"}, mode="fallback")
+    monkeypatch.setattr(workload, "_timed_workload", lambda *args: 1)
+    with pytest.raises(RuntimeError, match="fallback refused"):
+        workload._measure_phase(engine, "scalar", Namespace(), 0)
+    assert engine._cache == {}
+
+
+def test_phase_refuses_no_completed_work(monkeypatch):
+    engine = SimpleNamespace(_cache={}, mode="neural")
+    monkeypatch.setattr(workload, "_timed_workload", lambda *args: 0)
+    with pytest.raises(RuntimeError, match="no embedding work"):
+        workload._measure_phase(engine, "scalar", Namespace(), 0)
+
+
+def test_stream_timeout_is_explicit(tmp_path, monkeypatch):
+    path = tmp_path / "power.txt"
+    path.write_text("")
+    ticks = iter([0, 0, 0, 2])
+    monkeypatch.setattr(workload.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(workload.time, "sleep", lambda duration: None)
+    args = Namespace(duration_seconds=1, sample_rate_ms=1, external_power_file=path)
+    with pytest.raises(RuntimeError, match="stream did not become ready"):
+        workload.wait_for_stream(args)
+
+
+def test_stream_file_error_is_not_swallowed(tmp_path):
+    args = Namespace(
+        duration_seconds=1, sample_rate_ms=1, external_power_file=tmp_path / "missing"
+    )
+    with pytest.raises(FileNotFoundError):
+        workload.wait_for_stream(args)

--- a/tests_py/scripts/test_check_ci_file_count.py
+++ b/tests_py/scripts/test_check_ci_file_count.py
@@ -1,0 +1,43 @@
+"""Guard against GitHub silently truncating a pull request's changed files."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from scripts.check_ci_file_count import check
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_ci_file_count.py"
+
+
+class FileCountTests(unittest.TestCase):
+    def test_complete_api_range_is_accepted(self):
+        for count in (0, 1, 3000):
+            with self.subTest(count=count):
+                self.assertIsNone(check(count))
+
+    def test_truncated_api_range_is_refused(self):
+        self.assertIn("3000-file API limit", check(3001))
+
+    def test_missing_or_invalid_count_is_refused(self):
+        for count in (None, True, False, -1, "1", 1.0, {}):
+            with self.subTest(count=count):
+                self.assertIn("nonnegative integer", check(count))
+
+    def test_cli_refuses_truncation_with_a_diagnostic(self):
+        with tempfile.TemporaryDirectory() as directory:
+            event = Path(directory) / "event.json"
+            event.write_text(json.dumps({"pull_request": {"changed_files": 3001}}))
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                env={**os.environ, "GITHUB_EVENT_PATH": str(event)},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("refusing incomplete classification", result.stderr)

--- a/tests_py/scripts/test_check_ci_gate_complete.py
+++ b/tests_py/scripts/test_check_ci_gate_complete.py
@@ -114,6 +114,18 @@ class RefusesIncompleteGate(unittest.TestCase):
         )
         self.assertIn("'lint'", self._only_failure(workflow))
 
+    def test_gate_must_always_run(self) -> None:
+        for condition in ("", "    if: success()\n"):
+            workflow = _COMPLETE.replace("    if: always()\n", condition)
+            self.assertIn("always()", self._only_failure(workflow))
+
+    def test_duplicate_or_self_needs_fail(self) -> None:
+        for job in ("lint", "ci-green"):
+            workflow = _COMPLETE.replace(
+                "      - lint\n", f"      - lint\n      - {job}\n"
+            )
+            self.assertIn("dependency", self._only_failure(workflow))
+
 
 _WITH_EXEMPT_JOB = _workflow(
     """  lint:
@@ -199,6 +211,30 @@ class RepositoryWorkflowIsGated(unittest.TestCase):
             gate.check(gate.CI_WORKFLOW.read_text(encoding="utf-8")),
             [],
         )
+
+    def test_runtime_policy_matches_live_workflow(self) -> None:
+        self.assertEqual(gate.check_runtime_contract(gate.CI_WORKFLOW.read_text()), [])
+
+    def test_costly_jobs_must_wait_for_lint_and_changes(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        for prerequisites in ("[changes]", "[lint]", "[changes, lint, test]"):
+            changed = workflow.replace("[changes, lint]", prerequisites, 1)
+            failures = gate.check_runtime_contract(changed)
+            self.assertTrue(any("depend on exactly" in f for f in failures))
+
+    def test_lint_and_changes_cannot_be_conditional(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        for job in ("changes", "lint"):
+            changed = workflow.replace(f"  {job}:\n", f"  {job}:\n    if: false\n")
+            self.assertTrue(gate.check_runtime_contract(changed))
+
+    def test_new_skip_needs_an_executable_policy(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        workflow = workflow.replace(
+            "ALLOWED_SKIPS: test,", "ALLOWED_SKIPS: unknown-job,test,"
+        )
+        failures = gate.check_runtime_contract(workflow)
+        self.assertTrue(any("runtime skip policy" in f for f in failures))
 
 
 if __name__ == "__main__":

--- a/tests_py/scripts/test_check_ci_gate_results.py
+++ b/tests_py/scripts/test_check_ci_gate_results.py
@@ -39,23 +39,23 @@ class JustifiedSkips(unittest.TestCase):
     def test_docker_only_requires_docker_jobs(self) -> None:
         needs = _skip(_needs("docker"), gate.CODE_JOBS)
         self.assertEqual(gate.check(needs, "pull_request", _event()), [])
-        for job in gate.DOCKER_JOBS:
+        for job in gate.DOCKER_BUILD_JOBS | {"docker-smoke"}:
             with self.subTest(job=job):
                 needs[job]["result"] = "skipped"
                 self.assertTrue(gate.check(needs, "pull_request", _event()))
                 needs[job]["result"] = "success"
 
-    def test_code_deps_workflows_require_every_job(self) -> None:
+    def test_code_deps_workflows_require_code_and_smoke(self) -> None:
         for changed in (("code",), ("docs", "code"), ("deps",), ("workflows",)):
-            needs = _needs(*changed)
+            needs = _skip(_needs(*changed), gate.DOCKER_BUILD_JOBS)
             self.assertEqual(gate.check(needs, "pull_request", _event()), [])
-            for job in gate.CONDITIONAL_JOBS:
+            for job in gate.CODE_JOBS | {"docker-smoke"}:
                 with self.subTest(changed=changed, job=job):
                     needs[job]["result"] = "skipped"
                     self.assertTrue(gate.check(needs, "pull_request", _event()))
                     needs[job]["result"] = "success"
 
-    def test_non_pr_runs_require_full_matrix_even_for_docs(self) -> None:
+    def test_push_and_dispatch_require_code_even_for_docs(self) -> None:
         for event_name in ("push", "workflow_dispatch"):
             needs = _needs("docs")
             self.assertEqual(gate.check(needs, event_name, {}), [])
@@ -69,6 +69,48 @@ class JustifiedSkips(unittest.TestCase):
         self.assertTrue(gate.check(needs, "pull_request", _event(False)))
         needs["test"]["result"] = "skipped"
         self.assertTrue(gate.check(needs, "pull_request", _event(True)))
+
+
+class DockerBuildPolicy(unittest.TestCase):
+    def test_push_without_docker_changes_skips_only_docker_builds(self) -> None:
+        for changed in (("docs",), ("code",), ("workflows",), ("deps",), ()):
+            needs = _skip(_needs(*changed), gate.DOCKER_BUILD_JOBS)
+            self.assertEqual(gate.check(needs, "push", {}), [])
+            needs["docker-smoke"]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "push", {}))
+
+    def test_push_with_docker_changes_requires_every_job(self) -> None:
+        needs = _needs("docker")
+        self.assertEqual(gate.check(needs, "push", {}), [])
+        for job in gate.CONDITIONAL_JOBS:
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "push", {}))
+            needs[job]["result"] = "success"
+
+    def test_dispatch_requires_builds_even_without_docker_changes(self) -> None:
+        needs = _needs("docs")
+        self.assertEqual(gate.check(needs, "workflow_dispatch", {}), [])
+        for job in gate.DOCKER_BUILD_JOBS:
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "workflow_dispatch", {}))
+            needs[job]["result"] = "success"
+
+    def test_schedule_skips_code_jobs_regardless_of_changed_paths(self) -> None:
+        for changed in ((), ("code",), ("docker",), ("docs",)):
+            needs = _skip(_needs(*changed), gate.CODE_JOBS)
+            self.assertEqual(gate.check(needs, "schedule", {}), [])
+            for job in gate.DOCKER_BUILD_JOBS | {"docker-smoke"} | gate.ALWAYS_JOBS:
+                with self.subTest(changed=changed, job=job):
+                    needs[job]["result"] = "skipped"
+                    self.assertTrue(gate.check(needs, "schedule", {}))
+                    needs[job]["result"] = "success"
+
+    def test_schedule_rejects_failed_and_cancelled_jobs_even_if_optional(self) -> None:
+        for job in gate.EXPECTED_JOBS:
+            for result in ("failure", "cancelled"):
+                needs = _skip(_needs("docs"), gate.CODE_JOBS)
+                needs[job]["result"] = result
+                self.assertTrue(gate.check(needs, "schedule", {}))
 
 
 class FailClosed(unittest.TestCase):

--- a/tests_py/scripts/test_check_ci_gate_results.py
+++ b/tests_py/scripts/test_check_ci_gate_results.py
@@ -1,0 +1,164 @@
+"""CI Green must fail closed without importing application code or its DB."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import check_ci_gate_results as gate
+
+
+def _event(fork: bool = False) -> dict:
+    return {"pull_request": {"head": {"repo": {"fork": fork}}}}
+
+
+def _needs(*changed: str) -> dict:
+    needs = {job: {"result": "success", "outputs": {}} for job in gate.EXPECTED_JOBS}
+    needs["changes"]["outputs"] = {
+        name: "true" if name in changed else "false" for name in gate.FILTERS
+    }
+    return needs
+
+
+def _skip(needs: dict, jobs: frozenset[str]) -> dict:
+    for job in jobs:
+        needs[job]["result"] = "skipped"
+    return needs
+
+
+class JustifiedSkips(unittest.TestCase):
+    def test_docs_only_runs_only_changes_and_lint(self) -> None:
+        needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+        self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+
+    def test_docker_only_requires_docker_jobs(self) -> None:
+        needs = _skip(_needs("docker"), gate.CODE_JOBS)
+        self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+        for job in gate.DOCKER_JOBS:
+            with self.subTest(job=job):
+                needs[job]["result"] = "skipped"
+                self.assertTrue(gate.check(needs, "pull_request", _event()))
+                needs[job]["result"] = "success"
+
+    def test_code_deps_workflows_require_every_job(self) -> None:
+        for changed in (("code",), ("docs", "code"), ("deps",), ("workflows",)):
+            needs = _needs(*changed)
+            self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+            for job in gate.CONDITIONAL_JOBS:
+                with self.subTest(changed=changed, job=job):
+                    needs[job]["result"] = "skipped"
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+                    needs[job]["result"] = "success"
+
+    def test_non_pr_runs_require_full_matrix_even_for_docs(self) -> None:
+        for event_name in ("push", "workflow_dispatch"):
+            needs = _needs("docs")
+            self.assertEqual(gate.check(needs, event_name, {}), [])
+            needs["test"]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, event_name, {}))
+
+    def test_fork_guard_applies_only_to_vendor_cli_job(self) -> None:
+        needs = _needs("code")
+        needs["mcp-host-config"]["result"] = "skipped"
+        self.assertEqual(gate.check(needs, "pull_request", _event(True)), [])
+        self.assertTrue(gate.check(needs, "pull_request", _event(False)))
+        needs["test"]["result"] = "skipped"
+        self.assertTrue(gate.check(needs, "pull_request", _event(True)))
+
+
+class FailClosed(unittest.TestCase):
+    def test_failures_cancellation_and_invalid_results_never_pass(self) -> None:
+        for result in ("failure", "cancelled", "pending", "", None):
+            for job in gate.EXPECTED_JOBS:
+                with self.subTest(result=result, job=job):
+                    needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+                    needs[job]["result"] = result
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_lint_failure_rejects_skipped_matrix(self) -> None:
+        needs = _skip(_needs("code"), gate.CONDITIONAL_JOBS)
+        needs["lint"]["result"] = "failure"
+        failures = gate.check(needs, "pull_request", _event())
+        self.assertTrue(any("lint=" in failure for failure in failures))
+
+    def test_changes_and_lint_may_never_skip(self) -> None:
+        for job in gate.ALWAYS_JOBS:
+            needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_and_unexpected_jobs_fail(self) -> None:
+        for job in gate.EXPECTED_JOBS:
+            needs = _needs("docs")
+            del needs[job]
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+        needs = _needs("docs")
+        needs["unwatched"] = {"result": "success"}
+        self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_and_invalid_classifications_fail(self) -> None:
+        for output in gate.FILTERS:
+            for value in (True, False, "", "TRUE", None, [], {}):
+                with self.subTest(output=output, value=value):
+                    needs = _needs("docs")
+                    needs["changes"]["outputs"][output] = value
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+            needs = _needs("docs")
+            del needs["changes"]["outputs"][output]
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_invalid_job_objects_and_output_objects_fail(self) -> None:
+        for value in (None, [], "success"):
+            needs = _needs("docs")
+            needs["changes"] = value
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+            needs = _needs("docs")
+            needs["changes"]["outputs"] = value
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_or_invalid_fork_context_fails(self) -> None:
+        for event in ({}, {"pull_request": None}, _event("false")):
+            self.assertTrue(gate.check(_needs("docs"), "pull_request", event))
+
+    def test_unsupported_event_context_fails(self) -> None:
+        self.assertTrue(gate.check(_needs("docs"), "", {}))
+        self.assertTrue(gate.check(_needs("docs"), "push", []))
+
+
+class ExecutableContract(unittest.TestCase):
+    def _run(self, needs: str) -> subprocess.CompletedProcess:
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = Path(directory) / "event.json"
+            event_path.write_text(json.dumps(_event()), encoding="utf-8")
+            env = {
+                **os.environ,
+                "NEEDS": needs,
+                "GITHUB_EVENT_PATH": str(event_path),
+                "GITHUB_EVENT_NAME": "pull_request",
+                "ALLOWED_SKIPS": ",".join(sorted(gate.CONDITIONAL_JOBS)),
+            }
+            return subprocess.run(
+                [sys.executable, str(Path(gate.__file__))],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_docs_only_cli_succeeds(self) -> None:
+        result = self._run(json.dumps(_skip(_needs("docs"), gate.CONDITIONAL_JOBS)))
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_malformed_json_cli_fails_with_diagnostic(self) -> None:
+        result = self._run("{bad json")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot read CI gate inputs", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Symptôme

W1-7 / H10-H11 : des jobs héritaient du timeout GitHub de 360 minutes et les
runs PR remplacés de Fuzz/HOL/Upstream continuaient en parallèle.
PR empilée sur #478.

## Cause racine

Délais non définis par job et absence de groupe de concurrence par PR.

## Changement

Chaque nouveau délai est `ceil(2 × maximum observé / 60)` minutes, avec run,
date, durée et formule dans un commentaire source. Les quatre jambes Python
conservent leur nom et reçoivent un délai propre via `matrix.include`.

Fuzz, HOL et Upstream regroupent les runs par workflow/ref et annulent ceux
remplacés seulement sur `pull_request`. Les runs planifiés ne sont pas annulés
par cette politique. Déclencheurs, matrices et validations restent présents.

## Preuve

Les quatre runs CI prescrits sont
[33990473565](https://github.com/cdeust/Cortex/actions/runs/33990473565) (74,33 min),
[33951959734](https://github.com/cdeust/Cortex/actions/runs/33951959734) (78,25 min),
[33951905125](https://github.com/cdeust/Cortex/actions/runs/33951905125) (78,50 min),
[33806380625](https://github.com/cdeust/Cortex/actions/runs/33806380625) (99,98 min).
Ces totaux sont les durées cumulées des jobs exécutés, hors file d'attente.

| Job CI | Maximum observé (s) | Timeout (min) |
|---|---:|---:|
| Python 3.10 / 3.11 / 3.12 / 3.13 | 545 / 1931 / 1143 / 577 | 19 / 65 / 39 / 20 |
| SQLite / Windows | 292 / 426 | 10 / 15 |
| Runtime / devcontainer / smoke | 514 / 349 / 369 | 18 / 12 / 13 |
| MCP hosts / release dependencies / typecheck | 61 / 109 / 94 | 3 / 4 / 4 |
| Lint / craftsmanship / build | 17 / 9 / 19 | 1 / 1 / 1 |
| CI Green / release gate | 4 / 12 | 1 / 1 |
| Changed paths (nouveau job, run34035713474) | 9 | 1 |

Les autres workflows sont sourcés sur quatre runs par workflow (Fuzz inclut
quatre runs planifiés) : 41 runs archivés dans
`/private/tmp/cortex-green-w1-7-other-sources.json` et maxima dans
`/private/tmp/cortex-green-w1-7-other-maxima.json`. Les quatre CI et leurs jobs
sont dans `/private/tmp/cortex-green-w1-timeout-sources.json`.

Actionlint sur tous les workflows, agrégateur statique et vérification de chaque
formule passent. Gates locaux ordonnés verts : Ruff 1 416 fichiers, craftsmanship et Pyright
zéro diagnostic ; couche scripts 830 passed, 5 skipped, 292 subtests ; suite
complète 7 577 passed, 221 skipped, 292 subtests en 151,26 s. Skips PostgreSQL
locaux explicites (localhost:1 indisponible), charge initiale 3,78 / 10 cœurs,
65 GiB libres avant/après. Les 31 formules numériques ajoutées sont vérifiées.

```sh
uv sync --locked --no-default-groups --extra dev --extra sqlite --group lint
.venv/bin/ruff check
.venv/bin/ruff format --check
.venv/bin/python scripts/check_craftsmanship.py
uv sync --locked --no-default-groups --extra dev --extra postgresql --extra sqlite --extra codebase --extra otel --group typecheck --group lint
.venv/bin/python -m pyright mcp_server/
export CORTEX_TEST_DATABASE_URL=postgresql://localhost:1/cortex_green_isolated
export CORTEX_MEMORY_STORE_BACKEND=sqlite DATABASE_URL=
export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 CORTEX_RERANKER_OFFLINE=1
.venv/bin/python -m pytest tests_py/scripts/ -q --tb=short
.venv/bin/python -m pytest -q --tb=short

actionlint .github/workflows/*.yml
.venv/bin/python scripts/check_ci_gate_complete.py
```

Log local : `/private/tmp/cortex-green-w1-7-gates.log`.
Acceptation externe prouvée par la [PR temporaire #480](https://github.com/cdeust/Cortex/pull/480)
ciblant main : premier [run Fuzz 34039387321](https://github.com/cdeust/Cortex/actions/runs/34039387321)
constaté en cours avant le second push, puis annulé automatiquement ; second
[run 34039414743](https://github.com/cdeust/Cortex/actions/runs/34039414743) vert.
Aucune annulation manuelle. Les deux révisions avaient passé tous les gates
avant leurs pushs rapprochés. La PR temporaire est fermée sans fusion.
La CI de cette PR est également [verte, run34038906477](https://github.com/cdeust/Cortex/actions/runs/34038906477).

## Conformité

Huit workflows, constantes toutes reliées aux mesures, aucune baseline ajoutée,
aucun import mémoire modifié. Tests sur données isolées. Pas de fusion/issue,
pas de déclenchement des jobs de publication pour fabriquer une mesure.

## Candidats issues

`publish-ccplugins` et `sync-ccplugins-fork` restent sans nouveau timeout : leurs
runs verts observables n'exécutent que la garde « PAT absent » (4 s), pas le
chemin de publication/synchronisation. Historique inspecté : 28 runs publish,
100 runs sync récents et sondes plus anciennes ; aucun maximum actif fiable.
Appliquer 1 minute à partir de cette garde serait une constante non justifiée.
Preuve : `/private/tmp/cortex-green-w1-7-guard-history.json`.
Ces deux délais restent donc une acceptation partielle explicite.

## Runbook

Le propriétaire décide de la fusion et pourra relever un vrai run actif des
deux jobs non mesurables pour fixer leur délai selon la même formule.
Aucune publication externe ou synchronisation de dépôt n'est exécutée ici.


Validation complémentaire du 7 septembre : le run PR 34061028434 a atteint 98 % de la suite Python 3.10 avant annulation à la limite de 19 minutes, sans test en échec dans le journal. Recalibrage selon la règle existante ceil(2 × maximum observé / 60) : Python 3.10 = 33 minutes, à partir du run réussi 34047249647 (980 s) ; Python 3.12 = 40 minutes, à partir de 34046091095 (1 197 s). Aucun changement de test ni assouplissement du gate. actionlint, Ruff, craftsmanship et Pyright passent ; 830 tests ciblés et 7 577 tests complets passent (221 ignorés, 292 sous-tests). Les contrôles distants sont relancés sur le nouveau commit.

Le run lent Python 3.13 déjà cité par le workflow initial est également conservé : 33688337476, terminé avec succès en 1 637 s le 2 septembre, donc ceil(2 × 1 637 / 60) = 55 minutes. Limites finales 3.10/3.11/3.12/3.13 : 33/65/40/55 minutes. Dernière validation complète : 7 577 tests réussis, 221 ignorés, 292 sous-tests, 130,90 s ; actionlint et tous les gates statiques passent.
