### PR TITLE
test(ci): Fuzz cancellation acceptance probe — do not merge

### DIFF
--- a/.craftsmanship-baseline.json
+++ b/.craftsmanship-baseline.json
@@ -2808,11 +2808,6 @@
       "detail": "pathlib"
     },
     {
-      "file": "mcp_server/core/telemetry.py",
-      "kind": "method-size",
-      "detail": "record"
-    },
-    {
       "file": "mcp_server/core/thermodynamics.py",
       "kind": "file-size",
       "detail": "exceeds 300-line cap"

--- a/.github/actions/test-suite/action.yml
+++ b/.github/actions/test-suite/action.yml
@@ -257,26 +257,21 @@ runs:
         HF_HUB_OFFLINE: "1"
         TRANSFORMERS_OFFLINE: "1"
         CORTEX_RERANKER_OFFLINE: "1"
-      run: pytest --tb=short -q
-
-    # The four steps below are CI-only: they run on the single matrix leg
-    # the ci.yml caller marks run-extended-checks: true (Python 3.12).
-    # release.yml never sets run-extended-checks — its test job is a
-    # pass/fail gate before publishing, not the leg that owns coverage, the
-    # MCP host contract check, or the advertised-test-count/badge check.
-    - name: Run tests with coverage
-      if: inputs.run-extended-checks == 'true'
-      shell: bash
-      env:
-        HF_HUB_OFFLINE: "1"
-        TRANSFORMERS_OFFLINE: "1"
-        CORTEX_RERANKER_OFFLINE: "1"
+        RUN_EXTENDED_CHECKS: ${{ inputs.run-extended-checks }}
       # --cov-fail-under is the statement-coverage floor (issue #196
       # criterion 4): seeded at the number this job itself achieved
       # (82.02% — 30,229 of 36,854 statements, run 30316539703,
       # coverage.py 7.15.2) so the figure can only ratchet up, never
       # silently fall back. Raise the floor when coverage rises.
-      run: pytest --cov=mcp_server --cov-report=xml --cov-report=term-missing --cov-fail-under=82
+      # W1-3: collect coverage during this same suite execution on the
+      # extended leg, preserving both reports and the existing floor.
+      run: |
+        set -euo pipefail
+        pytest_args=(--tb=short -q)
+        if [ "$RUN_EXTENDED_CHECKS" = "true" ]; then
+          pytest_args+=(--cov=mcp_server --cov-report=xml --cov-report=term-missing --cov-fail-under=82)
+        fi
+        pytest "${pytest_args[@]}"
 
     # Match the primary Claude and additive Codex client identities against
     # a real, explicitly configured PostgreSQL instance. Explicit targets
@@ -300,6 +295,8 @@ runs:
     # without collecting the suite, so it is checked in the job that already
     # has the suite installed. `--collect-only` re-collects (~seconds) rather
     # than parsing the run above, so the number is the collector's own.
+    # W1-3 retains this separate assertion: it executes no tests and keeps
+    # the advertised count and badge independent of coverage/run summaries.
     - name: Check advertised test count
       if: inputs.run-extended-checks == 'true'
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@
 #
 # Scope note: `open-pull-requests-limit` is deliberately low. The point is a
 # steady trickle that gets reviewed, not a queue nobody reads.
+# Group compatible version updates within each ecosystem/directory; major
+# updates retain individual PRs so unrelated breaking changes are not bundled.
+# source: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups
 version: 2
 updates:
   # Keeps the SHA pins in .github/workflows fresh. Dependabot rewrites the SHA
@@ -18,6 +21,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "ci"
 
@@ -28,6 +35,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -36,6 +47,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -44,6 +59,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -67,6 +86,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "deps"
     ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -15,6 +14,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+      docker: ${{ steps.filter.outputs.docker }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      deps: ${{ steps.filter.outputs.deps }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Verify pull request file-list completeness
+        if: github.event_name == 'pull_request'
+        run: python3 scripts/check_ci_file_count.py
+      # Classify each file independently. Unknown paths conservatively count
+      # as code; a docs file cannot hide code changed in the same PR.
+      # source: https://github.com/dorny/paths-filter/tree/v4.0.1#usage
+      # `every` applies all code exclusions to each file, not to the PR.
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - '**'
+              - '!{*.md,docs/**/*.md,tasks/**/*.md,Dockerfile,.dockerignore,docker/**,.devcontainer/**,.github/**,pyproject.toml,uv.lock,requirements/**,**/package.json,**/package-lock.json}'
+            docs:
+              - '{*.md,docs/**/*.md,tasks/**/*.md}'
+            docker:
+              - '{Dockerfile,.dockerignore,docker/**,.devcontainer/**}'
+            workflows:
+              - '.github/**'
+            deps:
+              - '{pyproject.toml,uv.lock,requirements/**,**/package.json,**/package-lock.json}'
+
   # Uses the composite action at .github/actions/test-suite/action.yml for
   # the step-level rationale, including why the shared unit is a composite
   # action and not a reusable workflow: a job delegating via `uses:` reports
@@ -26,6 +63,8 @@ jobs:
   # `requirements/ci-postgresql.txt` and tree-sitter grammars are now
   # installed unconditionally inside the action rather than passed in.
   test:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     # Bound a hung leg instead of inheriting GitHub's 360-minute default:
@@ -64,6 +103,8 @@ jobs:
           run-extended-checks: ${{ matrix.python-version == '3.12' }}
 
   test-sqlite:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (SQLite backend)
     runs-on: ubuntu-latest
 
@@ -204,12 +245,13 @@ jobs:
         run: python scripts/verify_mcp_hosts.py -- hypermnesia-mcp
 
   mcp-host-config:
+    needs: [changes, lint]
+    if: (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     name: Validate MCP host configurations
     # The pinned Claude package requires its postinstall to select the native
     # validator. Never execute install scripts from a lockfile modified by an
     # untrusted fork; same-repository PRs and main/workflow_dispatch remain
     # covered by this vendor-parser contract.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -284,6 +326,8 @@ jobs:
               -- "${plugin_command[@]}"
 
   test-windows:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (Windows, SQLite backend)
     runs-on: windows-latest
 
@@ -406,6 +450,8 @@ jobs:
   # under this narrower dependency set, with no PostgreSQL service needed
   # (`--storage-selection sqlite` is the default).
   release-deps:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Release dependency set (requirements/release.txt)
     runs-on: ubuntu-latest
     steps:
@@ -600,6 +646,8 @@ jobs:
   # scripts/craftsmanship_baseline.py for why pre-existing debt (recorded
   # in .craftsmanship-baseline.json) does not retroactively block.
   craftsmanship:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Craftsmanship Gate
     runs-on: ubuntu-latest
     steps:
@@ -623,6 +671,8 @@ jobs:
         run: python scripts/check_craftsmanship.py
 
   typecheck:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Type Check
     runs-on: ubuntu-latest
     steps:
@@ -679,6 +729,8 @@ jobs:
         run: .venv/bin/python -m pyright mcp_server/
 
   build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Build Package
     runs-on: ubuntu-latest
     steps:
@@ -709,6 +761,8 @@ jobs:
   # separate services. The claim here is narrow and worth making on its own:
   # the image still builds, and its hash-pinned installs still resolve.
   docker-runtime-build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Build (runtime image)
     runs-on: ubuntu-latest
     steps:
@@ -738,6 +792,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   devcontainer-build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Build (devcontainer image)
     runs-on: ubuntu-latest
     steps:
@@ -763,6 +819,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   docker-smoke:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Smoke (bare-container DB-less contract)
     runs-on: ubuntu-latest
     # BLOCKING: this job asserts the exact contract that silently broke for
@@ -807,8 +865,9 @@ jobs:
         env:
           CORTEX_SMOKE_IMAGE: cortex-smoke:local
 
-  # The one status check branch protection on `main` names. Everything else
-  # in this workflow is reached through its `needs:` list, so renaming a job,
+  # The aggregate required check for this workflow. CodeQL remains an
+  # independent required check outside ci.yml. Everything else here is reached
+  # through its `needs:` list, so renaming a job,
   # resizing the matrix, or delegating steps to a reusable workflow (which
   # rewrites check names to "<caller> / <callee>", issue #336) no longer
   # touches the protection settings — the contract is this file, in git,
@@ -827,6 +886,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
+      - changes
       - test
       - test-sqlite
       - mcp-host-config
@@ -840,30 +900,15 @@ jobs:
       - devcontainer-build
       - docker-smoke
     steps:
-      - name: Require every job above to have succeeded
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Require successful jobs or justified skips
         env:
           NEEDS: ${{ toJSON(needs) }}
-          # Jobs permitted to report `skipped`, with the reason. ONLY jobs
-          # carrying a job-level `if:` belong here; anything else that skips
-          # is a gap, not an exemption.
-          #   mcp-host-config — `if: github.event_name != 'pull_request' ||
-          #   github.event.pull_request.head.repo.fork == false`: a fork PR
-          #   has no access to the secrets it needs, so it cannot run there.
-          ALLOWED_SKIPS: mcp-host-config
-        run: |
-          set -euo pipefail
-          echo "$NEEDS"
-          failed=$(printf '%s' "$NEEDS" | jq -r --arg allowed "$ALLOWED_SKIPS" '
-            ($allowed | split(",") | map(ltrimstr(" ") | rtrimstr(" "))) as $ok
-            | to_entries[]
-            | select(.value.result != "success")
-            | select(.value.result != "skipped" or ([.key] | inside($ok) | not))
-            | "\(.key)=\(.value.result)"')
-          if [ -n "$failed" ]; then
-            echo "::error::CI Green refuses the merge — $(echo "$failed" | tr '\n' ' ')"
-            exit 1
-          fi
-          echo "every required job succeeded"
+          # Path skips are valid only for irrelevant PRs. mcp-host-config
+          # additionally skips fork PRs to avoid untrusted npm postinstall.
+          # The checker verifies these reasons against this run's inputs.
+          ALLOWED_SKIPS: test,test-sqlite,mcp-host-config,test-windows,release-deps,craftsmanship,typecheck,build,docker-runtime-build,devcontainer-build,docker-smoke
+        run: python3 scripts/check_ci_gate_results.py
 
   # The tag-as-output half of issue #392: a green push to `main` tags the
   # exact SHA that just passed CI Green, instead of a human hand-picking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  schedule:
+    # source: W1-4 in tasks/codex-green-remediation-plan.md requires weekly
+    # builds; reuse fuzz.yml's Monday 04:17 UTC window as a config choice.
+    - cron: "17 4 * * 1"
 
 permissions:
   contents: read
@@ -64,7 +68,7 @@ jobs:
   # installed unconditionally inside the action rather than passed in.
   test:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     # Bound a hung leg instead of inheriting GitHub's 360-minute default:
@@ -104,7 +108,7 @@ jobs:
 
   test-sqlite:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (SQLite backend)
     runs-on: ubuntu-latest
 
@@ -246,7 +250,7 @@ jobs:
 
   mcp-host-config:
     needs: [changes, lint]
-    if: (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    if: github.event_name != 'schedule' && ((github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false))
     name: Validate MCP host configurations
     # The pinned Claude package requires its postinstall to select the native
     # validator. Never execute install scripts from a lockfile modified by an
@@ -327,7 +331,7 @@ jobs:
 
   test-windows:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Windows, SQLite backend)
     runs-on: windows-latest
 
@@ -451,7 +455,7 @@ jobs:
   # (`--storage-selection sqlite` is the default).
   release-deps:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Release dependency set (requirements/release.txt)
     runs-on: ubuntu-latest
     steps:
@@ -647,7 +651,7 @@ jobs:
   # in .craftsmanship-baseline.json) does not retroactively block.
   craftsmanship:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Craftsmanship Gate
     runs-on: ubuntu-latest
     steps:
@@ -672,7 +676,7 @@ jobs:
 
   typecheck:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Type Check
     runs-on: ubuntu-latest
     steps:
@@ -730,7 +734,7 @@ jobs:
 
   build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Build Package
     runs-on: ubuntu-latest
     steps:
@@ -762,7 +766,7 @@ jobs:
   # the image still builds, and its hash-pinned installs still resolve.
   docker-runtime-build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (runtime image)
     runs-on: ubuntu-latest
     steps:
@@ -789,11 +793,13 @@ jobs:
           tags: cortex-runtime:ci
           load: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # source: https://docs.docker.com/build/cache/backends/#cache-mode
+          # min exports image layers; intermediate build layers are omitted.
+          cache-to: type=gha,mode=min
 
   devcontainer-build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (devcontainer image)
     runs-on: ubuntu-latest
     steps:
@@ -816,7 +822,9 @@ jobs:
           tags: cortex-devcontainer:ci
           load: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # source: https://docs.docker.com/build/cache/backends/#cache-mode
+          # min exports image layers; intermediate build layers are omitted.
+          cache-to: type=gha,mode=min
 
   docker-smoke:
     needs: [changes, lint]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,12 +698,6 @@ jobs:
       - name: Build sdist and wheel
         run: python -m build
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: dist
-          path: dist/
-
   # The two images below had NO CI build at all until this change, so a
   # regression in either was invisible until someone built it by hand. That
   # is not hypothetical: docker/Dockerfile copied a python3.12 site-packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
   changes:
     name: Changed paths
     runs-on: ubuntu-latest
+    # source: run 34035713474 (2026-09-06), max 9s; ceil(2 * 9 / 60).
+    timeout-minutes: 1
     permissions:
       contents: read
       pull-requests: read
@@ -71,25 +73,26 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    # Bound a hung leg instead of inheriting GitHub's 360-minute default:
-    # release run 30741657854 (v4.17.0, CHANGELOG 4.17.1) sat in FlashRank's
-    # timeout-less `requests.get` until pytest-timeout fired, and only that
-    # per-test guard, not the job, ever bounded the suite.
-    # source: measured 2026-09-03 over the last 12 green `main` runs of this
-    # workflow (gh run list --status success, runs 31417063954 to
-    # 33688337476, 48 legs, started_at to completed_at per job): Test (Python
-    # 3.12, the only leg running the extended checks) took 15-20 min (max
-    # 19 min 36 s, run 32747742631); the other three legs took 8-11 min in 11
-    # of the 12 runs, but in run 33688337476 (c5ec018a) Python 3.10 took
-    # 15 min 06 s and Python 3.13 took 27 min 17 s, the slowest green leg in
-    # the window. 60 min is about twice that maximum (60 / 27.3 = 2.2), so a
-    # slow runner still passes while a stalled job is cut within one ordinary
-    # run's wall time.
-    timeout-minutes: 60
+    # source: W1-7 review runs 33990473565, 33951959734, 33951905125,
+    # 33806380625; each matrix limit is twice that leg's maximum elapsed time.
+    timeout-minutes: ${{ matrix.timeout-minutes }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          - python-version: "3.10"
+            # source: run 33951959734 (2026-09-05), max 545s; ceil(2 * 545 / 60).
+            timeout-minutes: 19
+          - python-version: "3.11"
+            # source: run 33806380625 (2026-09-03), max 1931s; ceil(2 * 1931 / 60).
+            timeout-minutes: 65
+          - python-version: "3.12"
+            # source: run 33951959734 (2026-09-05), max 1143s; ceil(2 * 1143 / 60).
+            timeout-minutes: 39
+          - python-version: "3.13"
+            # source: run 33951959734 (2026-09-05), max 577s; ceil(2 * 577 / 60).
+            timeout-minutes: 20
 
     steps:
       # A local `uses: ./...` is resolved from the checked-out tree, so the
@@ -111,6 +114,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (SQLite backend)
     runs-on: ubuntu-latest
+    # source: run 33806380625 (2026-09-03), max 292s; ceil(2 * 292 / 60).
+    timeout-minutes: 10
 
     # Force the SQLite fallback path — no PostgreSQL installed or started.
     # The conftest detects PG-unreachable and sets CORTEX_MEMORY_STORE_BACKEND=sqlite
@@ -257,6 +262,8 @@ jobs:
     # untrusted fork; same-repository PRs and main/workflow_dispatch remain
     # covered by this vendor-parser contract.
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 61s; ceil(2 * 61 / 60).
+    timeout-minutes: 3
     permissions:
       contents: read
 
@@ -341,6 +348,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Windows, SQLite backend)
     runs-on: windows-latest
+    # source: run 33990473565 (2026-09-05), max 426s; ceil(2 * 426 / 60).
+    timeout-minutes: 15
 
     # Real NT proof for the cross-platform fixes (fcntl→msvcrt, sys.executable,
     # NTFS exec bits, $HOME override, path separators). We use the SQLite
@@ -467,6 +476,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Release dependency set (requirements/release.txt)
     runs-on: ubuntu-latest
+    # source: run 33806380625 (2026-09-03), max 109s; ceil(2 * 109 / 60).
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -513,6 +524,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 17s; ceil(2 * 17 / 60).
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -683,6 +696,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Craftsmanship Gate
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 9s; ceil(2 * 9 / 60).
+    timeout-minutes: 1
     steps:
       # fetch-depth: 0 so `origin/main` — the diff base the gate compares
       # the PR's changed files against — is resolvable locally, not just
@@ -708,6 +723,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Type Check
     runs-on: ubuntu-latest
+    # source: run 33990473565 (2026-09-05), max 94s; ceil(2 * 94 / 60).
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -770,6 +787,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Build Package
     runs-on: ubuntu-latest
+    # source: run 33951905125 (2026-09-05), max 19s; ceil(2 * 19 / 60).
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -804,6 +823,8 @@ jobs:
     if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (runtime image)
     runs-on: ubuntu-latest
+    # source: run 33951905125 (2026-09-05), max 514s; ceil(2 * 514 / 60).
+    timeout-minutes: 18
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -837,6 +858,8 @@ jobs:
     if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (devcontainer image)
     runs-on: ubuntu-latest
+    # source: run 33951905125 (2026-09-05), max 349s; ceil(2 * 349 / 60).
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -866,6 +889,8 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Smoke (bare-container DB-less contract)
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 369s; ceil(2 * 369 / 60).
+    timeout-minutes: 13
     # BLOCKING: this job asserts the exact contract that silently broke for
     # two months (fix/bare-container-contract, commit 5d71069c) — third-party
     # registry indexers (Glama et al.) `docker build` the bare repo, then
@@ -928,6 +953,8 @@ jobs:
     name: CI Green
     if: always()
     runs-on: ubuntu-latest
+    # source: run 33806380625 (2026-09-03), max 4s; ceil(2 * 4 / 60).
+    timeout-minutes: 1
     needs:
       - changes
       - test
@@ -973,6 +1000,8 @@ jobs:
     # has already merged — see the job comment above.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # source: run 33990473565 (2026-09-05), max 12s; ceil(2 * 12 / 60).
+    timeout-minutes: 1
     # `contents: read`, NOT write, and that is deliberate. The tag is pushed
     # with the RELEASE_TAG_SSH_KEY deploy key (persisted by the checkout step
     # below), never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,10 @@ jobs:
           # @anthropic-ai/claude-code 2.1.220 declares Node >=22; Node 24 is
           # the repository's existing release-toolchain pin.
           node-version: "24"
+          # source: https://github.com/actions/setup-node/tree/v7.0.0#caching-global-packages-data
+          # Cache downloads, not node_modules.
+          cache: npm
+          cache-dependency-path: tests_js/mcp-host-clis/package-lock.json
 
       - name: Install uv (pinned)
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -329,6 +333,9 @@ jobs:
               --storage-selection auto \
               -- "${plugin_command[@]}"
 
+  # source: https://github.com/actions/setup-python/tree/v7.0.0#caching-packages-dependencies
+  # pip caches below hash each job's exact exported constraints. Requirement
+  # installs still use --require-hashes; no installed environment is restored.
   test-windows:
     needs: [changes, lint]
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
@@ -350,6 +357,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/ci-sqlite-min.txt
 
       - name: Cache HuggingFace models
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -465,6 +474,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/release.txt
 
       - name: Cache HuggingFace models
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -509,6 +520,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/lint.txt
 
       - name: Install ruff
         # Pinned: ruff's formatter output changes across minor versions
@@ -624,12 +637,28 @@ jobs:
       # curl|bash), matching this repo's supply-chain-hardening stance (release.yml).
       # source: https://github.com/rhysd/actionlint/releases/tag/v1.7.12,
       # actionlint_1.7.12_checksums.txt, linux_amd64 entry, verified 2026-07-29.
+      # Cache only the release archive; verify its checksum on every run.
+      # source: https://github.com/actions/cache/tree/v6.1.0#usage
+      - name: Cache actionlint archive
+        id: actionlint-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/cortex-actionlint/actionlint_1.7.12_linux_amd64.tar.gz
+          key: ${{ runner.os }}-${{ runner.arch }}-actionlint-1.7.12-8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+
       - name: Install actionlint (pinned, checksum-verified)
+        env:
+          CACHE_HIT: ${{ steps.actionlint-cache.outputs.cache-hit }}
+          ACTIONLINT_CACHE_DIR: ${{ runner.temp }}/cortex-actionlint
         run: |
           set -euxo pipefail
           VERSION="1.7.12"
           ARCHIVE="actionlint_${VERSION}_linux_amd64.tar.gz"
-          curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/${ARCHIVE}"
+          mkdir -p "$ACTIONLINT_CACHE_DIR"
+          cd "$ACTIONLINT_CACHE_DIR"
+          if [ "$CACHE_HIT" != "true" ]; then
+            curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/${ARCHIVE}"
+          fi
           echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  ${ARCHIVE}" | sha256sum -c -
           tar -xzf "${ARCHIVE}" actionlint
           sudo install -m 0755 actionlint /usr/local/bin/actionlint
@@ -686,6 +715,10 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements/ci-typecheck.txt
+            requirements/typecheck-tool.txt
 
       # Pyright resolves third-party imports from ./.venv (pinned in
       # pyrightconfig.json: venvPath="."/venv=".venv"). The full stub set MUST
@@ -744,6 +777,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/packaging.txt
 
       - name: Install build tools
         # --no-deps: the file is the complete, uv-resolved dependency graph

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,6 @@
 name: Fuzz
 
-# W1-7 temporary cancellation acceptance probe: first revision; never merge.
+# W1-7 temporary cancellation acceptance probe: second revision; never merge.
 
 # Coverage-guided fuzzing of the pure parsers in fuzz/, via ClusterFuzzLite.
 #

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,11 +34,18 @@ on:
 
 permissions: read-all
 
+# source: W1-7 in tasks/codex-green-remediation-plan.md; superseded PR checks.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pr-batch:
     name: Fuzz (PR batch)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # source: run 34030977934 (2026-09-06), max 363s; ceil(2 * 363 / 60).
+    timeout-minutes: 13
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +74,8 @@ jobs:
     name: Fuzz (scheduled batch)
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # source: run 33384194242 (2026-08-31), max 1144s; ceil(2 * 1144 / 60).
+    timeout-minutes: 39
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,5 +1,7 @@
 name: Fuzz
 
+# W1-7 temporary cancellation acceptance probe: first revision; never merge.
+
 # Coverage-guided fuzzing of the pure parsers in fuzz/, via ClusterFuzzLite.
 #
 # Two cadences, because they answer different questions:

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -30,10 +30,17 @@ on:
 permissions:
   contents: read
 
+# source: W1-7 in tasks/codex-green-remediation-plan.md; superseded PR checks.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   scan:
     name: HOL plugin scan
     runs-on: ubuntu-latest
+    # source: run 34030977899 (2026-09-06), max 59s; ceil(2 * 59 / 60).
+    timeout-minutes: 2
     permissions:
       contents: read
       security-events: write   # SARIF upload to code scanning

--- a/.github/workflows/marketplace-pins.yml
+++ b/.github/workflows/marketplace-pins.yml
@@ -30,6 +30,8 @@ jobs:
   check-pins:
     name: pins current vs latest releases
     runs-on: ubuntu-latest
+    # source: run 33723724819 (2026-09-03), max 13s; ceil(2 * 13 / 60).
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check marketplace pins

--- a/.github/workflows/mcp-toplist-badge.yml
+++ b/.github/workflows/mcp-toplist-badge.yml
@@ -27,6 +27,8 @@ jobs:
   refresh:
     name: refresh rank badge from upstream
     runs-on: ubuntu-latest
+    # source: run 30692957797 (2026-08-01), max 32s; ceil(2 * 32 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
     # form; this one was the exception.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 39s; ceil(2 * 39 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write  # create the release + attach auto-generated notes
     steps:
@@ -134,6 +136,8 @@ jobs:
     # thing they all used to wait on) is gone (issue #392).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 33725153709 (2026-09-03), max 31s; ceil(2 * 31 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write       # upload attested wheel/sdist + checksums to release
       id-token: write       # OIDC token Sigstore exchanges for a signing cert
@@ -218,6 +222,8 @@ jobs:
     # nothing (see `build`'s identical comment for why there is no `needs:`).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 32s; ceil(2 * 32 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write       # upload SBOM + checksum to the release
       id-token: write       # OIDC for attestation
@@ -288,6 +294,8 @@ jobs:
     # identical comment for why there is no `needs:`).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 25s; ceil(2 * 25 / 60).
+    timeout-minutes: 1
     permissions:
       contents: write       # upload bundle + checksum + server.json to release
       id-token: write       # OIDC token Sigstore exchanges for a signing cert
@@ -398,6 +406,8 @@ jobs:
     # tag-only contract survives a future edit to `build`'s condition.
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 33809450915 (2026-09-03), max 23s; ceil(2 * 23 / 60).
+    timeout-minutes: 1
     # OIDC Trusted Publishing — no stored secret. Verified by PyPI against
     # the trusted-publisher entry for (cdeust/Cortex, release.yml,
     # environment=pypi). This is the same entry that published <= 3.14.7.
@@ -471,6 +481,8 @@ jobs:
     needs: publish-pypi
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 14s; ceil(2 * 14 / 60).
+    timeout-minutes: 1
     permissions:
       id-token: write   # OIDC — mcp-publisher login github-oidc
       contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,6 +37,8 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    # source: run 33806380608 (2026-09-03), max 40s; ceil(2 * 40 / 60).
+    timeout-minutes: 2
     permissions:
       security-events: write   # upload SARIF to code scanning
       id-token: write          # publish signed results to the OpenSSF API

--- a/.github/workflows/upstream-identity.yml
+++ b/.github/workflows/upstream-identity.yml
@@ -27,10 +27,17 @@ on:
 permissions:
   contents: read
 
+# source: W1-7 in tasks/codex-green-remediation-plan.md; superseded PR checks.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   contract:
     name: agree with the upstream identity contract
     runs-on: ubuntu-latest
+    # source: run 34034615566 (2026-09-06), max 9s; ceil(2 * 9 / 60).
+    timeout-minutes: 1
     env:
       CONTRACT_URL: https://raw.githubusercontent.com/cdeust/ai-architect-mcp-codebase/37728cc5747cebe39ea9d4011b7424de90f0a57b/mcp-contract.json
     steps:

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -54,6 +54,22 @@ reports **local** performance statistics only, and every recorded sample is
 appended to a local, no-egress JSONL file
 (`~/.claude/methodology/telemetry.jsonl`).
 
+`CORTEX_CLAUDE_DIR` redirects that file to the selected configuration root.
+Samples contain operation names, durations, byte counts, result counts and
+completion status, without prompt or response content. `query_methodology`,
+`session_start` and `auto_recall` are included. `tier` records the retrieval
+route actually executed (`pg` for the current memory-store pipeline, or the
+legacy dispatch tier); it is null when no retrieval route ran.
+`reranked_count` counts passages successfully processed by the reranker,
+including candidates later filtered out of the response.
+For MCP calls, `bytes_out` measures the SDK's final UTF-8 text payload, including
+error messages and excluding the transport envelope and structured-content
+duplicate. Direct handler calls measure their serialized response (zero when
+they raise without returning a response). Hook `bytes_out` measures stdout
+after encoding and newline conversion. A silent hook records zero bytes.
+Hook `ok` describes normal completion or exit code zero; it does not certify
+that every optional retrieval source was available.
+
 The only outbound network activity is:
 
 1. **One-time model download.** On first use, the open-source embedding model

--- a/benchmarks/energy/README.md
+++ b/benchmarks/energy/README.md
@@ -1,0 +1,130 @@
+# Embedding energy harness
+
+W0-2 repairs the float32 equivalence gate and makes carbon inputs explicit.
+The automated fixtures exercise arithmetic and failure paths; they do **not**
+measure device energy or establish an energy improvement.
+
+## Run
+
+Run from an interactive macOS terminal, after supplying your sourced protocol
+and carbon factors. These environment variables intentionally have no example
+carbon values:
+
+```sh
+benchmarks/energy/run.sh \
+  --duration-seconds "$ENERGY_PHASE_SECONDS" \
+  --repetitions "$ENERGY_REPETITIONS" \
+  --carbon-intensity "$ENERGY_INTENSITY_G_PER_KWH" \
+  --embodied "$ENERGY_EMBODIED_G_PER_SECOND"
+```
+
+`--carbon-intensity` and `--embodied` are mandatory, finite and nonnegative.
+The runner validates them, and the protocol, before any `sudo` or model import.
+`--validate-only` performs just that validation. `--batch-size` defaults to the
+batch from the review's W3-2 probe; `--sample-rate-ms` defaults to the system
+powermetrics manual's sampling interval. Both are configurable experimental
+protocol choices. Choose phases long enough to contain sensor samples.
+
+`run.sh` owns sensor authorization and cleanup; it replaces the duplicate
+AppleScript sensor launcher previously embedded in Python. Only powermetrics
+runs elevated. `ENERGY_PYTHON` can select a Python interpreter; otherwise the
+runner uses the repository's `.venv/bin/python`. The Python entry point can use
+an already running stream via `--external-power-file`; without it, it directs
+the operator to `run.sh`. An unavailable neural model is an explicit error.
+The harness does not change the model's cache location.
+
+## Units and equivalence
+
+`I = --carbon-intensity` is the electricity region's intensity in gCO2eq/kWh.
+`--embodied` is an **already allocated emission rate** in gCO2eq/s, not the total
+device footprint. Derive it from sourced lifecycle emissions divided by expected
+life in seconds, multiplied by the resource share reserved for this workload.
+Record the region, observation period, lifecycle assessment, expected lifetime
+and reservation assumptions alongside your run. The harness records input
+values and units but does not verify their provenance.
+
+For each measured phase, with `t` its actual elapsed seconds and `N` its actual
+model input token count:
+
+```text
+M_phase [gCO2eq] = embodied_rate [gCO2eq/s] * t [s]
+O_phase [gCO2eq] = (energy_j / 3600000) [kWh] * I [gCO2eq/kWh]
+carbon per 1000 tokens = (O_phase + M_phase) * 1000 / N
+joules per 1000 tokens = energy_j * 1000 / N
+```
+
+The model's `tokenize` method supplies `attention_mask`; summing it counts
+non-padding tokens after truncation, including special tokens. The harness
+reconstructs every completed input batch and counts tokens **after all timed
+phases**. It never estimates tokens from characters. Scalar and batch phases
+use the same deterministic text generator; their LRU cache is cleared before
+each phase so the probe cannot warm scalar inputs into cache hits.
+
+Equivalence decodes `encode`/`encode_batch` blobs using
+`np.frombuffer(blob, dtype=np.float32)`. Empty, malformed, nonfinite, mismatched
+outputs and errors above `np.finfo(np.float32).eps` are refused before phases.
+The tolerance is absolute (`rtol=0`) and deliberately strict. NumPy supplies its
+floating-point definition; this is **not** a universal bound on model inference
+error. The probe validates the selected batch, device and run only. A fixture
+at `0.5` and its next float32 value toward `1` demonstrates why comparing byte
+values was incorrect.
+
+## Measurement boundary and artifacts
+
+`raw_system_energy_j` covers the sensor's combined **CPU+GPU+ANE** estimate.
+It is neither wall-plug energy nor a complete device/application SCI score.
+Memory, storage, screen, power supply losses, model warm-up and token counting
+are excluded. Carbon uses raw energy; idle-subtracted energy is a separate
+diagnostic and retains negative values so idle noise remains visible.
+
+The phase energy estimate is mean sampled watts multiplied by elapsed seconds;
+samples are assigned by their end timestamps. Finite sampling introduces phase
+boundary error. CPU-only samples are refused. An incomplete final sample may
+be ignored only when its timestamp is after every measured phase, with an
+explicit warning; malformed samples inside phases are refused.
+
+Successful runs preserve `results.json`, `MANIFEST.json` (commit and source
+hashes) and the exact analyzed `powermetrics.txt` snapshot under
+`benchmarks/results/energy/`. The snapshot is taken while the external sensor
+is running. On failure, the shell reports the retained raw temporary file;
+it never stores a model there. Sensor stop failures return nonzero and do not
+wait indefinitely for a sensor that could not be signalled.
+
+Stopping sends `SIGINT` directly to the existing sudo parent, which relays it
+to powermetrics under macOS's normal sudoers/PAM process model. This requires
+no new sudo invocation, so an expired authentication ticket does not prevent
+cleanup. A nonstandard sudo policy that replaces its parent with the root
+command may deny the signal; the runner then reports failure without waiting.
+
+## Primary sources
+
+- [Green Software Foundation SCI specification](https://sci.greensoftware.foundation/):
+  operational emissions `O=E*I`, embodied allocation `M=TE*TS*RS`, functional units.
+- [NumPy frombuffer](https://numpy.org/doc/stable/reference/generated/numpy.frombuffer.html),
+  [finfo](https://numpy.org/doc/stable/reference/generated/numpy.finfo.html), and
+  [allclose](https://numpy.org/doc/stable/reference/generated/numpy.allclose.html):
+  byte interpretation, machine epsilon and explicit tolerance semantics.
+- [SentenceTransformer.tokenize](https://www.sbert.net/docs/package_reference/sentence_transformer/SentenceTransformer.html#sentence_transformers.SentenceTransformer.tokenize)
+  and [Hugging Face tokenizer attention masks](https://huggingface.co/docs/transformers/main_classes/tokenizer):
+  actual model preprocessing and non-padding token masks.
+- [NIST SP 811 chapter 4](https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-4-two-classes-si-units-and-si-prefixes)
+  and [chapter 5](https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-5-units-outside-si):
+  watt/joule, kilo/milli prefixes and seconds per hour.
+- Local macOS `powermetrics(1)`, `/usr/share/man/man1/powermetrics.1`, consulted
+  2026-09-06: sample-rate default, continuous sampling, flushing and stop signals.
+- Local macOS `sudo(8)` 1.9.17p2, `/usr/share/man/man8/sudo.8`, sections
+  "Process model" and "Signal handling", and [Apple kill(2)](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kill.2.html):
+  user-generated signal relay and real/effective UID permission checks.
+- Protocol/acceptance: `tasks/codex-green-remediation-plan.md`, W0-2 and W3-2.
+
+## Fixture verification
+
+```sh
+.venv/bin/pytest tests_py/benchmarks/test_energy_*.py
+.venv/bin/ruff check benchmarks/energy tests_py/benchmarks/test_energy_*.py
+.venv/bin/ruff format --check benchmarks/energy tests_py/benchmarks/test_energy_*.py
+```
+
+The shell tests use a fake sudo executable for validation and a simulated
+sensor under a PTY for successful and failing workload cleanup. No test starts
+powermetrics, invokes real sudo or downloads/loads model weights.

--- a/benchmarks/energy/measurement.py
+++ b/benchmarks/energy/measurement.py
@@ -1,0 +1,244 @@
+"""Power samples, explicit carbon arithmetic, and reproducible report artifacts.
+
+The SCI equation is used only for the disclosed CPU+GPU+ANE boundary, which is
+not a complete device/application SCI assessment. See README.md for sources.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import statistics
+import subprocess
+import warnings
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+import numpy as np
+
+from benchmarks.energy.workload import Phase
+
+
+REPO = Path(__file__).resolve().parent.parent.parent
+# source: W0-2 functional unit in tasks/codex-green-remediation-plan.md.
+TOKENS_PER_UNIT = 1000
+# source: NIST SP 811 ch. 4 (W = J/s, kilo = 10^3), ch. 5 (h = 3600 s).
+JOULES_PER_KWH = 3_600_000
+# source: NIST SP 811 ch. 4, milli = 10^-3.
+MILLIWATTS_PER_WATT = 1000
+COMBINED_POWER_RE = re.compile(
+    r"Combined Power \(CPU \+ GPU \+ ANE\):\s*([0-9.]+)\s*mW"
+)
+SAMPLE_RE = re.compile(
+    r"\*\*\* Sampled system activity \(([^)]+)\).*?\*\*\*\n"
+    r"(.*?)(?=\n\*\*\* Sampled system activity|\Z)",
+    re.DOTALL,
+)
+
+
+@dataclass
+class MeasuredPhase:
+    phase: Phase
+    samples: int
+    mean_system_power_w: float
+    idle_power_w: float
+
+    @property
+    def raw_system_energy_j(self) -> float:
+        # source: NIST SP 811 ch. 4, W = J/s; sampled mean power approximation.
+        return self.mean_system_power_w * self.phase.elapsed_s
+
+    @property
+    def dynamic_energy_j(self) -> float:
+        # Keep negative differences visible; they indicate idle/noise sensitivity.
+        return (self.mean_system_power_w - self.idle_power_w) * self.phase.elapsed_s
+
+
+def parse_power_samples(
+    text: str, phase_end: float | None = None
+) -> list[tuple[float, float]]:
+    samples = []
+    blocks = SAMPLE_RE.findall(text)
+    for index, (timestamp, body) in enumerate(blocks):
+        sampled_at = parsedate_to_datetime(timestamp).timestamp()
+        match = COMBINED_POWER_RE.search(body)
+        if (
+            match is None
+            and index == len(blocks) - 1
+            and phase_end is not None
+            and sampled_at > phase_end
+        ):
+            warnings.warn(
+                "Incomplete final power sample outside measured phases ignored; "
+                "raw snapshot preserved",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            continue
+        if match is None:
+            raise ValueError("sample lacks Combined Power (CPU + GPU + ANE)")
+        watts = float(match.group(1)) / MILLIWATTS_PER_WATT
+        if not math.isfinite(watts):
+            raise ValueError("non-finite power sample")
+        samples.append((sampled_at, watts))
+    if not samples:
+        raise ValueError("no combined CPU+GPU+ANE power samples")
+    return samples
+
+
+def _mean_power(phase: Phase, samples: list[tuple[float, float]]) -> tuple[int, float]:
+    values = [
+        watts
+        for timestamp, watts in samples
+        if phase.wall_start <= timestamp <= phase.wall_end
+    ]
+    if not values:
+        raise RuntimeError(f"no power samples in phase {phase.condition}")
+    return len(values), statistics.fmean(values)
+
+
+def apply_power_samples(
+    phases: list[Phase], samples: list[tuple[float, float]]
+) -> list[MeasuredPhase]:
+    power = [_mean_power(phase, samples) for phase in phases]
+    idle_by_rep = {
+        phase.repetition: mean
+        for phase, (_, mean) in zip(phases, power, strict=True)
+        if phase.condition == "idle"
+    }
+    return [
+        MeasuredPhase(phase, count, mean, idle_by_rep[phase.repetition])
+        for phase, (count, mean) in zip(phases, power, strict=True)
+        if phase.condition != "idle"
+    ]
+
+
+def carbon_per_1k_tokens(
+    energy_j: float, tokens: int, intensity: float, embodied_g: float
+) -> float:
+    if tokens <= 0:
+        raise ValueError("token count must be positive")
+    if any(not math.isfinite(x) or x < 0 for x in (energy_j, intensity, embodied_g)):
+        raise ValueError("energy and carbon inputs must be finite and nonnegative")
+    # source: https://sci.greensoftware.foundation/ : O = E*I, SCI = (O+M)/R.
+    operational_g = energy_j / JOULES_PER_KWH * intensity
+    return (operational_g + embodied_g) * TOKENS_PER_UNIT / tokens
+
+
+def summarize(
+    rows: list[MeasuredPhase], mode: str, args: argparse.Namespace
+) -> dict[str, float]:
+    selected = [row for row in rows if row.phase.condition == mode]
+    per_text = [row.raw_system_energy_j / row.phase.operations for row in selected]
+    per_tokens = [
+        row.raw_system_energy_j * TOKENS_PER_UNIT / row.phase.tokens for row in selected
+    ]
+    carbon = [
+        carbon_per_1k_tokens(
+            row.raw_system_energy_j,
+            row.phase.tokens,
+            args.carbon_intensity,
+            args.embodied * row.phase.elapsed_s,
+        )
+        for row in selected
+    ]
+    return {
+        "repetitions": len(selected),
+        "operations_total": sum(row.phase.operations for row in selected),
+        "tokens_total": sum(row.phase.tokens for row in selected),
+        "energy_j_per_text_mean": statistics.fmean(per_text),
+        "energy_j_per_text_stdev": statistics.stdev(per_text),
+        "energy_j_per_1k_tokens_mean": statistics.fmean(per_tokens),
+        "carbon_gco2eq_per_1k_tokens_mean": statistics.fmean(carbon),
+        "idle_subtracted_j_per_text_mean": statistics.fmean(
+            row.dynamic_energy_j / row.phase.operations for row in selected
+        ),
+        "texts_per_second_mean": statistics.fmean(
+            row.phase.operations / row.phase.elapsed_s for row in selected
+        ),
+    }
+
+
+def _report_row(row: MeasuredPhase, args: argparse.Namespace) -> dict[str, object]:
+    return {
+        **asdict(row.phase),
+        "samples": row.samples,
+        "mean_system_power_w": row.mean_system_power_w,
+        "idle_power_w": row.idle_power_w,
+        "raw_system_energy_j": row.raw_system_energy_j,
+        "dynamic_energy_j": row.dynamic_energy_j,
+        "embodied_gco2eq": args.embodied * row.phase.elapsed_s,
+        "carbon_gco2eq_per_1k_tokens": carbon_per_1k_tokens(
+            row.raw_system_energy_j,
+            row.phase.tokens,
+            args.carbon_intensity,
+            args.embodied * row.phase.elapsed_s,
+        ),
+    }
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "git_commit": subprocess.check_output(
+            ["git", "-C", str(REPO), "rev-parse", "HEAD"], text=True
+        ).strip(),
+        "source_sha256": {
+            path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in sorted(Path(__file__).parent.iterdir())
+            if path.is_file()
+        },
+        "host": subprocess.check_output(["uname", "-a"], text=True).strip(),
+        "raw_measurement": "powermetrics.txt",
+        "limitations": [
+            "System CPU+GPU+ANE estimates, not process-isolated or device-total energy",
+            "Excludes memory, storage, display, supply losses, model load and counting",
+            "Mean power uses sample end timestamps within each phase; boundary error",
+            "Operator-supplied I and allocated embodied rate are not verified here",
+            "Float32 tolerance validates this probe only, not all inputs/devices",
+        ],
+    }
+
+
+def write_report(
+    args: argparse.Namespace,
+    results: tuple[list[MeasuredPhase], dict[str, dict[str, float]]],
+    evidence: tuple[bytes, float],
+) -> dict[str, object]:
+    rows, summary = results
+    raw_power, delta = evidence
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    out_dir = REPO / "benchmarks" / "results" / "energy" / stamp
+    out_dir.mkdir(parents=True, exist_ok=False)
+    result = {
+        "functional_units": ["one embedded text", "1000 model input tokens"],
+        "token_definition": (
+            "attention_mask sum after truncation; special tokens included"
+        ),
+        "boundary": "CPU+GPU+ANE power during local inference phases",
+        "duration_seconds": args.duration_seconds,
+        "repetitions": args.repetitions,
+        "batch_size": args.batch_size,
+        "sample_rate_ms": args.sample_rate_ms,
+        "carbon_intensity_gco2eq_per_kwh": args.carbon_intensity,
+        "embodied_rate_gco2eq_per_second": args.embodied,
+        "carbon_formula": (
+            "((energy_j / 3600000) * I + embodied_rate * elapsed_s) * 1000 / tokens"
+        ),
+        "max_abs_output_delta_scalar_vs_batch": delta,
+        "equivalence_atol": float(np.finfo(np.float32).eps),
+        "equivalence_rtol": 0,
+        "rows": [_report_row(row, args) for row in rows],
+        "summary": summary,
+    }
+    (out_dir / "powermetrics.txt").write_bytes(raw_power)
+    for name, payload in (("results.json", result), ("MANIFEST.json", _manifest())):
+        (out_dir / name).write_text(
+            json.dumps(payload, indent=2, allow_nan=False) + "\n"
+        )
+    return {"result_dir": str(out_dir), "summary": summary}

--- a/benchmarks/energy/run.sh
+++ b/benchmarks/energy/run.sh
@@ -1,0 +1,92 @@
+#!/bin/zsh
+# One privileged sensor; Python validation and inference remain unprivileged.
+set -euo pipefail
+unsetopt BG_NICE
+
+SCRIPT_DIR=${0:A:h}
+REPO_DIR=${SCRIPT_DIR:h:h}
+BENCH_PY=${ENERGY_PYTHON:-${REPO_DIR}/.venv/bin/python}
+ENERGY_POWER_FILE=""
+ENERGY_METER_PID=""
+
+if [[ ! -x ${BENCH_PY} ]]; then
+  print -u2 "Missing benchmark interpreter: ${BENCH_PY}"
+  exit 2
+fi
+for ENERGY_ARG in "$@"; do
+  if [[ ${ENERGY_ARG} == --help || ${ENERGY_ARG} == -h ]]; then
+    exec "${BENCH_PY}" "${SCRIPT_DIR}/run_embedding_energy.py" --help
+  fi
+done
+# Required carbon flags and every numeric argument are checked before sudo.
+ENERGY_SAMPLE_RATE_MS=$("${BENCH_PY}" "${SCRIPT_DIR}/run_embedding_energy.py" "$@" --validate-only)
+for ENERGY_ARG in "$@"; do
+  if [[ ${ENERGY_ARG} == --validate-only ]]; then
+    print "${ENERGY_SAMPLE_RATE_MS}"
+    exit 0
+  fi
+  if [[ ${ENERGY_ARG} == --external-power-file* ]]; then
+    print -u2 "Use run_embedding_energy.py directly for --external-power-file."
+    exit 2
+  fi
+done
+if [[ ! -t 0 ]]; then
+  print -u2 "Run from an interactive terminal so macOS can read the sudo password."
+  exit 2
+fi
+
+stop_meter() {
+  if [[ -z ${ENERGY_METER_PID} ]]; then
+    return
+  fi
+  if kill -0 "${ENERGY_METER_PID}" 2>/dev/null; then
+    # source: macOS sudo(8), Signal handling: user-sent SIGINT is relayed
+    # to the command. Signal the existing sudo parent; no fresh ticket needed.
+    if ! kill -INT "${ENERGY_METER_PID}"; then
+      print -u2 "Failed to stop sensor ${ENERGY_METER_PID}; refusing to wait indefinitely."
+      return 1
+    fi
+  fi
+  local ENERGY_WAIT_STATUS=0
+  wait "${ENERGY_METER_PID}" || ENERGY_WAIT_STATUS=$?
+  # source: zsh exit status for SIGINT is 128 + signal 2; powermetrics(1)
+  # specifies SIGINT as its normal stop-sampling-and-exit signal.
+  if (( ENERGY_WAIT_STATUS != 0 && ENERGY_WAIT_STATUS != 130 )); then
+    print -u2 "Sensor exited with status ${ENERGY_WAIT_STATUS}."
+    return ${ENERGY_WAIT_STATUS}
+  fi
+  ENERGY_METER_PID=""
+}
+
+cleanup() {
+  local ENERGY_EXIT_STATUS=$?
+  trap - EXIT INT TERM
+  stop_meter || ENERGY_EXIT_STATUS=$?
+  if [[ -n ${ENERGY_POWER_FILE} ]]; then
+    if (( ENERGY_EXIT_STATUS == 0 )); then
+      rm -f "${ENERGY_POWER_FILE}"
+    else
+      print -u2 "Raw sensor output preserved at ${ENERGY_POWER_FILE}."
+    fi
+  fi
+  exit ${ENERGY_EXIT_STATUS}
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+print "Authorizing the macOS energy sensor (Cortex remains non-root)..."
+sudo -v
+ENERGY_POWER_FILE=$(mktemp /private/tmp/cortex-energy.XXXXXX.txt)
+# source: powermetrics(1): 0 samples means continuous capture; buffer-size 1
+# flushes each sample. The EXIT trap stops the sensor after the Python run.
+sudo -n /usr/bin/powermetrics \
+  --samplers cpu_power,gpu_power,ane_power \
+  --sample-rate "${ENERGY_SAMPLE_RATE_MS}" --sample-count 0 --buffer-size 1 \
+  --output-file "${ENERGY_POWER_FILE}" &
+ENERGY_METER_PID=$!
+
+"${BENCH_PY}" "${SCRIPT_DIR}/run_embedding_energy.py" "$@" \
+  --external-power-file "${ENERGY_POWER_FILE}"
+stop_meter
+print "Energy benchmark complete; raw samples are in the result directory."

--- a/benchmarks/energy/run_embedding_energy.py
+++ b/benchmarks/energy/run_embedding_energy.py
@@ -1,0 +1,96 @@
+"""Validate the energy protocol before importing optional model dependencies.
+
+Use run.sh to authorize and manage the sensor, or supply an existing sensor
+stream with --external-power-file. This process never requests privileges.
+The model/workload imports are deliberately deferred until CLI validation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent.parent
+# source: tasks/codex-green-remediation-plan.md W3-2's scalar/batch(32) probe.
+DEFAULT_BATCH_SIZE = 32
+# source: macOS powermetrics(1), --sample-rate default, /usr/share/man/man1/.
+DEFAULT_SAMPLE_RATE_MS = 5000
+# source: sample standard deviation requires two independent observations.
+MIN_REPETITIONS = 2
+
+
+def _nonnegative_float(value: str) -> float:
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        raise argparse.ArgumentTypeError("must be finite and nonnegative")
+    return number
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--duration-seconds", type=_nonnegative_float, required=True)
+    parser.add_argument("--repetitions", type=int, required=True)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--sample-rate-ms", type=int, default=DEFAULT_SAMPLE_RATE_MS)
+    parser.add_argument("--external-power-file", type=Path)
+    parser.add_argument("--validate-only", action="store_true")
+    parser.add_argument(
+        "--carbon-intensity",
+        type=_nonnegative_float,
+        required=True,
+        help="region-specific electricity intensity I, in gCO2eq/kWh; no default",
+    )
+    parser.add_argument(
+        "--embodied",
+        type=_nonnegative_float,
+        required=True,
+        help="allocated embodied emission rate, gCO2eq/s; M = rate * phase seconds",
+    )
+    args = parser.parse_args(argv)
+    if args.duration_seconds <= 0 or args.repetitions < MIN_REPETITIONS:
+        parser.error("duration must be positive and repetitions >= 2")
+    if args.batch_size <= 0 or args.sample_rate_ms <= 0:
+        parser.error("batch-size and sample-rate-ms must be positive")
+    if not args.validate_only and args.external_power_file is None:
+        parser.error(
+            "--external-power-file is required; use run.sh to start the sensor"
+        )
+    return args
+
+
+def _run(args: argparse.Namespace) -> dict[str, object]:
+    # Direct script invocation must resolve the sibling benchmarks package.
+    if str(REPO) not in sys.path:
+        sys.path.insert(0, str(REPO))
+    # Deferred: these modules require NumPy and the optional embedding stack.
+    from benchmarks.energy import measurement, workload  # noqa: PLC0415
+
+    workload.wait_for_stream(args)
+    engine = workload.load_engine()
+    max_abs_delta = workload.verify_equivalence(engine, args.batch_size)
+    phases = workload.run_phases(engine, args)
+    raw_power = args.external_power_file.read_bytes()
+    samples = measurement.parse_power_samples(
+        raw_power.decode("utf-8"), max(phase.wall_end for phase in phases)
+    )
+    rows = measurement.apply_power_samples(phases, samples)
+    summary = {
+        mode: measurement.summarize(rows, mode, args) for mode in ("scalar", "batch")
+    }
+    return measurement.write_report(args, (rows, summary), (raw_power, max_abs_delta))
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    if args.validate_only:
+        print(args.sample_rate_ms)
+        return
+    print(json.dumps(_run(args), indent=2, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/energy/workload.py
+++ b/benchmarks/energy/workload.py
@@ -1,0 +1,172 @@
+"""Neural inference, float32 equivalence, and actual model-token accounting."""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from mcp_server.infrastructure.embedding_engine import EmbeddingEngine
+
+
+class Encoder(Protocol):
+    def encode(self, text: str) -> bytes | None: ...
+
+    def encode_batch(self, texts: list[str]) -> list[bytes | None]: ...
+
+
+class TokenizingModel(Protocol):
+    def tokenize(self, texts: list[str]) -> dict[str, object]: ...
+
+
+class SummableMask(Protocol):
+    def sum(self) -> SummableMask: ...
+
+    def item(self) -> int: ...
+
+
+@dataclass
+class Phase:
+    condition: str
+    repetition: int
+    wall_start: float
+    wall_end: float
+    elapsed_s: float
+    operations: int
+    tokens: int = 0
+
+
+def texts(round_id: int, count: int) -> list[str]:
+    return [
+        f"Cortex energy benchmark unique memory {round_id}:{i}; "
+        "batch-equivalence probe."
+        for i in range(count)
+    ]
+
+
+def _float32_row(blob: bytes | None) -> NDArray[np.float32]:
+    if not blob:
+        raise ValueError("missing or empty embedding output")
+    # source: numpy.frombuffer docs; engine.encode serializes native float32.
+    row = np.frombuffer(blob, dtype=np.float32)
+    if not np.isfinite(row).all():
+        raise ValueError("non-finite embedding output")
+    return row
+
+
+def verify_equivalence(engine: Encoder, batch_size: int) -> float:
+    probes = texts(0, batch_size)
+    scalar = [engine.encode(text) for text in probes]
+    batched = engine.encode_batch(probes)
+    if len(batched) != len(scalar):
+        raise ValueError("scalar/batch output count mismatch")
+    # source: numpy.finfo documents eps as spacing above 1. No model-wide claim:
+    # this strict absolute error budget is checked for this run's probe only.
+    tolerance = float(np.finfo(np.float32).eps)
+    max_delta = 0.0
+    for scalar_blob, batch_blob in zip(scalar, batched, strict=True):
+        left, right = _float32_row(scalar_blob), _float32_row(batch_blob)
+        if left.shape != right.shape:
+            raise ValueError("scalar/batch embedding shape mismatch")
+        delta = float(np.max(np.abs(left.astype(np.float64) - right)))
+        max_delta = max(max_delta, delta)
+        # source: numpy.allclose; explicit atol and zero rtol avoid its defaults.
+        if not np.allclose(left, right, rtol=0, atol=tolerance, equal_nan=False):
+            raise ValueError(
+                f"scalar/batch float32 mismatch: max_abs_delta={delta}, "
+                f"atol={tolerance}"
+            )
+    return max_delta
+
+
+def count_tokens(model: TokenizingModel, values: list[str]) -> int:
+    # source: SentenceTransformer.tokenize returns attention_mask; its sum counts
+    # non-padding tokens after the model's truncation, including special tokens.
+    mask = cast(SummableMask, model.tokenize(values)["attention_mask"])
+    count = int(mask.sum().item())
+    if count <= 0:
+        raise ValueError("tokenizer returned no active tokens")
+    return count
+
+
+def load_engine() -> EmbeddingEngine:
+    # Optional model dependency is loaded only after required CLI arguments pass.
+    from mcp_server.infrastructure.embedding_engine import (  # noqa: PLC0415
+        EmbeddingEngine,
+    )
+
+    engine = EmbeddingEngine()
+    engine.encode("Cortex energy benchmark model warm-up")
+    if engine.mode != "neural":
+        raise RuntimeError(
+            "energy benchmark requires the neural model; fallback refused"
+        )
+    return engine
+
+
+def _timed_workload(engine: Encoder, mode: str, args: argparse.Namespace) -> int:
+    if mode == "idle":
+        time.sleep(args.duration_seconds)
+        return 0
+    deadline = time.perf_counter() + args.duration_seconds
+    round_id = 0
+    while time.perf_counter() < deadline:
+        values = texts(round_id, args.batch_size)
+        if mode == "scalar":
+            for value in values:
+                engine.encode(value)
+        else:
+            engine.encode_batch(values)
+        round_id += 1
+    return round_id * args.batch_size
+
+
+def _measure_phase(
+    engine: EmbeddingEngine, mode: str, args: argparse.Namespace, repetition: int
+) -> Phase:
+    # The probe and earlier phases must not turn scalar inference into LRU hits.
+    engine._cache.clear()
+    wall_start, perf_start = time.time(), time.perf_counter()
+    operations = _timed_workload(engine, mode, args)
+    elapsed = time.perf_counter() - perf_start
+    phase = Phase(mode, repetition, wall_start, time.time(), elapsed, operations)
+    if engine.mode != "neural":
+        raise RuntimeError("neural model unavailable after phase; fallback refused")
+    if mode != "idle" and operations == 0:
+        raise RuntimeError("phase completed no embedding work")
+    return phase
+
+
+def run_phases(engine: EmbeddingEngine, args: argparse.Namespace) -> list[Phase]:
+    phases = []
+    for repetition in range(args.repetitions):
+        # source: original protocol: alternate the two inference conditions.
+        modes = ("scalar", "batch")
+        order = modes if repetition % len(modes) == 0 else tuple(reversed(modes))
+        for condition in ("idle", *order):
+            phases.append(_measure_phase(engine, condition, args, repetition))
+    model = cast(TokenizingModel, engine._model)
+    # Tokenize after ALL timed phases: counting does not inflate measured energy.
+    for phase in phases:
+        phase.tokens = sum(
+            count_tokens(model, texts(round_id, args.batch_size))
+            for round_id in range(phase.operations // args.batch_size)
+        )
+    return phases
+
+
+def wait_for_stream(args: argparse.Namespace) -> None:
+    # One phase duration is the caller's readiness budget; no invented timeout.
+    deadline = time.monotonic() + args.duration_seconds
+    # source: SI milli prefix: 1000 ms/s (NIST SP 811, chapter 4).
+    interval = args.sample_rate_ms / 1000
+    while time.monotonic() < deadline:
+        if "*** Sampled system activity" in args.external_power_file.read_text():
+            return
+        time.sleep(min(interval, max(0.0, deadline - time.monotonic())))
+    raise RuntimeError("external powermetrics stream did not become ready")

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -64,6 +64,7 @@ from mcp_server import (
     tool_registry_wiki,
 )
 from mcp_server.core import telemetry
+from mcp_server.telemetry_middleware import TelemetryMiddleware
 from mcp_server.tool_profile_middleware import ToolProfileMiddleware
 from mcp_server.core.wiki_axis_registry import configure_default_wiki_root
 from mcp_server.core.wiki_classifier import configure_user_rules_provider
@@ -120,7 +121,7 @@ mcp = MCPServer(
     # started in (issue #177 criterion 3). FULL keeps the historical onboarding
     # line ("Call query_methodology…").
     instructions=tool_profiles.instructions(ACTIVE_PROFILE),
-    middleware=[ToolProfileMiddleware(ACTIVE_PROFILE)],
+    middleware=[TelemetryMiddleware(), ToolProfileMiddleware(ACTIVE_PROFILE)],
 )
 
 # ── Tool Registration ──────────────────────────────────────────────────────

--- a/mcp_server/core/pg_recall_stages.py
+++ b/mcp_server/core/pg_recall_stages.py
@@ -15,6 +15,7 @@ one object rather than passed as 8-13 positional parameters
 
 from __future__ import annotations
 
+from mcp_server.shared.telemetry_context import set_retrieval_tier
 from mcp_server.core.pg_recall_context import RecallContext, fetch_and_triage
 from mcp_server.core.pg_recall_signals import (
     _get_active_goal,
@@ -235,6 +236,7 @@ def run_recall_pipeline(ctx: RecallContext) -> list[dict]:
     pg_recall_context.py's ``RecallContext``/``fetch_and_triage`` for the
     per-parameter rationale and citations.
     """
+    set_retrieval_tier("pg")
     top_k = ctx.top_k
     candidates, ctx, early_return = fetch_and_triage(ctx)
     if early_return:

--- a/mcp_server/core/reranker.py
+++ b/mcp_server/core/reranker.py
@@ -43,6 +43,7 @@ from mcp_server.core.reranker_scoring import (
     _compute_retrieval_confidence,
 )
 from mcp_server.observability import silent_failure
+from mcp_server.shared.telemetry_context import count_reranked
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +193,7 @@ def rerank_results(
             for i, (mid, _) in enumerate(candidates)
         ]
         results = ranker.rerank(RerankRequest(query=query, passages=passages))
+        count_reranked(len(passages))
         ce_scores = {r["id"]: r["score"] for r in results}
         return _blend_scores(
             candidates, ce_scores, alpha, adaptive=adaptive, apply_platt=apply_platt

--- a/mcp_server/core/retrieval_dispatch.py
+++ b/mcp_server/core/retrieval_dispatch.py
@@ -17,6 +17,7 @@ from mcp_server.core.query_decomposition import decompose_query
 from mcp_server.core.query_intent import QueryIntent
 from mcp_server.core.reranker import rerank_results
 from mcp_server.observability import silent_failure
+from mcp_server.shared.telemetry_context import set_retrieval_tier
 
 # ── Tier Classification ──────────────────────────────────────────────────
 
@@ -237,6 +238,7 @@ def dispatch_retrieval(
     """Run 3-tier retrieval dispatch. Returns (results, tier_name)."""
     intent = intent_info.get("intent", QueryIntent.GENERAL)
     tier = classify_tier(intent)
+    set_retrieval_tier(tier)
     weights = compute_signal_weights(
         tier,
         intent_info.get("weights", {}),

--- a/mcp_server/core/telemetry.py
+++ b/mcp_server/core/telemetry.py
@@ -39,11 +39,9 @@ Layer:
 Contract (record):
   precondition: ``op`` is a non-empty string; ``latency_ms`` >= 0;
                 byte / count fields are non-negative ints.
-  postcondition: counters[op] is updated atomically; one JSONL line is
-                appended on success or silently dropped on OSError; the
-                registered exporter (if any) is invoked with the same
-                sample and any exception it raises is swallowed; no
-                exception escapes to the handler.
+  postcondition: a sample is published immediately, or captured until the
+                MCP response exists. Publication updates counters atomically
+                and writes JSONL/exporter best-effort, without failing callers.
 """
 
 from __future__ import annotations
@@ -53,8 +51,14 @@ import logging
 import os
 import threading
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, TypedDict, runtime_checkable
+
+from mcp_server.shared.telemetry_context import retrieval_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +70,7 @@ class TelemetryExporter(Protocol):
     Contract:
       - ``export`` receives the same dict shape written to the JSONL log
         (``ts``, ``op``, ``latency_ms``, ``bytes_in``, ``bytes_out``,
-        ``result_count``, ``ok``).
+        ``result_count``, ``ok``, ``tier``, ``reranked_count``).
       - ``export`` MUST NOT raise for control flow that reaches the
         caller -- ``record()`` catches any exception defensively, but a
         well-behaved implementation handles its own I/O errors.
@@ -93,16 +97,60 @@ def set_exporter(exporter: TelemetryExporter | None) -> None:
     _exporter = exporter
 
 
-_LOG_PATH = Path.home() / ".claude" / "methodology" / "telemetry.jsonl"
+# source: infrastructure/config.py — CORTEX_CLAUDE_DIR isolates all local data.
+# Existing filesystem ownership in this module is unchanged; no infrastructure
+# import is introduced into core to resolve the same configuration root.
+_root_override = os.environ.get("CORTEX_CLAUDE_DIR", "").strip()
+_LOG_PATH = (
+    (Path(_root_override).expanduser() if _root_override else Path.home() / ".claude")
+    / "methodology"
+    / "telemetry.jsonl"
+)
 try:
     _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 except OSError:
-    # Directory creation may fail under sandbox; record() is still
-    # safe -- the OSError on open() will be swallowed there too.
-    pass
+    logger.warning("Cannot create telemetry directory: %s", _LOG_PATH.parent)
 
 _lock = threading.Lock()
 _counters: dict[str, dict[str, float | int]] = {}
+
+
+class TelemetrySample(TypedDict):
+    """One operation, finalized with the concrete MCP response when available."""
+
+    ts: float
+    op: str
+    latency_ms: float
+    bytes_in: int
+    bytes_out: int
+    result_count: int
+    ok: bool
+    tier: str | None
+    reranked_count: int
+
+
+@dataclass
+class _Capture:
+    samples: list[TelemetrySample] = field(default_factory=list)
+    closed: bool = False
+
+
+_capture: ContextVar[_Capture | None] = ContextVar("telemetry_capture", default=None)
+
+
+@contextmanager
+def capture_records() -> Iterator[list[TelemetrySample]]:
+    """Defer publication; copied worker contexts publish directly after closure."""
+    captured = _Capture()
+    token = _capture.set(captured)
+    try:
+        yield captured.samples
+    finally:
+        # asyncio.to_thread copies context; a cancelled caller can finish first.
+        # Lock closure against late worker appends so no sample is stranded.
+        with _lock:
+            captured.closed = True
+        _capture.reset(token)
 
 
 def _disabled() -> bool:
@@ -119,18 +167,34 @@ def record(
     result_count: int = 0,
     ok: bool = True,
 ) -> None:
-    """Record one operation.
-
-    ``op`` is the canonical handler name, e.g. ``recall``, ``remember``,
-    ``forget``, ``recall_hierarchical``. Cheap by design: one dict
-    update + one short JSONL line. Target overhead < 1 ms (smoke-tested).
-    """
+    """Capture one operation, or publish immediately outside an MCP request."""
     if _disabled():
         return
-    record_line: dict[str, Any]
+    retrieval = retrieval_metrics()
+    sample: TelemetrySample = {
+        "ts": time.time(),
+        "op": op,
+        "latency_ms": latency_ms,
+        "bytes_in": bytes_in,
+        "bytes_out": bytes_out,
+        "result_count": result_count,
+        "ok": ok,
+        "tier": retrieval.tier,
+        "reranked_count": retrieval.reranked_count,
+    }
+    captured = _capture.get()
+    with _lock:
+        if captured is not None and not captured.closed:
+            captured.samples.append(sample)
+            return
+    publish_record(sample)
+
+
+def _update_counters(sample: TelemetrySample) -> None:
+    """Keep full-precision latency in counters, as before JSONL rounding."""
     with _lock:
         c = _counters.setdefault(
-            op,
+            sample["op"],
             {
                 "count": 0,
                 "ok": 0,
@@ -143,32 +207,26 @@ def record(
             },
         )
         c["count"] += 1
-        c["ok" if ok else "fail"] += 1
-        c["bytes_in"] += bytes_in
-        c["bytes_out"] += bytes_out
-        c["result_count"] += result_count
-        c["latency_ms_sum"] += latency_ms
-        if latency_ms > c["latency_ms_max"]:
-            c["latency_ms_max"] = latency_ms
-        record_line = {
-            "ts": time.time(),
-            "op": op,
-            "latency_ms": round(latency_ms, 3),
-            "bytes_in": bytes_in,
-            "bytes_out": bytes_out,
-            "result_count": result_count,
-            "ok": ok,
-        }
-    # JSONL append is best-effort: a full disk or permission error must
-    # never break the handler. The in-memory counters are already updated.
+        c["ok" if sample["ok"] else "fail"] += 1
+        c["bytes_in"] += sample["bytes_in"]
+        c["bytes_out"] += sample["bytes_out"]
+        c["result_count"] += sample["result_count"]
+        c["latency_ms_sum"] += sample["latency_ms"]
+        c["latency_ms_max"] = max(c["latency_ms_max"], sample["latency_ms"])
+
+
+def publish_record(sample: TelemetrySample) -> None:
+    """Publish one finalized sample to counters, JSONL and the optional exporter."""
+    if _disabled():
+        return
+    _update_counters(sample)
+    # source: existing JSONL contract rounds latency_ms to three decimal places.
+    record_line = {**sample, "latency_ms": round(sample["latency_ms"], 3)}
     try:
-        with _LOG_PATH.open("a") as f:
+        with _LOG_PATH.open("a", encoding="utf-8") as f:
             f.write(json.dumps(record_line) + "\n")
     except OSError:
-        pass
-    # Optional external export (issue #122): best-effort, never breaks the
-    # caller. Reads the module-level reference once so a concurrent
-    # set_exporter(None) mid-call degrades to a no-op rather than racing.
+        logger.warning("Cannot append telemetry sample: %s", _LOG_PATH, exc_info=True)
     exporter = _exporter
     if exporter is not None:
         try:
@@ -189,6 +247,9 @@ _READ_OPS = {
     "navigate_memory",
     "get_causal_chain",
     "drill_down",
+    "query_methodology",
+    "session_start",
+    "auto_recall",
 }
 _WRITE_OPS = {"remember", "forget", "validate_memory", "rate_memory"}
 

--- a/mcp_server/handlers/_telemetry_wrap.py
+++ b/mcp_server/handlers/_telemetry_wrap.py
@@ -1,9 +1,9 @@
 """Telemetry wrapping helper for handler entry points.
 
 Wrap a handler's ``handler(args)`` coroutine with this and the call is
-timed + recorded against the telemetry counters. Negligible overhead
-(<1ms measured): one ``perf_counter`` pair, one JSON-len, one dispatch
-to ``telemetry.record``.
+timed + recorded against the telemetry counters. Response byte volume uses
+the SDK's UTF-8 text-content serialization, after JSON-native normalization;
+it excludes the MCP transport envelope and structured-content duplication.
 
 Usage:
 
@@ -16,20 +16,40 @@ Usage:
 from __future__ import annotations
 
 import json
+import logging
 import time
 from typing import Any, Awaitable, Callable
 
+from pydantic_core import to_json
+
 from mcp_server.core import telemetry
+from mcp_server.shared.json_native import to_json_native
+from mcp_server.shared.telemetry_context import operation_metrics
 
 HandlerFn = Callable[[dict[str, Any] | None], Awaitable[dict[str, Any]]]
+logger = logging.getLogger(__name__)
 
 
 def _safe_json_len(args: dict[str, Any] | None) -> int:
     if not args:
         return 0
     try:
-        return len(json.dumps(args, default=str))
+        return len(json.dumps(args, default=str).encode("utf-8"))
     except (TypeError, ValueError):
+        logger.warning("Cannot serialize telemetry input", exc_info=True)
+        return 0
+
+
+def _response_bytes(result: dict[str, Any] | None) -> int:
+    """UTF-8 bytes of the MCP text response, excluding the transport envelope."""
+    if result is None:
+        return 0
+    try:
+        # source: MCP SDK utilities/func_metadata.py::_convert_to_content;
+        # safe_handler normalizes JSON-native values before SDK serialization.
+        return len(to_json(to_json_native(result), fallback=str, indent=2))
+    except (TypeError, ValueError):
+        logger.warning("Cannot serialize telemetry output", exc_info=True)
         return 0
 
 
@@ -55,32 +75,31 @@ def instrument(
     precondition: ``fn`` is an async callable accepting a single
                   ``args`` dict and returning a dict.
     postcondition: every call to the returned wrapper records exactly
-                   one telemetry sample (op, latency_ms, bytes_in,
-                   result_count, ok) and re-raises any exception
+                   one telemetry sample (op, latency_ms, bytes_in/out,
+                   result_count, retrieval work, ok) and re-raises any exception
                    unchanged after marking ok=False.
     """
 
     async def wrapped(args: dict[str, Any] | None = None) -> dict[str, Any]:
         t0 = time.perf_counter()
         ok = True
-        result: dict[str, Any] = {}
-        try:
-            result = await fn(args)
-            # The assignment above is not redundant: `result` also feeds
-            # `finally`'s `_result_count(result, ...)` telemetry sample.
-            # Inlining this into `return await fn(args)` would leave
-            # `result` at its pre-declared `{}` for that read.
-            return result  # noqa: RET504 — read by finally's telemetry sample
-        except Exception:
-            ok = False
-            raise
-        finally:
-            telemetry.record(
-                op,
-                latency_ms=(time.perf_counter() - t0) * 1000.0,
-                bytes_in=_safe_json_len(args),
-                result_count=_result_count(result, result_count_key),
-                ok=ok,
-            )
+        result: dict[str, Any] | None = None
+        with operation_metrics():
+            try:
+                result = await fn(args)
+                return result  # noqa: RET504 — read by finally's telemetry sample
+            except BaseException:
+                ok = False
+                raise
+            finally:
+                telemetry.record(
+                    op,
+                    # source: SI prefix milli; perf_counter returns seconds.
+                    latency_ms=(time.perf_counter() - t0) * 1000.0,
+                    bytes_in=_safe_json_len(args),
+                    bytes_out=_response_bytes(result),
+                    result_count=_result_count(result, result_count_key),
+                    ok=ok,
+                )
 
     return wrapped

--- a/mcp_server/handlers/query_methodology.py
+++ b/mcp_server/handlers/query_methodology.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+from functools import partial
 from typing import Any
 
 from mcp_server.core.context_generator import generate_context
@@ -17,6 +18,7 @@ from mcp_server.core.prospective import check_trigger
 from mcp_server.core.response_budget import ListTarget, TextTarget, bound_payload
 from mcp_server.infrastructure.profile_store import load_profiles
 from mcp_server.handlers._tool_meta import READ_ONLY
+from mcp_server.handlers._telemetry_wrap import instrument
 from mcp_server.infrastructure.memory_config import get_memory_settings
 from mcp_server.infrastructure.memory_store import get_shared_store
 
@@ -292,6 +294,7 @@ def _bounded(resp: dict) -> dict:
     )
 
 
+@partial(instrument, "query_methodology", result_count_key="hotMemories")
 async def handler(args: dict | None = None) -> dict:
     args = args or {}
     cwd = args.get("cwd", "")

--- a/mcp_server/hooks/_telemetry.py
+++ b/mcp_server/hooks/_telemetry.py
@@ -1,0 +1,140 @@
+"""Observe a hook's emitted UTF-8 text and process-level completion.
+
+The stream forwards writes immediately: injection text, receipt markers and
+print's trailing newlines stay unchanged. ``ok`` describes normal completion
+or exit code zero, including the hooks' intentionally tolerated degradations.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import logging
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, redirect_stdout
+from functools import wraps
+from typing import TYPE_CHECKING, BinaryIO, Protocol, TextIO, runtime_checkable
+
+from mcp_server.core import telemetry
+from mcp_server.shared.telemetry_context import operation_metrics
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from _typeshed import ReadableBuffer
+
+
+class _CountingOutput:
+    """Count unencoded test/custom text streams that have no binary buffer."""
+
+    def __init__(self, stream: TextIO) -> None:
+        self._stream = stream
+        self.bytes_out = 0
+
+    def write(self, text: str) -> int:
+        written = self._stream.write(text)
+        # source: UTF-8 encoding of the text accepted by TextIO.write.
+        self.bytes_out += len(text[:written].encode("utf-8"))
+        return written
+
+    def flush(self) -> None:
+        self._stream.flush()
+
+
+@runtime_checkable
+class _BufferedOutput(Protocol):
+    """Text streams exposing the binary destination after newline/encoding."""
+
+    @property
+    def buffer(self) -> BinaryIO: ...
+
+    def flush(self) -> None: ...
+
+
+class _CountingBuffer:
+    """Count bytes accepted after TextIOWrapper encoding and newline conversion."""
+
+    def __init__(self, buffer: BinaryIO) -> None:
+        self.write_original = buffer.write
+        self.bytes_out = 0
+
+    def write(self, data: ReadableBuffer) -> int:
+        written = self.write_original(data)
+        self.bytes_out += written
+        return written
+
+
+@contextmanager
+def _observe_output() -> Iterator[_CountingOutput | _CountingBuffer]:
+    """Observe the existing encoder; do not reconstruct its newline policy."""
+    stream = sys.stdout
+    if not isinstance(stream, _BufferedOutput):
+        output = _CountingOutput(stream)
+        with redirect_stdout(output):
+            yield output
+        return
+    # Flush pre-existing text before attaching the counter to this operation.
+    stream.flush()
+    counter = _CountingBuffer(stream.buffer)
+    stream.buffer.write = counter.write
+    failed = False
+    try:
+        yield counter
+    except BaseException:
+        failed = True
+        raise
+    finally:
+        try:
+            # TextIOWrapper may defer encoding until flush; count that output
+            # before restoring the original binary write method.
+            _flush_output(stream, failed)
+        finally:
+            stream.buffer.write = counter.write_original
+
+
+def _flush_output(stream: _BufferedOutput, failed: bool) -> None:
+    """A broken output stream must not replace an already-raised hook error."""
+    try:
+        stream.flush()
+    except (OSError, ValueError):
+        if not failed:
+            raise
+        logger.warning("Cannot flush failed hook output", exc_info=True)
+
+
+def _run_observed(op: str, hook: Callable[[], None]) -> None:
+    """Record once, preserving stdout, exceptions and the hook's exit code."""
+    started = time.perf_counter()
+    ok = False
+    output: _CountingOutput | _CountingBuffer = _CountingOutput(sys.stdout)
+    with operation_metrics():
+        try:
+            with _observe_output() as observed:
+                output = observed
+                hook()
+            ok = True
+        except SystemExit as exc:
+            # source: Python sys.exit: None and zero signal successful exit.
+            ok = exc.code is None or exc.code == 0
+            raise
+        finally:
+            telemetry.record(
+                op,
+                # source: SI conversion, one second equals 1000 milliseconds.
+                latency_ms=(time.perf_counter() - started) * 1000,
+                bytes_out=output.bytes_out,
+                ok=ok,
+            )
+
+
+def observe_hook(op: str) -> Callable[[Callable[[], None]], Callable[[], None]]:
+    """Decorate a CLI main, giving each hook invocation its own metrics."""
+
+    def decorate(hook: Callable[[], None]) -> Callable[[], None]:
+        @wraps(hook)
+        def observed() -> None:
+            _run_observed(op, hook)
+
+        return observed
+
+    return decorate

--- a/mcp_server/hooks/auto_recall.py
+++ b/mcp_server/hooks/auto_recall.py
@@ -77,6 +77,7 @@ from mcp_server.handlers.injection_receipts import (
     receipt_marker,
     session_id_from_transcript,
 )
+from mcp_server.hooks._telemetry import observe_hook
 from mcp_server.shared.freshness import provenance_suffix
 
 _LOG_PREFIX = "[cortex-auto-recall]"
@@ -453,6 +454,7 @@ def process_event(event: dict[str, Any]) -> None:
     sys.exit(0)
 
 
+@observe_hook("auto_recall")
 def main() -> None:
     """Entry point — read JSON event from stdin."""
     if sys.stdin.isatty():

--- a/mcp_server/hooks/session_start.py
+++ b/mcp_server/hooks/session_start.py
@@ -30,6 +30,7 @@ from mcp_server.handlers.injection_receipts import (
     receipt_marker,
     session_id_from_transcript,
 )
+from mcp_server.hooks._telemetry import observe_hook
 from mcp_server.shared.freshness import provenance_suffix
 from mcp_server.shared.platform import python_executable
 import sqlite3
@@ -1188,6 +1189,7 @@ def _sqlite_context(event: dict) -> None:
     _print_external_sources()
 
 
+@observe_hook("session_start")
 def main() -> None:
     """Entry point — print context block to stdout."""
 

--- a/mcp_server/shared/telemetry_context.py
+++ b/mcp_server/shared/telemetry_context.py
@@ -1,0 +1,57 @@
+"""Request-local retrieval measurements; no changes to ranking or responses.
+
+ContextVar scopes measurements to the current async task/thread. Reset tokens
+also preserve the outer operation when an instrumented handler calls another.
+Source: Python contextvars documentation, ContextVar.set/reset and asyncio support.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+
+@dataclass
+class RetrievalMetrics:
+    """Actual dispatch route and passages successfully scored by the model."""
+
+    tier: str | None = None
+    reranked_count: int = 0
+
+
+_metrics: ContextVar[RetrievalMetrics | None] = ContextVar(
+    "cortex_retrieval_metrics", default=None
+)
+
+
+@contextmanager
+def operation_metrics() -> Iterator[RetrievalMetrics]:
+    """Start an independent operation and restore its caller on every exit."""
+    current = RetrievalMetrics()
+    token = _metrics.set(current)
+    try:
+        yield current
+    finally:
+        _metrics.reset(token)
+
+
+def retrieval_metrics() -> RetrievalMetrics:
+    """Return recorded work, or an empty measurement outside an operation."""
+    current = _metrics.get()
+    return current if current is not None else RetrievalMetrics()
+
+
+def set_retrieval_tier(tier: str) -> None:
+    """Record the route actually executed, rather than inferring from intent."""
+    current = _metrics.get()
+    if current is not None:
+        current.tier = tier
+
+
+def count_reranked(count: int) -> None:
+    """Count successful model work; skipped/failed inference contributes zero."""
+    current = _metrics.get()
+    if current is not None:
+        current.reranked_count += count

--- a/mcp_server/telemetry_middleware.py
+++ b/mcp_server/telemetry_middleware.py
@@ -1,0 +1,83 @@
+"""Finalize existing operation samples from the MCP SDK's actual text response.
+
+The SDK converts handler exceptions to TextContent inside call_next. Measuring
+here includes those errors without reconstructing SDK messages or changing tool
+results. Source: mcp 2.0.0 MCPServer._handle_call_tool and ServerMiddleware.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict, cast
+
+from mcp.types import CallToolResult, TextContent
+from typing_extensions import NotRequired
+
+from mcp_server.core import telemetry
+
+if TYPE_CHECKING:
+    from mcp.server.context import CallNext, HandlerResult, ServerRequestContext
+
+
+class _ContentBlock(TypedDict):
+    type: str
+    text: NotRequired[str]
+
+
+class _ToolResponse(TypedDict):
+    content: list[_ContentBlock]
+    isError: NotRequired[bool]
+
+
+def _response_measurement(result: HandlerResult) -> tuple[int, bool] | None:
+    """Support both SDK result shapes without serializing the transport envelope."""
+    if isinstance(result, CallToolResult):
+        text = (
+            block.text for block in result.content if isinstance(block, TextContent)
+        )
+        return sum(len(value.encode("utf-8")) for value in text), not result.is_error
+    if isinstance(result, dict) and "content" in result:
+        response = cast("_ToolResponse", result)
+        text = (
+            block.get("text", "")
+            for block in response["content"]
+            if block["type"] == "text"
+        )
+        return sum(len(value.encode("utf-8")) for value in text), not response.get(
+            "isError", False
+        )
+    return None
+
+
+def _finalize_response(
+    samples: list[telemetry.TelemetrySample], name: str, result: HandlerResult
+) -> None:
+    """Update the outer operation only; nested handler samples retain their scope."""
+    measurement = _response_measurement(result)
+    if measurement is None:
+        return
+    for sample in reversed(samples):
+        if sample["op"] == name:
+            sample["bytes_out"], sample["ok"] = measurement
+            return
+
+
+class TelemetryMiddleware:
+    """Publish existing handler samples exactly once, after SDK conversion."""
+
+    async def __call__(
+        self, ctx: ServerRequestContext[object, object], call_next: CallNext
+    ) -> HandlerResult:
+        if ctx.method != "tools/call":
+            return await call_next(ctx)
+        name = (ctx.params or {}).get("name")
+        result = None
+        samples: list[telemetry.TelemetrySample] = []
+        try:
+            with telemetry.capture_records() as samples:
+                result = await call_next(ctx)
+        finally:
+            if isinstance(name, str):
+                _finalize_response(samples, name, result)
+            for sample in samples:
+                telemetry.publish_record(sample)
+        return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,19 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["mcp_server"]
 
+# W1-6: benchmark output, media and paper bundles dominate the source archive;
+# retain application source, tests, fixtures and packaging inputs.
+# source: https://hatch.pypa.io/latest/config/build/#patterns
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/benchmarks/beam/variance/*.txt",
+    "/video/captures",
+    "/video/output",
+    "/docs/**/*.png",
+    "/docs/arxiv-*/**",
+    "/docs/campaigns/*.json",
+]
+
 # ── Resolver constraints ─────────────────────────────────────────────────
 #
 # This table is declared before the `[[tool.uv.index]]` / `[tool.uv.sources]`

--- a/scripts/check_ci_file_count.py
+++ b/scripts/check_ci_file_count.py
@@ -1,0 +1,40 @@
+"""Refuse PR path classification when GitHub's file list may be incomplete."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+
+
+# source: https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
+# The REST endpoint used by dorny/paths-filter returns at most 3000 files.
+API_FILE_LIMIT = 3000
+
+
+def check(count: object) -> str | None:
+    if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+        return "pull_request.changed_files must be a nonnegative integer"
+    if count > API_FILE_LIMIT:
+        return (
+            f"PR changes {count} files, exceeding GitHub's {API_FILE_LIMIT}-file "
+            "API limit; refusing incomplete classification. Split the PR."
+        )
+    return None
+
+
+def main() -> int:
+    try:
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        failure = check(event["pull_request"].get("changed_files"))
+    except (KeyError, OSError, ValueError, TypeError, AttributeError) as error:
+        failure = f"cannot validate pull request file count: {error}"
+    if failure:
+        print(f"::error::{failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_ci_gate_complete.py
+++ b/scripts/check_ci_gate_complete.py
@@ -1,54 +1,12 @@
-"""CI-gate completeness: every ci.yml job must be behind the aggregate gate.
+"""Static CI-gate coverage and prerequisite checks without YAML dependencies.
 
-Branch protection on ``main`` names required status checks as strings, in
-GitHub settings — outside git, invisible in review, and unversioned. Naming
-individual jobs there makes the contract break on every rename: extracting
-the test steps into a reusable workflow (issue #336) renamed the four matrix
-legs to ``Test (Python X.Y) / Test (Python X.Y)``, so the four bare contexts
-``main`` required were never reported again and a fully green PR sat BLOCKED
-(PR #387, run 31250898534). Renaming the contexts fixes that one PR and
-leaves the next rename to rediscover it.
+Every job must be a direct CI Green dependency or declare a conditional
+post-merge exemption. Every conditional gated job belongs to ALLOWED_SKIPS;
+the runtime checker independently verifies the reason for each actual skip.
+CI Green must always run to report failures and rejected skips.
 
-So protection names ONE ci.yml context — ``CI Green`` — and the real list
-lives here, in git, where a diff shows it. That moves the failure mode: the
-gate is only as good as its ``needs:`` list, and a job added later that
-nobody adds to it is silently ungated. That is what this script refuses.
-
-It also refuses the second escape hatch. The gate treats any result other
-than ``success`` as failure, EXCEPT for jobs named in its ``ALLOWED_SKIPS``
-env — because a job carrying a job-level ``if:`` legitimately reports
-``skipped``. An unlisted conditional would therefore let a job skip its way
-past the gate, so every job with an ``if:`` must be declared, and every
-declared exemption must correspond to a job that actually has one (a stale
-exemption is a hole nobody is watching).
-
-A third case exists that ``needs:``/``ALLOWED_SKIPS`` cannot express:
-``release-gate`` (issue #392) runs ONLY on a push to ``main`` — after the PR
-it belongs to has already merged. There is nothing for it to gate: it cannot
-block a PR that is already closed, and putting it in ``ci-green.needs`` would
-make the branch-protection context depend on a job that never runs on a PR
-in the first place, permanently blocking every PR. Such a job declares itself
-with a ``# ci-gate-exempt: <reason>`` marker line in its body instead of
-appearing in ``needs:``. The marker is not a blank check: it is refused
-unless the job ALSO carries a job-level ``if:`` — an exempt job with no
-condition would run ungated on every push and PR, which is exactly the hole
-this script exists to close.
-
-Checks, all of them fatal:
-
-1. the gate job exists;
-2. every other ci.yml job appears in the gate's ``needs:`` OR carries a
-   ``# ci-gate-exempt:`` marker;
-3. every name in ``needs:`` is a real job;
-4. every job carrying a job-level ``if:`` and not exempt is listed in
-   ``ALLOWED_SKIPS``;
-5. every name in ``ALLOWED_SKIPS`` is a job that carries an ``if:``;
-6. every ``# ci-gate-exempt:`` job carries a job-level ``if:`` — an exemption
-   with no condition is not a narrower gate, it is no gate.
-
-Static only — regex over the workflow text, no PyYAML. The Lint job installs
-ruff and nothing else, and this script runs there alongside
-``check_doc_claims.py``, which is static for the same reason.
+Source: tasks/codex-green-remediation-plan.md W1-2 and GitHub workflow syntax:
+https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds
 """
 
 from __future__ import annotations
@@ -60,12 +18,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
-# The single job branch protection points at. Renaming it is a protection
-# change, not a refactor — hence a named constant rather than a literal.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+from check_ci_gate_results import check_policy  # noqa: E402
+
+# The aggregate context for this workflow. Renaming it requires updating
+# branch protection, hence a named constant rather than a literal.
 GATE_JOB = "ci-green"
 
 _JOB_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
 _JOB_IF_RE = re.compile(r"^    if:\s*(\S.*)$")
+_NEEDS_INLINE_RE = re.compile(r"^    needs:\s*\[([^]]*)\]\s*$")
 _NEEDS_BLOCK_RE = re.compile(r"^    needs:\s*$")
 _NEEDS_ITEM_RE = re.compile(r"^      - ([A-Za-z0-9_-]+)\s*$")
 _ALLOWED_SKIPS_RE = re.compile(r"^\s*ALLOWED_SKIPS:\s*(\S.*?)\s*$")
@@ -114,6 +78,10 @@ def _parse_needs(body: list[str]) -> list[str]:
     collecting = False
 
     for line in body:
+        inline = _NEEDS_INLINE_RE.match(line)
+        if inline:
+            needs.extend(name.strip() for name in inline.group(1).split(","))
+            continue
         if _NEEDS_BLOCK_RE.match(line):
             collecting = True
             continue
@@ -205,7 +173,7 @@ def _check_allowed_skips(
 ) -> list[str]:
     """Checks 4 and 5: ALLOWED_SKIPS and the set of conditional jobs agree.
 
-    Exempt jobs never appear in ``needs:``, so ci-green's jq never evaluates
+    Exempt jobs never appear in ``needs:``, so CI Green never evaluates
     their result — ALLOWED_SKIPS governs skip results INSIDE the gate only,
     and does not apply to a job structurally outside it.
     """
@@ -242,6 +210,32 @@ def _check_exempt_jobs_are_conditional(
     ]
 
 
+def _check_gate_execution(bodies: dict[str, list[str]], needs: list[str]) -> list[str]:
+    conditions = [
+        match.group(1) for line in bodies[GATE_JOB] if (match := _JOB_IF_RE.match(line))
+    ]
+    if conditions != ["always()"]:
+        return [f"{GATE_JOB} must have exactly 'if: always()'"]
+    if len(needs) != len(set(needs)) or GATE_JOB in needs:
+        return [f"{GATE_JOB}.needs has a duplicate or self dependency"]
+    return []
+
+
+def check_runtime_contract(text: str) -> list[str]:
+    """Check production workflow policy and lint-before-matrix dependencies."""
+    _, needs, allowed, _ = parse_workflow(text)
+    failures = check_policy(needs, allowed)
+    bodies = _job_bodies(text)
+    for job in allowed:
+        if set(_parse_needs(bodies.get(job, []))) != {"changes", "lint"}:
+            failures.append(f"{job} must depend on exactly changes and lint")
+    for job in ("changes", "lint"):
+        body = bodies.get(job, [])
+        if _parse_needs(body) or any(_JOB_IF_RE.match(line) for line in body):
+            failures.append(f"{job} must always run without prerequisites")
+    return failures
+
+
 def check(text: str) -> list[str]:
     """Return the list of failures; empty means the gate is complete."""
     jobs, needs, allowed_skips, exempt = parse_workflow(text)
@@ -257,7 +251,8 @@ def check(text: str) -> list[str]:
         ]
 
     return (
-        _check_every_job_is_gated(jobs, set(needs) | exempt)
+        _check_gate_execution(_job_bodies(text), needs)
+        + _check_every_job_is_gated(jobs, set(needs) | exempt)
         + _check_needs_are_real_jobs(jobs, needs)
         + _check_allowed_skips(jobs, allowed_skips, exempt)
         + _check_exempt_jobs_are_conditional(jobs, exempt)
@@ -269,7 +264,8 @@ def main() -> int:
         print(f"FAIL: {CI_WORKFLOW} not found", file=sys.stderr)
         return 1
 
-    failures = check(CI_WORKFLOW.read_text(encoding="utf-8"))
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+    failures = check(text) + check_runtime_contract(text)
     if failures:
         print("CI gate completeness: FAIL", file=sys.stderr)
         for failure in failures:

--- a/scripts/check_ci_gate_results.py
+++ b/scripts/check_ci_gate_results.py
@@ -1,11 +1,12 @@
 """Fail CI Green unless every job succeeded or has a verified skip reason.
 
-The policy mirrors ci.yml: non-PR runs execute the full matrix; code,
-dependency or workflow changes do so on PRs. Docker changes also run Docker
-jobs. The vendor CLI job skips fork PRs because it executes npm postinstall.
-Missing classifications and unknown jobs fail closed.
+The policy mirrors ci.yml: code, dependency or workflow PR changes run code
+jobs and Docker smoke. Pushes and dispatches also run those jobs; schedules
+run smoke but skip code jobs. Runtime/devcontainer builds require Docker
+changes, a schedule or a dispatch. The vendor CLI job skips fork PRs because
+it executes npm postinstall. Missing classifications and unknown jobs fail closed.
 
-Source: tasks/codex-green-remediation-plan.md W1-2 and ci.yml job predicates.
+Source: tasks/codex-green-remediation-plan.md W1-2/W1-4 and ci.yml predicates.
 GitHub's needs context exposes result and outputs for direct dependencies:
 https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context
 """
@@ -30,13 +31,13 @@ CODE_JOBS = frozenset(
         "build",
     }
 )
-DOCKER_JOBS = frozenset({"docker-runtime-build", "devcontainer-build", "docker-smoke"})
+DOCKER_BUILD_JOBS = frozenset({"docker-runtime-build", "devcontainer-build"})
 ALWAYS_JOBS = frozenset({"changes", "lint"})
-CONDITIONAL_JOBS = CODE_JOBS | DOCKER_JOBS
+CONDITIONAL_JOBS = CODE_JOBS | DOCKER_BUILD_JOBS | {"docker-smoke"}
 EXPECTED_JOBS = ALWAYS_JOBS | CONDITIONAL_JOBS
 # source: .github/workflows/ci.yml changes.outputs and on triggers.
 FILTERS = frozenset({"code", "docs", "docker", "workflows", "deps"})
-EVENTS = frozenset({"pull_request", "push", "workflow_dispatch"})
+EVENTS = frozenset({"pull_request", "push", "workflow_dispatch", "schedule"})
 
 
 def check_policy(needs: list[str], allowed: list[str]) -> list[str]:
@@ -75,10 +76,12 @@ def _required_jobs(flags: dict[str, bool], event_name: str, fork: bool) -> set[s
         flags[name] for name in ("code", "deps", "workflows")
     )
     required = set(ALWAYS_JOBS)
-    if full:
+    if full and event_name != "schedule":
         required.update(CODE_JOBS)
     if full or flags["docker"]:
-        required.update(DOCKER_JOBS)
+        required.add("docker-smoke")
+    if flags["docker"] or event_name in ("schedule", "workflow_dispatch"):
+        required.update(DOCKER_BUILD_JOBS)
     if fork:
         required.discard("mcp-host-config")
     return required

--- a/scripts/check_ci_gate_results.py
+++ b/scripts/check_ci_gate_results.py
@@ -1,0 +1,130 @@
+"""Fail CI Green unless every job succeeded or has a verified skip reason.
+
+The policy mirrors ci.yml: non-PR runs execute the full matrix; code,
+dependency or workflow changes do so on PRs. Docker changes also run Docker
+jobs. The vendor CLI job skips fork PRs because it executes npm postinstall.
+Missing classifications and unknown jobs fail closed.
+
+Source: tasks/codex-green-remediation-plan.md W1-2 and ci.yml job predicates.
+GitHub's needs context exposes result and outputs for direct dependencies:
+https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# source: .github/workflows/ci.yml, jobs gated by changes and lint.
+CODE_JOBS = frozenset(
+    {
+        "test",
+        "test-sqlite",
+        "mcp-host-config",
+        "test-windows",
+        "release-deps",
+        "craftsmanship",
+        "typecheck",
+        "build",
+    }
+)
+DOCKER_JOBS = frozenset({"docker-runtime-build", "devcontainer-build", "docker-smoke"})
+ALWAYS_JOBS = frozenset({"changes", "lint"})
+CONDITIONAL_JOBS = CODE_JOBS | DOCKER_JOBS
+EXPECTED_JOBS = ALWAYS_JOBS | CONDITIONAL_JOBS
+# source: .github/workflows/ci.yml changes.outputs and on triggers.
+FILTERS = frozenset({"code", "docs", "docker", "workflows", "deps"})
+EVENTS = frozenset({"pull_request", "push", "workflow_dispatch"})
+
+
+def check_policy(needs: list[str], allowed: list[str]) -> list[str]:
+    """Keep the workflow and the executable skip policy in exact agreement."""
+    failures = []
+    if set(needs) != EXPECTED_JOBS:
+        failures.append("CI Green needs do not match the runtime job policy")
+    if set(allowed) != CONDITIONAL_JOBS:
+        failures.append("ALLOWED_SKIPS does not match the runtime skip policy")
+    return failures
+
+
+def _classifications(needs: dict) -> dict[str, bool]:
+    outputs = needs["changes"].get("outputs")
+    if not isinstance(outputs, dict) or set(outputs) != FILTERS:
+        raise ValueError("changes must provide exactly the five path outputs")
+    if any(value not in ("true", "false") for value in outputs.values()):
+        raise ValueError("changes outputs must be the strings 'true' or 'false'")
+    return {name: value == "true" for name, value in outputs.items()}
+
+
+def _is_fork(event_name: str, event: dict) -> bool:
+    if event_name != "pull_request":
+        return False
+    try:
+        fork = event["pull_request"]["head"]["repo"]["fork"]
+    except (KeyError, TypeError) as error:
+        raise ValueError("pull_request event is missing head.repo.fork") from error
+    if not isinstance(fork, bool):
+        raise ValueError("pull_request head.repo.fork must be a boolean")
+    return fork
+
+
+def _required_jobs(flags: dict[str, bool], event_name: str, fork: bool) -> set[str]:
+    full = event_name != "pull_request" or any(
+        flags[name] for name in ("code", "deps", "workflows")
+    )
+    required = set(ALWAYS_JOBS)
+    if full:
+        required.update(CODE_JOBS)
+    if full or flags["docker"]:
+        required.update(DOCKER_JOBS)
+    if fork:
+        required.discard("mcp-host-config")
+    return required
+
+
+def check(needs: dict, event_name: str, event: dict) -> list[str]:
+    """Evaluate actual results, never treating an allowlist as a skip reason."""
+    if not isinstance(needs, dict) or set(needs) != EXPECTED_JOBS:
+        return ["needs must contain exactly the expected CI jobs"]
+    if event_name not in EVENTS or not isinstance(event, dict):
+        return ["missing or unsupported GitHub event context"]
+    if any(not isinstance(value, dict) for value in needs.values()):
+        return ["every needs entry must be a job result object"]
+    try:
+        flags = _classifications(needs)
+        required = _required_jobs(flags, event_name, _is_fork(event_name, event))
+    except ValueError as error:
+        return [str(error)]
+    failures = []
+    for job, value in sorted(needs.items()):
+        result = value.get("result")
+        if result == "success":
+            continue
+        if result == "skipped" and job not in required:
+            continue
+        failures.append(f"{job}={result!r} (success required or invalid result)")
+    return failures
+
+
+def main() -> int:
+    try:
+        allowed = os.environ["ALLOWED_SKIPS"].split(",")
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        needs = json.loads(os.environ["NEEDS"])
+        failures = check(needs, os.environ["GITHUB_EVENT_NAME"], event)
+        if set(allowed) != CONDITIONAL_JOBS:
+            failures.append("ALLOWED_SKIPS does not match the runtime skip policy")
+    except (KeyError, OSError, ValueError) as error:
+        failures = [f"cannot read CI gate inputs: {error}"]
+    if failures:
+        for failure in failures:
+            print(f"::error::CI Green: {failure}", file=sys.stderr)
+        return 1
+    print("CI Green: all required jobs succeeded; every skip is justified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_py/benchmarks/test_energy_cli.py
+++ b/tests_py/benchmarks/test_energy_cli.py
@@ -1,0 +1,113 @@
+"""CLI validation must precede optional imports, stream access and sudo."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from benchmarks.energy import run_embedding_energy as cli
+
+
+SCRIPT = Path(cli.__file__)
+PROTOCOL = ["--duration-seconds", "1", "--repetitions", "2"]
+# Synthetic CLI inputs only, not measured or recommended carbon factors.
+CARBON = ["--carbon-intensity", "1", "--embodied", "1"]
+
+
+@pytest.mark.parametrize(
+    ("provided", "missing"),
+    [
+        ([], ["--carbon-intensity", "--embodied"]),
+        (["--carbon-intensity", "1"], ["--embodied"]),
+        (["--embodied", "1"], ["--carbon-intensity"]),
+    ],
+)
+def test_missing_carbon_fails_before_optional_imports(provided, missing):
+    # -S excludes site-packages: even NumPy import would fail before argparse.
+    result = subprocess.run(
+        [sys.executable, "-S", str(SCRIPT), *PROTOCOL, *provided],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert all(option in result.stderr for option in missing)
+    assert "ModuleNotFoundError" not in result.stderr
+    assert "--external-power-file is required" not in result.stderr
+
+
+@pytest.mark.parametrize("flag", ["--carbon-intensity", "--embodied"])
+@pytest.mark.parametrize("value", ["nan", "inf", "-1"])
+def test_invalid_carbon_refused_before_run(flag, value, monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_run", lambda args: pytest.fail("ran workload"))
+    with pytest.raises(SystemExit) as error:
+        cli.main([*PROTOCOL, *CARBON, flag, value])
+    assert error.value.code != 0
+    assert flag in capsys.readouterr().err
+
+
+def test_validate_only_needs_no_stream_or_model(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_run", lambda args: pytest.fail("ran workload"))
+    cli.main([*PROTOCOL, *CARBON, "--validate-only"])
+    assert capsys.readouterr().out.strip() == str(cli.DEFAULT_SAMPLE_RATE_MS)
+
+
+def test_valid_carbon_without_stream_points_to_runner(capsys):
+    with pytest.raises(SystemExit) as error:
+        cli.main([*PROTOCOL, *CARBON])
+    assert error.value.code != 0
+    assert "--external-power-file is required; use run.sh" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("flag", "value"),
+    [
+        ("--duration-seconds", "0"),
+        ("--repetitions", "1"),
+        ("--batch-size", "0"),
+        ("--sample-rate-ms", "0"),
+    ],
+)
+def test_invalid_protocol_refused(flag, value):
+    with pytest.raises(SystemExit) as error:
+        cli.main([*PROTOCOL, *CARBON, flag, value, "--validate-only"])
+    assert error.value.code != 0
+
+
+@pytest.mark.skipif(shutil.which("zsh") is None, reason="runner requires macOS/zsh")
+@pytest.mark.parametrize(
+    ("provided", "expected"),
+    [
+        ([], "--carbon-intensity"),
+        (["--carbon-intensity", "1"], "--embodied"),
+        (["--embodied", "1"], "--carbon-intensity"),
+        ([*CARBON, "--validate-only"], None),
+    ],
+)
+def test_shell_validates_before_sudo(provided, expected, tmp_path):
+    marker = tmp_path / "sudo-called"
+    fake_sudo = tmp_path / "sudo"
+    fake_sudo.write_text('#!/bin/sh\ntouch "$ENERGY_SUDO_MARKER"\nexit 99\n')
+    fake_sudo.chmod(0o755)
+    env = {
+        **os.environ,
+        "ENERGY_PYTHON": sys.executable,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "ENERGY_SUDO_MARKER": str(marker),
+    }
+    result = subprocess.run(
+        [shutil.which("zsh"), str(SCRIPT.with_name("run.sh")), *PROTOCOL, *provided],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert not marker.exists()
+    if expected is None:
+        assert result.returncode == 0, result.stderr
+    else:
+        assert result.returncode != 0
+        assert expected in result.stderr

--- a/tests_py/benchmarks/test_energy_measurement.py
+++ b/tests_py/benchmarks/test_energy_measurement.py
@@ -1,0 +1,115 @@
+"""Algebraic fixtures for energy/carbon units; no physical measurement occurs."""
+
+from argparse import Namespace
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks.energy import measurement
+from benchmarks.energy.workload import Phase
+
+
+def test_carbon_formula_per_thousand_tokens():
+    # Synthetic unit check: 1 kWh, I=2 g/kWh, M=3 g, 2000 tokens -> 2.5 g/1k.
+    assert measurement.carbon_per_1k_tokens(3_600_000, 2000, 2, 3) == 2.5
+    assert measurement.carbon_per_1k_tokens(3_600_000, 1000, 2, 3) == 5
+
+
+@pytest.mark.parametrize("tokens", [0, -1])
+def test_carbon_formula_refuses_invalid_denominator(tokens):
+    with pytest.raises(ValueError, match="token count"):
+        measurement.carbon_per_1k_tokens(1, tokens, 1, 1)
+
+
+@pytest.mark.parametrize("value", [-1, float("inf"), float("nan")])
+@pytest.mark.parametrize("position", [0, 2, 3])
+def test_carbon_formula_refuses_invalid_inputs(value, position):
+    args = [1, 1, 1, 1]
+    args[position] = value
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        measurement.carbon_per_1k_tokens(*args)
+
+
+def test_summary_uses_actual_token_counts_and_embodied_phase_duration():
+    args = Namespace(carbon_intensity=2, embodied=3)
+    phase = Phase("scalar", 0, 0, 2, 2, 4, tokens=2000)
+    row = measurement.MeasuredPhase(phase, 1, 1_800_000, 0)
+    summary = measurement.summarize([row, row], "scalar", args)
+    assert summary["tokens_total"] == 4000
+    assert summary["energy_j_per_1k_tokens_mean"] == 1_800_000
+    # One kWh * 2 g/kWh + (3 g/s * 2 s) = 8 g for 2000 tokens.
+    assert summary["carbon_gco2eq_per_1k_tokens_mean"] == 4
+
+
+def test_power_parser_requires_combined_boundary():
+    text = (
+        "*** Sampled system activity (Sun, 06 Sep 2026 12:00:00 +0000) ***\n"
+        "Combined Power (CPU + GPU + ANE): 2000 mW\n"
+    )
+    samples = measurement.parse_power_samples(text)
+    assert len(samples) == 1
+    assert samples[0][1] == 2
+    with pytest.raises(ValueError, match="lacks Combined Power"):
+        measurement.parse_power_samples(
+            text.replace("Combined Power (CPU + GPU + ANE)", "CPU Power")
+        )
+    with pytest.raises(ValueError, match="no combined"):
+        measurement.parse_power_samples("")
+
+
+def test_power_samples_are_applied_to_corresponding_idle_phase():
+    idle = Phase("idle", 0, 0, 1, 1, 0)
+    scalar = Phase("scalar", 0, 2, 4, 2, 4, tokens=10)
+    rows = measurement.apply_power_samples([idle, scalar], [(0.5, 2), (3, 1)])
+    assert rows[0].raw_system_energy_j == 2
+    assert rows[0].idle_power_w == 2
+    assert rows[0].dynamic_energy_j == -2  # No silent clamp of idle noise.
+    with pytest.raises(RuntimeError, match="no power samples in phase scalar"):
+        measurement.apply_power_samples([idle, scalar], [(0.5, 2)])
+
+
+def test_only_incomplete_final_sample_outside_phases_is_ignored():
+    complete = (
+        "*** Sampled system activity (Sun, 06 Sep 2026 12:00:00 +0000) ***\n"
+        "Combined Power (CPU + GPU + ANE): 2000 mW\n"
+    )
+    partial = (
+        "\n*** Sampled system activity (Sun, 06 Sep 2026 12:00:01 +0000) ***\n"
+        "CPU Power: 1000 mW\n"
+    )
+    expected = measurement.parse_power_samples(complete)
+    phase_end = expected[0][0]
+    with pytest.warns(RuntimeWarning, match="outside measured phases"):
+        assert (
+            measurement.parse_power_samples(complete + partial, phase_end) == expected
+        )
+    with pytest.raises(ValueError, match="lacks Combined Power"):
+        measurement.parse_power_samples(complete + partial, phase_end + 1)
+    with pytest.raises(ValueError, match="lacks Combined Power"):
+        measurement.parse_power_samples(partial + complete, phase_end)
+
+
+def test_report_preserves_raw_power_and_explicit_units(tmp_path, monkeypatch):
+    monkeypatch.setattr(measurement, "REPO", tmp_path)
+    monkeypatch.setattr(measurement, "_manifest", lambda: {"fixture": True})
+    args = Namespace(
+        carbon_intensity=2,
+        embodied=3,
+        duration_seconds=2,
+        repetitions=2,
+        batch_size=4,
+        sample_rate_ms=1,
+    )
+    phase = Phase("scalar", 0, 0, 2, 2, 4, tokens=2000)
+    row = measurement.MeasuredPhase(phase, 1, 1_800_000, 0)
+    raw = b"synthetic raw sensor fixture\n"
+    result = measurement.write_report(args, ([row], {}), (raw, 0))
+    output = Path(result["result_dir"])
+    assert (output / "powermetrics.txt").read_bytes() == raw
+    data = json.loads((output / "results.json").read_text())
+    assert data["carbon_intensity_gco2eq_per_kwh"] == 2
+    assert data["embodied_rate_gco2eq_per_second"] == 3
+    assert data["rows"][0]["embodied_gco2eq"] == 6
+    assert data["rows"][0]["carbon_gco2eq_per_1k_tokens"] == 4
+    assert "1000 model input tokens" in data["functional_units"]

--- a/tests_py/benchmarks/test_energy_runner.py
+++ b/tests_py/benchmarks/test_energy_runner.py
@@ -1,0 +1,161 @@
+"""Run the real shell lifecycle with an unprivileged, synthetic sensor.
+
+The fake sudo accepts authorization/start, but rejects a later sudo kill as an
+expired ticket would. FIFO synchronization avoids model/sensor timing assumptions.
+"""
+
+import json
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+RUNNER = Path(__file__).resolve().parents[2] / "benchmarks" / "energy" / "run.sh"
+FAKE_SUDO = """
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+
+args = sys.argv[1:]
+with Path(os.environ["ENERGY_SUDO_LOG"]).open("a") as log:
+    log.write(json.dumps(args) + "\\n")
+if args == ["-v"]:
+    sys.exit(0)
+if args[:2] == ["-n", "kill"]:
+    sys.exit("sudo: a password is required")
+if args[:2] != ["-n", "/usr/bin/powermetrics"]:
+    sys.exit("unexpected fake sudo invocation")
+
+def stop_sensor(signum, frame):
+    Path(os.environ["ENERGY_STOPPED"]).write_text("SIGINT received")
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, stop_sensor)
+Path(os.environ["ENERGY_SENSOR_PID"]).write_text(str(os.getpid()))
+output = Path(args[args.index("--output-file") + 1])
+output.write_text("synthetic raw sensor output\\n")
+with Path(os.environ["ENERGY_READY"]).open("w") as ready:
+    ready.write("ready")
+while True:
+    signal.pause()
+"""
+FAKE_WORKLOAD = """
+import os
+from pathlib import Path
+import sys
+
+if "--validate-only" in sys.argv:
+    print(1)
+    sys.exit(0)
+with Path(os.environ["ENERGY_READY"]).open() as ready:
+    assert ready.read() == "ready"
+power = Path(sys.argv[sys.argv.index("--external-power-file") + 1])
+Path(os.environ["ENERGY_SNAPSHOT"]).write_bytes(power.read_bytes())
+sys.exit(int(os.environ["ENERGY_WORKLOAD_STATUS"]))
+"""
+FAKE_MKTEMP = """
+import os
+from pathlib import Path
+
+path = Path(os.environ["ENERGY_RAW"])
+path.touch()
+print(path)
+"""
+
+
+def _executable(path, source):
+    path.write_text(f"#!{sys.executable}\n" + textwrap.dedent(source))
+    path.chmod(0o755)
+
+
+def _environment(tmp_path, workload_status):
+    for name, source in (
+        ("sudo", FAKE_SUDO),
+        ("workload", FAKE_WORKLOAD),
+        ("mktemp", FAKE_MKTEMP),
+    ):
+        _executable(tmp_path / name, source)
+    os.mkfifo(tmp_path / "ready")
+    return {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "ENERGY_PYTHON": str(tmp_path / "workload"),
+        "ENERGY_SUDO_LOG": str(tmp_path / "sudo.log"),
+        "ENERGY_STOPPED": str(tmp_path / "stopped"),
+        "ENERGY_SENSOR_PID": str(tmp_path / "sensor.pid"),
+        "ENERGY_READY": str(tmp_path / "ready"),
+        "ENERGY_SNAPSHOT": str(tmp_path / "snapshot.txt"),
+        "ENERGY_RAW": str(tmp_path / "raw.txt"),
+        "ENERGY_WORKLOAD_STATUS": str(workload_status),
+    }
+
+
+def _remove_test_process_group(pid):
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return  # Successful runs have already reaped the sensor and exited.
+
+
+@contextmanager
+def _run_shell(env):
+    master, slave = os.openpty()
+    args = [shutil.which("zsh"), str(RUNNER)]
+    process = subprocess.Popen(
+        args,
+        env=env,
+        stdin=slave,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        # Test-only hang protection; no benchmark timing assertion uses this limit.
+        stdout, stderr = process.communicate(timeout=10)
+        yield subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+    finally:
+        _remove_test_process_group(process.pid)
+        process.wait()
+        os.close(slave)
+        os.close(master)
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or shutil.which("zsh") is None,
+    reason="sensor runner requires POSIX PTY and zsh",
+)
+@pytest.mark.parametrize("workload_status", [0, 7])
+def test_runner_stops_sensor_without_reauthenticating(tmp_path, workload_status):
+    with _run_shell(_environment(tmp_path, workload_status)) as result:
+        assert result.returncode == workload_status, result.stderr
+        assert (tmp_path / "stopped").read_text() == "SIGINT received"
+        calls = [
+            json.loads(line)
+            for line in (tmp_path / "sudo.log").read_text().splitlines()
+        ]
+        assert len(calls) == 2  # Only initial authorization and sensor startup.
+        assert calls[0] == ["-v"]
+        assert calls[1][:2] == ["-n", "/usr/bin/powermetrics"]
+        # Assert before fixture cleanup: cleanup must not hide an orphaned sensor.
+        with pytest.raises(ProcessLookupError):
+            os.kill(int((tmp_path / "sensor.pid").read_text()), 0)
+        assert (
+            tmp_path / "snapshot.txt"
+        ).read_text() == "synthetic raw sensor output\n"
+        if workload_status:
+            assert "Raw sensor output preserved" in result.stderr
+            assert (tmp_path / "raw.txt").read_bytes() == (
+                tmp_path / "snapshot.txt"
+            ).read_bytes()
+        else:
+            assert not (tmp_path / "raw.txt").exists()

--- a/tests_py/benchmarks/test_energy_workload.py
+++ b/tests_py/benchmarks/test_energy_workload.py
@@ -1,0 +1,176 @@
+"""Energy harness contracts with deterministic float32/token-mask fixtures.
+
+All numbers here describe synthetic fixtures; none is a host energy measurement.
+"""
+
+from argparse import Namespace
+from types import SimpleNamespace
+import sys
+
+import numpy as np
+import pytest
+
+from benchmarks.energy import workload
+
+
+class FixtureEncoder:
+    def __init__(self, scalar, batch):
+        self.scalar = scalar
+        self.batch = batch
+
+    def encode(self, text):
+        return self.scalar
+
+    def encode_batch(self, values):
+        return [self.batch] * len(values)
+
+
+def test_float32_equivalence_accepts_different_bytes():
+    scalar = np.array([0.5], dtype=np.float32)
+    batch = np.nextafter(scalar, np.float32(1))
+    assert scalar.tobytes() != batch.tobytes()
+    # Before W0-2 the same fixture returned the byte difference 1.0.
+    assert (
+        max(abs(a - b) for a, b in zip(scalar.tobytes(), batch.tobytes(), strict=True))
+        == 1
+    )
+    delta = workload.verify_equivalence(
+        FixtureEncoder(scalar.tobytes(), batch.tobytes()), 4
+    )
+    assert delta == float(batch[0]) - float(scalar[0])
+    assert 0 < delta <= np.finfo(np.float32).eps
+
+
+def test_float32_equivalence_rejects_real_difference():
+    engine = FixtureEncoder(
+        np.array([0.5], dtype=np.float32).tobytes(),
+        np.array([0.75], dtype=np.float32).tobytes(),
+    )
+    with pytest.raises(ValueError, match="float32 mismatch"):
+        workload.verify_equivalence(engine, 4)
+
+
+@pytest.mark.parametrize(
+    ("batch", "message"),
+    [
+        (None, "missing"),
+        (b"", "empty"),
+        (b"abc", "multiple"),
+        (np.array([float("nan")], dtype=np.float32).tobytes(), "non-finite"),
+        (np.array([float("inf")], dtype=np.float32).tobytes(), "non-finite"),
+        (np.array([0.5, 0.5], dtype=np.float32).tobytes(), "shape mismatch"),
+    ],
+)
+def test_float32_equivalence_refuses_invalid_outputs(batch, message):
+    engine = FixtureEncoder(np.array([0.5], dtype=np.float32).tobytes(), batch)
+    with pytest.raises(ValueError, match=message):
+        workload.verify_equivalence(engine, 4)
+
+
+def test_float32_equivalence_refuses_output_count_mismatch(monkeypatch):
+    engine = FixtureEncoder(np.array([0.5], dtype=np.float32).tobytes(), None)
+    monkeypatch.setattr(engine, "encode_batch", lambda values: [])
+    with pytest.raises(ValueError, match="count mismatch"):
+        workload.verify_equivalence(engine, 4)
+
+
+class FixtureTokenizer:
+    def __init__(self):
+        self.calls = []
+
+    def tokenize(self, values):
+        self.calls.append(values)
+        # Already truncated model input: three active tokens, two active, padding.
+        return {"attention_mask": np.array([[1, 1, 1, 0], [1, 1, 0, 0]])}
+
+
+def test_token_count_uses_model_attention_mask():
+    model = FixtureTokenizer()
+    values = ["é", "a much longer input whose character count is irrelevant"]
+    assert workload.count_tokens(model, values) == 5
+    assert model.calls == [values]
+
+
+def test_token_count_refuses_empty_mask():
+    model = SimpleNamespace(
+        tokenize=lambda values: {"attention_mask": np.zeros((1, 1))}
+    )
+    with pytest.raises(ValueError, match="no active tokens"):
+        workload.count_tokens(model, ["input"])
+
+
+def test_phases_count_exact_completed_batches_outside_measurement(monkeypatch):
+    model = FixtureTokenizer()
+
+    def measure(engine, mode, args, repetition):
+        assert not model.calls, "token counting must follow all timed phases"
+        return workload.Phase(mode, repetition, 0, 1, 1, 0 if mode == "idle" else 4)
+
+    monkeypatch.setattr(workload, "_measure_phase", measure)
+    args = Namespace(repetitions=2, batch_size=2)
+    phases = workload.run_phases(SimpleNamespace(_model=model), args)
+    assert [phase.condition for phase in phases] == [
+        "idle",
+        "scalar",
+        "batch",
+        "idle",
+        "batch",
+        "scalar",
+    ]
+    assert [phase.tokens for phase in phases] == [0, 10, 10, 0, 10, 10]
+    assert model.calls == [workload.texts(i, 2) for _ in range(4) for i in range(2)]
+
+
+@pytest.mark.parametrize("mode", ["scalar", "batch"])
+def test_timed_workload_counts_completed_texts(mode, monkeypatch):
+    ticks = iter([0, 0, 2])
+    monkeypatch.setattr(workload.time, "perf_counter", lambda: next(ticks))
+    calls = []
+    engine = SimpleNamespace(encode=calls.append, encode_batch=calls.extend)
+    args = Namespace(duration_seconds=1, batch_size=4)
+    assert workload._timed_workload(engine, mode, args) == 4
+    assert calls == workload.texts(0, 4)
+
+
+def test_load_engine_refuses_algorithmic_fallback(monkeypatch):
+    engine = SimpleNamespace(encode=lambda text: None, mode="fallback")
+    module = SimpleNamespace(EmbeddingEngine=lambda: engine)
+    monkeypatch.setitem(
+        sys.modules, "mcp_server.infrastructure.embedding_engine", module
+    )
+    with pytest.raises(RuntimeError, match="fallback refused"):
+        workload.load_engine()
+
+
+def test_phase_clears_warm_cache_and_refuses_fallback(monkeypatch):
+    engine = SimpleNamespace(_cache={"warm": b"embedding"}, mode="fallback")
+    monkeypatch.setattr(workload, "_timed_workload", lambda *args: 1)
+    with pytest.raises(RuntimeError, match="fallback refused"):
+        workload._measure_phase(engine, "scalar", Namespace(), 0)
+    assert engine._cache == {}
+
+
+def test_phase_refuses_no_completed_work(monkeypatch):
+    engine = SimpleNamespace(_cache={}, mode="neural")
+    monkeypatch.setattr(workload, "_timed_workload", lambda *args: 0)
+    with pytest.raises(RuntimeError, match="no embedding work"):
+        workload._measure_phase(engine, "scalar", Namespace(), 0)
+
+
+def test_stream_timeout_is_explicit(tmp_path, monkeypatch):
+    path = tmp_path / "power.txt"
+    path.write_text("")
+    ticks = iter([0, 0, 0, 2])
+    monkeypatch.setattr(workload.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(workload.time, "sleep", lambda duration: None)
+    args = Namespace(duration_seconds=1, sample_rate_ms=1, external_power_file=path)
+    with pytest.raises(RuntimeError, match="stream did not become ready"):
+        workload.wait_for_stream(args)
+
+
+def test_stream_file_error_is_not_swallowed(tmp_path):
+    args = Namespace(
+        duration_seconds=1, sample_rate_ms=1, external_power_file=tmp_path / "missing"
+    )
+    with pytest.raises(FileNotFoundError):
+        workload.wait_for_stream(args)

--- a/tests_py/core/test_retrieval_telemetry.py
+++ b/tests_py/core/test_retrieval_telemetry.py
@@ -1,0 +1,71 @@
+"""W0-1: count model work without changing results or leaking across calls."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import Mock
+
+from mcp_server.core import reranker, retrieval_dispatch
+from mcp_server.shared.telemetry_context import (
+    count_reranked,
+    operation_metrics,
+    retrieval_metrics,
+    set_retrieval_tier,
+)
+
+
+def test_metrics_are_nested_and_task_local():
+    async def collect(tier, count):
+        with operation_metrics() as measured:
+            set_retrieval_tier(tier)
+            count_reranked(count)
+            await asyncio.sleep(0)
+            with operation_metrics() as nested:
+                assert nested.tier is None
+                count_reranked(1)
+            assert retrieval_metrics() is measured
+            return measured.tier, measured.reranked_count
+
+    async def run():
+        return await asyncio.gather(collect("simple", 2), collect("deep", 3))
+
+    assert asyncio.run(run()) == [("simple", 2), ("deep", 3)]
+    assert retrieval_metrics().reranked_count == 0
+    assert retrieval_metrics().tier is None
+
+
+def test_successful_reranking_counts_input_and_preserves_result(monkeypatch):
+    model = Mock()
+    model.rerank.return_value = [{"id": 0, "score": 0.9}, {"id": 1, "score": 0.8}]
+    monkeypatch.setattr(reranker, "_ensure_reranker", lambda: model)
+    candidates = [(1, 0.7), (2, 0.6)]
+    content = {1: "first", 2: "second"}
+    uninstrumented = reranker.rerank_results("query", candidates, content)
+    with operation_metrics() as measured:
+        instrumented = reranker.rerank_results("query", candidates, content)
+    assert instrumented == uninstrumented
+    assert measured.reranked_count == len(model.rerank.call_args.args[0].passages)
+
+
+def test_skipped_or_failed_model_is_not_counted(monkeypatch, caplog):
+    monkeypatch.setattr(reranker, "_ensure_reranker", lambda: None)
+    with operation_metrics() as measured:
+        assert reranker.rerank_results("q", [(1, 0.5)], {}) == [(1, 0.5)]
+        assert measured.reranked_count == 0
+    model = Mock()
+    model.rerank.side_effect = RuntimeError("fixture inference failure")
+    monkeypatch.setattr(reranker, "_ensure_reranker", lambda: model)
+    with operation_metrics() as measured:
+        assert reranker.rerank_results("q", [(1, 0.5)], {}) == [(1, 0.5)]
+        assert measured.reranked_count == 0
+    assert "fixture inference failure" in caplog.text
+
+
+def test_legacy_dispatch_records_executed_tier_without_changing_output(monkeypatch):
+    monkeypatch.setattr(retrieval_dispatch, "rerank_results", lambda q, p, c: p)
+    args = ("q", {"vector": [(1, 0.5)]}, {"intent": "general"}, {1: "text"})
+    original = retrieval_dispatch.dispatch_retrieval(*args)
+    with operation_metrics() as measured:
+        observed = retrieval_dispatch.dispatch_retrieval(*args)
+    assert observed == original
+    assert measured.tier == observed[1]

--- a/tests_py/core/test_telemetry_isolation.py
+++ b/tests_py/core/test_telemetry_isolation.py
@@ -1,0 +1,29 @@
+"""The telemetry log follows the same disposable root as every other store."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def test_fresh_process_respects_configuration_root(tmp_path):
+    isolated = tmp_path / "claude"
+    script = (
+        "from mcp_server.core import telemetry; "
+        "telemetry.record('fixture', latency_ms=0); "
+        "print(telemetry.summary()['log_path'])"
+    )
+    env = dict(os.environ, CORTEX_CLAUDE_DIR=str(isolated))
+    env.pop("CORTEX_TELEMETRY_DISABLED", None)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    expected = isolated / "methodology" / "telemetry.jsonl"
+    assert result.stdout.strip() == str(expected)
+    assert json.loads(expected.read_text())["op"] == "fixture"

--- a/tests_py/handlers/test_telemetry_response.py
+++ b/tests_py/handlers/test_telemetry_response.py
@@ -1,0 +1,98 @@
+"""W0-1: response bytes and request-scoped retrieval work are observable."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from pydantic_core import to_json
+
+from mcp_server.core import telemetry
+from mcp_server.handlers._telemetry_wrap import instrument
+from mcp_server.handlers import recall, remember
+from mcp_server.shared.telemetry_context import count_reranked, set_retrieval_tier
+
+
+@pytest.fixture
+def telemetry_log(tmp_path, monkeypatch):
+    path = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", path)
+    monkeypatch.delenv("CORTEX_TELEMETRY_DISABLED", raising=False)
+    telemetry.reset()
+    yield path
+    telemetry.reset()
+
+
+def test_public_recall_remember_record_response_bytes(telemetry_log):
+    """Even empty-query / rejected-write responses carry serialized output."""
+    responses = [asyncio.run(recall.handler({})), asyncio.run(remember.handler({}))]
+    samples = [json.loads(line) for line in telemetry_log.read_text().splitlines()]
+    assert [sample["op"] for sample in samples] == ["recall", "remember"]
+    for sample, response in zip(samples, responses, strict=True):
+        assert sample["bytes_out"] == len(to_json(response, fallback=str, indent=2))
+        assert sample["bytes_out"] > 0
+        assert sample["tier"] is None
+        assert sample["reranked_count"] == 0
+
+
+def test_wrapper_preserves_result_and_records_failure(telemetry_log):
+    async def fail(args):
+        raise ValueError("fixture failure")
+
+    with pytest.raises(ValueError, match="fixture failure"):
+        asyncio.run(instrument("fixture", fail)({"query": "café"}))
+    sample = json.loads(telemetry_log.read_text())
+    assert sample["ok"] is False
+    assert sample["bytes_out"] == 0
+    assert sample["bytes_in"] == len(json.dumps({"query": "café"}).encode("utf-8"))
+
+
+def test_unicode_response_matches_sdk_and_records_retrieval_work(telemetry_log):
+    response = {"memories": [{"id": 1, "content": "café 🧠"}]}
+
+    async def retrieve(args):
+        set_retrieval_tier("pg")
+        count_reranked(2)
+        return response
+
+    assert asyncio.run(instrument("recall", retrieve)({})) is response
+    sample = json.loads(telemetry_log.read_text())
+    assert sample["bytes_out"] == len(to_json(response, fallback=str, indent=2))
+    assert sample["bytes_out"] > len(to_json(response, indent=2).decode("utf-8"))
+    assert sample["tier"] == "pg"
+    assert sample["reranked_count"] == 2
+
+
+def test_cancelled_handler_records_failure_and_restores_metrics(telemetry_log):
+    async def cancel(args):
+        set_retrieval_tier("deep")
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(instrument("recall", cancel)({}))
+    asyncio.run(recall.handler({}))
+    samples = [json.loads(line) for line in telemetry_log.read_text().splitlines()]
+    assert samples[0]["ok"] is False
+    assert samples[0]["tier"] == "deep"
+    assert samples[1]["tier"] is None
+
+
+def test_real_store_round_trip_records_nonempty_response_sizes(telemetry_log):
+    content = "We decided to verify UTF-8 telemetry with an isolated SQLite store."
+    stored = asyncio.run(remember.handler({"content": content, "force": True}))
+    assert stored["stored"] is True
+    telemetry_log.write_text("")
+    recalled = asyncio.run(recall.handler({"query": "UTF-8 telemetry"}))
+    written = asyncio.run(
+        remember.handler({"content": "Follow-up decision", "force": True})
+    )
+    assert recalled["count"] > 0
+    assert written["stored"] is True
+    samples = [json.loads(line) for line in telemetry_log.read_text().splitlines()]
+    assert [sample["op"] for sample in samples] == ["recall", "remember"]
+    for sample, response in zip(samples, [recalled, written], strict=True):
+        assert sample["bytes_out"] == len(to_json(response, fallback=str, indent=2))
+        assert sample["bytes_out"] > 0
+        assert "tier" in sample and "reranked_count" in sample
+    assert samples[0]["tier"] == "pg"

--- a/tests_py/hooks/test_hook_telemetry.py
+++ b/tests_py/hooks/test_hook_telemetry.py
@@ -1,0 +1,289 @@
+"""Hook telemetry measures emitted text without changing CLI behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from mcp_server.core import telemetry
+from mcp_server.handlers import query_methodology
+from mcp_server.hooks import _telemetry, auto_recall, session_start
+from mcp_server.shared.telemetry_context import (
+    count_reranked,
+    operation_metrics,
+    retrieval_metrics,
+    set_retrieval_tier,
+)
+
+
+@pytest.fixture(autouse=True)
+def telemetry_log(tmp_path, monkeypatch):
+    path = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", path)
+    monkeypatch.delenv("CORTEX_TELEMETRY_DISABLED", raising=False)
+    telemetry.set_exporter(None)
+    telemetry.reset()
+    yield path
+    telemetry.set_exporter(None)
+    telemetry.reset()
+
+
+def _sample(path):
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    return json.loads(lines[0])
+
+
+def test_counting_output_counts_only_text_accepted_by_stream():
+    accepted = []
+    flushed = []
+
+    def partial_write(text):
+        accepted.append(text[:1])
+        return 1
+
+    stream = SimpleNamespace(write=partial_write, flush=lambda: flushed.append(True))
+    output = _telemetry._CountingOutput(stream)
+    assert output.write("été") == 1
+    output.flush()
+    assert accepted == ["é"]
+    assert output.bytes_out == len("é".encode("utf-8"))
+    assert flushed == [True]
+
+
+def test_counting_output_preserves_write_failures():
+    stream = io.StringIO()
+    stream.close()
+    output = _telemetry._CountingOutput(stream)
+    with pytest.raises(ValueError, match="closed file"):
+        output.write("mémoire")
+    assert output.bytes_out == 0
+
+
+def test_observer_measures_complete_utf8_output_and_duration(
+    telemetry_log, monkeypatch, capsys
+):
+    clock = iter((5.0, 5.25))
+    monkeypatch.setattr(_telemetry.time, "perf_counter", lambda: next(clock))
+    original_stdout = sys.stdout
+
+    @_telemetry.observe_hook("session_start")
+    def hook():
+        print("Décision 🧠", end=" ", flush=True)
+        print("⟦rcpt:7⟧")
+        print("\nSources externes : mémoire")
+        print("diagnostic", file=sys.stderr)
+
+    hook()
+    assert sys.stdout is original_stdout
+    out, err = capsys.readouterr()
+    assert out == "Décision 🧠 ⟦rcpt:7⟧\n\nSources externes : mémoire\n"
+    assert err == "diagnostic\n"
+    sample = _sample(telemetry_log)
+    assert sample["bytes_out"] == len(out.encode("utf-8"))
+    assert sample["latency_ms"] == 250.0
+    assert sample["ok"] is True
+
+
+@pytest.mark.parametrize("code", [None, 0, 1, "failure"])
+def test_exit_code_is_preserved_and_recorded(code, telemetry_log, capsys):
+    original_stdout = sys.stdout
+    failure = SystemExit(code)
+
+    @_telemetry.observe_hook("auto_recall")
+    def hook():
+        print("déjà émis")
+        raise failure
+
+    with pytest.raises(SystemExit) as caught:
+        hook()
+    assert caught.value is failure
+    assert sys.stdout is original_stdout
+    sample = _sample(telemetry_log)
+    assert sample["ok"] is (code is None or code == 0)
+    assert sample["bytes_out"] == len(capsys.readouterr().out.encode("utf-8"))
+
+
+def test_exception_records_partial_output_and_remains_visible(telemetry_log, capsys):
+    original_stdout = sys.stdout
+    failure = RuntimeError("hook failed")
+
+    @_telemetry.observe_hook("session_start")
+    def hook():
+        print("émission partielle")
+        raise failure
+
+    with pytest.raises(RuntimeError) as caught:
+        hook()
+    assert caught.value is failure
+    assert sys.stdout is original_stdout
+    sample = _sample(telemetry_log)
+    assert sample["ok"] is False
+    assert sample["bytes_out"] == len(capsys.readouterr().out.encode("utf-8"))
+
+
+def test_metrics_are_isolated_and_recorded_before_context_exit(telemetry_log):
+    @_telemetry.observe_hook("auto_recall")
+    def hook():
+        assert retrieval_metrics().tier is None
+        assert retrieval_metrics().reranked_count == 0
+        set_retrieval_tier("hook")
+        count_reranked(2)
+
+    with operation_metrics():
+        set_retrieval_tier("outer")
+        count_reranked(3)
+        hook()
+        assert retrieval_metrics().tier == "outer"
+        assert retrieval_metrics().reranked_count == 3
+    sample = _sample(telemetry_log)
+    assert sample["tier"] == "hook"
+    assert sample["reranked_count"] == 2
+    assert sample["bytes_out"] == 0
+    assert sample["ok"] is True
+
+
+def test_disabled_telemetry_preserves_output(telemetry_log, monkeypatch, capsys):
+    monkeypatch.setenv("CORTEX_TELEMETRY_DISABLED", "1")
+
+    @_telemetry.observe_hook("auto_recall")
+    def hook():
+        print("mémoire")
+
+    hook()
+    assert capsys.readouterr().out == "mémoire\n"
+    assert not telemetry_log.exists()
+    assert telemetry.snapshot() == {}
+
+
+def test_log_write_failure_does_not_break_hook(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(telemetry, "_LOG_PATH", tmp_path)
+
+    @_telemetry.observe_hook("auto_recall")
+    def hook():
+        print("mémoire")
+
+    hook()
+    assert capsys.readouterr().out == "mémoire\n"
+    assert telemetry.snapshot()["auto_recall"]["ok"] == 1
+
+
+def _patch_session_main(monkeypatch):
+    for name in (
+        "_refresh_session_registry",
+        "_auto_wire_pipeline",
+        "_maybe_background_reanalyze",
+        "_maybe_background_consolidate",
+    ):
+        monkeypatch.setattr(session_start, name, lambda *args: None)
+    values = {
+        "_read_event": {},
+        "_backend_is_sqlite": False,
+        "_connect_pg": SimpleNamespace(close=lambda: None),
+        "_count_memories": 1,
+        "_fetch_anchors": [{"id": 1, "content": "Décision 🧠"}],
+        "_fetch_hot_memories": [],
+        "_fetch_team_decisions": [],
+        "_fetch_checkpoint": None,
+        "_count_pending_curations": 0,
+        "_fetch_grooming_staleness": [],
+        "_emit_banner_receipt": 7,
+        "_has_sentence_transformers": True,
+        "_detect_external_sources": [],
+    }
+    for name, value in values.items():
+        monkeypatch.setattr(session_start, name, lambda *args, value=value: value)
+
+
+def test_session_main_counts_banner_receipt_and_external_sources(
+    telemetry_log, monkeypatch, capsys
+):
+    _patch_session_main(monkeypatch)
+    monkeypatch.setattr(
+        session_start,
+        "_detect_external_sources",
+        lambda: [{"name": "Mémoire externe", "path": "/fixture/été", "count": 1}],
+    )
+
+    session_start.main()
+
+    out = capsys.readouterr().out
+    assert "Décision 🧠" in out
+    assert "⟦rcpt:7⟧" in out
+    assert "Mémoire externe" in out
+    sample = _sample(telemetry_log)
+    assert sample["op"] == "session_start"
+    assert sample["bytes_out"] == len(out.encode("utf-8"))
+    assert sample["ok"] is True
+
+
+def _patch_auto_main(monkeypatch):
+    monkeypatch.setattr(
+        sys, "stdin", io.StringIO('{"prompt":"remember this decision"}')
+    )
+    monkeypatch.setattr(auto_recall, "_refresh_session_registry", lambda event: None)
+    monkeypatch.setattr(auto_recall, "_backend_is_sqlite", lambda: False)
+    monkeypatch.setattr(
+        auto_recall, "_connect", lambda: SimpleNamespace(close=lambda: None)
+    )
+    monkeypatch.setattr(
+        auto_recall,
+        "_recall_memories",
+        lambda conn, query: [{"id": 1, "content": "Décision 🧠"}],
+    )
+    monkeypatch.setattr(auto_recall, "emit_hook_receipt", lambda *args, **kwargs: 9)
+
+
+def test_isolated_session_records_all_context_operations(
+    telemetry_log, monkeypatch, capsys
+):
+    monkeypatch.setattr(query_methodology, "load_profiles", lambda: {})
+    monkeypatch.setattr(query_methodology, "_try_get_memory_store", lambda: None)
+    monkeypatch.setattr(query_methodology, "_bounded", lambda response: response)
+    response = asyncio.run(
+        query_methodology.handler({"cwd": str(telemetry_log.parent)})
+    )
+    assert response["coldStart"] is True
+    _patch_session_main(monkeypatch)
+    session_start.main()
+    banner = capsys.readouterr().out
+    _patch_auto_main(monkeypatch)
+    with pytest.raises(SystemExit) as caught:
+        auto_recall.main()
+    assert caught.value.code == 0
+    out = capsys.readouterr().out
+    assert "Décision 🧠" in out
+    assert "⟦rcpt:9⟧" in out
+    samples = [json.loads(line) for line in telemetry_log.read_text().splitlines()]
+    assert [sample["op"] for sample in samples] == [
+        "query_methodology",
+        "session_start",
+        "auto_recall",
+    ]
+    assert samples[0]["bytes_out"] > 0
+    assert samples[1]["bytes_out"] == len(banner.encode("utf-8")) > 0
+    assert samples[2]["bytes_out"] == len(out.encode("utf-8")) > 0
+    assert all(sample["ok"] for sample in samples)
+
+
+@pytest.mark.parametrize("raw", ["", "{bad json", '{"prompt":"ok"}'])
+def test_auto_recall_main_silent_exits_are_recorded(
+    raw, telemetry_log, monkeypatch, capsys
+):
+    monkeypatch.setattr(sys, "stdin", io.StringIO(raw))
+    monkeypatch.setattr(auto_recall, "_refresh_session_registry", lambda event: None)
+
+    with pytest.raises(SystemExit) as caught:
+        auto_recall.main()
+
+    assert caught.value.code == 0
+    assert capsys.readouterr().out == ""
+    sample = _sample(telemetry_log)
+    assert sample["op"] == "auto_recall"
+    assert sample["bytes_out"] == 0
+    assert sample["ok"] is True

--- a/tests_py/hooks/test_hook_telemetry_bytes.py
+++ b/tests_py/hooks/test_hook_telemetry_bytes.py
@@ -1,0 +1,88 @@
+"""Count actual stdout bytes after encoding, errors policy, and CRLF expansion."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+
+import pytest
+
+from mcp_server.core import telemetry
+from mcp_server.hooks._telemetry import observe_hook
+
+
+@pytest.mark.parametrize("newline", [None, "\r\n", ""])
+def test_observer_counts_binary_output_after_text_transformations(
+    newline, tmp_path, monkeypatch
+):
+    log = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", log)
+    sink = io.BytesIO()
+    stream = io.TextIOWrapper(sink, encoding="utf-8", errors="replace", newline=newline)
+    monkeypatch.setattr(sys, "stdout", stream)
+    original_write = sink.write
+    stream.write("previous output\n")
+
+    @observe_hook("session_start")
+    def emit():
+        print("café\n\ud800")
+
+    emit()
+    # source: TextIOWrapper newline=None translates LF to os.linesep.
+    translated = os.linesep if newline is None else newline or "\n"
+    expected = "café\n?\n".replace("\n", translated).encode("utf-8")
+    sample = json.loads(log.read_text())
+    assert sink.getvalue().endswith(expected)
+    assert sample["bytes_out"] == len(expected)
+    assert sample["ok"] is True
+    assert sys.stdout is stream
+    assert sink.write == original_write
+    stream.detach()
+
+
+def test_flush_failure_does_not_replace_original_exception(
+    tmp_path, monkeypatch, caplog
+):
+    log = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", log)
+    stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-8")
+    monkeypatch.setattr(sys, "stdout", stream)
+    failure = RuntimeError("original failure")
+
+    @observe_hook("auto_recall")
+    def emit():
+        print("partial output")
+        stream.close()
+        raise failure
+
+    with pytest.raises(RuntimeError) as caught:
+        emit()
+    assert caught.value is failure
+    assert "Cannot flush failed hook output" in caplog.text
+    assert json.loads(log.read_text())["ok"] is False
+
+
+def test_binary_stdout_is_restored_after_hook_exception(tmp_path, monkeypatch):
+    log = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", log)
+    sink = io.BytesIO()
+    stream = io.TextIOWrapper(sink, encoding="utf-8", newline="\r\n")
+    monkeypatch.setattr(sys, "stdout", stream)
+    original_write = sink.write
+    failure = RuntimeError("original failure")
+
+    @observe_hook("auto_recall")
+    def emit():
+        print("déjà émis")
+        raise failure
+
+    with pytest.raises(RuntimeError) as caught:
+        emit()
+    sample = json.loads(log.read_text())
+    assert caught.value is failure
+    assert sample["bytes_out"] == len(sink.getvalue()) > 0
+    assert sample["ok"] is False
+    assert sink.write == original_write
+    stream.detach()

--- a/tests_py/scripts/test_check_ci_file_count.py
+++ b/tests_py/scripts/test_check_ci_file_count.py
@@ -1,0 +1,43 @@
+"""Guard against GitHub silently truncating a pull request's changed files."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from scripts.check_ci_file_count import check
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_ci_file_count.py"
+
+
+class FileCountTests(unittest.TestCase):
+    def test_complete_api_range_is_accepted(self):
+        for count in (0, 1, 3000):
+            with self.subTest(count=count):
+                self.assertIsNone(check(count))
+
+    def test_truncated_api_range_is_refused(self):
+        self.assertIn("3000-file API limit", check(3001))
+
+    def test_missing_or_invalid_count_is_refused(self):
+        for count in (None, True, False, -1, "1", 1.0, {}):
+            with self.subTest(count=count):
+                self.assertIn("nonnegative integer", check(count))
+
+    def test_cli_refuses_truncation_with_a_diagnostic(self):
+        with tempfile.TemporaryDirectory() as directory:
+            event = Path(directory) / "event.json"
+            event.write_text(json.dumps({"pull_request": {"changed_files": 3001}}))
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                env={**os.environ, "GITHUB_EVENT_PATH": str(event)},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("refusing incomplete classification", result.stderr)

--- a/tests_py/scripts/test_check_ci_gate_complete.py
+++ b/tests_py/scripts/test_check_ci_gate_complete.py
@@ -114,6 +114,18 @@ class RefusesIncompleteGate(unittest.TestCase):
         )
         self.assertIn("'lint'", self._only_failure(workflow))
 
+    def test_gate_must_always_run(self) -> None:
+        for condition in ("", "    if: success()\n"):
+            workflow = _COMPLETE.replace("    if: always()\n", condition)
+            self.assertIn("always()", self._only_failure(workflow))
+
+    def test_duplicate_or_self_needs_fail(self) -> None:
+        for job in ("lint", "ci-green"):
+            workflow = _COMPLETE.replace(
+                "      - lint\n", f"      - lint\n      - {job}\n"
+            )
+            self.assertIn("dependency", self._only_failure(workflow))
+
 
 _WITH_EXEMPT_JOB = _workflow(
     """  lint:
@@ -199,6 +211,30 @@ class RepositoryWorkflowIsGated(unittest.TestCase):
             gate.check(gate.CI_WORKFLOW.read_text(encoding="utf-8")),
             [],
         )
+
+    def test_runtime_policy_matches_live_workflow(self) -> None:
+        self.assertEqual(gate.check_runtime_contract(gate.CI_WORKFLOW.read_text()), [])
+
+    def test_costly_jobs_must_wait_for_lint_and_changes(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        for prerequisites in ("[changes]", "[lint]", "[changes, lint, test]"):
+            changed = workflow.replace("[changes, lint]", prerequisites, 1)
+            failures = gate.check_runtime_contract(changed)
+            self.assertTrue(any("depend on exactly" in f for f in failures))
+
+    def test_lint_and_changes_cannot_be_conditional(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        for job in ("changes", "lint"):
+            changed = workflow.replace(f"  {job}:\n", f"  {job}:\n    if: false\n")
+            self.assertTrue(gate.check_runtime_contract(changed))
+
+    def test_new_skip_needs_an_executable_policy(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        workflow = workflow.replace(
+            "ALLOWED_SKIPS: test,", "ALLOWED_SKIPS: unknown-job,test,"
+        )
+        failures = gate.check_runtime_contract(workflow)
+        self.assertTrue(any("runtime skip policy" in f for f in failures))
 
 
 if __name__ == "__main__":

--- a/tests_py/scripts/test_check_ci_gate_results.py
+++ b/tests_py/scripts/test_check_ci_gate_results.py
@@ -39,23 +39,23 @@ class JustifiedSkips(unittest.TestCase):
     def test_docker_only_requires_docker_jobs(self) -> None:
         needs = _skip(_needs("docker"), gate.CODE_JOBS)
         self.assertEqual(gate.check(needs, "pull_request", _event()), [])
-        for job in gate.DOCKER_JOBS:
+        for job in gate.DOCKER_BUILD_JOBS | {"docker-smoke"}:
             with self.subTest(job=job):
                 needs[job]["result"] = "skipped"
                 self.assertTrue(gate.check(needs, "pull_request", _event()))
                 needs[job]["result"] = "success"
 
-    def test_code_deps_workflows_require_every_job(self) -> None:
+    def test_code_deps_workflows_require_code_and_smoke(self) -> None:
         for changed in (("code",), ("docs", "code"), ("deps",), ("workflows",)):
-            needs = _needs(*changed)
+            needs = _skip(_needs(*changed), gate.DOCKER_BUILD_JOBS)
             self.assertEqual(gate.check(needs, "pull_request", _event()), [])
-            for job in gate.CONDITIONAL_JOBS:
+            for job in gate.CODE_JOBS | {"docker-smoke"}:
                 with self.subTest(changed=changed, job=job):
                     needs[job]["result"] = "skipped"
                     self.assertTrue(gate.check(needs, "pull_request", _event()))
                     needs[job]["result"] = "success"
 
-    def test_non_pr_runs_require_full_matrix_even_for_docs(self) -> None:
+    def test_push_and_dispatch_require_code_even_for_docs(self) -> None:
         for event_name in ("push", "workflow_dispatch"):
             needs = _needs("docs")
             self.assertEqual(gate.check(needs, event_name, {}), [])
@@ -69,6 +69,48 @@ class JustifiedSkips(unittest.TestCase):
         self.assertTrue(gate.check(needs, "pull_request", _event(False)))
         needs["test"]["result"] = "skipped"
         self.assertTrue(gate.check(needs, "pull_request", _event(True)))
+
+
+class DockerBuildPolicy(unittest.TestCase):
+    def test_push_without_docker_changes_skips_only_docker_builds(self) -> None:
+        for changed in (("docs",), ("code",), ("workflows",), ("deps",), ()):
+            needs = _skip(_needs(*changed), gate.DOCKER_BUILD_JOBS)
+            self.assertEqual(gate.check(needs, "push", {}), [])
+            needs["docker-smoke"]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "push", {}))
+
+    def test_push_with_docker_changes_requires_every_job(self) -> None:
+        needs = _needs("docker")
+        self.assertEqual(gate.check(needs, "push", {}), [])
+        for job in gate.CONDITIONAL_JOBS:
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "push", {}))
+            needs[job]["result"] = "success"
+
+    def test_dispatch_requires_builds_even_without_docker_changes(self) -> None:
+        needs = _needs("docs")
+        self.assertEqual(gate.check(needs, "workflow_dispatch", {}), [])
+        for job in gate.DOCKER_BUILD_JOBS:
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "workflow_dispatch", {}))
+            needs[job]["result"] = "success"
+
+    def test_schedule_skips_code_jobs_regardless_of_changed_paths(self) -> None:
+        for changed in ((), ("code",), ("docker",), ("docs",)):
+            needs = _skip(_needs(*changed), gate.CODE_JOBS)
+            self.assertEqual(gate.check(needs, "schedule", {}), [])
+            for job in gate.DOCKER_BUILD_JOBS | {"docker-smoke"} | gate.ALWAYS_JOBS:
+                with self.subTest(changed=changed, job=job):
+                    needs[job]["result"] = "skipped"
+                    self.assertTrue(gate.check(needs, "schedule", {}))
+                    needs[job]["result"] = "success"
+
+    def test_schedule_rejects_failed_and_cancelled_jobs_even_if_optional(self) -> None:
+        for job in gate.EXPECTED_JOBS:
+            for result in ("failure", "cancelled"):
+                needs = _skip(_needs("docs"), gate.CODE_JOBS)
+                needs[job]["result"] = result
+                self.assertTrue(gate.check(needs, "schedule", {}))
 
 
 class FailClosed(unittest.TestCase):

--- a/tests_py/scripts/test_check_ci_gate_results.py
+++ b/tests_py/scripts/test_check_ci_gate_results.py
@@ -1,0 +1,164 @@
+"""CI Green must fail closed without importing application code or its DB."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import check_ci_gate_results as gate
+
+
+def _event(fork: bool = False) -> dict:
+    return {"pull_request": {"head": {"repo": {"fork": fork}}}}
+
+
+def _needs(*changed: str) -> dict:
+    needs = {job: {"result": "success", "outputs": {}} for job in gate.EXPECTED_JOBS}
+    needs["changes"]["outputs"] = {
+        name: "true" if name in changed else "false" for name in gate.FILTERS
+    }
+    return needs
+
+
+def _skip(needs: dict, jobs: frozenset[str]) -> dict:
+    for job in jobs:
+        needs[job]["result"] = "skipped"
+    return needs
+
+
+class JustifiedSkips(unittest.TestCase):
+    def test_docs_only_runs_only_changes_and_lint(self) -> None:
+        needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+        self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+
+    def test_docker_only_requires_docker_jobs(self) -> None:
+        needs = _skip(_needs("docker"), gate.CODE_JOBS)
+        self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+        for job in gate.DOCKER_JOBS:
+            with self.subTest(job=job):
+                needs[job]["result"] = "skipped"
+                self.assertTrue(gate.check(needs, "pull_request", _event()))
+                needs[job]["result"] = "success"
+
+    def test_code_deps_workflows_require_every_job(self) -> None:
+        for changed in (("code",), ("docs", "code"), ("deps",), ("workflows",)):
+            needs = _needs(*changed)
+            self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+            for job in gate.CONDITIONAL_JOBS:
+                with self.subTest(changed=changed, job=job):
+                    needs[job]["result"] = "skipped"
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+                    needs[job]["result"] = "success"
+
+    def test_non_pr_runs_require_full_matrix_even_for_docs(self) -> None:
+        for event_name in ("push", "workflow_dispatch"):
+            needs = _needs("docs")
+            self.assertEqual(gate.check(needs, event_name, {}), [])
+            needs["test"]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, event_name, {}))
+
+    def test_fork_guard_applies_only_to_vendor_cli_job(self) -> None:
+        needs = _needs("code")
+        needs["mcp-host-config"]["result"] = "skipped"
+        self.assertEqual(gate.check(needs, "pull_request", _event(True)), [])
+        self.assertTrue(gate.check(needs, "pull_request", _event(False)))
+        needs["test"]["result"] = "skipped"
+        self.assertTrue(gate.check(needs, "pull_request", _event(True)))
+
+
+class FailClosed(unittest.TestCase):
+    def test_failures_cancellation_and_invalid_results_never_pass(self) -> None:
+        for result in ("failure", "cancelled", "pending", "", None):
+            for job in gate.EXPECTED_JOBS:
+                with self.subTest(result=result, job=job):
+                    needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+                    needs[job]["result"] = result
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_lint_failure_rejects_skipped_matrix(self) -> None:
+        needs = _skip(_needs("code"), gate.CONDITIONAL_JOBS)
+        needs["lint"]["result"] = "failure"
+        failures = gate.check(needs, "pull_request", _event())
+        self.assertTrue(any("lint=" in failure for failure in failures))
+
+    def test_changes_and_lint_may_never_skip(self) -> None:
+        for job in gate.ALWAYS_JOBS:
+            needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_and_unexpected_jobs_fail(self) -> None:
+        for job in gate.EXPECTED_JOBS:
+            needs = _needs("docs")
+            del needs[job]
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+        needs = _needs("docs")
+        needs["unwatched"] = {"result": "success"}
+        self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_and_invalid_classifications_fail(self) -> None:
+        for output in gate.FILTERS:
+            for value in (True, False, "", "TRUE", None, [], {}):
+                with self.subTest(output=output, value=value):
+                    needs = _needs("docs")
+                    needs["changes"]["outputs"][output] = value
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+            needs = _needs("docs")
+            del needs["changes"]["outputs"][output]
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_invalid_job_objects_and_output_objects_fail(self) -> None:
+        for value in (None, [], "success"):
+            needs = _needs("docs")
+            needs["changes"] = value
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+            needs = _needs("docs")
+            needs["changes"]["outputs"] = value
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_or_invalid_fork_context_fails(self) -> None:
+        for event in ({}, {"pull_request": None}, _event("false")):
+            self.assertTrue(gate.check(_needs("docs"), "pull_request", event))
+
+    def test_unsupported_event_context_fails(self) -> None:
+        self.assertTrue(gate.check(_needs("docs"), "", {}))
+        self.assertTrue(gate.check(_needs("docs"), "push", []))
+
+
+class ExecutableContract(unittest.TestCase):
+    def _run(self, needs: str) -> subprocess.CompletedProcess:
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = Path(directory) / "event.json"
+            event_path.write_text(json.dumps(_event()), encoding="utf-8")
+            env = {
+                **os.environ,
+                "NEEDS": needs,
+                "GITHUB_EVENT_PATH": str(event_path),
+                "GITHUB_EVENT_NAME": "pull_request",
+                "ALLOWED_SKIPS": ",".join(sorted(gate.CONDITIONAL_JOBS)),
+            }
+            return subprocess.run(
+                [sys.executable, str(Path(gate.__file__))],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_docs_only_cli_succeeds(self) -> None:
+        result = self._run(json.dumps(_skip(_needs("docs"), gate.CONDITIONAL_JOBS)))
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_malformed_json_cli_fails_with_diagnostic(self) -> None:
+        result = self._run("{bad json")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot read CI gate inputs", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/test_telemetry_middleware.py
+++ b/tests_py/test_telemetry_middleware.py
@@ -1,0 +1,162 @@
+"""Measure real MCP success/error TextContent once, including worker offload."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextvars import copy_context
+from types import SimpleNamespace
+
+import pytest
+from mcp import Client
+from mcp.server.mcpserver import MCPServer
+from mcp.types import CallToolResult, TextContent
+from pydantic import BaseModel
+
+from mcp_server.core import telemetry
+from mcp_server.handlers._telemetry_wrap import instrument
+from mcp_server.shared.telemetry_context import count_reranked, set_retrieval_tier
+from mcp_server.telemetry_middleware import TelemetryMiddleware
+from mcp_server.tool_error_handler import safe_handler
+
+
+@pytest.fixture
+def telemetry_log(tmp_path, monkeypatch):
+    path = tmp_path / "telemetry.jsonl"
+    monkeypatch.setattr(telemetry, "_LOG_PATH", path)
+    monkeypatch.delenv("CORTEX_TELEMETRY_DISABLED", raising=False)
+    telemetry.set_exporter(None)
+    telemetry.reset()
+    yield path
+    telemetry.reset()
+    telemetry.set_exporter(None)
+
+
+def _samples(path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def _server(*, fail=False, invalid_output=False, measured=True):
+    server = MCPServer(name="telemetry-fixture", middleware=[TelemetryMiddleware()])
+
+    async def handler(args):
+        set_retrieval_tier("pg")
+        count_reranked(2)
+        if fail:
+            raise ValueError("échec de fixture 🧠")
+        return {"message": "café 🧠"}
+
+    observed = instrument("fixture", handler) if measured else handler
+
+    @server.tool(name="fixture")
+    async def fixture() -> dict[str, str]:
+        return await safe_handler(observed, {})
+
+    if invalid_output:
+        tool = server._tool_manager.get_tool("fixture")
+        assert tool is not None
+
+        # The SDK validates this model after the instrumented handler returns.
+        class RequiredOutput(BaseModel):
+            required_field: int
+
+        tool.fn_metadata.output_model = RequiredOutput
+    return server
+
+
+def _call(server):
+    async def run():
+        async with Client(server) as client:
+            return await client.call_tool("fixture", {})
+
+    return asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    "fail,invalid_output", [(False, False), (True, False), (False, True)]
+)
+def test_sdk_text_response_is_counted_exactly_once(fail, invalid_output, telemetry_log):
+    result = _call(_server(fail=fail, invalid_output=invalid_output))
+    samples = _samples(telemetry_log)
+    assert len(samples) == 1
+    sample = samples[0]
+    text = [block.text for block in result.content if isinstance(block, TextContent)]
+    assert sample["bytes_out"] == sum(len(value.encode("utf-8")) for value in text) > 0
+    assert sample["ok"] is (not result.is_error)
+    assert result.is_error is (fail or invalid_output)
+    if fail:
+        assert "échec de fixture 🧠" in "".join(text)
+    elif not invalid_output:
+        assert json.loads("".join(text)) == {"message": "café 🧠"}
+    assert sample["tier"] == "pg"
+    assert sample["reranked_count"] == 2
+    counters = telemetry.snapshot()["fixture"]
+    assert counters["count"] == 1
+    assert counters["bytes_out"] == sample["bytes_out"]
+    assert counters["fail"] == int(result.is_error)
+
+
+def test_uninstrumented_sdk_tool_creates_no_sample(telemetry_log):
+    result = _call(_server(measured=False))
+    assert not result.is_error
+    assert not telemetry_log.exists()
+    assert telemetry.snapshot() == {}
+
+
+@pytest.mark.parametrize("as_dict", [False, True])
+def test_middleware_preserves_response_and_nested_operation(as_dict, telemetry_log):
+    response = CallToolResult(
+        content=[TextContent(type="text", text="réponse 🧠")], is_error=True
+    )
+    expected = response.model_dump(by_alias=True) if as_dict else response
+
+    async def call_next(ctx):
+        telemetry.record("nested", latency_ms=1, bytes_out=5)
+        telemetry.record("fixture", latency_ms=2, bytes_out=0)
+        assert telemetry.snapshot() == {}
+        assert not telemetry_log.exists()
+        return expected
+
+    context = SimpleNamespace(method="tools/call", params={"name": "fixture"})
+    result = asyncio.run(TelemetryMiddleware()(context, call_next))
+    assert result is expected
+    nested, outer = _samples(telemetry_log)
+    assert nested["bytes_out"] == 5
+    assert nested["ok"] is True
+    assert outer["bytes_out"] == len("réponse 🧠".encode("utf-8"))
+    assert outer["ok"] is False
+
+
+def test_missing_response_publishes_failure_without_swallowing_it(telemetry_log):
+    failure = RuntimeError("transport fixture failure")
+
+    async def call_next(ctx):
+        telemetry.record("fixture", latency_ms=1, ok=False)
+        raise failure
+
+    context = SimpleNamespace(method="tools/call", params={"name": "fixture"})
+    with pytest.raises(RuntimeError) as caught:
+        asyncio.run(TelemetryMiddleware()(context, call_next))
+    assert caught.value is failure
+    sample = _samples(telemetry_log)
+    assert len(sample) == 1
+    assert sample[0]["bytes_out"] == 0
+    assert sample[0]["ok"] is False
+
+
+def test_capture_restores_context_and_late_worker_can_publish(telemetry_log):
+    with telemetry.capture_records() as samples:
+        worker_context = copy_context()
+        telemetry.record("captured", latency_ms=1.23456)
+        assert telemetry.snapshot() == {}
+    assert not telemetry_log.exists()
+    telemetry.publish_record(samples[0])
+    worker_context.run(telemetry.record, "late_worker", latency_ms=2)
+    telemetry.record("direct", latency_ms=3)
+    assert [sample["op"] for sample in _samples(telemetry_log)] == [
+        "captured",
+        "late_worker",
+        "direct",
+    ]
+    assert len(samples) == 1
+    assert telemetry.snapshot()["captured"]["latency_ms_sum"] == 1.23456


### PR DESCRIPTION
## Symptôme

PR temporaire d'acceptation W1-7 / #479. Ne pas fusionner.

## Cause racine

L'annulation des runs Fuzz remplacés doit être observée sur une vraie PR ciblant
main, conformément au filtre de branche du workflow.

## Changement

Deux révisions d'un commentaire sans effet fonctionnel dans fuzz.yml.
Cette PR temporaire inclut l'ascendance W0/W1 pour exercer la configuration
préparée ; les PR de remédiation restent chacune limitées à leur item.

## Preuve

Les deux révisions ont passé leurs gates ordonnés avant le premier push :
Ruff 1 416 fichiers, craftsmanship, Pyright zéro diagnostic ; scripts 830 passed,
5 skipped, 292 subtests ; suites complètes 7 577 passed, 221 skipped,
292 subtests en 147,06 s puis 145,72 s. Données isolées, modèles hors ligne.
Logs `/private/tmp/cortex-green-w1-7-fuzz-probe{1,2}-gates.log`.
Le premier [run Fuzz 34039387321](https://github.com/cdeust/Cortex/actions/runs/34039387321)
au SHA `27a5da21` était `in_progress` avant le second push. Il est désormais
`cancelled`. Le second [run 34039414743](https://github.com/cdeust/Cortex/actions/runs/34039414743)
au SHA `588ff137` est entièrement vert. Aucun cancel manuel n'a été envoyé.
La concurrence a donc réellement annulé le run remplacé. Archives jobs dans
`/private/tmp/cortex-green-w1-7-fuzz-{first,second}-jobs.jsonl`.

## Conformité

Sonde demandée par W1-7. Aucun changement fonctionnel ni donnée de production.
Deux révisions vérifiées avant leur publication rapprochée.

## Candidats issues

Aucun.

## Runbook

Fermer après relevé du résultat, sans fusion.
