### PR TITLE
build: bound local Docker context (W1-8)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,17 @@ build
 .DS_Store
 benchmarks/longmemeval/*.json
 benchmarks/locomo/*.json
+
+# Local installs and generated state; preserve tracked project policy.
+.venv
+deps
+.claude/*
+!.claude/settings.json
+graphify-out
+**/node_modules
+**/__pycache__
+**/*.pyc
+
+# Generated benchmark stdout; retain scripts, inputs and summaries.
+benchmarks/beam/variance/*.txt
+benchmarks/results/**/*.log


### PR DESCRIPTION
## Symptôme

W1-8 / H9 : un build local transmet les installations Python et l'état généré
du poste au démon Docker. Le contexte mesuré atteint 11,99 Go. PR empilée sur #479.

## Cause racine

Les 14 règles de `.dockerignore` ne couvraient ni `.venv`, ni `deps`, ni les
données `.claude`, ni `graphify-out`, ni les journaux de benchmark générés.
Le Dockerfile runtime utilise `COPY .` dans ses deux stages.

## Changement

Un seul fichier modifié : `.dockerignore`. Exclusions des installations locales,
caches Python/node, état généré et sorties texte/logs de benchmark. Le fichier
suivi `.claude/settings.json` reste inclus, ainsi que `.claude-plugin`, les
sources, tests, contraintes, scripts et entrées de benchmark.

## Preuve

Hôte macOS ARM64, 10 cœurs. Base `d72e8b83955234d8f944ac95ec39059723f710f6` ;
seul diff de production : `.dockerignore`. Docker 28.3.3, Buildx 0.37.0,
BuildKit 0.33.0, profil Colima temporaire dédié (4 CPU, 4 GiB RAM, disque 40 GiB).
Un constructeur neuf par phase empêche le transfert incrémental de fausser
l'avant/après. `FROM scratch` + `COPY . /context/`, export `type=cacheonly` :

| Mesure BuildKit | Avant | Après |
| --- | ---: | ---: |
| `transferring context` | 11.99 GB | 47.73 MB |
| Durée affichée du transfert | 159.8 s | 0.4 s |
| Charge hôte initiale / 10 cœurs | 4.15 | 3.03 |
| Disque hôte disponible initial | 63 GiB | 62 GiB |

Valeurs de taille arrondies affichées par BuildKit, pas une mesure d'énergie.
Le contexte après est inférieur à 100 Mo. Les scripts avant et après terminent
avec le code 0.

Les trois images complètes se construisent ensuite séquentiellement avec
`--load`, sans changer leurs Dockerfiles, pins ou préchargements de modèles :

| Dockerfile | Image construite (SHA256) | Champ `docker image inspect .Size` |
| --- | --- | ---: |
| `Dockerfile` | `fb51535bcf5ddae03c121b4691fd989ccbc8c2a7167c87ddaf75533ad53f7e54` | 427605273 |
| `docker/Dockerfile` | `c8d5ebd8fce4d9f6948f302eb43be1cce6ef52d018c9f46206dec258a1c82e92` | 988262767 |
| `.devcontainer/Dockerfile` | `7a11088330325905a72a05b1fb1e3446e0e4a9c97f76fcae9352a62a2e47466c` | 652019780 |

Commandes exactes archivées dans
`/private/tmp/cortex-green-docker-context-proof.sh` et
`/private/tmp/cortex-green-docker-images-proof.sh` :

```bash
bash /private/tmp/cortex-green-docker-context-proof.sh before
# appliquer le diff .dockerignore
bash /private/tmp/cortex-green-docker-context-proof.sh after
bash /private/tmp/cortex-green-docker-images-proof.sh
```

La première commande a précédé le diff. Les deux scripts contiennent les appels
`docker buildx build --progress=plain`, la création de constructeurs distincts,
`git rev-parse HEAD`, `uptime` et `df -h /`. Les trois builds terminent avec le
code 0. Journaux : `cortex-green-w1-8-{before,after}-context.log`,
`cortex-green-w1-8-images.log` ; identifiants archivés dans
`cortex-green-w1-8-image-inspect.json`, tous sous `/private/tmp/`.

Commit final : `d0f7c19bf64a2d994b2e9a2a9818244c994bc972` (aucun rebase après les mesures).

Gates locaux ordonnés, code final 0 : Ruff/format (1 416 fichiers), craftsmanship,
Pyright (zéro diagnostic), scripts **830 passed / 5 skipped / 292 subtests**,
puis suite complète **7 577 passed / 221 skipped / 292 subtests en 149,00 s**.
Charge initiale 4,29 / 10 cœurs ; disque 62 GiB avant et après.

```bash
bash /private/tmp/cortex-green-local-gates.sh w1-8 tests_py/scripts/
```

Le driver effectue `uv sync --locked --no-default-groups --extra dev --extra sqlite
--group lint`, Ruff check/format, craftsmanship ; puis sync des extras
`dev,postgresql,sqlite,codebase,otel` avec groupes `typecheck,lint`, Pyright sur
`mcp_server/`, pytest scripts et pytest complet. Journal :
`/private/tmp/cortex-green-w1-8-gates.log`.
Les dépendances du launcher et les données sont dans un arbre privé jetable ;
les trois DSN explicites visent un socket Unix inexistant. Les skips PostgreSQL
sont signalés, sans accès à une base de production.
CI externe [34042623702](https://github.com/cdeust/Cortex/actions/runs/34042623702) : `success`. Les trois jobs Docker sont verts ; les jobs Python sont ignorés conformément au filtre Docker seul, après validation locale complète.

## Conformité

Diff limité à un fichier de configuration ; aucune constante algorithmique,
aucune nouvelle baseline craftsmanship, aucun changement mémoire. Un seul
travail local lourd à la fois, charge initiale toujours inférieure aux cœurs.
Données de validation jetables, aucun accès à la production. Aucun cache de
modèle sous `/tmp` : les préchargements Docker restent dans les images.

## Candidats issues

Les tailles des installations et sorties générées dépendent du poste. Les
Dockerfiles conservent leurs dépendances et préchargements existants ; leurs
coûts ne sont pas assimilés au seul contexte de build. Aucun nouveau ticket créé.

## Runbook

Le profil Colima `cortex-green-w1-8` créé pour cette preuve a été supprimé après
les trois builds. Le profil utilisateur `default` est toujours en cours et ses
images/caches ont été conservés ; 62 GiB disponibles au début des gates suivants.
Le propriétaire décide de la fusion. Aucun nettoyage de ses installations n'a
été effectué, aucune image publiée dans un registre.
