### PR TITLE
fix: persist hook cascade cadence and cool down misses (W2-4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -71,22 +71,38 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",
             "command": "bash -c 'PY=$(command -v python3 || command -v python) && if [ -z \"${CLAUDE_PLUGIN_ROOT:-}\" ]; then echo \"cortex hook: CLAUDE_PLUGIN_ROOT is unset; refusing to guess the plugin root\" >&2; exit 1; fi; ROOT=\"$CLAUDE_PLUGIN_ROOT\" && \"$PY\" \"$ROOT/scripts/launcher.py\" mcp_server.hooks.post_tool_capture'",
             "timeout": 10
-          },
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|Read",
+        "hooks": [
           {
             "type": "command",
             "command": "bash -c 'PY=$(command -v python3 || command -v python) && if [ -z \"${CLAUDE_PLUGIN_ROOT:-}\" ]; then echo \"cortex hook: CLAUDE_PLUGIN_ROOT is unset; refusing to guess the plugin root\" >&2; exit 1; fi; ROOT=\"$CLAUDE_PLUGIN_ROOT\" && \"$PY\" \"$ROOT/scripts/launcher.py\" mcp_server.hooks.preemptive_context'",
             "timeout": 5
-          },
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
           {
             "type": "command",
             "command": "bash -c 'PY=$(command -v python3 || command -v python) && if [ -z \"${CLAUDE_PLUGIN_ROOT:-}\" ]; then echo \"cortex hook: CLAUDE_PLUGIN_ROOT is unset; refusing to guess the plugin root\" >&2; exit 1; fi; ROOT=\"$CLAUDE_PLUGIN_ROOT\" && \"$PY\" \"$ROOT/scripts/launcher.py\" mcp_server.hooks.pipeline_impact_bump'",
             "timeout": 5
-          },
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
           {
             "type": "command",
             "command": "bash -c 'PY=$(command -v python3 || command -v python) && if [ -z \"${CLAUDE_PLUGIN_ROOT:-}\" ]; then echo \"cortex hook: CLAUDE_PLUGIN_ROOT is unset; refusing to guess the plugin root\" >&2; exit 1; fi; ROOT=\"$CLAUDE_PLUGIN_ROOT\" && \"$PY\" \"$ROOT/scripts/launcher.py\" mcp_server.hooks.post_commit_reindex'",

--- a/.craftsmanship-baseline.json
+++ b/.craftsmanship-baseline.json
@@ -4840,11 +4840,6 @@
     {
       "file": "mcp_server/hooks/post_tool_capture.py",
       "kind": "unsourced-constant",
-      "detail": "_CASCADE_INTERVAL"
-    },
-    {
-      "file": "mcp_server/hooks/post_tool_capture.py",
-      "kind": "unsourced-constant",
       "detail": "_MIN_OUTPUT_LENGTH"
     },
     {

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,17 @@ build
 .DS_Store
 benchmarks/longmemeval/*.json
 benchmarks/locomo/*.json
+
+# Local installs and generated state; preserve tracked project policy.
+.venv
+deps
+.claude/*
+!.claude/settings.json
+graphify-out
+**/node_modules
+**/__pycache__
+**/*.pyc
+
+# Generated benchmark stdout; retain scripts, inputs and summaries.
+benchmarks/beam/variance/*.txt
+benchmarks/results/**/*.log

--- a/.github/actions/test-suite/action.yml
+++ b/.github/actions/test-suite/action.yml
@@ -257,26 +257,21 @@ runs:
         HF_HUB_OFFLINE: "1"
         TRANSFORMERS_OFFLINE: "1"
         CORTEX_RERANKER_OFFLINE: "1"
-      run: pytest --tb=short -q
-
-    # The four steps below are CI-only: they run on the single matrix leg
-    # the ci.yml caller marks run-extended-checks: true (Python 3.12).
-    # release.yml never sets run-extended-checks — its test job is a
-    # pass/fail gate before publishing, not the leg that owns coverage, the
-    # MCP host contract check, or the advertised-test-count/badge check.
-    - name: Run tests with coverage
-      if: inputs.run-extended-checks == 'true'
-      shell: bash
-      env:
-        HF_HUB_OFFLINE: "1"
-        TRANSFORMERS_OFFLINE: "1"
-        CORTEX_RERANKER_OFFLINE: "1"
+        RUN_EXTENDED_CHECKS: ${{ inputs.run-extended-checks }}
       # --cov-fail-under is the statement-coverage floor (issue #196
       # criterion 4): seeded at the number this job itself achieved
       # (82.02% — 30,229 of 36,854 statements, run 30316539703,
       # coverage.py 7.15.2) so the figure can only ratchet up, never
       # silently fall back. Raise the floor when coverage rises.
-      run: pytest --cov=mcp_server --cov-report=xml --cov-report=term-missing --cov-fail-under=82
+      # W1-3: collect coverage during this same suite execution on the
+      # extended leg, preserving both reports and the existing floor.
+      run: |
+        set -euo pipefail
+        pytest_args=(--tb=short -q)
+        if [ "$RUN_EXTENDED_CHECKS" = "true" ]; then
+          pytest_args+=(--cov=mcp_server --cov-report=xml --cov-report=term-missing --cov-fail-under=82)
+        fi
+        pytest "${pytest_args[@]}"
 
     # Match the primary Claude and additive Codex client identities against
     # a real, explicitly configured PostgreSQL instance. Explicit targets
@@ -300,6 +295,8 @@ runs:
     # without collecting the suite, so it is checked in the job that already
     # has the suite installed. `--collect-only` re-collects (~seconds) rather
     # than parsing the run above, so the number is the collector's own.
+    # W1-3 retains this separate assertion: it executes no tests and keeps
+    # the advertised count and badge independent of coverage/run summaries.
     - name: Check advertised test count
       if: inputs.run-extended-checks == 'true'
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@
 #
 # Scope note: `open-pull-requests-limit` is deliberately low. The point is a
 # steady trickle that gets reviewed, not a queue nobody reads.
+# Group compatible version updates within each ecosystem/directory; major
+# updates retain individual PRs so unrelated breaking changes are not bundled.
+# source: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups
 version: 2
 updates:
   # Keeps the SHA pins in .github/workflows fresh. Dependabot rewrites the SHA
@@ -18,6 +21,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "ci"
 
@@ -28,6 +35,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -36,6 +47,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -44,6 +59,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "build"
 
@@ -67,6 +86,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "deps"
     ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -15,6 +14,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+      docker: ${{ steps.filter.outputs.docker }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      deps: ${{ steps.filter.outputs.deps }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Verify pull request file-list completeness
+        if: github.event_name == 'pull_request'
+        run: python3 scripts/check_ci_file_count.py
+      # Classify each file independently. Unknown paths conservatively count
+      # as code; a docs file cannot hide code changed in the same PR.
+      # source: https://github.com/dorny/paths-filter/tree/v4.0.1#usage
+      # `every` applies all code exclusions to each file, not to the PR.
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - '**'
+              - '!{*.md,docs/**/*.md,tasks/**/*.md,Dockerfile,.dockerignore,docker/**,.devcontainer/**,.github/**,pyproject.toml,uv.lock,requirements/**,**/package.json,**/package-lock.json}'
+            docs:
+              - '{*.md,docs/**/*.md,tasks/**/*.md}'
+            docker:
+              - '{Dockerfile,.dockerignore,docker/**,.devcontainer/**}'
+            workflows:
+              - '.github/**'
+            deps:
+              - '{pyproject.toml,uv.lock,requirements/**,**/package.json,**/package-lock.json}'
+
   # Uses the composite action at .github/actions/test-suite/action.yml for
   # the step-level rationale, including why the shared unit is a composite
   # action and not a reusable workflow: a job delegating via `uses:` reports
@@ -26,6 +63,8 @@ jobs:
   # `requirements/ci-postgresql.txt` and tree-sitter grammars are now
   # installed unconditionally inside the action rather than passed in.
   test:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     # Bound a hung leg instead of inheriting GitHub's 360-minute default:
@@ -64,6 +103,8 @@ jobs:
           run-extended-checks: ${{ matrix.python-version == '3.12' }}
 
   test-sqlite:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (SQLite backend)
     runs-on: ubuntu-latest
 
@@ -204,12 +245,13 @@ jobs:
         run: python scripts/verify_mcp_hosts.py -- hypermnesia-mcp
 
   mcp-host-config:
+    needs: [changes, lint]
+    if: (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     name: Validate MCP host configurations
     # The pinned Claude package requires its postinstall to select the native
     # validator. Never execute install scripts from a lockfile modified by an
     # untrusted fork; same-repository PRs and main/workflow_dispatch remain
     # covered by this vendor-parser contract.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -284,6 +326,8 @@ jobs:
               -- "${plugin_command[@]}"
 
   test-windows:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Test (Windows, SQLite backend)
     runs-on: windows-latest
 
@@ -406,6 +450,8 @@ jobs:
   # under this narrower dependency set, with no PostgreSQL service needed
   # (`--storage-selection sqlite` is the default).
   release-deps:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Release dependency set (requirements/release.txt)
     runs-on: ubuntu-latest
     steps:
@@ -600,6 +646,8 @@ jobs:
   # scripts/craftsmanship_baseline.py for why pre-existing debt (recorded
   # in .craftsmanship-baseline.json) does not retroactively block.
   craftsmanship:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Craftsmanship Gate
     runs-on: ubuntu-latest
     steps:
@@ -623,6 +671,8 @@ jobs:
         run: python scripts/check_craftsmanship.py
 
   typecheck:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Type Check
     runs-on: ubuntu-latest
     steps:
@@ -679,6 +729,8 @@ jobs:
         run: .venv/bin/python -m pyright mcp_server/
 
   build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
     name: Build Package
     runs-on: ubuntu-latest
     steps:
@@ -709,6 +761,8 @@ jobs:
   # separate services. The claim here is narrow and worth making on its own:
   # the image still builds, and its hash-pinned installs still resolve.
   docker-runtime-build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Build (runtime image)
     runs-on: ubuntu-latest
     steps:
@@ -738,6 +792,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   devcontainer-build:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Build (devcontainer image)
     runs-on: ubuntu-latest
     steps:
@@ -763,6 +819,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   docker-smoke:
+    needs: [changes, lint]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Smoke (bare-container DB-less contract)
     runs-on: ubuntu-latest
     # BLOCKING: this job asserts the exact contract that silently broke for
@@ -807,8 +865,9 @@ jobs:
         env:
           CORTEX_SMOKE_IMAGE: cortex-smoke:local
 
-  # The one status check branch protection on `main` names. Everything else
-  # in this workflow is reached through its `needs:` list, so renaming a job,
+  # The aggregate required check for this workflow. CodeQL remains an
+  # independent required check outside ci.yml. Everything else here is reached
+  # through its `needs:` list, so renaming a job,
   # resizing the matrix, or delegating steps to a reusable workflow (which
   # rewrites check names to "<caller> / <callee>", issue #336) no longer
   # touches the protection settings — the contract is this file, in git,
@@ -827,6 +886,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
+      - changes
       - test
       - test-sqlite
       - mcp-host-config
@@ -840,30 +900,15 @@ jobs:
       - devcontainer-build
       - docker-smoke
     steps:
-      - name: Require every job above to have succeeded
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Require successful jobs or justified skips
         env:
           NEEDS: ${{ toJSON(needs) }}
-          # Jobs permitted to report `skipped`, with the reason. ONLY jobs
-          # carrying a job-level `if:` belong here; anything else that skips
-          # is a gap, not an exemption.
-          #   mcp-host-config — `if: github.event_name != 'pull_request' ||
-          #   github.event.pull_request.head.repo.fork == false`: a fork PR
-          #   has no access to the secrets it needs, so it cannot run there.
-          ALLOWED_SKIPS: mcp-host-config
-        run: |
-          set -euo pipefail
-          echo "$NEEDS"
-          failed=$(printf '%s' "$NEEDS" | jq -r --arg allowed "$ALLOWED_SKIPS" '
-            ($allowed | split(",") | map(ltrimstr(" ") | rtrimstr(" "))) as $ok
-            | to_entries[]
-            | select(.value.result != "success")
-            | select(.value.result != "skipped" or ([.key] | inside($ok) | not))
-            | "\(.key)=\(.value.result)"')
-          if [ -n "$failed" ]; then
-            echo "::error::CI Green refuses the merge — $(echo "$failed" | tr '\n' ' ')"
-            exit 1
-          fi
-          echo "every required job succeeded"
+          # Path skips are valid only for irrelevant PRs. mcp-host-config
+          # additionally skips fork PRs to avoid untrusted npm postinstall.
+          # The checker verifies these reasons against this run's inputs.
+          ALLOWED_SKIPS: test,test-sqlite,mcp-host-config,test-windows,release-deps,craftsmanship,typecheck,build,docker-runtime-build,devcontainer-build,docker-smoke
+        run: python3 scripts/check_ci_gate_results.py
 
   # The tag-as-output half of issue #392: a green push to `main` tags the
   # exact SHA that just passed CI Green, instead of a human hand-picking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  schedule:
+    # source: W1-4 in tasks/codex-green-remediation-plan.md requires weekly
+    # builds; reuse fuzz.yml's Monday 04:17 UTC window as a config choice.
+    - cron: "17 4 * * 1"
 
 permissions:
   contents: read
@@ -64,7 +68,7 @@ jobs:
   # installed unconditionally inside the action rather than passed in.
   test:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     # Bound a hung leg instead of inheriting GitHub's 360-minute default:
@@ -104,7 +108,7 @@ jobs:
 
   test-sqlite:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (SQLite backend)
     runs-on: ubuntu-latest
 
@@ -246,7 +250,7 @@ jobs:
 
   mcp-host-config:
     needs: [changes, lint]
-    if: (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    if: github.event_name != 'schedule' && ((github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false))
     name: Validate MCP host configurations
     # The pinned Claude package requires its postinstall to select the native
     # validator. Never execute install scripts from a lockfile modified by an
@@ -327,7 +331,7 @@ jobs:
 
   test-windows:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Windows, SQLite backend)
     runs-on: windows-latest
 
@@ -451,7 +455,7 @@ jobs:
   # (`--storage-selection sqlite` is the default).
   release-deps:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Release dependency set (requirements/release.txt)
     runs-on: ubuntu-latest
     steps:
@@ -647,7 +651,7 @@ jobs:
   # in .craftsmanship-baseline.json) does not retroactively block.
   craftsmanship:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Craftsmanship Gate
     runs-on: ubuntu-latest
     steps:
@@ -672,7 +676,7 @@ jobs:
 
   typecheck:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Type Check
     runs-on: ubuntu-latest
     steps:
@@ -730,7 +734,7 @@ jobs:
 
   build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Build Package
     runs-on: ubuntu-latest
     steps:
@@ -762,7 +766,7 @@ jobs:
   # the image still builds, and its hash-pinned installs still resolve.
   docker-runtime-build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (runtime image)
     runs-on: ubuntu-latest
     steps:
@@ -789,11 +793,13 @@ jobs:
           tags: cortex-runtime:ci
           load: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # source: https://docs.docker.com/build/cache/backends/#cache-mode
+          # min exports image layers; intermediate build layers are omitted.
+          cache-to: type=gha,mode=min
 
   devcontainer-build:
     needs: [changes, lint]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (devcontainer image)
     runs-on: ubuntu-latest
     steps:
@@ -816,7 +822,9 @@ jobs:
           tags: cortex-devcontainer:ci
           load: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # source: https://docs.docker.com/build/cache/backends/#cache-mode
+          # min exports image layers; intermediate build layers are omitted.
+          cache-to: type=gha,mode=min
 
   docker-smoke:
     needs: [changes, lint]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
   changes:
     name: Changed paths
     runs-on: ubuntu-latest
+    # source: run 34035713474 (2026-09-06), max 9s; ceil(2 * 9 / 60).
+    timeout-minutes: 1
     permissions:
       contents: read
       pull-requests: read
@@ -71,25 +73,26 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    # Bound a hung leg instead of inheriting GitHub's 360-minute default:
-    # release run 30741657854 (v4.17.0, CHANGELOG 4.17.1) sat in FlashRank's
-    # timeout-less `requests.get` until pytest-timeout fired, and only that
-    # per-test guard, not the job, ever bounded the suite.
-    # source: measured 2026-09-03 over the last 12 green `main` runs of this
-    # workflow (gh run list --status success, runs 31417063954 to
-    # 33688337476, 48 legs, started_at to completed_at per job): Test (Python
-    # 3.12, the only leg running the extended checks) took 15-20 min (max
-    # 19 min 36 s, run 32747742631); the other three legs took 8-11 min in 11
-    # of the 12 runs, but in run 33688337476 (c5ec018a) Python 3.10 took
-    # 15 min 06 s and Python 3.13 took 27 min 17 s, the slowest green leg in
-    # the window. 60 min is about twice that maximum (60 / 27.3 = 2.2), so a
-    # slow runner still passes while a stalled job is cut within one ordinary
-    # run's wall time.
-    timeout-minutes: 60
+    # source: W1-7 review runs 33990473565, 33951959734, 33951905125,
+    # 33806380625; each matrix limit is twice that leg's maximum elapsed time.
+    timeout-minutes: ${{ matrix.timeout-minutes }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          - python-version: "3.10"
+            # source: run 33951959734 (2026-09-05), max 545s; ceil(2 * 545 / 60).
+            timeout-minutes: 19
+          - python-version: "3.11"
+            # source: run 33806380625 (2026-09-03), max 1931s; ceil(2 * 1931 / 60).
+            timeout-minutes: 65
+          - python-version: "3.12"
+            # source: run 33951959734 (2026-09-05), max 1143s; ceil(2 * 1143 / 60).
+            timeout-minutes: 39
+          - python-version: "3.13"
+            # source: run 33951959734 (2026-09-05), max 577s; ceil(2 * 577 / 60).
+            timeout-minutes: 20
 
     steps:
       # A local `uses: ./...` is resolved from the checked-out tree, so the
@@ -111,6 +114,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (SQLite backend)
     runs-on: ubuntu-latest
+    # source: run 33806380625 (2026-09-03), max 292s; ceil(2 * 292 / 60).
+    timeout-minutes: 10
 
     # Force the SQLite fallback path — no PostgreSQL installed or started.
     # The conftest detects PG-unreachable and sets CORTEX_MEMORY_STORE_BACKEND=sqlite
@@ -257,6 +262,8 @@ jobs:
     # untrusted fork; same-repository PRs and main/workflow_dispatch remain
     # covered by this vendor-parser contract.
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 61s; ceil(2 * 61 / 60).
+    timeout-minutes: 3
     permissions:
       contents: read
 
@@ -341,6 +348,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Test (Windows, SQLite backend)
     runs-on: windows-latest
+    # source: run 33990473565 (2026-09-05), max 426s; ceil(2 * 426 / 60).
+    timeout-minutes: 15
 
     # Real NT proof for the cross-platform fixes (fcntl→msvcrt, sys.executable,
     # NTFS exec bits, $HOME override, path separators). We use the SQLite
@@ -467,6 +476,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Release dependency set (requirements/release.txt)
     runs-on: ubuntu-latest
+    # source: run 33806380625 (2026-09-03), max 109s; ceil(2 * 109 / 60).
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -513,6 +524,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 17s; ceil(2 * 17 / 60).
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -683,6 +696,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Craftsmanship Gate
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 9s; ceil(2 * 9 / 60).
+    timeout-minutes: 1
     steps:
       # fetch-depth: 0 so `origin/main` — the diff base the gate compares
       # the PR's changed files against — is resolvable locally, not just
@@ -708,6 +723,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Type Check
     runs-on: ubuntu-latest
+    # source: run 33990473565 (2026-09-05), max 94s; ceil(2 * 94 / 60).
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -770,6 +787,8 @@ jobs:
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
     name: Build Package
     runs-on: ubuntu-latest
+    # source: run 33951905125 (2026-09-05), max 19s; ceil(2 * 19 / 60).
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -804,6 +823,8 @@ jobs:
     if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (runtime image)
     runs-on: ubuntu-latest
+    # source: run 33951905125 (2026-09-05), max 514s; ceil(2 * 514 / 60).
+    timeout-minutes: 18
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -837,6 +858,8 @@ jobs:
     if: needs.changes.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Docker Build (devcontainer image)
     runs-on: ubuntu-latest
+    # source: run 33951905125 (2026-09-05), max 349s; ceil(2 * 349 / 60).
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -866,6 +889,8 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Smoke (bare-container DB-less contract)
     runs-on: ubuntu-latest
+    # source: run 33951959734 (2026-09-05), max 369s; ceil(2 * 369 / 60).
+    timeout-minutes: 13
     # BLOCKING: this job asserts the exact contract that silently broke for
     # two months (fix/bare-container-contract, commit 5d71069c) — third-party
     # registry indexers (Glama et al.) `docker build` the bare repo, then
@@ -928,6 +953,8 @@ jobs:
     name: CI Green
     if: always()
     runs-on: ubuntu-latest
+    # source: run 33806380625 (2026-09-03), max 4s; ceil(2 * 4 / 60).
+    timeout-minutes: 1
     needs:
       - changes
       - test
@@ -973,6 +1000,8 @@ jobs:
     # has already merged — see the job comment above.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # source: run 33990473565 (2026-09-05), max 12s; ceil(2 * 12 / 60).
+    timeout-minutes: 1
     # `contents: read`, NOT write, and that is deliberate. The tag is pushed
     # with the RELEASE_TAG_SSH_KEY deploy key (persisted by the checkout step
     # below), never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,10 @@ jobs:
           # @anthropic-ai/claude-code 2.1.220 declares Node >=22; Node 24 is
           # the repository's existing release-toolchain pin.
           node-version: "24"
+          # source: https://github.com/actions/setup-node/tree/v7.0.0#caching-global-packages-data
+          # Cache downloads, not node_modules.
+          cache: npm
+          cache-dependency-path: tests_js/mcp-host-clis/package-lock.json
 
       - name: Install uv (pinned)
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -329,6 +333,9 @@ jobs:
               --storage-selection auto \
               -- "${plugin_command[@]}"
 
+  # source: https://github.com/actions/setup-python/tree/v7.0.0#caching-packages-dependencies
+  # pip caches below hash each job's exact exported constraints. Requirement
+  # installs still use --require-hashes; no installed environment is restored.
   test-windows:
     needs: [changes, lint]
     if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true')
@@ -350,6 +357,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/ci-sqlite-min.txt
 
       - name: Cache HuggingFace models
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -465,6 +474,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/release.txt
 
       - name: Cache HuggingFace models
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -509,6 +520,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/lint.txt
 
       - name: Install ruff
         # Pinned: ruff's formatter output changes across minor versions
@@ -624,12 +637,28 @@ jobs:
       # curl|bash), matching this repo's supply-chain-hardening stance (release.yml).
       # source: https://github.com/rhysd/actionlint/releases/tag/v1.7.12,
       # actionlint_1.7.12_checksums.txt, linux_amd64 entry, verified 2026-07-29.
+      # Cache only the release archive; verify its checksum on every run.
+      # source: https://github.com/actions/cache/tree/v6.1.0#usage
+      - name: Cache actionlint archive
+        id: actionlint-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/cortex-actionlint/actionlint_1.7.12_linux_amd64.tar.gz
+          key: ${{ runner.os }}-${{ runner.arch }}-actionlint-1.7.12-8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+
       - name: Install actionlint (pinned, checksum-verified)
+        env:
+          CACHE_HIT: ${{ steps.actionlint-cache.outputs.cache-hit }}
+          ACTIONLINT_CACHE_DIR: ${{ runner.temp }}/cortex-actionlint
         run: |
           set -euxo pipefail
           VERSION="1.7.12"
           ARCHIVE="actionlint_${VERSION}_linux_amd64.tar.gz"
-          curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/${ARCHIVE}"
+          mkdir -p "$ACTIONLINT_CACHE_DIR"
+          cd "$ACTIONLINT_CACHE_DIR"
+          if [ "$CACHE_HIT" != "true" ]; then
+            curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/${ARCHIVE}"
+          fi
           echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  ${ARCHIVE}" | sha256sum -c -
           tar -xzf "${ARCHIVE}" actionlint
           sudo install -m 0755 actionlint /usr/local/bin/actionlint
@@ -686,6 +715,10 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements/ci-typecheck.txt
+            requirements/typecheck-tool.txt
 
       # Pyright resolves third-party imports from ./.venv (pinned in
       # pyrightconfig.json: venvPath="."/venv=".venv"). The full stub set MUST
@@ -744,6 +777,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/packaging.txt
 
       - name: Install build tools
         # --no-deps: the file is the complete, uv-resolved dependency graph

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,11 +34,18 @@ on:
 
 permissions: read-all
 
+# source: W1-7 in tasks/codex-green-remediation-plan.md; superseded PR checks.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pr-batch:
     name: Fuzz (PR batch)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # source: run 34030977934 (2026-09-06), max 363s; ceil(2 * 363 / 60).
+    timeout-minutes: 13
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +74,8 @@ jobs:
     name: Fuzz (scheduled batch)
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # source: run 33384194242 (2026-08-31), max 1144s; ceil(2 * 1144 / 60).
+    timeout-minutes: 39
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -30,10 +30,17 @@ on:
 permissions:
   contents: read
 
+# source: W1-7 in tasks/codex-green-remediation-plan.md; superseded PR checks.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   scan:
     name: HOL plugin scan
     runs-on: ubuntu-latest
+    # source: run 34030977899 (2026-09-06), max 59s; ceil(2 * 59 / 60).
+    timeout-minutes: 2
     permissions:
       contents: read
       security-events: write   # SARIF upload to code scanning

--- a/.github/workflows/marketplace-pins.yml
+++ b/.github/workflows/marketplace-pins.yml
@@ -30,6 +30,8 @@ jobs:
   check-pins:
     name: pins current vs latest releases
     runs-on: ubuntu-latest
+    # source: run 33723724819 (2026-09-03), max 13s; ceil(2 * 13 / 60).
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check marketplace pins

--- a/.github/workflows/mcp-toplist-badge.yml
+++ b/.github/workflows/mcp-toplist-badge.yml
@@ -27,6 +27,8 @@ jobs:
   refresh:
     name: refresh rank badge from upstream
     runs-on: ubuntu-latest
+    # source: run 30692957797 (2026-08-01), max 32s; ceil(2 * 32 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
     # form; this one was the exception.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 39s; ceil(2 * 39 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write  # create the release + attach auto-generated notes
     steps:
@@ -134,6 +136,8 @@ jobs:
     # thing they all used to wait on) is gone (issue #392).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 33725153709 (2026-09-03), max 31s; ceil(2 * 31 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write       # upload attested wheel/sdist + checksums to release
       id-token: write       # OIDC token Sigstore exchanges for a signing cert
@@ -218,6 +222,8 @@ jobs:
     # nothing (see `build`'s identical comment for why there is no `needs:`).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 32s; ceil(2 * 32 / 60).
+    timeout-minutes: 2
     permissions:
       contents: write       # upload SBOM + checksum to the release
       id-token: write       # OIDC for attestation
@@ -288,6 +294,8 @@ jobs:
     # identical comment for why there is no `needs:`).
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 25s; ceil(2 * 25 / 60).
+    timeout-minutes: 1
     permissions:
       contents: write       # upload bundle + checksum + server.json to release
       id-token: write       # OIDC token Sigstore exchanges for a signing cert
@@ -398,6 +406,8 @@ jobs:
     # tag-only contract survives a future edit to `build`'s condition.
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 33809450915 (2026-09-03), max 23s; ceil(2 * 23 / 60).
+    timeout-minutes: 1
     # OIDC Trusted Publishing — no stored secret. Verified by PyPI against
     # the trusted-publisher entry for (cdeust/Cortex, release.yml,
     # environment=pypi). This is the same entry that published <= 3.14.7.
@@ -471,6 +481,8 @@ jobs:
     needs: publish-pypi
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    # source: run 32889444672 (2026-08-25), max 14s; ceil(2 * 14 / 60).
+    timeout-minutes: 1
     permissions:
       id-token: write   # OIDC — mcp-publisher login github-oidc
       contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,6 +37,8 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    # source: run 33806380608 (2026-09-03), max 40s; ceil(2 * 40 / 60).
+    timeout-minutes: 2
     permissions:
       security-events: write   # upload SARIF to code scanning
       id-token: write          # publish signed results to the OpenSSF API

--- a/.github/workflows/upstream-identity.yml
+++ b/.github/workflows/upstream-identity.yml
@@ -27,10 +27,17 @@ on:
 permissions:
   contents: read
 
+# source: W1-7 in tasks/codex-green-remediation-plan.md; superseded PR checks.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   contract:
     name: agree with the upstream identity contract
     runs-on: ubuntu-latest
+    # source: run 34034615566 (2026-09-06), max 9s; ceil(2 * 9 / 60).
+    timeout-minutes: 1
     env:
       CONTRACT_URL: https://raw.githubusercontent.com/cdeust/ai-architect-mcp-codebase/37728cc5747cebe39ea9d4011b7424de90f0a57b/mcp-contract.json
     steps:

--- a/docs/runbooks/local-log-rotation.md
+++ b/docs/runbooks/local-log-rotation.md
@@ -1,0 +1,83 @@
+# Local log rotation and legacy-file migration
+
+`telemetry.jsonl`, `consolidate.log`, and `pipeline_reanalyze.log` retain an
+active file and one previous segment named `.1`. The threshold is 5,880,000
+bytes: F9 measured 196 kB/day on 2026-09-06, multiplied by the 30-day interval
+specified in `tasks/codex-green-remediation-plan.md`, W2-3. This is a size
+policy derived from that observation, not a guaranteed retention duration.
+
+Telemetry checks before each UTF-8 append. A record is kept whole, even if a
+single record exceeds the threshold. Its in-memory counters continue across
+rotation. A stable `.lock` sidecar serializes cooperating writers across
+processes; do not remove that file while writers are running. This follows the
+[Python warning about multiprocess file handlers](https://docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes).
+
+Workers rotate before spawning. Their inherited stdout/stderr descriptors
+remain open until they exit, so an active worker can exceed the threshold or
+keep writing to `.1` after another spawn rotates it. This is not a hard disk
+quota. On Windows an open file can prevent renaming; the existing hook failure
+boundary reports the error. No additional collector process is introduced.
+The parent closes its own log descriptor after `Popen` returns.
+
+The initial rotation preserves the entire existing file as `.1`, even if it is
+already larger than the threshold. A later rotation replaces that previous
+segment. Archive existing logs before enabling this version if their full
+history must be retained. No historical files were rotated during development.
+
+## Legacy migration — owner only
+
+At the implementation baseline, `rg -n -F 'session_log.json' mcp_server scripts`
+already returned no matches; there is no `hooks/` directory at the repository
+root. There is no remaining legacy reader or writer to remove. The canonical
+path is `session-log.json` in
+`mcp_server/infrastructure/config.py`; `session_store.py` serves its readers
+and writers. No compatibility shim is added.
+
+The old file may still exist on an owner's machine. After stopping Cortex
+sessions, the owner can run this one-shot command with an explicit root. It
+only removes an ordinary legacy file whose parsed JSON exactly matches the
+canonical file, preserving JSON types and refusing non-finite numbers.
+Different or malformed content requires manual reconciliation;
+the command refuses rather than merging or discarding unknown data.
+
+```bash
+CORTEX_CLAUDE_DIR=/absolute/claude-root python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+def unique_keys(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise SystemExit(f"Refused: duplicate JSON key {key}")
+        result[key] = value
+    return result
+
+root = Path(os.environ["CORTEX_CLAUDE_DIR"])
+if not root.is_absolute() or ".." in root.parts:
+    raise SystemExit("Refused: provide an absolute root without '..'")
+folder = root / "methodology"
+for path in (folder, *folder.parents):
+    if path.is_symlink():
+        raise SystemExit(f"Refused: symlink ancestor {path}")
+legacy = folder / "session_log.json"
+canonical = folder / "session-log.json"
+for path in (legacy, canonical):
+    if path.is_symlink() or not path.is_file():
+        raise SystemExit(f"Refused: expected an ordinary existing file: {path}")
+def canonical_json(path):
+    value = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=unique_keys)
+    return json.dumps(value, sort_keys=True, allow_nan=False)
+
+old = canonical_json(legacy)
+new = canonical_json(canonical)
+if old != new:
+    raise SystemExit("Refused: contents differ; reconcile them manually")
+legacy.unlink()
+print(f"Removed verified duplicate: {legacy}")
+PY
+```
+
+This migration is not run at startup or during installation. No production
+directory was inspected, and no freed-space or energy reduction is claimed.

--- a/mcp_server/core/telemetry.py
+++ b/mcp_server/core/telemetry.py
@@ -7,9 +7,9 @@ not assertion (Popper C6).
 
 Storage:
   * In-memory dict (per process) for fast snapshot/inspection.
-  * Append-only JSONL at ~/.claude/methodology/telemetry.jsonl as the
-    durable artifact for offline analysis. Restart-loss of the in-memory
-    counters is acceptable because every call is captured in the JSONL.
+  * Size-rotated JSONL at ~/.claude/methodology/telemetry.jsonl, with one
+    previous segment (.1) for offline analysis. In-memory counters span the
+    process lifetime; the files retain only the current and previous segments.
 
 Threading:
   Counter increments are guarded by a Lock so the MCP-thread + any
@@ -59,6 +59,7 @@ from pathlib import Path
 from typing import Any, Protocol, TypedDict, runtime_checkable
 
 from mcp_server.shared.telemetry_context import retrieval_metrics
+from mcp_server.shared.log_rotation import open_rotating_log
 
 logger = logging.getLogger(__name__)
 
@@ -223,8 +224,9 @@ def publish_record(sample: TelemetrySample) -> None:
     # source: existing JSONL contract rounds latency_ms to three decimal places.
     record_line = {**sample, "latency_ms": round(sample["latency_ms"], 3)}
     try:
-        with _LOG_PATH.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(record_line) + "\n")
+        line = json.dumps(record_line) + "\n"
+        with open_rotating_log(_LOG_PATH, len(line.encode("utf-8"))) as f:
+            f.write(line)
     except OSError:
         logger.warning("Cannot append telemetry sample: %s", _LOG_PATH, exc_info=True)
     exporter = _exporter

--- a/mcp_server/handlers/ingest_helpers.py
+++ b/mcp_server/handlers/ingest_helpers.py
@@ -1,7 +1,5 @@
 """Shared helpers for ingest_codebase and ingest_prd handlers.
 
-Two concerns live here:
-
 1. Graph-path memoisation — after a codebase analysis, the returned
    graph_path is stored as a protected Cortex memory tagged
    ``_code_graph:<project-id>`` so subsequent ingest runs can reuse
@@ -22,8 +20,6 @@ import os
 from pathlib import Path
 from typing import Any
 
-from mcp_server.infrastructure.mcp_client_pool import get_client
-from mcp_server.infrastructure.upstream_governor import govern
 from mcp_server.observability import silent_failure
 
 CODE_GRAPH_TAG_PREFIX = "_code_graph:"
@@ -265,6 +261,9 @@ async def call_upstream(
     Raises McpConnectionError on connection/transport failure. Returns
     the tool result as a plain dict when the server answers successfully.
     """
+    from mcp_server.infrastructure.mcp_client_pool import get_client  # noqa: PLC0415 — graph memo lookups do not need the upstream client
+    from mcp_server.infrastructure.upstream_governor import govern  # noqa: PLC0415 — create admission machinery only for an upstream call
+
     client = await get_client(server_name)
     # Bound concurrent in-flight calls to this single-process upstream child
     # across every Cortex handler. Without this, two batch tools (distinct

--- a/mcp_server/hooks/_store_lifecycle.py
+++ b/mcp_server/hooks/_store_lifecycle.py
@@ -53,7 +53,7 @@ return, a raised exception, or ``sys.exit()`` (which raises ``SystemExit``,
 still caught by a ``finally``) — closes the store before the process ends.
 
 This module has zero dependencies beyond the standard library at import
-time (the store import is deferred inside the context manager), matching
+time and teardown never imports a store that was not loaded, matching
 ``_headless_guard.py``'s contract that importing a hook helper can never
 fail for a missing third-party package.
 """
@@ -61,6 +61,7 @@ fail for a missing third-party package.
 from __future__ import annotations
 
 import logging
+import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 
@@ -83,12 +84,12 @@ def close_shared_store_on_exit() -> Iterator[None]:
     try:
         yield
     finally:
-        from mcp_server.infrastructure.memory_store import (  # noqa: PLC0415 — deferred: keep this module import-safe with zero third-party deps
-            reset_shared_store,
-        )
-
         try:
-            reset_shared_store()
+            # No loaded factory means no process-wide store cache to close.
+            # source: Python import reference §5.3.1 (sys.modules cache).
+            module = sys.modules.get("mcp_server.infrastructure.memory_store")
+            if module is not None:
+                module.reset_shared_store()
         except Exception:  # noqa: BLE001 — teardown boundary: must never mask the hook's own outcome
             logger.debug(
                 "reset_shared_store failed during hook teardown", exc_info=True

--- a/mcp_server/hooks/pipeline_impact_bump.py
+++ b/mcp_server/hooks/pipeline_impact_bump.py
@@ -43,12 +43,13 @@ import json
 import os
 import sys
 import time
-from pathlib import Path
 from typing import Any, cast
+
+from mcp_server.shared.hook_state_paths import cooldown_path
 
 _LOG_PREFIX = "[pipeline-impact-bump]"
 _COOLDOWN_SECONDS = 30
-_COOLDOWN_FILE = Path("/tmp/cortex_pipeline_impact_cooldown.json")
+_COOLDOWN_FILE = cooldown_path("cortex_pipeline_impact_cooldown.json")
 _FILE_TOOLS = {"Edit", "Write", "MultiEdit"}
 _IMPACT_BOOST = 0.15  # Slightly higher than preemptive — graph precision earns it.
 _MAX_BUMPS = 20  # Don't over-boost on massive impact sets.
@@ -88,6 +89,7 @@ def _update_cooldown(file_path: str) -> None:
             # Prune oldest entries.
             sorted_items = sorted(data.items(), key=lambda x: x[1], reverse=True)
             data = dict(sorted_items[:_MAX_COOLDOWN_ENTRIES])
+        _COOLDOWN_FILE.parent.mkdir(parents=True, exist_ok=True)
         _COOLDOWN_FILE.write_text(json.dumps(data))
     except (OSError, ValueError, TypeError):
         # Cooldown cache is disposable: a failed write only means the next
@@ -220,13 +222,14 @@ def process_event(event: dict[str, Any]) -> None:
     except Exception as exc:  # noqa: BLE001 — hook boundary — failure is logged to the hook log; the hook stays non-fatal
         _log(f"pipeline call failed: {exc}")
         return
+    finally:
+        _update_cooldown(file_path)
 
     if not symbols:
         return
 
     count = _bump_heat_for_symbols(symbols)
     if count > 0:
-        _update_cooldown(file_path)
         _log(f"bumped {count} memories for {len(symbols)} impacted symbols")
 
 

--- a/mcp_server/hooks/pipeline_impact_bump.py
+++ b/mcp_server/hooks/pipeline_impact_bump.py
@@ -212,7 +212,11 @@ def process_event(event: dict[str, Any]) -> None:
 
     project_root = os.environ.get("CLAUDE_PROJECT_ROOT") or os.getcwd()
     try:
-        symbols = asyncio.run(_pipeline_detect_changes(project_root, file_path))
+        from mcp_server.hooks._store_lifecycle import close_shared_store_on_exit  # noqa: PLC0415 — rejected events must not import the store teardown path
+
+        # issue #398: close cached stores on success, exception and SystemExit.
+        with close_shared_store_on_exit():
+            symbols = asyncio.run(_pipeline_detect_changes(project_root, file_path))
     except Exception as exc:  # noqa: BLE001 — hook boundary — failure is logged to the hook log; the hook stays non-fatal
         _log(f"pipeline call failed: {exc}")
         return
@@ -246,13 +250,6 @@ if __name__ == "__main__":
     from mcp_server.hooks._headless_guard import (
         exit_if_headless_authoring_child,
     )
-    from mcp_server.hooks._store_lifecycle import close_shared_store_on_exit
 
     exit_if_headless_authoring_child()
-    # issue #398: closes the store before this one-shot process exits
-    # (see _store_lifecycle.py for the verified mechanism -- psycopg pool
-    # threads are daemon threads; the fragile path is __del__'s
-    # finalization-time join, which close() pre-empts by setting
-    # _closed=True while the interpreter is still alive).
-    with close_shared_store_on_exit():
-        main()
+    main()

--- a/mcp_server/hooks/post_commit_reindex.py
+++ b/mcp_server/hooks/post_commit_reindex.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Any
 
 from mcp_server.shared.platform import python_executable
+from mcp_server.shared.log_rotation import methodology_log_path, open_rotating_log
 
 _LOG_PREFIX = "[post-commit-reindex]"
 _COOLDOWN_FILE = Path("/tmp/cortex_reindex_cooldown.json")
@@ -232,10 +233,9 @@ def _spawn_reanalyze(root: str) -> bool:
         root,
         "--reindex",
     ]
-    log_path = Path.home() / ".claude" / "methodology" / "pipeline_reanalyze.log"
+    log_path = methodology_log_path("pipeline_reanalyze.log")
     try:
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(log_path, "a") as log:
+        with open_rotating_log(log_path) as log:
             subprocess.Popen(  # noqa: S603 — cmd built from trusted sources
                 cmd,
                 stdin=subprocess.DEVNULL,

--- a/mcp_server/hooks/post_tool_capture.py
+++ b/mcp_server/hooks/post_tool_capture.py
@@ -25,6 +25,7 @@ from mcp_server.core.gist_extraction import (
     format_artifact_pointer,
     needs_gist,
 )
+from mcp_server.infrastructure.hook_cascade_counter import advance_after_tool
 from mcp_server.shared.redaction import scrub_secrets
 
 _LOG_PREFIX = "[cortex-post-tool-capture]"
@@ -347,30 +348,29 @@ def _store_memory(tool_name: str, content: str, tags: list[str], cwd: str) -> No
 # Biological basis: consolidation occurs during waking rest periods
 # (Dewar et al. 2012), not only during sleep.
 
-_CASCADE_INTERVAL = 20  # Run cascade every 20 tool calls
-_tool_call_counter = 0
+
+def _run_cascade() -> None:
+    """Advance existing consolidation stages after a reserved interval."""
+    from mcp_server.handlers.consolidation.cascade import (  # noqa: PLC0415 — hook latency boundary: the per-event hook process defers the handler/store stack (hook boot ~0.05 s vs ~0.6 s registry import, measured 2026-07-28)
+        run_cascade_advancement,
+    )
+    from mcp_server.infrastructure.memory_store import get_shared_store  # noqa: PLC0415 — hook latency boundary: the per-event hook process defers the handler/store stack (hook boot ~0.05 s vs ~0.6 s registry import, measured 2026-07-28)
+
+    store = get_shared_store()
+    result = run_cascade_advancement(store)
+    if "error" in result:
+        raise RuntimeError(str(result["error"]))
+    advanced = result.get("advanced", 0)
+    if advanced > 0:
+        _log(f"cascade: {advanced} memories advanced")
 
 
-def _maybe_run_cascade() -> None:
-    """Run cascade advancement if enough tool calls have accumulated."""
-    global _tool_call_counter
-    _tool_call_counter += 1
-    if _tool_call_counter < _CASCADE_INTERVAL:
-        return
-    _tool_call_counter = 0
-
+def _maybe_run_cascade(event: dict[str, Any]) -> None:
+    """Count every tool call across hook processes; preserve pending work."""
     try:
-        from mcp_server.handlers.consolidation.cascade import (  # noqa: PLC0415 — hook latency boundary: the per-event hook process defers the handler/store stack (hook boot ~0.05 s vs ~0.6 s registry import, measured 2026-07-28)
-            run_cascade_advancement,
-        )
-        from mcp_server.infrastructure.memory_store import get_shared_store  # noqa: PLC0415 — hook latency boundary: the per-event hook process defers the handler/store stack (hook boot ~0.05 s vs ~0.6 s registry import, measured 2026-07-28)
-
-        store = get_shared_store()
-        result = run_cascade_advancement(store)
-        advanced = result.get("advanced", 0)
-        if advanced > 0:
-            _log(f"cascade: {advanced} memories advanced")
-    except Exception as exc:  # noqa: BLE001 — hook boundary — failure is logged to the hook log; the hook stays non-fatal
+        if advance_after_tool(event.get("transcript_path"), _run_cascade) == "pending":
+            _log("cascade pending: execution lock busy or unavailable")
+    except Exception as exc:  # noqa: BLE001 — hook boundary; the cause is logged and capture continues
         _log(f"cascade failed (non-fatal): {exc}")
 
 
@@ -382,7 +382,7 @@ def process_event(event: dict[str, Any]) -> None:
     output = _normalize_output(event.get("tool_response") or "")
 
     # Periodic cascade check
-    _maybe_run_cascade()
+    _maybe_run_cascade(event)
 
     should, reason = _should_capture(tool_name, tool_input, output)
     if not should:

--- a/mcp_server/hooks/preemptive_context.py
+++ b/mcp_server/hooks/preemptive_context.py
@@ -64,11 +64,13 @@ import time
 from pathlib import Path
 from typing import Any
 
+from mcp_server.shared.hook_state_paths import cooldown_path
+
 _LOG_PREFIX = "[cortex-preemptive]"
 _DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://localhost:5432/cortex")
 _HEAT_BOOST = 0.1  # Small boost — primes without dominating
 _COOLDOWN_SECONDS = 60
-_COOLDOWN_FILE = Path("/tmp/cortex_preemptive_cooldown.json")
+_COOLDOWN_FILE = cooldown_path("cortex_preemptive_cooldown.json")
 
 # Tools that indicate file interaction worth priming for
 _FILE_TOOLS = {"Edit", "Write", "Read"}
@@ -99,7 +101,7 @@ _MAX_COOLDOWN_ENTRIES = 50
 
 
 def _update_cooldown(file_path: str) -> None:
-    """Record that we primed memories for this file."""
+    """Record that we scanned this file, including a miss."""
     try:
         data = {}
         if _COOLDOWN_FILE.exists():
@@ -109,6 +111,7 @@ def _update_cooldown(file_path: str) -> None:
         if len(data) > _MAX_COOLDOWN_ENTRIES:
             sorted_items = sorted(data.items(), key=lambda x: x[1], reverse=True)
             data = dict(sorted_items[:_MAX_COOLDOWN_ENTRIES])
+        _COOLDOWN_FILE.parent.mkdir(parents=True, exist_ok=True)
         _COOLDOWN_FILE.write_text(json.dumps(data))
     except (OSError, ValueError, TypeError):
         # Cooldown cache is disposable: a failed write only means the next
@@ -177,8 +180,8 @@ def process_event(event: dict[str, Any]) -> None:
         return
 
     count = _prime_file_memories(file_path)
+    _update_cooldown(file_path)
     if count > 0:
-        _update_cooldown(file_path)
         _log(f"primed {count} memories for {Path(file_path).name}")
 
 

--- a/mcp_server/hooks/session_start.py
+++ b/mcp_server/hooks/session_start.py
@@ -33,6 +33,7 @@ from mcp_server.handlers.injection_receipts import (
 from mcp_server.hooks._telemetry import observe_hook
 from mcp_server.shared.freshness import provenance_suffix
 from mcp_server.shared.platform import python_executable
+from mcp_server.shared.log_rotation import methodology_log_path, open_rotating_log
 import sqlite3
 import asyncio
 from datetime import datetime as _dt, timezone as _tz
@@ -848,15 +849,15 @@ def _spawn_consolidate_cycle() -> int | None:
         # Fall back to direct -m invocation (dev source is the package root).
         cmd = [py, "-m", "mcp_server.hooks.consolidate_background"]
 
-    log_path = Path.home() / ".claude" / "methodology" / "consolidate.log"
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    proc = subprocess.Popen(  # noqa: S603 — cmd built from trusted sources
-        cmd,
-        stdin=subprocess.DEVNULL,
-        stdout=open(log_path, "a"),
-        stderr=subprocess.STDOUT,
-        start_new_session=True,
-    )
+    log_path = methodology_log_path("consolidate.log")
+    with open_rotating_log(log_path) as log:
+        proc = subprocess.Popen(  # noqa: S603 — cmd built from trusted sources
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
     _log(f"background consolidate spawned → {log_path}")
     return proc.pid
 
@@ -982,17 +983,16 @@ def _maybe_background_reanalyze() -> None:
             "mcp_server.hooks.ingest_codebase_background",
             project_root,
         ]
-        # Detach: no stdin, redirect stdout/stderr to a log file so we
-        # can diagnose later.
-        log_path = Path.home() / ".claude" / "methodology" / "pipeline_reanalyze.log"
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.Popen(  # noqa: S603 — cmd built from trusted sources
-            cmd,
-            stdin=subprocess.DEVNULL,
-            stdout=open(log_path, "a"),
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-        )
+        # Rotate before spawn; the inherited fd stays open for the worker.
+        log_path = methodology_log_path("pipeline_reanalyze.log")
+        with open_rotating_log(log_path) as log:
+            subprocess.Popen(  # noqa: S603 — cmd built from trusted sources
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
         _log(f"background pipeline reanalysis spawned → {log_path}")
     except Exception as exc:  # noqa: BLE001 — hook boundary — failure is logged to the hook log; the hook stays non-fatal
         _log(f"background pipeline reanalysis skipped: {exc}")

--- a/mcp_server/infrastructure/hook_cascade_counter.py
+++ b/mcp_server/infrastructure/hook_cascade_counter.py
@@ -1,0 +1,107 @@
+"""Persistent PostToolUse cadence, independent of one-shot hook processes.
+
+All tool events count, including tools whose content is not captured. A
+stable counter lock protects atomic JSON replacements. A separate,
+non-blocking execution lock per Claude root serializes hook cascades without blocking
+counter writers. Contention/failure leaves due work for a later event.
+
+This is best effort, not exactly once: a crash after DB advancement but
+before its acknowledgement can repeat advancement. It never resets due
+work merely because another hook is executing a cascade. One invocation
+attempts at most one pending interval, keeping catch-up work bounded.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+from mcp_server.infrastructure.config import METHODOLOGY_DIR
+from mcp_server.infrastructure.groomer_coordinator_io import (
+    DecisionLock,
+    atomic_write_json,
+)
+from mcp_server.infrastructure.hook_counter_lock import counter_lock
+
+# source: post_tool_capture.py at 5de4f4a4; existing cadence preserved,
+# empirical tuning provenance was not recorded at introduction.
+CASCADE_INTERVAL = 20
+
+
+def _session_directory(transcript_path: object) -> Path:
+    """Use the same canonical transcript stem as injection_receipts.
+
+    source: injection_receipts.session_id_from_transcript, decision 4255039
+    correction 7 (148/200 fixture lines had a divergent event session_id).
+    Do not import that handler here: it eagerly imports the PG stack.
+    """
+    if not isinstance(transcript_path, str) or not transcript_path.strip():
+        raise ValueError("cascade skipped: missing transcript identity")
+    identity = Path(transcript_path).stem
+    if not identity or "\x00" in identity:
+        raise ValueError("cascade skipped: invalid transcript identity")
+    # Digest the identity, never interpret an external stem as a state path.
+    key = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    return METHODOLOGY_DIR / "hook-cascade" / key
+
+
+def _read_counter(directory: Path) -> dict[str, int]:
+    try:
+        state = json.loads((directory / "counter.json").read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {"tool_calls": 0, "completed": 0}
+    if not isinstance(state, dict) or set(state) != {"tool_calls", "completed"}:
+        raise ValueError("invalid cascade counter shape; state preserved")
+    if any(type(value) is not int or value < 0 for value in state.values()):
+        raise ValueError("invalid cascade counter values; state preserved")
+    if (
+        state["completed"] > state["tool_calls"]
+        or state["completed"] % CASCADE_INTERVAL
+    ):
+        raise ValueError("invalid cascade counter progress; state preserved")
+    return state
+
+
+def _write_counter(directory: Path, state: dict[str, int]) -> None:
+    if not atomic_write_json(directory / "counter.json", state):
+        raise OSError("cascade counter write failed; advancement not acknowledged")
+
+
+def _tick(directory: Path) -> bool:
+    with counter_lock(directory / "counter.lock"):
+        state = _read_counter(directory)
+        state["tool_calls"] += 1
+        _write_counter(directory, state)
+        return state["tool_calls"] - state["completed"] >= CASCADE_INTERVAL
+
+
+def _pending_deadline(directory: Path) -> int | None:
+    with counter_lock(directory / "counter.lock"):
+        state = _read_counter(directory)
+        deadline = state["completed"] + CASCADE_INTERVAL
+        return deadline if deadline <= state["tool_calls"] else None
+
+
+def _acknowledge(directory: Path, deadline: int) -> None:
+    with counter_lock(directory / "counter.lock"):
+        state = _read_counter(directory)
+        state["completed"] = deadline
+        _write_counter(directory, state)
+
+
+def advance_after_tool(transcript_path: object, advance: Callable[[], None]) -> str:
+    """Count this event and attempt one due cascade; I/O errors propagate."""
+    directory = _session_directory(transcript_path)
+    if not _tick(directory):
+        return "not_due"
+    with DecisionLock(directory.parent / "cascade.lock") as acquired:
+        if not acquired:
+            return "pending"
+        deadline = _pending_deadline(directory)
+        if deadline is None:
+            return "not_due"
+        advance()
+        _acknowledge(directory, deadline)
+        return "advanced"

--- a/mcp_server/infrastructure/hook_counter_lock.py
+++ b/mcp_server/infrastructure/hook_counter_lock.py
@@ -1,0 +1,54 @@
+"""Short counter transactions using a stable cross-platform lock file.
+
+Like pipeline_install_lock, the lock is separate from replaceable JSON.
+Acquisition waits only for a filesystem counter transaction; callers must
+never run models, DB operations, or the cascade while holding it.
+
+source: https://docs.python.org/3/library/fcntl.html#fcntl.flock
+source: https://docs.python.org/3/library/msvcrt.html#msvcrt.locking
+Windows LK_LOCK uses the CRT's documented retry policy; errors propagate.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+
+@contextmanager
+def counter_lock(path: Path) -> Iterator[None]:
+    """Serialize read/modify/replace without dropping contending ticks."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # source: POSIX owner read/write bits; no session-state access for peers.
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        _acquire(fd)
+        try:
+            yield
+        finally:
+            _release(fd)
+    finally:
+        os.close(fd)
+
+
+if sys.platform == "win32":
+    import msvcrt
+
+    def _acquire(fd: int) -> None:
+        # source: msvcrt locks a byte range, including beyond end of file.
+        msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+
+    def _release(fd: int) -> None:
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+
+else:
+    import fcntl
+
+    def _acquire(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+
+    def _release(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_UN)

--- a/mcp_server/shared/hook_state_paths.py
+++ b/mcp_server/shared/hook_state_paths.py
@@ -1,0 +1,14 @@
+"""Keep explicit Claude roots independent from legacy global hook state."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def cooldown_path(filename: str) -> Path:
+    """Honor config.py's override; preserve the existing default /tmp path."""
+    override = os.environ.get("CORTEX_CLAUDE_DIR", "").strip()
+    if override:
+        return Path(override).expanduser() / "methodology" / "hook-cooldowns" / filename
+    return Path("/tmp") / filename

--- a/mcp_server/shared/log_file_lock.py
+++ b/mcp_server/shared/log_file_lock.py
@@ -1,0 +1,56 @@
+"""Serialize cooperating log writers across processes and threads.
+
+FileHandler locks are thread-local, not interprocess (Python Logging Cookbook,
+https://docs.python.org/3/howto/logging-cookbook.html). Use one stable sidecar
+inode so renaming the data file cannot detach the lock from other writers.
+The lock covers rotate/open/write or Popen, never the worker's runtime.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+_THREAD_LOCK = threading.Lock()
+
+
+@contextmanager
+def log_file_lock(path: Path) -> Iterator[None]:
+    """Keep the sidecar: unlinking it would split concurrent lock holders."""
+    # source: owner-only permission for the lock metadata; os.open mode contract.
+    descriptor = os.open(str(path) + ".lock", os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        with _THREAD_LOCK:
+            _acquire(descriptor)
+            try:
+                yield
+            finally:
+                _release(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+if sys.platform == "win32":
+    import msvcrt
+
+    def _acquire(descriptor: int) -> None:
+        # source: https://docs.python.org/3/library/msvcrt.html#msvcrt.locking
+        # One shared byte is sufficient; locking beyond EOF is supported.
+        msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+
+    def _release(descriptor: int) -> None:
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+
+else:
+    import fcntl
+
+    def _acquire(descriptor: int) -> None:
+        # source: https://docs.python.org/3/library/fcntl.html#fcntl.flock
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+
+    def _release(descriptor: int) -> None:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)

--- a/mcp_server/shared/log_rotation.py
+++ b/mcp_server/shared/log_rotation.py
@@ -1,0 +1,67 @@
+"""Size rotation for JSONL appends and detached-worker log opens.
+
+Retain the active file plus one previous segment (.1), the minimum rotating
+history in Python's RotatingFileHandler contract. This helper adds a process
+lock because separate hook processes cannot share that handler's thread lock.
+Source: https://docs.python.org/3/library/logging.handlers.html#rotatingfilehandler
+
+Telemetry checks before every append and preserves complete records, including
+an oversized record. Workers check before spawn: an inherited stdout descriptor
+continues to reference its opened file and can exceed the threshold while the
+worker runs. This is not a hard quota and adds no collector process.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TextIO
+
+from mcp_server.shared.log_file_lock import log_file_lock
+
+# source: F9, tasks/codex-green-remediation-plan.md W2-3 — 196 kB/day
+# measured 2026-09-06; 30 days = 5,880,000 decimal bytes (approximately 6 MB).
+MAX_LOG_BYTES = 196_000 * 30
+
+
+def methodology_log_path(filename: str) -> Path:
+    """Use the same explicit local-data root as infrastructure/config.py."""
+    override = os.environ.get("CORTEX_CLAUDE_DIR", "").strip()
+    root = Path(override).expanduser() if override else Path.home() / ".claude"
+    return root / "methodology" / filename
+
+
+def _regular_file_size(path: Path) -> int:
+    """A missing log starts empty; symlinks and special files are refused."""
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return 0
+    if not stat.S_ISREG(info.st_mode):
+        raise OSError(f"log is not a regular file: {path}")
+    return info.st_size
+
+
+def _rotate_if_needed(path: Path, incoming_bytes: int) -> None:
+    size = _regular_file_size(path)
+    if size and (size >= MAX_LOG_BYTES or size + incoming_bytes > MAX_LOG_BYTES):
+        previous = path.with_name(path.name + ".1")
+        _regular_file_size(previous)
+        path.replace(previous)
+
+
+@contextmanager
+def open_rotating_log(path: Path, incoming_bytes: int = 0) -> Iterator[TextIO]:
+    """Rotate/open under one lock; close the parent's descriptor on exit.
+
+    The caller must keep its write or Popen inside this context. Any filesystem
+    or locking error propagates to the writer's existing logged failure boundary.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with log_file_lock(path):
+        _rotate_if_needed(path, incoming_bytes)
+        with open(path, "a", encoding="utf-8", newline="\n") as stream:
+            yield stream

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,19 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["mcp_server"]
 
+# W1-6: benchmark output, media and paper bundles dominate the source archive;
+# retain application source, tests, fixtures and packaging inputs.
+# source: https://hatch.pypa.io/latest/config/build/#patterns
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/benchmarks/beam/variance/*.txt",
+    "/video/captures",
+    "/video/output",
+    "/docs/**/*.png",
+    "/docs/arxiv-*/**",
+    "/docs/campaigns/*.json",
+]
+
 # ── Resolver constraints ─────────────────────────────────────────────────
 #
 # This table is declared before the `[[tool.uv.index]]` / `[tool.uv.sources]`

--- a/scripts/aggregate_hook_timings.py
+++ b/scripts/aggregate_hook_timings.py
@@ -1,0 +1,226 @@
+"""Validate and aggregate measured PostToolUse timings; never executes hooks.
+
+Usage: python scripts/aggregate_hook_timings.py --before before.json \
+    --after after.json --plugin-before plugin-before.json \
+    --plugin-after plugin-after.json --output comparison.json
+
+Each input JSON report contains entrypoint ('module' or 'launcher'), python,
+platform, plugin_sha256, and cases: [{payload: {...}, samples: [...]}]. Each
+sample contains repetition (0..3), module (fully qualified), exit_code,
+user_seconds, system_seconds, wall_seconds, and max_rss_native.
+Alternatively provide time_log instead of those four metrics: the parser
+reads a real macOS /usr/bin/time -l stderr log, with LC_ALL=C.
+
+source: tasks/codex-green-remediation-plan.md §3/W2-1: four repetitions,
+first excluded; identical Read/Bash payloads and environment before/after.
+Sum user+system CPU across the hooks actually routed for each repetition.
+The wall sum is sequential work, NOT Claude latency: matching hooks run in
+parallel. Keep individual peak RSS values; their sum is not a measured peak.
+Routing source: https://code.claude.com/docs/en/hooks#matcher-patterns.
+Only the exact-name / pipe-separated matchers used here are supported.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+
+# source: remediation plan §3, four repetitions and the first discarded.
+REPETITIONS = 4
+_PREFIX = "mcp_server.hooks."
+MODULES = {
+    _PREFIX + name
+    for name in (
+        "post_tool_capture",
+        "preemptive_context",
+        "pipeline_impact_bump",
+        "post_commit_reindex",
+    )
+}
+_METRICS = ("user_seconds", "system_seconds", "wall_seconds", "max_rss_native")
+
+
+def read_time_log(path: Path) -> dict:
+    """Parse BSD time's measured values; reject ambiguous or missing output.
+
+    source: apple-oss-distributions/shell_cmds, time/time.c (real/user/sys
+    summary and maximum resident set size output under -l).
+    """
+    raw = path.read_text()
+    duration = r"([0-9]+(?:\.[0-9]+)?)"
+    summary = re.findall(
+        rf"^\s*{duration}\s+real\s+{duration}\s+user\s+{duration}\s+sys\s*$",
+        raw,
+        re.MULTILINE,
+    )
+    rss = re.findall(r"^\s*([0-9]+)\s+maximum resident set size\s*$", raw, re.MULTILINE)
+    if len(summary) != 1 or len(rss) != 1:
+        raise ValueError(f"Missing or ambiguous BSD time measurements: {path}")
+    wall, user, system = map(float, summary[0])
+    return {
+        "wall_seconds": wall,
+        "user_seconds": user,
+        "system_seconds": system,
+        "max_rss_native": int(rss[0]),
+    }
+
+
+def _measured_sample(sample: dict) -> dict:
+    if "time_log" not in sample:
+        return sample
+    if any(metric in sample for metric in _METRICS):
+        raise ValueError("Supply either a raw timing log or explicit metrics, not both")
+    return {**sample, **read_time_log(Path(sample["time_log"]))}
+
+
+def selected_modules(plugin: dict, tool: str) -> set[str]:
+    """Resolve this plugin's exact matchers without executing its shell strings."""
+    selected = set()
+    configured = []
+    for group in plugin["hooks"]["PostToolUse"]:
+        matcher = group.get("matcher", "*")
+        if matcher not in ("", "*") and not re.fullmatch(
+            r"[A-Za-z_]+(?:\|[A-Za-z_]+)*", matcher
+        ):
+            raise ValueError(f"Unsupported matcher: {matcher!r}")
+        matches = matcher in ("", "*") or tool in matcher.split("|")
+        for handler in group["hooks"]:
+            names = re.findall(r"mcp_server\.hooks\.[a-z_]+", handler["command"])
+            if len(names) != 1 or handler.get("type") != "command":
+                raise ValueError("Expected one module per command hook")
+            configured.extend(names)
+            if matches:
+                selected.add(names[0])
+    if set(configured) != MODULES or len(configured) != len(MODULES):
+        raise ValueError("Missing, unexpected or duplicate PostToolUse hook")
+    return selected
+
+
+def _sample_key(sample: dict) -> tuple[int, str]:
+    repetition = sample["repetition"]
+    if type(repetition) is not int or repetition not in range(REPETITIONS):
+        raise ValueError("Repetition must be an integer in 0..3")
+    if type(sample["exit_code"]) is not int or sample["exit_code"] != 0:
+        raise ValueError("Failed hook measurement")
+    for metric in _METRICS:
+        value = sample[metric]
+        if type(value) not in (int, float) or not math.isfinite(value) or value < 0:
+            raise ValueError(f"Invalid measured value for {metric}")
+    return repetition, sample["module"]
+
+
+def aggregate_case(case: dict, plugin: dict) -> dict:
+    payload = case["payload"]
+    modules = selected_modules(plugin, payload["tool_name"])
+    indexed = {}
+    for sample in case["samples"]:
+        sample = _measured_sample(sample)
+        key = _sample_key(sample)
+        if key in indexed:
+            raise ValueError(f"Duplicate sample: {key}")
+        indexed[key] = sample
+    expected = {(rep, module) for rep in range(REPETITIONS) for module in modules}
+    if set(indexed) != expected:
+        raise ValueError(
+            "Samples must cover every routed hook exactly once per repetition"
+        )
+    repetitions = []
+    for rep in range(REPETITIONS):
+        rows = [indexed[(rep, module)] for module in sorted(modules)]
+        repetitions.append(
+            {
+                "repetition": rep,
+                "discarded": rep == 0,
+                "cpu_seconds": sum(
+                    row["user_seconds"] + row["system_seconds"] for row in rows
+                ),
+                "wall_seconds_sum": sum(row["wall_seconds"] for row in rows),
+                "hooks": rows,
+            }
+        )
+    return {"payload": payload, "modules": sorted(modules), "repetitions": repetitions}
+
+
+def _case_key(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def validate_report(report: dict, plugin_path: Path) -> dict[str, dict]:
+    raw = plugin_path.read_bytes()
+    if report["plugin_sha256"] != hashlib.sha256(raw).hexdigest():
+        raise ValueError("Plugin fingerprint does not match its supplied snapshot")
+    if report["entrypoint"] not in ("module", "launcher"):
+        raise ValueError("Specify direct module or launcher measurement explicitly")
+    plugin = json.loads(raw)
+    cases = {}
+    for case in report["cases"]:
+        key = _case_key(case["payload"])
+        if key in cases:
+            raise ValueError("Duplicate payload case")
+        cases[key] = aggregate_case(case, plugin)
+    if {case["payload"]["tool_name"] for case in cases.values()} != {"Read", "Bash"}:
+        raise ValueError("The §3 protocol requires both Read and Bash payloads")
+    return cases
+
+
+def compare_reports(before: dict, after: dict, plugins: tuple[Path, Path]) -> dict:
+    for field in ("entrypoint", "python", "platform"):
+        if (
+            not isinstance(before[field], str)
+            or not before[field]
+            or before[field] != after[field]
+        ):
+            raise ValueError(f"Before/after {field} must match")
+    old = validate_report(before, plugins[0])
+    new = validate_report(after, plugins[1])
+    if old.keys() != new.keys():
+        raise ValueError("Before/after payloads must be identical")
+    comparisons = []
+    for key in old:
+        pairs = zip(old[key]["repetitions"], new[key]["repetitions"], strict=True)
+        deltas = [
+            {
+                "repetition": left["repetition"],
+                "cpu_seconds_after_minus_before": right["cpu_seconds"]
+                - left["cpu_seconds"],
+            }
+            for left, right in pairs
+            if not left["discarded"]
+        ]
+        comparisons.append(
+            {"before": old[key], "after": new[key], "retained_deltas": deltas}
+        )
+    return {
+        "entrypoint": before["entrypoint"],
+        "python": before["python"],
+        "platform": before["platform"],
+        "cases": comparisons,
+        "wall_note": "Wall sums are sequential work, not parallel Claude hook latency.",
+        "rss_note": "Per-hook native RSS retained; no aggregate peak is inferred.",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for name in ("before", "after", "plugin-before", "plugin-after", "output"):
+        parser.add_argument(f"--{name}", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        result = compare_reports(
+            json.loads(args.before.read_text()),
+            json.loads(args.after.read_text()),
+            (args.plugin_before, args.plugin_after),
+        )
+    except (KeyError, TypeError, ValueError, OSError) as exc:
+        parser.error(str(exc))
+    with args.output.open("x") as output:
+        json.dump(result, output, indent=2)
+        output.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_ci_file_count.py
+++ b/scripts/check_ci_file_count.py
@@ -1,0 +1,40 @@
+"""Refuse PR path classification when GitHub's file list may be incomplete."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+
+
+# source: https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
+# The REST endpoint used by dorny/paths-filter returns at most 3000 files.
+API_FILE_LIMIT = 3000
+
+
+def check(count: object) -> str | None:
+    if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+        return "pull_request.changed_files must be a nonnegative integer"
+    if count > API_FILE_LIMIT:
+        return (
+            f"PR changes {count} files, exceeding GitHub's {API_FILE_LIMIT}-file "
+            "API limit; refusing incomplete classification. Split the PR."
+        )
+    return None
+
+
+def main() -> int:
+    try:
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        failure = check(event["pull_request"].get("changed_files"))
+    except (KeyError, OSError, ValueError, TypeError, AttributeError) as error:
+        failure = f"cannot validate pull request file count: {error}"
+    if failure:
+        print(f"::error::{failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_ci_gate_complete.py
+++ b/scripts/check_ci_gate_complete.py
@@ -1,54 +1,12 @@
-"""CI-gate completeness: every ci.yml job must be behind the aggregate gate.
+"""Static CI-gate coverage and prerequisite checks without YAML dependencies.
 
-Branch protection on ``main`` names required status checks as strings, in
-GitHub settings — outside git, invisible in review, and unversioned. Naming
-individual jobs there makes the contract break on every rename: extracting
-the test steps into a reusable workflow (issue #336) renamed the four matrix
-legs to ``Test (Python X.Y) / Test (Python X.Y)``, so the four bare contexts
-``main`` required were never reported again and a fully green PR sat BLOCKED
-(PR #387, run 31250898534). Renaming the contexts fixes that one PR and
-leaves the next rename to rediscover it.
+Every job must be a direct CI Green dependency or declare a conditional
+post-merge exemption. Every conditional gated job belongs to ALLOWED_SKIPS;
+the runtime checker independently verifies the reason for each actual skip.
+CI Green must always run to report failures and rejected skips.
 
-So protection names ONE ci.yml context — ``CI Green`` — and the real list
-lives here, in git, where a diff shows it. That moves the failure mode: the
-gate is only as good as its ``needs:`` list, and a job added later that
-nobody adds to it is silently ungated. That is what this script refuses.
-
-It also refuses the second escape hatch. The gate treats any result other
-than ``success`` as failure, EXCEPT for jobs named in its ``ALLOWED_SKIPS``
-env — because a job carrying a job-level ``if:`` legitimately reports
-``skipped``. An unlisted conditional would therefore let a job skip its way
-past the gate, so every job with an ``if:`` must be declared, and every
-declared exemption must correspond to a job that actually has one (a stale
-exemption is a hole nobody is watching).
-
-A third case exists that ``needs:``/``ALLOWED_SKIPS`` cannot express:
-``release-gate`` (issue #392) runs ONLY on a push to ``main`` — after the PR
-it belongs to has already merged. There is nothing for it to gate: it cannot
-block a PR that is already closed, and putting it in ``ci-green.needs`` would
-make the branch-protection context depend on a job that never runs on a PR
-in the first place, permanently blocking every PR. Such a job declares itself
-with a ``# ci-gate-exempt: <reason>`` marker line in its body instead of
-appearing in ``needs:``. The marker is not a blank check: it is refused
-unless the job ALSO carries a job-level ``if:`` — an exempt job with no
-condition would run ungated on every push and PR, which is exactly the hole
-this script exists to close.
-
-Checks, all of them fatal:
-
-1. the gate job exists;
-2. every other ci.yml job appears in the gate's ``needs:`` OR carries a
-   ``# ci-gate-exempt:`` marker;
-3. every name in ``needs:`` is a real job;
-4. every job carrying a job-level ``if:`` and not exempt is listed in
-   ``ALLOWED_SKIPS``;
-5. every name in ``ALLOWED_SKIPS`` is a job that carries an ``if:``;
-6. every ``# ci-gate-exempt:`` job carries a job-level ``if:`` — an exemption
-   with no condition is not a narrower gate, it is no gate.
-
-Static only — regex over the workflow text, no PyYAML. The Lint job installs
-ruff and nothing else, and this script runs there alongside
-``check_doc_claims.py``, which is static for the same reason.
+Source: tasks/codex-green-remediation-plan.md W1-2 and GitHub workflow syntax:
+https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds
 """
 
 from __future__ import annotations
@@ -60,12 +18,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
-# The single job branch protection points at. Renaming it is a protection
-# change, not a refactor — hence a named constant rather than a literal.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+from check_ci_gate_results import check_policy  # noqa: E402
+
+# The aggregate context for this workflow. Renaming it requires updating
+# branch protection, hence a named constant rather than a literal.
 GATE_JOB = "ci-green"
 
 _JOB_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
 _JOB_IF_RE = re.compile(r"^    if:\s*(\S.*)$")
+_NEEDS_INLINE_RE = re.compile(r"^    needs:\s*\[([^]]*)\]\s*$")
 _NEEDS_BLOCK_RE = re.compile(r"^    needs:\s*$")
 _NEEDS_ITEM_RE = re.compile(r"^      - ([A-Za-z0-9_-]+)\s*$")
 _ALLOWED_SKIPS_RE = re.compile(r"^\s*ALLOWED_SKIPS:\s*(\S.*?)\s*$")
@@ -114,6 +78,10 @@ def _parse_needs(body: list[str]) -> list[str]:
     collecting = False
 
     for line in body:
+        inline = _NEEDS_INLINE_RE.match(line)
+        if inline:
+            needs.extend(name.strip() for name in inline.group(1).split(","))
+            continue
         if _NEEDS_BLOCK_RE.match(line):
             collecting = True
             continue
@@ -205,7 +173,7 @@ def _check_allowed_skips(
 ) -> list[str]:
     """Checks 4 and 5: ALLOWED_SKIPS and the set of conditional jobs agree.
 
-    Exempt jobs never appear in ``needs:``, so ci-green's jq never evaluates
+    Exempt jobs never appear in ``needs:``, so CI Green never evaluates
     their result — ALLOWED_SKIPS governs skip results INSIDE the gate only,
     and does not apply to a job structurally outside it.
     """
@@ -242,6 +210,32 @@ def _check_exempt_jobs_are_conditional(
     ]
 
 
+def _check_gate_execution(bodies: dict[str, list[str]], needs: list[str]) -> list[str]:
+    conditions = [
+        match.group(1) for line in bodies[GATE_JOB] if (match := _JOB_IF_RE.match(line))
+    ]
+    if conditions != ["always()"]:
+        return [f"{GATE_JOB} must have exactly 'if: always()'"]
+    if len(needs) != len(set(needs)) or GATE_JOB in needs:
+        return [f"{GATE_JOB}.needs has a duplicate or self dependency"]
+    return []
+
+
+def check_runtime_contract(text: str) -> list[str]:
+    """Check production workflow policy and lint-before-matrix dependencies."""
+    _, needs, allowed, _ = parse_workflow(text)
+    failures = check_policy(needs, allowed)
+    bodies = _job_bodies(text)
+    for job in allowed:
+        if set(_parse_needs(bodies.get(job, []))) != {"changes", "lint"}:
+            failures.append(f"{job} must depend on exactly changes and lint")
+    for job in ("changes", "lint"):
+        body = bodies.get(job, [])
+        if _parse_needs(body) or any(_JOB_IF_RE.match(line) for line in body):
+            failures.append(f"{job} must always run without prerequisites")
+    return failures
+
+
 def check(text: str) -> list[str]:
     """Return the list of failures; empty means the gate is complete."""
     jobs, needs, allowed_skips, exempt = parse_workflow(text)
@@ -257,7 +251,8 @@ def check(text: str) -> list[str]:
         ]
 
     return (
-        _check_every_job_is_gated(jobs, set(needs) | exempt)
+        _check_gate_execution(_job_bodies(text), needs)
+        + _check_every_job_is_gated(jobs, set(needs) | exempt)
         + _check_needs_are_real_jobs(jobs, needs)
         + _check_allowed_skips(jobs, allowed_skips, exempt)
         + _check_exempt_jobs_are_conditional(jobs, exempt)
@@ -269,7 +264,8 @@ def main() -> int:
         print(f"FAIL: {CI_WORKFLOW} not found", file=sys.stderr)
         return 1
 
-    failures = check(CI_WORKFLOW.read_text(encoding="utf-8"))
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+    failures = check(text) + check_runtime_contract(text)
     if failures:
         print("CI gate completeness: FAIL", file=sys.stderr)
         for failure in failures:

--- a/scripts/check_ci_gate_results.py
+++ b/scripts/check_ci_gate_results.py
@@ -1,11 +1,12 @@
 """Fail CI Green unless every job succeeded or has a verified skip reason.
 
-The policy mirrors ci.yml: non-PR runs execute the full matrix; code,
-dependency or workflow changes do so on PRs. Docker changes also run Docker
-jobs. The vendor CLI job skips fork PRs because it executes npm postinstall.
-Missing classifications and unknown jobs fail closed.
+The policy mirrors ci.yml: code, dependency or workflow PR changes run code
+jobs and Docker smoke. Pushes and dispatches also run those jobs; schedules
+run smoke but skip code jobs. Runtime/devcontainer builds require Docker
+changes, a schedule or a dispatch. The vendor CLI job skips fork PRs because
+it executes npm postinstall. Missing classifications and unknown jobs fail closed.
 
-Source: tasks/codex-green-remediation-plan.md W1-2 and ci.yml job predicates.
+Source: tasks/codex-green-remediation-plan.md W1-2/W1-4 and ci.yml predicates.
 GitHub's needs context exposes result and outputs for direct dependencies:
 https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context
 """
@@ -30,13 +31,13 @@ CODE_JOBS = frozenset(
         "build",
     }
 )
-DOCKER_JOBS = frozenset({"docker-runtime-build", "devcontainer-build", "docker-smoke"})
+DOCKER_BUILD_JOBS = frozenset({"docker-runtime-build", "devcontainer-build"})
 ALWAYS_JOBS = frozenset({"changes", "lint"})
-CONDITIONAL_JOBS = CODE_JOBS | DOCKER_JOBS
+CONDITIONAL_JOBS = CODE_JOBS | DOCKER_BUILD_JOBS | {"docker-smoke"}
 EXPECTED_JOBS = ALWAYS_JOBS | CONDITIONAL_JOBS
 # source: .github/workflows/ci.yml changes.outputs and on triggers.
 FILTERS = frozenset({"code", "docs", "docker", "workflows", "deps"})
-EVENTS = frozenset({"pull_request", "push", "workflow_dispatch"})
+EVENTS = frozenset({"pull_request", "push", "workflow_dispatch", "schedule"})
 
 
 def check_policy(needs: list[str], allowed: list[str]) -> list[str]:
@@ -75,10 +76,12 @@ def _required_jobs(flags: dict[str, bool], event_name: str, fork: bool) -> set[s
         flags[name] for name in ("code", "deps", "workflows")
     )
     required = set(ALWAYS_JOBS)
-    if full:
+    if full and event_name != "schedule":
         required.update(CODE_JOBS)
     if full or flags["docker"]:
-        required.update(DOCKER_JOBS)
+        required.add("docker-smoke")
+    if flags["docker"] or event_name in ("schedule", "workflow_dispatch"):
+        required.update(DOCKER_BUILD_JOBS)
     if fork:
         required.discard("mcp-host-config")
     return required

--- a/scripts/check_ci_gate_results.py
+++ b/scripts/check_ci_gate_results.py
@@ -1,0 +1,130 @@
+"""Fail CI Green unless every job succeeded or has a verified skip reason.
+
+The policy mirrors ci.yml: non-PR runs execute the full matrix; code,
+dependency or workflow changes do so on PRs. Docker changes also run Docker
+jobs. The vendor CLI job skips fork PRs because it executes npm postinstall.
+Missing classifications and unknown jobs fail closed.
+
+Source: tasks/codex-green-remediation-plan.md W1-2 and ci.yml job predicates.
+GitHub's needs context exposes result and outputs for direct dependencies:
+https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# source: .github/workflows/ci.yml, jobs gated by changes and lint.
+CODE_JOBS = frozenset(
+    {
+        "test",
+        "test-sqlite",
+        "mcp-host-config",
+        "test-windows",
+        "release-deps",
+        "craftsmanship",
+        "typecheck",
+        "build",
+    }
+)
+DOCKER_JOBS = frozenset({"docker-runtime-build", "devcontainer-build", "docker-smoke"})
+ALWAYS_JOBS = frozenset({"changes", "lint"})
+CONDITIONAL_JOBS = CODE_JOBS | DOCKER_JOBS
+EXPECTED_JOBS = ALWAYS_JOBS | CONDITIONAL_JOBS
+# source: .github/workflows/ci.yml changes.outputs and on triggers.
+FILTERS = frozenset({"code", "docs", "docker", "workflows", "deps"})
+EVENTS = frozenset({"pull_request", "push", "workflow_dispatch"})
+
+
+def check_policy(needs: list[str], allowed: list[str]) -> list[str]:
+    """Keep the workflow and the executable skip policy in exact agreement."""
+    failures = []
+    if set(needs) != EXPECTED_JOBS:
+        failures.append("CI Green needs do not match the runtime job policy")
+    if set(allowed) != CONDITIONAL_JOBS:
+        failures.append("ALLOWED_SKIPS does not match the runtime skip policy")
+    return failures
+
+
+def _classifications(needs: dict) -> dict[str, bool]:
+    outputs = needs["changes"].get("outputs")
+    if not isinstance(outputs, dict) or set(outputs) != FILTERS:
+        raise ValueError("changes must provide exactly the five path outputs")
+    if any(value not in ("true", "false") for value in outputs.values()):
+        raise ValueError("changes outputs must be the strings 'true' or 'false'")
+    return {name: value == "true" for name, value in outputs.items()}
+
+
+def _is_fork(event_name: str, event: dict) -> bool:
+    if event_name != "pull_request":
+        return False
+    try:
+        fork = event["pull_request"]["head"]["repo"]["fork"]
+    except (KeyError, TypeError) as error:
+        raise ValueError("pull_request event is missing head.repo.fork") from error
+    if not isinstance(fork, bool):
+        raise ValueError("pull_request head.repo.fork must be a boolean")
+    return fork
+
+
+def _required_jobs(flags: dict[str, bool], event_name: str, fork: bool) -> set[str]:
+    full = event_name != "pull_request" or any(
+        flags[name] for name in ("code", "deps", "workflows")
+    )
+    required = set(ALWAYS_JOBS)
+    if full:
+        required.update(CODE_JOBS)
+    if full or flags["docker"]:
+        required.update(DOCKER_JOBS)
+    if fork:
+        required.discard("mcp-host-config")
+    return required
+
+
+def check(needs: dict, event_name: str, event: dict) -> list[str]:
+    """Evaluate actual results, never treating an allowlist as a skip reason."""
+    if not isinstance(needs, dict) or set(needs) != EXPECTED_JOBS:
+        return ["needs must contain exactly the expected CI jobs"]
+    if event_name not in EVENTS or not isinstance(event, dict):
+        return ["missing or unsupported GitHub event context"]
+    if any(not isinstance(value, dict) for value in needs.values()):
+        return ["every needs entry must be a job result object"]
+    try:
+        flags = _classifications(needs)
+        required = _required_jobs(flags, event_name, _is_fork(event_name, event))
+    except ValueError as error:
+        return [str(error)]
+    failures = []
+    for job, value in sorted(needs.items()):
+        result = value.get("result")
+        if result == "success":
+            continue
+        if result == "skipped" and job not in required:
+            continue
+        failures.append(f"{job}={result!r} (success required or invalid result)")
+    return failures
+
+
+def main() -> int:
+    try:
+        allowed = os.environ["ALLOWED_SKIPS"].split(",")
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        needs = json.loads(os.environ["NEEDS"])
+        failures = check(needs, os.environ["GITHUB_EVENT_NAME"], event)
+        if set(allowed) != CONDITIONAL_JOBS:
+            failures.append("ALLOWED_SKIPS does not match the runtime skip policy")
+    except (KeyError, OSError, ValueError) as error:
+        failures = [f"cannot read CI gate inputs: {error}"]
+    if failures:
+        for failure in failures:
+            print(f"::error::CI Green: {failure}", file=sys.stderr)
+        return 1
+    print("CI Green: all required jobs succeeded; every skip is justified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/launcher.py
+++ b/scripts/launcher.py
@@ -177,5 +177,29 @@ def main() -> None:
         sys.exit(1)
 
 
-if __name__ == "__main__":
+def entrypoint() -> None:
+    """Keep cleanup imports and registry I/O out of per-tool hook launches."""
+    arguments = sys.argv[1:]
+    if arguments and arguments[0].partition("=")[0] in {
+        "--cleanup-deps",
+        "--dry-run",
+        "--apply",
+        "--plugin-id",
+    }:
+        from launcher_cleanup import cli  # noqa: PLC0415 — explicit maintenance only
+
+        _reconfigure_streams_utf8()
+        sys.exit(cli(arguments))
+    if (
+        arguments
+        and arguments[0] == "mcp_server"
+        and os.environ.get("CORTEX_CLAUDE_DIR")
+    ):
+        from launcher_cleanup import audit_startup  # noqa: PLC0415 — server startup only
+
+        audit_startup()
     main()
+
+
+if __name__ == "__main__":
+    entrypoint()

--- a/scripts/launcher_cleanup.py
+++ b/scripts/launcher_cleanup.py
@@ -1,0 +1,167 @@
+"""Audit dependency directories; remove selected orphans only on owner opt-in.
+
+Runbook: set CORTEX_CLAUDE_DIR and CLAUDE_PLUGIN_DATA to explicit absolute
+paths, stop sessions using the selected plugin, then run launcher.py
+--cleanup-deps --dry-run --plugin-id old@marketplace; review the JSON, then
+replace --dry-run with --apply. Only deps is removed, never the identity folder.
+
+Startup is audit-only: Claude's inline/synced plugins have no install record,
+and registries cannot enumerate every project, managed setting or live session.
+Source: https://code.claude.com/docs/en/plugins-reference . An explicit
+--plugin-id supplies the owner-verified identity, not an inferred folder suffix.
+The owner must verify absence from undiscovered settings and stopped sessions.
+Missing/corrupt/incomplete known registries refuse deletion. Python 3.10 and
+platforms without descriptor-bound symlink protection refuse --apply.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from launcher_cleanup_fs import (
+    CleanupRefusedError,
+    child_names,
+    directory,
+    inspect_deps,
+    remove_deps,
+    require_removal_support,
+)
+from launcher_cleanup_registry import CleanupScope, identity, protections
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CleanupReport:
+    """Candidates are verified only within the explicit, known registry scope."""
+
+    candidates: list[str] = field(default_factory=list)
+    protected: list[str] = field(default_factory=list)
+    indeterminate: list[str] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+    refused: list[str] = field(default_factory=list)
+
+
+def _selected(plugin_ids: list[str]) -> set[str]:
+    result: set[str] = set()
+    for plugin_id in plugin_ids:
+        name = identity(plugin_id)
+        if plugin_id.endswith(("@inline", "@synced")) or name.endswith(
+            ("-inline", "-synced")
+        ):
+            raise CleanupRefusedError(
+                f"unregistered inline/synced identity cannot be verified: {plugin_id}"
+            )
+        result.add(name)
+    return result
+
+
+def _audit(scope: CleanupScope, selected: set[str], report: CleanupReport) -> None:
+    protected = protections(scope)
+    # Validate the current directory's ancestors even when it has no deps yet.
+    with directory(scope.current_deps.parent):
+        names = child_names(scope.data_root)
+    for name in names:
+        path = scope.data_root / name / "deps"
+        if not inspect_deps(path):
+            continue
+        if name in protected:
+            report.protected.append(str(path))
+        elif name in selected:
+            inspect_deps(path, recursive=True)
+            report.candidates.append(str(path))
+        else:
+            report.indeterminate.append(str(path))
+    missing = selected - {Path(path).parent.name for path in report.candidates}
+    if missing:
+        raise CleanupRefusedError(
+            f"selected identities protected, absent or without deps: {sorted(missing)}"
+        )
+
+
+def _apply(scope: CleanupScope, report: CleanupReport) -> None:
+    require_removal_support()
+    for candidate in report.candidates:
+        path = Path(candidate)
+        # Re-read all registries immediately before each deletion. The owner
+        # must stop sessions; no cross-process Claude registry lock is published.
+        if path.parent.name in protections(scope):
+            raise CleanupRefusedError(
+                f"identity became protected before removal: {path.parent.name}"
+            )
+        remove_deps(path)
+        report.removed.append(candidate)
+
+
+def sweep(
+    scope: CleanupScope, plugin_ids: list[str], *, apply: bool = False
+) -> CleanupReport:
+    """Audit first, then optionally remove only explicitly selected candidates."""
+    report = CleanupReport()
+    try:
+        selected = _selected(plugin_ids)
+        if apply and not selected:
+            raise CleanupRefusedError(
+                "--apply requires at least one owner-verified --plugin-id"
+            )
+        _audit(scope, selected, report)
+        if apply:
+            _apply(scope, report)
+    except (OSError, ValueError) as exc:
+        report.refused.append(str(exc))
+        logger.warning("dependency cleanup refused: %s", exc)
+    return report
+
+
+def _scope_from_environment() -> CleanupScope:
+    root = os.environ.get("CORTEX_CLAUDE_DIR")
+    current = os.environ.get("CLAUDE_PLUGIN_DATA")
+    if not root or not current:
+        raise CleanupRefusedError(
+            "CORTEX_CLAUDE_DIR and CLAUDE_PLUGIN_DATA are required for cleanup"
+        )
+    return CleanupScope(Path(root), Path(current) / "deps")
+
+
+def audit_startup() -> None:
+    """Opt-in audit; an unset root does no I/O and emits no diagnostic."""
+    if not os.environ.get("CORTEX_CLAUDE_DIR"):
+        return
+    try:
+        scope = _scope_from_environment()
+    except CleanupRefusedError as exc:
+        logger.warning("dependency cleanup refused: %s", exc)
+        return
+    report = sweep(scope, [])
+    if report.indeterminate:
+        logger.warning(
+            "dependency cleanup audit retained unverified dirs: %s",
+            report.indeterminate,
+        )
+
+
+def cli(arguments: list[str]) -> int:
+    """Handle cleanup before dependency installation or backend imports."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cleanup-deps", action="store_true", required=True)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="list only (the default)")
+    mode.add_argument(
+        "--apply", action="store_true", help="owner confirms selected plugins unused"
+    )
+    parser.add_argument("--plugin-id", action="append", default=[])
+    options = parser.parse_args(arguments)
+    try:
+        scope = _scope_from_environment()
+    except CleanupRefusedError as exc:
+        logger.warning("dependency cleanup refused: %s", exc)
+        print(json.dumps(asdict(CleanupReport(refused=[str(exc)]))))
+        return 1
+    report = sweep(scope, options.plugin_id, apply=options.apply)
+    print(json.dumps(asdict(report), indent=2))
+    return int(bool(report.refused))

--- a/scripts/launcher_cleanup_fs.py
+++ b/scripts/launcher_cleanup_fs.py
@@ -1,0 +1,147 @@
+"""Stdlib, descriptor-bound filesystem access for explicit deps cleanup.
+
+Sources: https://docs.python.org/3/library/os.html#files-and-directories
+and https://docs.python.org/3/library/shutil.html#shutil.rmtree.
+Every ancestor is opened with O_NOFOLLOW; removal never receives an absolute
+path. Unsupported platforms fail closed, without changing normal launching.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import shutil
+import stat
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+
+class CleanupRefusedError(ValueError):
+    """The filesystem or registry cannot establish safe cleanup conditions."""
+
+
+def require_directory_support() -> None:
+    """Refuse platforms without descriptor-relative, no-follow access."""
+    if not hasattr(os, "O_NOFOLLOW") or not hasattr(os, "O_DIRECTORY"):
+        raise CleanupRefusedError("no-follow directory access is unavailable")
+    if os.open not in os.supports_dir_fd or os.stat not in os.supports_dir_fd:
+        raise CleanupRefusedError("descriptor-relative directory access is unavailable")
+
+
+@contextmanager
+def directory(path: Path) -> Iterator[int]:
+    """Open an absolute directory without following any ancestor symlink."""
+    require_directory_support()
+    if not path.is_absolute() or ".." in path.parts:
+        raise CleanupRefusedError(f"expected absolute path without '..': {path}")
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    descriptor = os.open(path.anchor, flags)
+    try:
+        for part in path.parts[1:]:
+            child = os.open(part, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = child
+        yield descriptor
+    finally:
+        os.close(descriptor)
+
+
+def _unique_pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    """Do not let duplicate JSON keys hide protected plugin references."""
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CleanupRefusedError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def read_object(path: Path) -> dict[str, object]:
+    """Read a regular JSON file; reject links, FIFOs and duplicate keys."""
+    with directory(path.parent) as parent:
+        descriptor = os.open(
+            path.name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=parent
+        )
+        with os.fdopen(descriptor, encoding="utf-8") as stream:
+            if not stat.S_ISREG(os.fstat(stream.fileno()).st_mode):
+                raise CleanupRefusedError(f"registry is not a regular file: {path}")
+            result = json.load(stream, object_pairs_hook=_unique_pairs)
+    if not isinstance(result, dict):
+        raise CleanupRefusedError(f"registry is not an object: {path}")
+    return result
+
+
+def child_names(path: Path) -> list[str]:
+    """List only one level: startup audits never traverse installed deps."""
+    with directory(path) as descriptor:
+        names = os.listdir(descriptor)
+        return sorted(
+            name
+            for name in names
+            if not stat.S_ISREG(
+                os.stat(name, dir_fd=descriptor, follow_symlinks=False).st_mode
+            )
+        )
+
+
+def _raise_walk_error(error: OSError) -> None:
+    raise error
+
+
+def _check_tree(parent: int) -> None:
+    """Reject existing symlinks throughout a selected dependency tree."""
+    for root, dirs, files, descriptor in os.fwalk(
+        "deps", dir_fd=parent, follow_symlinks=False, onerror=_raise_walk_error
+    ):
+        for name in dirs + files:
+            mode = os.stat(name, dir_fd=descriptor, follow_symlinks=False).st_mode
+            if not (stat.S_ISDIR(mode) or stat.S_ISREG(mode)):
+                raise CleanupRefusedError(
+                    f"symlink or special file in dependency tree: {root}/{name}"
+                )
+
+
+def _has_deps(parent: int) -> bool:
+    """An absent deps child is preserved; a non-directory child is refused."""
+    try:
+        mode = os.stat("deps", dir_fd=parent, follow_symlinks=False).st_mode
+    except FileNotFoundError:
+        return False
+    if not stat.S_ISDIR(mode):
+        raise CleanupRefusedError("deps is a symlink or is not a directory")
+    return True
+
+
+def inspect_deps(path: Path, *, recursive: bool = False) -> bool:
+    """Inspect only the deps child of an already constrained identity path."""
+    with directory(path.parent) as parent:
+        if not _has_deps(parent):
+            return False
+        if recursive:
+            _check_tree(parent)
+        return True
+
+
+def require_removal_support() -> None:
+    """Python 3.10 can audit, but rmtree's dir_fd requires Python 3.11+."""
+    # Capability checks follow the documented API, including vendor runtimes.
+    if "dir_fd" not in inspect.signature(shutil.rmtree).parameters:
+        raise CleanupRefusedError(
+            "safe removal requires rmtree(dir_fd=...), added in Python 3.11"
+        )
+    if not getattr(shutil.rmtree, "avoids_symlink_attacks", False):
+        raise CleanupRefusedError("symlink-resistant rmtree is unavailable")
+
+
+def remove_deps(path: Path) -> None:
+    """Delete deps only, retaining its parent and all sibling user data."""
+    require_removal_support()
+    with directory(path.parent) as parent:
+        if not _has_deps(parent):
+            raise CleanupRefusedError(
+                f"dependency tree disappeared before removal: {path}"
+            )
+        _check_tree(parent)
+        shutil.rmtree("deps", dir_fd=parent)

--- a/scripts/launcher_cleanup_registry.py
+++ b/scripts/launcher_cleanup_registry.py
@@ -1,0 +1,120 @@
+"""Conservative protection set for the launcher's dependency cleanup.
+
+Identity mapping and settings scopes are documented at
+https://code.claude.com/docs/en/plugins-reference . The registry's plugins ->
+list[installPath] shape is exercised by tests_py/infrastructure/
+test_pipeline_discovery.py. This cleanup additionally requires explicit scope
+and projectPath for project/local records; incomplete/unknown schemas refuse
+cleanup instead of interpreting missing information as uninstallation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from launcher_cleanup_fs import CleanupRefusedError, read_object
+
+
+def identity(plugin_id: str) -> str:
+    """Apply Claude's documented identifier-to-data-directory mapping."""
+    name, separator, marketplace = plugin_id.partition("@")
+    if (
+        not name
+        or not separator
+        or not marketplace
+        or "@" in marketplace
+        or any(char.isspace() for char in plugin_id)
+    ):
+        raise CleanupRefusedError(f"unsupported plugin identifier: {plugin_id!r}")
+    return re.sub(r"[^a-zA-Z0-9_-]", "-", plugin_id)
+
+
+def _absolute_path(value: object, field: str) -> Path:
+    if not isinstance(value, str) or not value:
+        raise CleanupRefusedError(f"missing or invalid {field}")
+    path = Path(value)
+    if not path.is_absolute() or ".." in path.parts:
+        raise CleanupRefusedError(f"{field} must be absolute without '..'")
+    return path
+
+
+def _project(entry: object) -> Path | None:
+    """Unknown scope must not conceal project-specific protection settings."""
+    if not isinstance(entry, dict):
+        raise CleanupRefusedError("installed plugin entry is not an object")
+    _absolute_path(entry.get("installPath"), "installPath")
+    scope = entry.get("scope")
+    if not isinstance(scope, str) or scope not in {"user", "project", "local"}:
+        raise CleanupRefusedError(
+            "missing or unsupported install scope (including managed)"
+        )
+    if scope in {"project", "local"} or "projectPath" in entry:
+        return _absolute_path(entry.get("projectPath"), "projectPath")
+    return None
+
+
+def _installed(path: Path) -> tuple[set[str], set[Path]]:
+    records = read_object(path).get("plugins")
+    if not isinstance(records, dict):
+        raise CleanupRefusedError(f"missing or invalid plugins registry: {path}")
+    protected: set[str] = set()
+    projects: set[Path] = set()
+    for plugin_id, entries in records.items():
+        protected.add(identity(plugin_id))
+        if not isinstance(entries, list) or not entries:
+            raise CleanupRefusedError(f"missing install records: {plugin_id}")
+        for entry in entries:
+            project = _project(entry)
+            if project is not None:
+                projects.add(project)
+    return protected, projects
+
+
+def _settings(path: Path) -> set[str]:
+    records = read_object(path).get("enabledPlugins")
+    if not isinstance(records, dict):
+        raise CleanupRefusedError(f"missing or invalid enabledPlugins: {path}")
+    if not all(isinstance(value, bool) for value in records.values()):
+        raise CleanupRefusedError(f"non-boolean enabledPlugins entry: {path}")
+    # False means disabled, not uninstalled; protect every key.
+    return {identity(plugin_id) for plugin_id in records}
+
+
+@dataclass(frozen=True)
+class CleanupScope:
+    """Explicit root and current identity; never defaults to the home folder."""
+
+    claude_root: Path
+    current_deps: Path
+
+    @property
+    def data_root(self) -> Path:
+        return self.claude_root / "plugins" / "data"
+
+    def current_identity(self) -> str:
+        if (
+            not self.claude_root.is_absolute()
+            or ".." in self.claude_root.parts
+            or self.current_deps.name != "deps"
+            or self.current_deps.parent.parent != self.data_root
+        ):
+            raise CleanupRefusedError(
+                "current CLAUDE_PLUGIN_DATA must be directly under root/plugins/data"
+            )
+        return self.current_deps.parent.name
+
+
+def protections(scope: CleanupScope) -> set[str]:
+    """Fail closed unless every discovered protection source is readable."""
+    current = scope.current_identity()
+    protected, projects = _installed(
+        scope.claude_root / "plugins" / "installed_plugins.json"
+    )
+    protected.update(_settings(scope.claude_root / "settings.json"))
+    for project in sorted(projects):
+        protected.update(_settings(project / ".claude" / "settings.json"))
+        protected.update(_settings(project / ".claude" / "settings.local.json"))
+    protected.add(current)
+    return protected

--- a/scripts/measure_pipeline_hook.py
+++ b/scripts/measure_pipeline_hook.py
@@ -1,0 +1,180 @@
+"""Measure the pipeline hook directly in fresh processes and isolated paths.
+
+Run only when the shared host is idle, once per before/after checkout:
+python scripts/measure_pipeline_hook.py --repo /path/to/checkout \
+    --python /path/to/prepared/venv/bin/python --output /tmp/hook-before
+
+This measures ``python -m``, not launcher dependency bootstrap. It never
+installs dependencies. Read and Bash are both rejected by this hook; an
+Edit with no graph still needs the canonical store lookup and is outside
+this probe. Import traces are separate from CPU samples.
+
+source: tasks/codex-green-remediation-plan.md §3, W2-1: four repetitions,
+discard the first; retain user+system CPU, wall time, and peak RSS.
+Measurement APIs: https://docs.python.org/3/library/os.html#os.wait4 and
+https://docs.python.org/3/library/resource.html#resource.getrusage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from urllib.parse import quote
+
+_MODULE = "mcp_server.hooks.pipeline_impact_bump"
+# source: remediation plan §3 — four repetitions, first discarded.
+_REPETITIONS = 4
+_SOURCES = (
+    "mcp_server/hooks/pipeline_impact_bump.py",
+    "mcp_server/hooks/_store_lifecycle.py",
+    "mcp_server/handlers/ingest_helpers.py",
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--python", default=sys.executable)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def _environment(repo: Path, sandbox: Path) -> dict[str, str]:
+    env = {
+        key: os.environ[key]
+        for key in ("HOME", "PATH", "SYSTEMROOT", "WINDIR")
+        if key in os.environ
+    }
+    project = sandbox / "project"
+    project.mkdir()
+    socket_dir = sandbox.resolve() / "no-postgres"
+    if socket_dir.exists():
+        raise ValueError("The probe requires a nonexistent PostgreSQL socket directory")
+    # libpq accepts a percent-encoded Unix socket directory in the URI authority.
+    # An empty DSN would instead select the user's default database connection.
+    dsn = f"postgresql://{quote(str(socket_dir), safe='')}/cortex_hook_probe"
+    env.update(
+        {
+            "PYTHONPATH": str(repo),
+            "PYTHONNOUSERSITE": "1",
+            "CLAUDE_PROJECT_ROOT": str(project),
+            "CORTEX_CLAUDE_DIR": str(sandbox / "claude"),
+            "CORTEX_MEMORY_STORE_BACKEND": "sqlite",
+            "CORTEX_MEMORY_DB_PATH": str(sandbox / "memory.db"),
+            "CORTEX_MEMORY_SQLITE_FALLBACK_PATH": str(sandbox / "memory.db"),
+            "CORTEX_MEMORY_DATABASE_URL": dsn,
+            "CORTEX_TEST_DATABASE_URL": dsn,
+            "DATABASE_URL": dsn,
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+            "CORTEX_RERANKER_OFFLINE": "1",
+            "CORTEX_EMBEDDING_ZERO_DOWNLOAD": "1",
+        }
+    )
+    return env
+
+
+def _run_sample(command: list[str], payload: str, env: dict, log: Path) -> dict:
+    """wait4 returns per-child usage; cumulative RUSAGE_CHILDREN would skew RSS."""
+    with (
+        log.with_suffix(".stdout").open("w") as out,
+        log.with_suffix(".stderr").open("w") as err,
+    ):
+        started = time.perf_counter()
+        with subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=out,
+            stderr=err,
+            text=True,
+            cwd=env["CLAUDE_PROJECT_ROOT"],
+            env=env,
+        ) as child:
+            assert child.stdin is not None
+            child.stdin.write(payload)
+            child.stdin.close()
+            _, status, usage = os.wait4(child.pid, 0)
+            child.returncode = os.waitstatus_to_exitcode(status)
+        wall_seconds = time.perf_counter() - started
+    if child.returncode:
+        raise RuntimeError(f"Hook exited {child.returncode}; inspect {log}.stderr")
+    return {
+        "command": command,
+        "wall_seconds": wall_seconds,
+        "user_seconds": usage.ru_utime,
+        "system_seconds": usage.ru_stime,
+        "cpu_seconds": usage.ru_utime + usage.ru_stime,
+        "max_rss_native": usage.ru_maxrss,
+        "stdout": str(log.with_suffix(".stdout")),
+        "stderr": str(log.with_suffix(".stderr")),
+    }
+
+
+def _host_state() -> dict:
+    return {
+        "load_average": os.getloadavg(),
+        "logical_cpus": os.cpu_count(),
+        "root_disk_bytes": dict(shutil.disk_usage("/")._asdict()),
+    }
+
+
+def _measure_case(name: str, args: argparse.Namespace, env: dict) -> dict:
+    payload = json.dumps({"tool_name": name, "tool_input": {}})
+    command = [args.python, "-m", _MODULE]
+    samples = []
+    for index in range(_REPETITIONS):
+        sample = _run_sample(command, payload, env, args.output / f"{name}-{index}")
+        sample["discarded"] = index == 0
+        samples.append(sample)
+    trace = _run_sample(
+        [args.python, "-X", "importtime", "-m", _MODULE],
+        payload,
+        env,
+        args.output / f"{name}-importtime",
+    )
+    return {"payload": payload, "samples": samples, "import_trace": trace["stderr"]}
+
+
+def main() -> None:
+    args = _parse_args()
+    if not hasattr(os, "wait4"):
+        raise SystemExit(
+            "This per-child resource probe requires a Unix host with wait4."
+        )
+    args.repo = args.repo.resolve()
+    args.output = args.output.resolve()
+    args.output.mkdir(parents=True, exist_ok=False)
+    report = {
+        "entrypoint": "module (launcher bootstrap excluded)",
+        "platform": platform.platform(),
+        "python": subprocess.check_output([args.python, "-VV"], text=True).strip(),
+        "rss_note": "Native getrusage ru_maxrss units; compare on the same OS.",
+        "repo": str(args.repo),
+        "source_sha256": {
+            path: hashlib.sha256((args.repo / path).read_bytes()).hexdigest()
+            for path in _SOURCES
+        },
+        "host_before": _host_state(),
+    }
+    with tempfile.TemporaryDirectory(prefix="cortex-hook-probe-") as temporary:
+        env = _environment(args.repo, Path(temporary))
+        report["cases"] = {
+            name: _measure_case(name, args, env) for name in ("Read", "Bash")
+        }
+    report["host_after"] = _host_state()
+    destination = args.output / "report.json"
+    destination.write_text(json.dumps(report, indent=2) + "\n")
+    print(destination)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_py/core/test_telemetry_rotation.py
+++ b/tests_py/core/test_telemetry_rotation.py
@@ -1,0 +1,71 @@
+"""Exercise the real telemetry writer in an isolated, stdlib-only process."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestTelemetryRotation(unittest.TestCase):
+    def test_two_samples_remain_valid_across_rotation_and_counters_accumulate(
+        self,
+    ) -> None:
+        script = """
+import json
+from mcp_server.core import telemetry
+from mcp_server.shared import log_rotation
+telemetry.record('fixture', latency_ms=1, bytes_in=2, bytes_out=3)
+log_rotation.MAX_LOG_BYTES = telemetry._LOG_PATH.stat().st_size
+telemetry.record('fixture', latency_ms=4, bytes_in=5, bytes_out=6)
+print(json.dumps(telemetry.snapshot()))
+"""
+        with tempfile.TemporaryDirectory(
+            prefix="cortex-telemetry-rotation-"
+        ) as directory:
+            env = dict(os.environ, CORTEX_CLAUDE_DIR=directory)
+            env.pop("CORTEX_TELEMETRY_DISABLED", None)
+            result = subprocess.run(
+                [sys.executable, "-S", "-c", script],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            root = Path(directory) / "methodology"
+            old = json.loads((root / "telemetry.jsonl.1").read_text())
+            new = json.loads((root / "telemetry.jsonl").read_text())
+        self.assertEqual((old["bytes_in"], new["bytes_in"]), (2, 5))
+        self.assertEqual((old["bytes_out"], new["bytes_out"]), (3, 6))
+        self.assertEqual(json.loads(result.stdout)["fixture"]["count"], 2)
+        self.assertEqual(result.stderr, "")
+
+    def test_write_failure_still_emits_diagnostic_and_preserves_counters(self) -> None:
+        script = """
+from mcp_server.core import telemetry
+telemetry._LOG_PATH.mkdir()
+telemetry.record('fixture', latency_ms=1)
+print(telemetry.snapshot()['fixture']['count'])
+"""
+        with tempfile.TemporaryDirectory(
+            prefix="cortex-telemetry-failure-"
+        ) as directory:
+            env = dict(os.environ, CORTEX_CLAUDE_DIR=directory)
+            env.pop("CORTEX_TELEMETRY_DISABLED", None)
+            result = subprocess.run(
+                [sys.executable, "-S", "-c", script],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        self.assertEqual(result.stdout.strip(), "1")
+        self.assertIn("Cannot append telemetry sample", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/hooks/test_cascade_counter_processes.py
+++ b/tests_py/hooks/test_cascade_counter_processes.py
@@ -1,0 +1,262 @@
+"""One-shot, concurrent hook regression tests: stdlib only, no DB/model."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import redirect_stderr
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from mcp_server.hooks import post_tool_capture as hook
+from mcp_server.infrastructure import hook_cascade_counter as counter
+from mcp_server.infrastructure.groomer_coordinator_io import DecisionLock
+
+_CHILD = """
+import os
+from pathlib import Path
+from mcp_server.hooks import post_tool_capture as hook
+root = Path(os.environ['CORTEX_CLAUDE_DIR'])
+def advance():
+    with (root / 'advances.txt').open('a', encoding='utf-8') as output:
+        output.write('advanced\\n')
+hook._run_cascade = advance
+hook._store_memory = lambda *args: None
+hook.main()
+"""
+
+
+class CascadeCounterProcesses(unittest.TestCase):
+    def setUp(self):
+        self.tree = tempfile.TemporaryDirectory(prefix="cortex-cascade-test-")
+        self.addCleanup(self.tree.cleanup)
+        self.root = Path(self.tree.name)
+        self.patch = patch.object(counter, "METHODOLOGY_DIR", self.root / "methodology")
+        self.patch.start()
+        self.addCleanup(self.patch.stop)
+
+    def event(self, index=0, transcript="session.jsonl"):
+        return {
+            "tool_name": "Task" if index % 2 else "Bash",
+            "transcript_path": str(self.root / transcript),
+            "session_id": f"changing-envelope-{index}",
+            "tool_response": "Build succeeded; enough output to capture this event.",
+        }
+
+    def child(self, event):
+        env = {**os.environ, "CORTEX_CLAUDE_DIR": str(self.root), "DATABASE_URL": ""}
+        result = subprocess.run(
+            [sys.executable, "-S", "-c", _CHILD],
+            cwd=Path(__file__).resolve().parents[2],
+            input=json.dumps(event),
+            text=True,
+            capture_output=True,
+            env=env,
+            timeout=10,  # source: plugin.json PostToolUse capture timeout.
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("cascade failed", result.stderr)
+        return result
+
+    def state(self, transcript="session.jsonl"):
+        directory = counter._session_directory(str(self.root / transcript))
+        return json.loads((directory / "counter.json").read_text())
+
+    def advances(self):
+        output = self.root / "advances.txt"
+        return output.read_text().splitlines() if output.exists() else []
+
+    def test_twentieth_and_fortieth_separate_processes_advance(self):
+        for index in range(40):
+            self.child(self.event(index))
+            self.assertEqual(len(self.advances()), (index + 1) // 20)
+        self.assertEqual(self.state(), {"tool_calls": 40, "completed": 40})
+
+    def test_concurrent_processes_preserve_every_tick_and_due_interval(self):
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            list(pool.map(self.child, [self.event(index) for index in range(40)]))
+        self.assertEqual(self.state()["tool_calls"], 40)
+        # Last contenders may leave one pending interval; a later event drains it.
+        self.child(self.event(40))
+        self.assertEqual(self.state(), {"tool_calls": 41, "completed": 40})
+        self.assertEqual(len(self.advances()), 2)
+
+    def test_distinct_transcripts_do_not_share_counter(self):
+        for _ in range(19):
+            counter.advance_after_tool("one.jsonl", lambda: self.fail("too early"))
+            counter.advance_after_tool("two.jsonl", lambda: self.fail("too early"))
+        advanced = []
+        counter.advance_after_tool("one.jsonl", lambda: advanced.append("one"))
+        self.assertEqual(advanced, ["one"])
+        directory = counter._session_directory("two.jsonl")
+        self.assertEqual(counter._read_counter(directory)["tool_calls"], 19)
+
+    def test_resume_same_transcript_keeps_count_despite_event_session_id(self):
+        advanced = []
+        with patch.object(hook, "_run_cascade", lambda: advanced.append(True)):
+            with redirect_stderr(io.StringIO()):
+                for index in range(20):
+                    hook.process_event({**self.event(index), "tool_name": "Task"})
+        self.assertEqual(advanced, [True])
+        self.assertEqual(self.state(), {"tool_calls": 20, "completed": 20})
+
+    def test_busy_cascade_retains_deadlines_and_does_not_lock_counter(self):
+        transcript = "session.jsonl"
+        directory = counter._session_directory(transcript)
+        advanced = []
+        with DecisionLock(directory.parent / "cascade.lock") as acquired:
+            self.assertTrue(acquired)
+            for _ in range(40):
+                status = counter.advance_after_tool(
+                    transcript, lambda: advanced.append(1)
+                )
+            self.assertEqual(status, "pending")
+            self.assertEqual(
+                counter._read_counter(directory), {"tool_calls": 40, "completed": 0}
+            )
+        for _ in range(2):
+            counter.advance_after_tool(transcript, lambda: advanced.append(1))
+        self.assertEqual(advanced, [1, 1])
+        self.assertEqual(
+            counter._read_counter(directory), {"tool_calls": 42, "completed": 40}
+        )
+
+    def test_two_sessions_share_execution_lock_and_keep_separate_due_work(self):
+        for _ in range(19):
+            counter.advance_after_tool("one.jsonl", lambda: None)
+            counter.advance_after_tool("two.jsonl", lambda: None)
+        advanced = []
+
+        def first_cascade():
+            advanced.append("one")
+            status = counter.advance_after_tool(
+                "two.jsonl", lambda: advanced.append("two")
+            )
+            self.assertEqual(status, "pending")
+
+        counter.advance_after_tool("one.jsonl", first_cascade)
+        self.assertEqual(advanced, ["one"])
+        counter.advance_after_tool("two.jsonl", lambda: advanced.append("two"))
+        self.assertEqual(advanced, ["one", "two"])
+
+    def test_failure_does_not_acknowledge_due_cascade(self):
+        transcript = "session.jsonl"
+        for _ in range(19):
+            counter.advance_after_tool(transcript, lambda: None)
+        with self.assertRaisesRegex(RuntimeError, "DB failed"):
+            counter.advance_after_tool(transcript, self.fail_cascade)
+        directory = counter._session_directory(transcript)
+        self.assertEqual(
+            counter._read_counter(directory), {"tool_calls": 20, "completed": 0}
+        )
+        self.assertEqual(
+            counter.advance_after_tool(transcript, lambda: None), "advanced"
+        )
+        self.assertEqual(
+            counter._read_counter(directory), {"tool_calls": 21, "completed": 20}
+        )
+
+    @staticmethod
+    def fail_cascade():
+        raise RuntimeError("DB failed")
+
+    def test_cascade_never_holds_counter_lock_during_database_callback(self):
+        for _ in range(19):
+            counter.advance_after_tool("session.jsonl", lambda: None)
+        counter.advance_after_tool("session.jsonl", lambda: self.child(self.event(20)))
+        self.assertEqual(self.state(), {"tool_calls": 21, "completed": 20})
+
+    def test_missing_identity_logs_and_capture_still_runs(self):
+        event = self.event()
+        del event["transcript_path"]
+        with patch.object(hook, "_store_memory") as captured:
+            with redirect_stderr(io.StringIO()) as log:
+                hook.process_event(event)
+        captured.assert_called_once()
+        self.assertIn("missing transcript identity", log.getvalue())
+        self.assertFalse((self.root / "methodology").exists())
+
+    def test_invalid_identity_is_not_fabricated(self):
+        for invalid in (None, "", " ", [], 12, "/", "\x00.jsonl"):
+            with self.subTest(identity=invalid):
+                with self.assertRaises(ValueError):
+                    counter.advance_after_tool(invalid, lambda: self.fail("invalid"))
+
+    def test_corrupt_counter_is_preserved_and_logged(self):
+        directory = counter._session_directory(self.event()["transcript_path"])
+        directory.mkdir(parents=True)
+        state_path = directory / "counter.json"
+        state_path.write_text("corrupt")
+        with patch.object(hook, "_store_memory") as captured:
+            with redirect_stderr(io.StringIO()) as log:
+                hook.process_event(self.event())
+        captured.assert_called_once()
+        self.assertIn("cascade failed", log.getvalue())
+        self.assertEqual(state_path.read_text(), "corrupt")
+
+    def test_structured_cascade_error_leaves_interval_pending(self):
+        for _ in range(19):
+            counter.advance_after_tool("session.jsonl", lambda: None)
+        modules = {
+            "mcp_server.handlers.consolidation.cascade": SimpleNamespace(
+                run_cascade_advancement=MagicMock(return_value={"error": "DB failed"})
+            ),
+            "mcp_server.infrastructure.memory_store": SimpleNamespace(
+                get_shared_store=MagicMock(return_value=object())
+            ),
+        }
+        with patch.dict(sys.modules, modules):
+            with patch.object(hook, "_store_memory") as captured:
+                with redirect_stderr(io.StringIO()) as log:
+                    hook.process_event(self.event())
+        captured.assert_called_once()
+        self.assertIn("DB failed", log.getvalue())
+        self.assertEqual(self.state(), {"tool_calls": 20, "completed": 0})
+
+    def test_unavailable_execution_lock_is_reported_and_preserves_due_work(self):
+        for _ in range(19):
+            counter.advance_after_tool("session.jsonl", lambda: None)
+        lock = MagicMock()
+        lock.return_value.__enter__.return_value = False
+        with patch.object(counter, "DecisionLock", lock):
+            with patch.object(hook, "_store_memory") as captured:
+                with redirect_stderr(io.StringIO()) as log:
+                    hook.process_event(self.event())
+        captured.assert_called_once()
+        self.assertIn("execution lock busy or unavailable", log.getvalue())
+        self.assertEqual(self.state(), {"tool_calls": 20, "completed": 0})
+
+    def test_invalid_counter_values_are_rejected(self):
+        directory = counter._session_directory("session.jsonl")
+        directory.mkdir(parents=True)
+        for state in (
+            [],
+            {},
+            {"tool_calls": True, "completed": 0},
+            {"tool_calls": -1, "completed": 0},
+            {"tool_calls": 20, "completed": 21},
+            {"tool_calls": 40, "completed": 19},
+        ):
+            with self.subTest(state=state):
+                (directory / "counter.json").write_text(json.dumps(state))
+                with self.assertRaises(ValueError):
+                    counter.advance_after_tool("session.jsonl", lambda: None)
+
+    def test_write_failure_prevents_advancement_and_remains_visible(self):
+        with patch.object(counter, "atomic_write_json", return_value=False):
+            with self.assertRaisesRegex(OSError, "write failed"):
+                counter.advance_after_tool(
+                    "session.jsonl", lambda: self.fail("I/O failed")
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/hooks/test_miss_cooldowns.py
+++ b/tests_py/hooks/test_miss_cooldowns.py
@@ -1,0 +1,75 @@
+"""Misses respect the existing 60/30 second windows; no DB or model used."""
+
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from mcp_server.hooks import pipeline_impact_bump as impact
+from mcp_server.hooks import preemptive_context as preemptive
+
+
+class MissCooldowns(unittest.TestCase):
+    def setUp(self):
+        tree = tempfile.TemporaryDirectory(prefix="cortex-miss-test-")
+        self.addCleanup(tree.cleanup)
+        self.root = Path(tree.name)
+        self.event = {"tool_name": "Edit", "tool_input": {"file_path": "/no/memory.py"}}
+        for module in (preemptive, impact):
+            edit = patch.object(
+                module, "_COOLDOWN_FILE", self.root / f"{module.__name__}.json"
+            )
+            edit.start()
+            self.addCleanup(edit.stop)
+
+    def exercise_window(self, module, scan):
+        with patch.object(module.time, "time", return_value=1000) as clock:
+            module.process_event(self.event)
+            clock.return_value = 1000 + module._COOLDOWN_SECONDS - 1
+            module.process_event(self.event)
+            self.assertEqual(scan.call_count, 1, "a miss must not be rescanned early")
+            clock.return_value = 1000 + module._COOLDOWN_SECONDS
+            module.process_event(self.event)
+            self.assertEqual(
+                scan.call_count, 2, "the exact deadline allows another scan"
+            )
+
+    def test_preemptive_miss_waits_sixty_seconds(self):
+        self.assertEqual(preemptive._COOLDOWN_SECONDS, 60)
+        with patch.object(preemptive, "_prime_file_memories", return_value=0) as prime:
+            self.exercise_window(preemptive, prime)
+
+    def test_pipeline_no_symbols_waits_thirty_seconds(self):
+        self.assertEqual(impact._COOLDOWN_SECONDS, 30)
+        with patch.object(
+            impact, "_pipeline_detect_changes", new=AsyncMock(return_value=[])
+        ) as scan:
+            with patch.object(impact, "_bump_heat_for_symbols") as bump:
+                self.exercise_window(impact, scan)
+        bump.assert_not_called()
+
+    def test_pipeline_symbols_without_memories_wait_thirty_seconds(self):
+        with patch.object(
+            impact, "_pipeline_detect_changes", new=AsyncMock(return_value=["symbol"])
+        ) as scan:
+            with patch.object(impact, "_bump_heat_for_symbols", return_value=0) as bump:
+                self.exercise_window(impact, scan)
+        self.assertEqual(bump.call_count, 2)
+
+    def test_pipeline_exception_is_logged_and_respects_window(self):
+        with patch.object(
+            impact,
+            "_pipeline_detect_changes",
+            new=AsyncMock(side_effect=RuntimeError("upstream failed")),
+        ) as scan:
+            with redirect_stderr(io.StringIO()) as log:
+                self.exercise_window(impact, scan)
+        self.assertEqual(log.getvalue().count("upstream failed"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/hooks/test_pipeline_lazy_imports.py
+++ b/tests_py/hooks/test_pipeline_lazy_imports.py
@@ -1,0 +1,264 @@
+"""Stdlib-only regressions for W2-1a; no real store, MCP child or model.
+
+Run independently of the database-owning pytest conftest:
+python -m unittest tests_py.hooks.test_pipeline_lazy_imports
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+from urllib.parse import unquote, urlsplit
+
+from mcp_server.handlers import ingest_helpers
+from mcp_server.hooks import pipeline_impact_bump as hook
+from mcp_server.hooks._store_lifecycle import close_shared_store_on_exit
+from scripts import measure_pipeline_hook as probe
+
+_STORE_MODULE = "mcp_server.infrastructure.memory_store"
+
+
+class ColdImportTests(unittest.TestCase):
+    def run_cold(self, source: str) -> None:
+        result = subprocess.run(
+            [sys.executable, "-S", "-c", source],
+            cwd=Path(__file__).resolve().parents[2],
+            env={**os.environ, "CORTEX_HEADLESS_AUTHORING_CHILD": "0"},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejected_events_do_not_import_store_or_lifecycle(self):
+        self.run_cold("""
+import io, json, runpy, sys
+from unittest.mock import patch
+blocked = ('mcp_server.__main__', 'mcp_server.hooks._store_lifecycle',
+           'mcp_server.infrastructure.memory_store')
+for raw in ('', '{', json.dumps({'tool_name': 'Read'}),
+            json.dumps({'tool_name': 'Bash'}),
+            json.dumps({'tool_name': 'Edit', 'tool_input': {}})):
+    with patch('sys.stdin', io.StringIO(raw)):
+        runpy.run_module('mcp_server.hooks.pipeline_impact_bump', run_name='__main__')
+    imported = set(blocked).intersection(sys.modules)
+    assert not imported, imported
+""")
+
+    def test_cooldown_does_not_import_lifecycle(self):
+        self.run_cold("""
+import sys
+from unittest.mock import patch
+from mcp_server.hooks import pipeline_impact_bump as hook
+with patch.object(hook, '_check_cooldown', return_value=True):
+    hook.process_event({'tool_name': 'Edit', 'tool_input': {'file_path': '/x.py'}})
+assert 'mcp_server.hooks._store_lifecycle' not in sys.modules
+assert 'mcp_server.infrastructure.memory_store' not in sys.modules
+""")
+
+    def test_graph_helpers_do_not_import_upstream(self):
+        self.run_cold("""
+import sys
+from mcp_server.handlers import ingest_helpers
+assert 'mcp_server.infrastructure.mcp_client_pool' not in sys.modules
+assert 'mcp_server.infrastructure.upstream_governor' not in sys.modules
+assert 'mcp_server.__main__' not in sys.modules
+""")
+
+    def test_teardown_without_store_does_not_import_it(self):
+        self.run_cold("""
+import sys
+from mcp_server.hooks._store_lifecycle import close_shared_store_on_exit
+with close_shared_store_on_exit():
+    pass
+assert 'mcp_server.infrastructure.memory_store' not in sys.modules
+""")
+
+
+class StoreTeardownTests(unittest.TestCase):
+    def setUp(self):
+        self.store_module = ModuleType(_STORE_MODULE)
+        self.reset = Mock()
+        self.store_module.reset_shared_store = self.reset
+        self.modules = patch.dict(sys.modules, {_STORE_MODULE: self.store_module})
+        self.modules.start()
+        self.addCleanup(self.modules.stop)
+
+    def test_success_closes_a_store_loaded_inside_the_block(self):
+        sys.modules.pop(_STORE_MODULE)
+        with close_shared_store_on_exit():
+            sys.modules[_STORE_MODULE] = self.store_module
+        self.reset.assert_called_once_with()
+
+    def _assert_exception_closure(self):
+        for error in (ValueError("original"), SystemExit(7)):
+            self.reset.reset_mock()
+            with self.assertRaises(type(error)) as caught:
+                with close_shared_store_on_exit():
+                    raise error
+            self.assertIs(caught.exception, error)
+            self.reset.assert_called_once_with()
+
+    def test_exception_and_system_exit_close_store(self):
+        self._assert_exception_closure()
+
+    def test_teardown_failure_preserves_every_outcome(self):
+        self.reset.side_effect = RuntimeError("close failed")
+        with close_shared_store_on_exit():
+            pass
+        self._assert_exception_closure()
+
+
+class PipelineGraphTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.project = self.root / "project"
+        self.project.mkdir()
+        self.graph = self.root / "custom-output" / "graph"
+        self.graph.parent.mkdir()
+        self.graph.write_text("materialised graph")
+        self.store = Mock()
+        self.store.get_memories_by_tag.return_value = [
+            {
+                "tags": [ingest_helpers.code_graph_tag(str(self.project))],
+                "content": f"graph_path={self.graph}",
+            }
+        ]
+        self.factory = ModuleType(_STORE_MODULE)
+        self.factory.get_shared_store = Mock(return_value=self.store)
+        self.factory.reset_shared_store = Mock()
+        self.upstream = AsyncMock(return_value={"impacted_symbols": ["module::symbol"]})
+        self.bump = Mock(return_value=0)
+        self.event = {"tool_name": "Edit", "tool_input": {"file_path": "/changed.py"}}
+        patches = (
+            patch.dict(sys.modules, {_STORE_MODULE: self.factory}),
+            patch.dict(os.environ, {"CLAUDE_PROJECT_ROOT": str(self.project)}),
+            patch.object(hook, "_COOLDOWN_FILE", self.root / "cooldown.json"),
+            patch.object(ingest_helpers, "call_upstream", self.upstream),
+            patch.object(hook, "_bump_heat_for_symbols", self.bump),
+        )
+        for replacement in patches:
+            replacement.start()
+            self.addCleanup(replacement.stop)
+
+    def test_custom_output_dir_is_found_and_store_closed(self):
+        hook.process_event(self.event)
+        self.upstream.assert_awaited_once_with(
+            "codebase",
+            "detect_changes",
+            {
+                "graph_path": str(self.graph),
+                "diff_text": "diff --git a//changed.py b//changed.py\n",
+            },
+        )
+        self.bump.assert_called_once_with(["module::symbol"])
+        self.factory.reset_shared_store.assert_called_once_with()
+
+    def test_absent_graph_skips_upstream_and_closes_store(self):
+        self.store.get_memories_by_tag.return_value = []
+        hook.process_event(self.event)
+        self.upstream.assert_not_awaited()
+        self.bump.assert_not_called()
+        self.factory.reset_shared_store.assert_called_once_with()
+
+    def test_missing_graph_artifact_skips_upstream(self):
+        self.graph.unlink()
+        hook.process_event(self.event)
+        self.upstream.assert_not_awaited()
+        self.factory.reset_shared_store.assert_called_once_with()
+
+    def test_empty_graph_artifact_skips_upstream(self):
+        self.graph.write_text("")
+        hook.process_event(self.event)
+        self.upstream.assert_not_awaited()
+        self.factory.reset_shared_store.assert_called_once_with()
+
+    def test_upstream_failure_closes_store(self):
+        self.upstream.side_effect = RuntimeError("upstream failed")
+        with patch.object(hook, "_log") as log:
+            hook.process_event(self.event)
+        self.assertIn("upstream failed", log.call_args.args[0])
+        self.factory.reset_shared_store.assert_called_once_with()
+
+    def test_system_exit_during_lookup_closes_store(self):
+        self.store.get_memories_by_tag.side_effect = SystemExit(7)
+        with self.assertRaises(SystemExit) as caught:
+            hook.process_event(self.event)
+        self.assertEqual(caught.exception.code, 7)
+        self.factory.reset_shared_store.assert_called_once_with()
+
+
+class UpstreamImportTests(unittest.TestCase):
+    def test_deferred_import_preserves_client_and_governor_calls(self):
+        client = Mock(max_concurrent_calls=3)
+        client.call = AsyncMock(return_value='{"ok": true}')
+        pool = ModuleType("mcp_server.infrastructure.mcp_client_pool")
+        pool.get_client = AsyncMock(return_value=client)
+        governor = ModuleType("mcp_server.infrastructure.upstream_governor")
+        governor.govern = Mock(return_value=AsyncMock())
+        with patch.dict(
+            sys.modules, {pool.__name__: pool, governor.__name__: governor}
+        ):
+            result = asyncio.run(ingest_helpers.call_upstream("codebase", "probe", {}))
+        self.assertEqual(result, {"ok": True})
+        pool.get_client.assert_awaited_once_with("codebase")
+        governor.govern.assert_called_once_with("codebase", 3)
+        client.call.assert_awaited_once_with("probe", {})
+
+
+class MeasurementProtocolTests(unittest.TestCase):
+    def test_environment_overrides_live_roots_and_headless_flag(self):
+        hostile = {
+            "DATABASE_URL": "postgresql://production",
+            "CORTEX_MEMORY_DATABASE_URL": "postgresql://production",
+            "CORTEX_MEMORY_DB_PATH": "/production/memory.db",
+            "CORTEX_HEADLESS_AUTHORING_CHILD": "1",
+            "PGHOSTADDR": "127.0.0.1",
+            "PGSERVICE": "production",
+        }
+        with (
+            tempfile.TemporaryDirectory() as temporary,
+            patch.dict(os.environ, hostile),
+        ):
+            root = Path(temporary)
+            env = probe._environment(root / "repo", root)
+        self.assertEqual(env["DATABASE_URL"], env["CORTEX_MEMORY_DATABASE_URL"])
+        self.assertEqual(env["DATABASE_URL"], env["CORTEX_TEST_DATABASE_URL"])
+        self.assertEqual(
+            unquote(urlsplit(env["DATABASE_URL"]).netloc),
+            str(root.resolve() / "no-postgres"),
+        )
+        self.assertEqual(env["CORTEX_MEMORY_STORE_BACKEND"], "sqlite")
+        self.assertEqual(env["CORTEX_MEMORY_DB_PATH"], str(root / "memory.db"))
+        self.assertEqual(
+            env["CORTEX_MEMORY_SQLITE_FALLBACK_PATH"], str(root / "memory.db")
+        )
+        self.assertEqual(env["CORTEX_CLAUDE_DIR"], str(root / "claude"))
+        self.assertNotIn("CORTEX_HEADLESS_AUTHORING_CHILD", env)
+        self.assertFalse({"PGHOSTADDR", "PGSERVICE"}.intersection(env))
+
+    def test_four_samples_discard_first_and_profile_separately(self):
+        args = SimpleNamespace(python="/prepared/python", output=Path("/isolated"))
+        with patch.object(
+            probe, "_run_sample", side_effect=lambda *args: {"stderr": "trace"}
+        ) as run:
+            case = probe._measure_case("Read", args, {})
+        self.assertEqual(
+            [row["discarded"] for row in case["samples"]], [True, False, False, False]
+        )
+        self.assertEqual(len(run.call_args_list), 5)
+        self.assertNotIn("-X", run.call_args_list[0].args[0])
+        self.assertIn("importtime", run.call_args_list[-1].args[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/hooks/test_post_commit_reindex.py
+++ b/tests_py/hooks/test_post_commit_reindex.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mcp_server.hooks import post_commit_reindex as hook
+from mcp_server.shared import log_rotation
 
 
 @pytest.fixture(autouse=True)
@@ -126,6 +127,7 @@ class TestSpawnReanalyzeInterpreterResolution:
         (plugin_root / "scripts").mkdir(parents=True)
         (plugin_root / "scripts" / "launcher.py").write_text("# stub\n")
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.delenv("CORTEX_CLAUDE_DIR", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         return plugin_root
 
@@ -166,7 +168,7 @@ class TestSpawnReanalyzeInterpreterResolution:
             return real_open(path, *args, **kwargs)
 
         monkeypatch.setattr(hook.subprocess, "Popen", _fake_popen)
-        monkeypatch.setattr(hook, "open", _tracking_open, raising=False)
+        monkeypatch.setattr(log_rotation, "open", _tracking_open, raising=False)
 
         assert hook._spawn_reanalyze("/some/repo") is True
         launcher = plugin_root / "scripts" / "launcher.py"
@@ -195,6 +197,7 @@ class TestSpawnReanalyzeInterpreterResolution:
         self, tmp_path, monkeypatch
     ):
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path / "no-scripts-dir"))
+        monkeypatch.delenv("CORTEX_CLAUDE_DIR", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         with patch.object(hook.subprocess, "Popen") as popen:
             assert hook._spawn_reanalyze("/some/repo") is False
@@ -208,6 +211,7 @@ class TestSpawnReanalyzeInterpreterResolution:
         root shipping this very hook's scripts/launcher.py.
         """
         monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        monkeypatch.delenv("CORTEX_CLAUDE_DIR", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         captured = {}
 

--- a/tests_py/hooks/test_post_tool_matchers.py
+++ b/tests_py/hooks/test_post_tool_matchers.py
@@ -1,0 +1,224 @@
+"""Light routing and aggregation tests; timings below are synthetic fixtures.
+
+source: Claude Code hooks reference, matcher-patterns and hook-handler-fields;
+the hook guards themselves define each accepted tool set.
+Run: python -S -m unittest tests_py.hooks.test_post_tool_matchers
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from mcp_server.hooks import (
+    pipeline_impact_bump,
+    post_commit_reindex,
+    preemptive_context,
+)
+from scripts import aggregate_hook_timings as timing
+
+_PLUGIN = Path(__file__).resolve().parents[2] / ".claude-plugin" / "plugin.json"
+_PREFIX = "mcp_server.hooks."
+_CAPTURE = _PREFIX + "post_tool_capture"
+
+
+def synthetic_report(plugin_path: Path) -> dict:
+    """Made-up values test arithmetic only; never benchmark evidence."""
+    raw = plugin_path.read_bytes()
+    plugin = json.loads(raw)
+    cases = []
+    for tool in ("Read", "Bash"):
+        samples = [
+            {
+                "repetition": rep,
+                "module": module,
+                "exit_code": 0,
+                "user_seconds": 1,
+                "system_seconds": 2,
+                "wall_seconds": 4,
+                "max_rss_native": 5,
+            }
+            for rep in range(timing.REPETITIONS)
+            for module in timing.selected_modules(plugin, tool)
+        ]
+        cases.append({"payload": {"tool_name": tool}, "samples": samples})
+    return {
+        "entrypoint": "module",
+        "python": "test-python",
+        "platform": "test-os",
+        "plugin_sha256": hashlib.sha256(raw).hexdigest(),
+        "cases": cases,
+    }
+
+
+class MatcherTests(unittest.TestCase):
+    def setUp(self):
+        self.plugin = json.loads(_PLUGIN.read_text())
+
+    def test_file_matchers_follow_real_guard_sets(self):
+        accepted = {
+            "preemptive_context": preemptive_context._FILE_TOOLS,
+            "pipeline_impact_bump": pipeline_impact_bump._FILE_TOOLS,
+        }
+        for module, tools in accepted.items():
+            routed = {
+                tool
+                for tool in ("Read", "Edit", "Write", "MultiEdit", "Bash")
+                if _PREFIX + module in timing.selected_modules(self.plugin, tool)
+            }
+            self.assertEqual(routed, tools)
+
+    def test_bash_reindex_matcher_follows_real_guard(self):
+        with patch.object(
+            post_commit_reindex, "_is_commit_command", return_value=False
+        ) as check:
+            post_commit_reindex.process_event({"tool_name": "Read"})
+            check.assert_not_called()
+            post_commit_reindex.process_event({"tool_name": "Bash"})
+            check.assert_called_once_with("")
+        self.assertIn(
+            _PREFIX + "post_commit_reindex",
+            timing.selected_modules(self.plugin, "Bash"),
+        )
+        self.assertNotIn(
+            _PREFIX + "post_commit_reindex",
+            timing.selected_modules(self.plugin, "Read"),
+        )
+
+    def test_capture_keeps_every_tool_for_cascade_tick(self):
+        groups = self.plugin["hooks"]["PostToolUse"]
+        capture = [
+            group for group in groups if _CAPTURE in group["hooks"][0]["command"]
+        ]
+        self.assertEqual(len(capture), 1)
+        self.assertEqual(capture[0]["matcher"], "*")
+        for tool in (
+            "Grep",
+            "Glob",
+            "NotebookEdit",
+            "WebFetch",
+            "WebSearch",
+            "mcp__x__y",
+            "NewTool",
+        ):
+            self.assertEqual(timing.selected_modules(self.plugin, tool), {_CAPTURE})
+
+    def test_matchers_do_not_match_partial_or_wrong_case_names(self):
+        for tool in ("NotebookEdit", "ReadFile", "SomeWrite", "bash", "edit", ""):
+            self.assertEqual(timing.selected_modules(self.plugin, tool), {_CAPTURE})
+
+    def test_every_handler_is_preserved_exactly_once(self):
+        modules = set()
+        for tool in ("Edit", "Write", "Read", "MultiEdit", "Bash"):
+            modules.update(timing.selected_modules(self.plugin, tool))
+        self.assertEqual(modules, timing.MODULES)
+
+
+class AggregationTests(unittest.TestCase):
+    def setUp(self):
+        self.plugin = json.loads(_PLUGIN.read_text())
+        self.report = synthetic_report(_PLUGIN)
+        self.case = self.report["cases"][0]
+
+    def test_cpu_sum_first_discarded_and_individual_rss_retained(self):
+        result = timing.aggregate_case(self.case, self.plugin)
+        rows = result["repetitions"]
+        self.assertEqual(
+            [row["discarded"] for row in rows], [True, False, False, False]
+        )
+        self.assertEqual(rows[1]["cpu_seconds"], 6)
+        self.assertEqual(rows[1]["wall_seconds_sum"], 8)
+        self.assertEqual([hook["max_rss_native"] for hook in rows[1]["hooks"]], [5, 5])
+
+    def test_raw_bsd_time_log_is_parsed_without_entering_metrics_manually(self):
+        raw = (
+            "hook stderr\n  4.00 real  1.00 user  2.00 sys\n"
+            "  5 maximum resident set size\n"
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "time.log"
+            path.write_text(raw)
+            measured = timing._measured_sample({"time_log": str(path)})
+        self.assertEqual(measured["user_seconds"] + measured["system_seconds"], 3)
+        self.assertEqual(measured["wall_seconds"], 4)
+        self.assertEqual(measured["max_rss_native"], 5)
+
+    def test_missing_ambiguous_and_mixed_timing_data_are_rejected(self):
+        row = " 4.00 real 1.00 user 2.00 sys\n 5 maximum resident set size\n"
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "time.log"
+            for raw in ("", row + row):
+                path.write_text(raw)
+                with self.assertRaises(ValueError):
+                    timing.read_time_log(path)
+        with self.assertRaises(ValueError):
+            timing._measured_sample({"time_log": "unused", "user_seconds": 1})
+
+    def test_missing_duplicate_and_unexpected_samples_are_rejected(self):
+        samples = self.case["samples"]
+        altered = (
+            samples[:-1],
+            samples + [samples[0]],
+            [{**samples[0], "module": "unknown"}, *samples[1:]],
+        )
+        for replacement in altered:
+            with self.assertRaises(ValueError):
+                timing.aggregate_case(
+                    {**self.case, "samples": replacement}, self.plugin
+                )
+
+    def test_invalid_metrics_and_failed_runs_are_rejected(self):
+        for bad in (float("nan"), float("inf"), -1, True, "0.1"):
+            sample = {**self.case["samples"][0], "user_seconds": bad}
+            with self.assertRaises(ValueError):
+                timing._sample_key(sample)
+        with self.assertRaises(ValueError):
+            timing._sample_key({**self.case["samples"][0], "exit_code": 1})
+
+    def test_entrypoint_and_payload_mismatches_are_rejected(self):
+        for field, value in (
+            ("entrypoint", "launcher"),
+            ("python", "other"),
+            ("platform", "other"),
+        ):
+            with self.assertRaises(ValueError):
+                timing.compare_reports(
+                    self.report, {**self.report, field: value}, (_PLUGIN, _PLUGIN)
+                )
+        after = copy.deepcopy(self.report)
+        after["cases"][0]["payload"]["tool_input"] = {}
+        with self.assertRaises(ValueError):
+            timing.compare_reports(self.report, after, (_PLUGIN, _PLUGIN))
+
+    def test_plugin_fingerprint_and_required_payloads_are_checked(self):
+        with self.assertRaises(ValueError):
+            timing.validate_report({**self.report, "plugin_sha256": "stale"}, _PLUGIN)
+        with self.assertRaises(ValueError):
+            timing.validate_report({**self.report, "cases": [self.case]}, _PLUGIN)
+
+    def test_before_four_hooks_after_two_hooks_aggregate_actual_routes(self):
+        before_plugin = copy.deepcopy(self.plugin)
+        for group in before_plugin["hooks"]["PostToolUse"]:
+            group["matcher"] = "*"
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "before.json"
+            path.write_text(json.dumps(before_plugin))
+            before = synthetic_report(path)
+            result = timing.compare_reports(before, self.report, (path, _PLUGIN))
+        for case in result["cases"]:
+            self.assertEqual(len(case["retained_deltas"]), 3)
+            self.assertTrue(
+                all(
+                    row["cpu_seconds_after_minus_before"] == -6
+                    for row in case["retained_deltas"]
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/hooks/test_preemptive_context.py
+++ b/tests_py/hooks/test_preemptive_context.py
@@ -94,12 +94,12 @@ def test_expired_cooldown_primes_again():
     prime.assert_called_once()
 
 
-def test_priming_nothing_leaves_the_cooldown_unset():
-    """A no-op prime must stay retryable — no cooldown, no log line."""
+def test_priming_nothing_sets_the_cooldown():
+    """A miss is a completed scan and must respect the same cooldown."""
     with patch.object(hook, "_prime_file_memories", return_value=0):
         hook.process_event({"tool_name": "Edit", "tool_input": {"file_path": "/a.py"}})
 
-    assert not hook._COOLDOWN_FILE.exists()
+    assert hook._COOLDOWN_FILE.exists()
 
 
 def test_successful_prime_reports_the_file_it_primed(capsys):

--- a/tests_py/hooks/test_session_start.py
+++ b/tests_py/hooks/test_session_start.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from mcp_server.hooks import session_start as hook
+from mcp_server.shared import log_rotation
 
 # ── Event reading ─────────────────────────────────────────────────────
 
@@ -692,19 +693,15 @@ def test_auto_backfill_failure_is_logged_and_returns_zero(capsys, monkeypatch):
 
 
 # ── Background spawn: interpreter resolution (issue #315) ─────────────
-#
 # Both spawn helpers must resolve the interpreter via python_executable()
 # (== sys.executable), never by resolving "python3"/"python" on PATH
-# first — on Windows that hits the Microsoft Store stub, which exits
-# without running anything and silently disables the spawn.
+# first — on Windows that hits the Microsoft Store stub and disables spawning.
 
 
-def _tracking_open(monkeypatch, target):
-    """Patch ``target.open`` (a hook module) to record every path opened,
-    while still delegating to the real ``open`` — string equality on the
-    recorded path is case-sensitive on every host OS, unlike
-    ``Path.exists()`` (macOS APFS is case-insensitive by default, so it
-    cannot distinguish ``.claude`` from ``.CLAUDE``).
+def _tracking_open(monkeypatch):
+    """Record rotating-writer log paths, delegating to the real open.
+    String comparisons remain case-sensitive on every OS; Path.exists cannot
+    distinguish .claude from .CLAUDE on default case-insensitive macOS APFS.
     """
     opened: list[str] = []
     real_open = open
@@ -713,7 +710,7 @@ def _tracking_open(monkeypatch, target):
         opened.append(str(path))
         return real_open(path, *args, **kwargs)
 
-    monkeypatch.setattr(target, "open", _open, raising=False)
+    monkeypatch.setattr(log_rotation, "open", _open, raising=False)
     return opened
 
 
@@ -723,6 +720,7 @@ class TestSpawnConsolidateCycleInterpreterResolution:
         (plugin_root / "scripts").mkdir(parents=True)
         (plugin_root / "scripts" / "launcher.py").write_text("# stub\n")
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.delenv("CORTEX_CLAUDE_DIR", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         return plugin_root
 
@@ -735,7 +733,7 @@ class TestSpawnConsolidateCycleInterpreterResolution:
         """
         plugin_root = self._write_launcher(tmp_path, monkeypatch)
         monkeypatch.setattr("shutil.which", lambda name: f"/fake/store-stub/{name}")
-        opened = _tracking_open(monkeypatch, hook)
+        opened = _tracking_open(monkeypatch)
         captured = {}
 
         def _fake_popen(cmd, **kwargs):
@@ -769,6 +767,7 @@ class TestSpawnConsolidateCycleInterpreterResolution:
         self, tmp_path, monkeypatch
     ):
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path / "no-scripts-here"))
+        monkeypatch.delenv("CORTEX_CLAUDE_DIR", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         captured = {}
@@ -791,6 +790,7 @@ class TestSpawnConsolidateCycleInterpreterResolution:
         self, tmp_path, monkeypatch
     ):
         monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        monkeypatch.delenv("CORTEX_CLAUDE_DIR", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         captured = {}
 
@@ -836,6 +836,7 @@ class TestMaybeBackgroundReanalyzeInterpreterResolution:
         (plugin_root / "scripts" / "launcher.py").write_text("# stub\n")
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
         monkeypatch.setenv("CLAUDE_PROJECT_ROOT", "/the/project")
+        monkeypatch.delenv("CORTEX_CLAUDE_DIR", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         return plugin_root
 
@@ -845,7 +846,7 @@ class TestMaybeBackgroundReanalyzeInterpreterResolution:
         plugin_root = self._write_launcher(tmp_path, monkeypatch)
         stale_mock, lookup_mock = self._mock_pipeline(monkeypatch)
         monkeypatch.setattr("shutil.which", lambda name: f"/fake/store-stub/{name}")
-        opened = _tracking_open(monkeypatch, hook)
+        opened = _tracking_open(monkeypatch)
         captured = {}
 
         def _fake_popen(cmd, **kwargs):
@@ -891,6 +892,7 @@ class TestMaybeBackgroundReanalyzeInterpreterResolution:
     ):
         monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
         monkeypatch.setenv("CLAUDE_PROJECT_ROOT", "/the/project")
+        monkeypatch.delenv("CORTEX_CLAUDE_DIR", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         self._mock_pipeline(monkeypatch)
         captured = {}

--- a/tests_py/hooks/test_worker_log_rotation.py
+++ b/tests_py/hooks/test_worker_log_rotation.py
@@ -1,0 +1,87 @@
+"""Verify each worker spawn rotates its log before handing off the fd."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from mcp_server.shared import log_rotation
+
+
+class TestWorkerLogRotation(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory(prefix="cortex-worker-rotation-")
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.plugin = self.root / "plugin"
+        (self.plugin / "scripts").mkdir(parents=True)
+        (self.plugin / "scripts/launcher.py").write_text("# fixture", encoding="utf-8")
+        environment = patch.dict(
+            os.environ,
+            {
+                "CLAUDE_PLUGIN_ROOT": str(self.plugin),
+                "CORTEX_CLAUDE_DIR": str(self.root / "isolated-claude"),
+            },
+        )
+        environment.start()
+        self.addCleanup(environment.stop)
+        home = patch.object(Path, "home", return_value=self.root)
+        home.start()
+        self.addCleanup(home.stop)
+        self.session = importlib.import_module("mcp_server.hooks.session_start")
+        self.commit = importlib.import_module("mcp_server.hooks.post_commit_reindex")
+
+    def assert_spawn_rotates(self, filename: str, spawn) -> None:
+        path = self.root / "isolated-claude/methodology" / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("old\n", encoding="utf-8")
+        captured = []
+
+        def popen(command, **options):
+            self.assertEqual(path.with_name(filename + ".1").read_text(), "old\n")
+            self.assertFalse(options["stdout"].closed)
+            options["stdout"].write("new\n")
+            captured.append(options["stdout"])
+            return SimpleNamespace(pid=42)
+
+        with patch.object(log_rotation, "MAX_LOG_BYTES", len("old\n")):
+            with patch("subprocess.Popen", side_effect=popen):
+                spawn()
+        self.assertEqual(path.read_text(), "new\n")
+        self.assertEqual(len(captured), 1)
+        self.assertTrue(captured[0].closed)
+
+    def test_consolidate_spawn_rotates_and_closes_parent_descriptor(self) -> None:
+        self.assert_spawn_rotates(
+            "consolidate.log", self.session._spawn_consolidate_cycle
+        )
+
+    def test_post_commit_spawn_rotates_and_closes_parent_descriptor(self) -> None:
+        self.assert_spawn_rotates(
+            "pipeline_reanalyze.log", lambda: self.commit._spawn_reanalyze("fixture")
+        )
+
+    def test_session_reanalyze_rotates_and_closes_parent_descriptor(self) -> None:
+        discovery = ModuleType("mcp_server.infrastructure.pipeline_discovery")
+        discovery.discover_pipeline_command = lambda: ["fixture"]
+        ttl = ModuleType("mcp_server.infrastructure.pipeline_graph_ttl")
+        ttl.graph_is_stale = lambda path: True
+        with patch.dict(
+            sys.modules, {discovery.__name__: discovery, ttl.__name__: ttl}
+        ):
+            with patch.object(
+                self.session, "_lookup_cached_graph_path", return_value="fixture"
+            ):
+                self.assert_spawn_rotates(
+                    "pipeline_reanalyze.log", self.session._maybe_background_reanalyze
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/infrastructure/test_hook_counter_lock.py
+++ b/tests_py/infrastructure/test_hook_counter_lock.py
@@ -1,0 +1,70 @@
+"""Counter lock protocol on native POSIX and the simulated Windows branch."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+from mcp_server.infrastructure import hook_counter_lock as native
+
+
+def windows_module(fake_msvcrt):
+    spec = importlib.util.spec_from_file_location(
+        "counter_lock_windows_probe", native.__file__
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    with patch("sys.platform", "win32"):
+        with patch.dict("sys.modules", {"msvcrt": fake_msvcrt}):
+            spec.loader.exec_module(module)
+    return module
+
+
+class CounterLockProtocol(unittest.TestCase):
+    def setUp(self):
+        tree = tempfile.TemporaryDirectory(prefix="cortex-counter-lock-test-")
+        self.addCleanup(tree.cleanup)
+        self.path = Path(tree.name) / "counter.lock"
+
+    def test_lock_file_survives_release(self):
+        with native.counter_lock(self.path):
+            self.assertTrue(self.path.exists())
+        self.assertTrue(
+            self.path.exists(), "removing an active lock path would split locks"
+        )
+
+    def test_windows_locks_and_unlocks_the_same_byte(self):
+        fake = MagicMock()
+        module = windows_module(fake)
+        with module.counter_lock(self.path):
+            fd = fake.locking.call_args.args[0]
+        self.assertEqual(
+            fake.locking.call_args_list,
+            [call(fd, fake.LK_LOCK, 1), call(fd, fake.LK_UNLCK, 1)],
+        )
+
+    def test_windows_acquisition_error_closes_without_unlocking(self):
+        fake = MagicMock()
+        fake.locking.side_effect = OSError("CRT lock failed")
+        module = windows_module(fake)
+        with patch.object(module.os, "close", wraps=module.os.close) as closed:
+            with self.assertRaisesRegex(OSError, "CRT lock failed"):
+                with module.counter_lock(self.path):
+                    self.fail("failed acquire must not enter transaction")
+        self.assertEqual(fake.locking.call_count, 1)
+        closed.assert_called_once()
+
+    def test_transaction_exception_releases_windows_lock(self):
+        fake = MagicMock()
+        module = windows_module(fake)
+        with self.assertRaisesRegex(RuntimeError, "transaction failed"):
+            with module.counter_lock(self.path):
+                raise RuntimeError("transaction failed")
+        self.assertEqual(fake.locking.call_args.args[1], fake.LK_UNLCK)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/invariants/test_I2_canonical_writer.py
+++ b/tests_py/invariants/test_I2_canonical_writer.py
@@ -113,10 +113,12 @@ _ALLOWED_WRITERS: set[tuple[str, int]] = {
     # Anchor pin: heat_base=1.0 + no_decay=TRUE preserves resist-decay.
     ("handlers/anchor.py", 149),
     # Preemptive boost: heat_base += 0.1 on Read/Edit/Write hook.
-    ("hooks/preemptive_context.py", 145),
+    # W2-4: private cooldown paths shifted these sites; both writer function
+    # sources remain byte-identical to 3243dfed, including their A3 SQL.
+    ("hooks/preemptive_context.py", 148),
     # Pipeline-impact boost: heat_base += 0.15 for symbols touched by an
     # edit, resolved via pipeline detect_changes (PostToolUse hook).
-    ("hooks/pipeline_impact_bump.py", 182),
+    ("hooks/pipeline_impact_bump.py", 184),
     # I6-D5 deliberate re-heat campaign (INC6.6): CAS-guarded single-row
     # writer. Cannot route through bump_heat_raw — that would (1) turn a
     # concurrent-write race into a silent overwrite instead of a detected

--- a/tests_py/scripts/_cleanup_fixture.py
+++ b/tests_py/scripts/_cleanup_fixture.py
@@ -1,0 +1,75 @@
+"""Synthetic-only Claude trees for launcher cleanup tests (stdlib runner)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from launcher_cleanup_registry import CleanupScope, identity  # noqa: E402
+
+HAS_SAFE_FS = hasattr(os, "O_NOFOLLOW") and os.open in os.supports_dir_fd
+HAS_SAFE_REMOVE = (
+    HAS_SAFE_FS
+    and sys.version_info >= (3, 11)
+    and getattr(shutil.rmtree, "avoids_symlink_attacks", False)
+)
+
+
+class CleanupFixture(unittest.TestCase):
+    """No home-directory access, database connection or dependency bootstrap."""
+
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory(prefix="cortex-cleanup-test-")
+        self.addCleanup(temporary.cleanup)
+        self.workspace = Path(temporary.name).resolve()
+        self.root = self.workspace / "claude"
+        self.scope = CleanupScope(
+            self.root, self.root / "plugins/data/current-market/deps"
+        )
+        self.registry = self.root / "plugins/installed_plugins.json"
+        self.installs = {"installed@market": [self.install_record()]}
+        self.write(self.registry, {"plugins": self.installs})
+        self.write(
+            self.root / "settings.json",
+            {
+                "enabledPlugins": {
+                    "enabled@market": True,
+                    "disabled@market": False,
+                }
+            },
+        )
+        for plugin in (
+            "current@market",
+            "installed@market",
+            "enabled@market",
+            "disabled@market",
+            "orphan@market",
+            "scratch@inline",
+            "cloud@synced",
+        ):
+            self.make_deps(plugin)
+
+    def write(self, path: Path, value: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value), encoding="utf-8")
+
+    def install_record(self, scope: str = "user") -> dict[str, str]:
+        return {"scope": scope, "installPath": str(self.workspace / "install")}
+
+    def make_deps(self, plugin: str) -> Path:
+        path = self.scope.data_root / identity(plugin) / "deps"
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "fixture.txt").write_text("fixture bytes", encoding="utf-8")
+        (path.parent / "keep.json").write_text("user data", encoding="utf-8")
+        return path
+
+    def all_deps(self) -> list[Path]:
+        return sorted(self.scope.data_root.glob("*/deps"))

--- a/tests_py/scripts/test_check_ci_file_count.py
+++ b/tests_py/scripts/test_check_ci_file_count.py
@@ -1,0 +1,43 @@
+"""Guard against GitHub silently truncating a pull request's changed files."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from scripts.check_ci_file_count import check
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_ci_file_count.py"
+
+
+class FileCountTests(unittest.TestCase):
+    def test_complete_api_range_is_accepted(self):
+        for count in (0, 1, 3000):
+            with self.subTest(count=count):
+                self.assertIsNone(check(count))
+
+    def test_truncated_api_range_is_refused(self):
+        self.assertIn("3000-file API limit", check(3001))
+
+    def test_missing_or_invalid_count_is_refused(self):
+        for count in (None, True, False, -1, "1", 1.0, {}):
+            with self.subTest(count=count):
+                self.assertIn("nonnegative integer", check(count))
+
+    def test_cli_refuses_truncation_with_a_diagnostic(self):
+        with tempfile.TemporaryDirectory() as directory:
+            event = Path(directory) / "event.json"
+            event.write_text(json.dumps({"pull_request": {"changed_files": 3001}}))
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                env={**os.environ, "GITHUB_EVENT_PATH": str(event)},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("refusing incomplete classification", result.stderr)

--- a/tests_py/scripts/test_check_ci_gate_complete.py
+++ b/tests_py/scripts/test_check_ci_gate_complete.py
@@ -114,6 +114,18 @@ class RefusesIncompleteGate(unittest.TestCase):
         )
         self.assertIn("'lint'", self._only_failure(workflow))
 
+    def test_gate_must_always_run(self) -> None:
+        for condition in ("", "    if: success()\n"):
+            workflow = _COMPLETE.replace("    if: always()\n", condition)
+            self.assertIn("always()", self._only_failure(workflow))
+
+    def test_duplicate_or_self_needs_fail(self) -> None:
+        for job in ("lint", "ci-green"):
+            workflow = _COMPLETE.replace(
+                "      - lint\n", f"      - lint\n      - {job}\n"
+            )
+            self.assertIn("dependency", self._only_failure(workflow))
+
 
 _WITH_EXEMPT_JOB = _workflow(
     """  lint:
@@ -199,6 +211,30 @@ class RepositoryWorkflowIsGated(unittest.TestCase):
             gate.check(gate.CI_WORKFLOW.read_text(encoding="utf-8")),
             [],
         )
+
+    def test_runtime_policy_matches_live_workflow(self) -> None:
+        self.assertEqual(gate.check_runtime_contract(gate.CI_WORKFLOW.read_text()), [])
+
+    def test_costly_jobs_must_wait_for_lint_and_changes(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        for prerequisites in ("[changes]", "[lint]", "[changes, lint, test]"):
+            changed = workflow.replace("[changes, lint]", prerequisites, 1)
+            failures = gate.check_runtime_contract(changed)
+            self.assertTrue(any("depend on exactly" in f for f in failures))
+
+    def test_lint_and_changes_cannot_be_conditional(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        for job in ("changes", "lint"):
+            changed = workflow.replace(f"  {job}:\n", f"  {job}:\n    if: false\n")
+            self.assertTrue(gate.check_runtime_contract(changed))
+
+    def test_new_skip_needs_an_executable_policy(self) -> None:
+        workflow = gate.CI_WORKFLOW.read_text()
+        workflow = workflow.replace(
+            "ALLOWED_SKIPS: test,", "ALLOWED_SKIPS: unknown-job,test,"
+        )
+        failures = gate.check_runtime_contract(workflow)
+        self.assertTrue(any("runtime skip policy" in f for f in failures))
 
 
 if __name__ == "__main__":

--- a/tests_py/scripts/test_check_ci_gate_results.py
+++ b/tests_py/scripts/test_check_ci_gate_results.py
@@ -39,23 +39,23 @@ class JustifiedSkips(unittest.TestCase):
     def test_docker_only_requires_docker_jobs(self) -> None:
         needs = _skip(_needs("docker"), gate.CODE_JOBS)
         self.assertEqual(gate.check(needs, "pull_request", _event()), [])
-        for job in gate.DOCKER_JOBS:
+        for job in gate.DOCKER_BUILD_JOBS | {"docker-smoke"}:
             with self.subTest(job=job):
                 needs[job]["result"] = "skipped"
                 self.assertTrue(gate.check(needs, "pull_request", _event()))
                 needs[job]["result"] = "success"
 
-    def test_code_deps_workflows_require_every_job(self) -> None:
+    def test_code_deps_workflows_require_code_and_smoke(self) -> None:
         for changed in (("code",), ("docs", "code"), ("deps",), ("workflows",)):
-            needs = _needs(*changed)
+            needs = _skip(_needs(*changed), gate.DOCKER_BUILD_JOBS)
             self.assertEqual(gate.check(needs, "pull_request", _event()), [])
-            for job in gate.CONDITIONAL_JOBS:
+            for job in gate.CODE_JOBS | {"docker-smoke"}:
                 with self.subTest(changed=changed, job=job):
                     needs[job]["result"] = "skipped"
                     self.assertTrue(gate.check(needs, "pull_request", _event()))
                     needs[job]["result"] = "success"
 
-    def test_non_pr_runs_require_full_matrix_even_for_docs(self) -> None:
+    def test_push_and_dispatch_require_code_even_for_docs(self) -> None:
         for event_name in ("push", "workflow_dispatch"):
             needs = _needs("docs")
             self.assertEqual(gate.check(needs, event_name, {}), [])
@@ -69,6 +69,48 @@ class JustifiedSkips(unittest.TestCase):
         self.assertTrue(gate.check(needs, "pull_request", _event(False)))
         needs["test"]["result"] = "skipped"
         self.assertTrue(gate.check(needs, "pull_request", _event(True)))
+
+
+class DockerBuildPolicy(unittest.TestCase):
+    def test_push_without_docker_changes_skips_only_docker_builds(self) -> None:
+        for changed in (("docs",), ("code",), ("workflows",), ("deps",), ()):
+            needs = _skip(_needs(*changed), gate.DOCKER_BUILD_JOBS)
+            self.assertEqual(gate.check(needs, "push", {}), [])
+            needs["docker-smoke"]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "push", {}))
+
+    def test_push_with_docker_changes_requires_every_job(self) -> None:
+        needs = _needs("docker")
+        self.assertEqual(gate.check(needs, "push", {}), [])
+        for job in gate.CONDITIONAL_JOBS:
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "push", {}))
+            needs[job]["result"] = "success"
+
+    def test_dispatch_requires_builds_even_without_docker_changes(self) -> None:
+        needs = _needs("docs")
+        self.assertEqual(gate.check(needs, "workflow_dispatch", {}), [])
+        for job in gate.DOCKER_BUILD_JOBS:
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "workflow_dispatch", {}))
+            needs[job]["result"] = "success"
+
+    def test_schedule_skips_code_jobs_regardless_of_changed_paths(self) -> None:
+        for changed in ((), ("code",), ("docker",), ("docs",)):
+            needs = _skip(_needs(*changed), gate.CODE_JOBS)
+            self.assertEqual(gate.check(needs, "schedule", {}), [])
+            for job in gate.DOCKER_BUILD_JOBS | {"docker-smoke"} | gate.ALWAYS_JOBS:
+                with self.subTest(changed=changed, job=job):
+                    needs[job]["result"] = "skipped"
+                    self.assertTrue(gate.check(needs, "schedule", {}))
+                    needs[job]["result"] = "success"
+
+    def test_schedule_rejects_failed_and_cancelled_jobs_even_if_optional(self) -> None:
+        for job in gate.EXPECTED_JOBS:
+            for result in ("failure", "cancelled"):
+                needs = _skip(_needs("docs"), gate.CODE_JOBS)
+                needs[job]["result"] = result
+                self.assertTrue(gate.check(needs, "schedule", {}))
 
 
 class FailClosed(unittest.TestCase):

--- a/tests_py/scripts/test_check_ci_gate_results.py
+++ b/tests_py/scripts/test_check_ci_gate_results.py
@@ -1,0 +1,164 @@
+"""CI Green must fail closed without importing application code or its DB."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import check_ci_gate_results as gate
+
+
+def _event(fork: bool = False) -> dict:
+    return {"pull_request": {"head": {"repo": {"fork": fork}}}}
+
+
+def _needs(*changed: str) -> dict:
+    needs = {job: {"result": "success", "outputs": {}} for job in gate.EXPECTED_JOBS}
+    needs["changes"]["outputs"] = {
+        name: "true" if name in changed else "false" for name in gate.FILTERS
+    }
+    return needs
+
+
+def _skip(needs: dict, jobs: frozenset[str]) -> dict:
+    for job in jobs:
+        needs[job]["result"] = "skipped"
+    return needs
+
+
+class JustifiedSkips(unittest.TestCase):
+    def test_docs_only_runs_only_changes_and_lint(self) -> None:
+        needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+        self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+
+    def test_docker_only_requires_docker_jobs(self) -> None:
+        needs = _skip(_needs("docker"), gate.CODE_JOBS)
+        self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+        for job in gate.DOCKER_JOBS:
+            with self.subTest(job=job):
+                needs[job]["result"] = "skipped"
+                self.assertTrue(gate.check(needs, "pull_request", _event()))
+                needs[job]["result"] = "success"
+
+    def test_code_deps_workflows_require_every_job(self) -> None:
+        for changed in (("code",), ("docs", "code"), ("deps",), ("workflows",)):
+            needs = _needs(*changed)
+            self.assertEqual(gate.check(needs, "pull_request", _event()), [])
+            for job in gate.CONDITIONAL_JOBS:
+                with self.subTest(changed=changed, job=job):
+                    needs[job]["result"] = "skipped"
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+                    needs[job]["result"] = "success"
+
+    def test_non_pr_runs_require_full_matrix_even_for_docs(self) -> None:
+        for event_name in ("push", "workflow_dispatch"):
+            needs = _needs("docs")
+            self.assertEqual(gate.check(needs, event_name, {}), [])
+            needs["test"]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, event_name, {}))
+
+    def test_fork_guard_applies_only_to_vendor_cli_job(self) -> None:
+        needs = _needs("code")
+        needs["mcp-host-config"]["result"] = "skipped"
+        self.assertEqual(gate.check(needs, "pull_request", _event(True)), [])
+        self.assertTrue(gate.check(needs, "pull_request", _event(False)))
+        needs["test"]["result"] = "skipped"
+        self.assertTrue(gate.check(needs, "pull_request", _event(True)))
+
+
+class FailClosed(unittest.TestCase):
+    def test_failures_cancellation_and_invalid_results_never_pass(self) -> None:
+        for result in ("failure", "cancelled", "pending", "", None):
+            for job in gate.EXPECTED_JOBS:
+                with self.subTest(result=result, job=job):
+                    needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+                    needs[job]["result"] = result
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_lint_failure_rejects_skipped_matrix(self) -> None:
+        needs = _skip(_needs("code"), gate.CONDITIONAL_JOBS)
+        needs["lint"]["result"] = "failure"
+        failures = gate.check(needs, "pull_request", _event())
+        self.assertTrue(any("lint=" in failure for failure in failures))
+
+    def test_changes_and_lint_may_never_skip(self) -> None:
+        for job in gate.ALWAYS_JOBS:
+            needs = _skip(_needs("docs"), gate.CONDITIONAL_JOBS)
+            needs[job]["result"] = "skipped"
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_and_unexpected_jobs_fail(self) -> None:
+        for job in gate.EXPECTED_JOBS:
+            needs = _needs("docs")
+            del needs[job]
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+        needs = _needs("docs")
+        needs["unwatched"] = {"result": "success"}
+        self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_and_invalid_classifications_fail(self) -> None:
+        for output in gate.FILTERS:
+            for value in (True, False, "", "TRUE", None, [], {}):
+                with self.subTest(output=output, value=value):
+                    needs = _needs("docs")
+                    needs["changes"]["outputs"][output] = value
+                    self.assertTrue(gate.check(needs, "pull_request", _event()))
+            needs = _needs("docs")
+            del needs["changes"]["outputs"][output]
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_invalid_job_objects_and_output_objects_fail(self) -> None:
+        for value in (None, [], "success"):
+            needs = _needs("docs")
+            needs["changes"] = value
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+            needs = _needs("docs")
+            needs["changes"]["outputs"] = value
+            self.assertTrue(gate.check(needs, "pull_request", _event()))
+
+    def test_missing_or_invalid_fork_context_fails(self) -> None:
+        for event in ({}, {"pull_request": None}, _event("false")):
+            self.assertTrue(gate.check(_needs("docs"), "pull_request", event))
+
+    def test_unsupported_event_context_fails(self) -> None:
+        self.assertTrue(gate.check(_needs("docs"), "", {}))
+        self.assertTrue(gate.check(_needs("docs"), "push", []))
+
+
+class ExecutableContract(unittest.TestCase):
+    def _run(self, needs: str) -> subprocess.CompletedProcess:
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = Path(directory) / "event.json"
+            event_path.write_text(json.dumps(_event()), encoding="utf-8")
+            env = {
+                **os.environ,
+                "NEEDS": needs,
+                "GITHUB_EVENT_PATH": str(event_path),
+                "GITHUB_EVENT_NAME": "pull_request",
+                "ALLOWED_SKIPS": ",".join(sorted(gate.CONDITIONAL_JOBS)),
+            }
+            return subprocess.run(
+                [sys.executable, str(Path(gate.__file__))],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_docs_only_cli_succeeds(self) -> None:
+        result = self._run(json.dumps(_skip(_needs("docs"), gate.CONDITIONAL_JOBS)))
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_malformed_json_cli_fails_with_diagnostic(self) -> None:
+        result = self._run("{bad json")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot read CI gate inputs", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/scripts/test_launcher_cleanup.py
+++ b/tests_py/scripts/test_launcher_cleanup.py
@@ -1,0 +1,129 @@
+"""Bounded stdlib tests: conservative classification and owner-only removal."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from tests_py.scripts._cleanup_fixture import (
+    HAS_SAFE_FS,
+    HAS_SAFE_REMOVE,
+    CleanupFixture,
+)
+
+import launcher_cleanup
+from launcher_cleanup_fs import CleanupRefusedError
+from launcher_cleanup_registry import identity
+
+
+@unittest.skipUnless(HAS_SAFE_FS, "platform lacks no-follow descriptor operations")
+class TestCleanupAudit(CleanupFixture):
+    def test_audit_preserves_installed_enabled_disabled_and_current(self) -> None:
+        before = self.all_deps()
+        report = launcher_cleanup.sweep(self.scope, [])
+        self.assertFalse(report.refused)
+        self.assertEqual(before, self.all_deps())
+        self.assertEqual(len(report.protected), 4)
+        self.assertEqual(len(report.indeterminate), 3)
+        self.assertFalse(report.candidates)
+        self.assertFalse(report.removed)
+
+    def test_explicit_identity_dry_run_lists_candidate_without_deletion(self) -> None:
+        before = self.all_deps()
+        report = launcher_cleanup.sweep(self.scope, ["orphan@market"])
+        self.assertEqual(
+            report.candidates, [str(self.scope.data_root / "orphan-market/deps")]
+        )
+        self.assertEqual(before, self.all_deps())
+        self.assertFalse(report.refused)
+        self.assertFalse(report.removed)
+
+    @unittest.skipUnless(HAS_SAFE_REMOVE, "safe removal needs Python 3.11+")
+    def test_apply_removes_only_selected_deps_and_retains_user_data(self) -> None:
+        before = self.all_deps()
+        orphan = self.scope.data_root / "orphan-market/deps"
+        report = launcher_cleanup.sweep(self.scope, ["orphan@market"], apply=True)
+        self.assertFalse(report.refused)
+        self.assertEqual(report.removed, [str(orphan)])
+        self.assertEqual(self.all_deps(), [path for path in before if path != orphan])
+        self.assertEqual((orphan.parent / "keep.json").read_text(), "user data")
+
+    def test_apply_without_explicit_identity_refuses(self) -> None:
+        before = self.all_deps()
+        with self.assertLogs("launcher_cleanup", level="WARNING") as logs:
+            report = launcher_cleanup.sweep(self.scope, [], apply=True)
+        self.assertIn("owner-verified --plugin-id", report.refused[0])
+        self.assertIn("refused", logs.output[0])
+        self.assertEqual(before, self.all_deps())
+
+    def test_protected_and_unregistered_selections_refuse(self) -> None:
+        before = self.all_deps()
+        for plugin in (
+            "current@market",
+            "installed@market",
+            "enabled@market",
+            "disabled@market",
+            "scratch@inline",
+            "cloud@synced",
+            "absent@market",
+        ):
+            with self.subTest(plugin=plugin), self.assertLogs("launcher_cleanup"):
+                report = launcher_cleanup.sweep(self.scope, [plugin], apply=True)
+                self.assertTrue(report.refused)
+                self.assertFalse(report.removed)
+        self.assertEqual(before, self.all_deps())
+
+    @unittest.skipUnless(HAS_SAFE_REMOVE, "safe removal needs Python 3.11+")
+    def test_registry_changed_after_audit_prevents_removal(self) -> None:
+        original = launcher_cleanup.protections
+        calls = []
+
+        def changed(scope):
+            calls.append(scope)
+            if len(calls) > 1:
+                self.write(
+                    self.root / "settings.json",
+                    {"enabledPlugins": {"orphan@market": False}},
+                )
+            return original(scope)
+
+        with patch.object(launcher_cleanup, "protections", side_effect=changed):
+            with self.assertLogs("launcher_cleanup"):
+                report = launcher_cleanup.sweep(
+                    self.scope, ["orphan@market"], apply=True
+                )
+        self.assertIn("became protected", report.refused[0])
+        self.assertTrue((self.scope.data_root / "orphan-market/deps").is_dir())
+
+    def test_non_deps_sibling_directory_is_not_removed(self) -> None:
+        extra = self.scope.data_root / "no-deps-market"
+        extra.mkdir()
+        (extra / "personal.txt").write_text("keep", encoding="utf-8")
+        (self.scope.data_root / "personal.txt").write_text(
+            "root file", encoding="utf-8"
+        )
+        report = launcher_cleanup.sweep(self.scope, [])
+        self.assertFalse(report.refused)
+        self.assertEqual((extra / "personal.txt").read_text(), "keep")
+        self.assertEqual(
+            (self.scope.data_root / "personal.txt").read_text(), "root file"
+        )
+
+
+class TestIdentityMapping(unittest.TestCase):
+    def test_official_documentation_examples_and_punctuation(self) -> None:
+        self.assertEqual(
+            identity("formatter@my-marketplace"), "formatter-my-marketplace"
+        )
+        self.assertEqual(
+            identity("my.plugin@my_marketplace"), "my-plugin-my_marketplace"
+        )
+
+    def test_unsupported_identifier_refuses(self) -> None:
+        for value in ("missing-market", "@market", "plugin@", "a@b@c", "a b@market"):
+            with self.subTest(value=value), self.assertRaises(CleanupRefusedError):
+                identity(value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/scripts/test_launcher_cleanup_cli.py
+++ b/tests_py/scripts/test_launcher_cleanup_cli.py
@@ -1,0 +1,160 @@
+"""CLI dispatch precedes all bootstrap and backend activity."""
+
+from __future__ import annotations
+
+import builtins
+import io
+import json
+import os
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from tests_py.scripts._cleanup_fixture import HAS_SAFE_FS, SCRIPTS, CleanupFixture
+
+import launcher_cleanup
+import launcher
+
+
+@unittest.skipUnless(HAS_SAFE_FS, "platform lacks no-follow descriptor operations")
+class TestCleanupCli(CleanupFixture):
+    def environment(self) -> dict[str, str]:
+        return {
+            **os.environ,
+            "CORTEX_CLAUDE_DIR": str(self.root),
+            "CLAUDE_PLUGIN_DATA": str(self.scope.current_deps.parent),
+            "CLAUDE_PLUGIN_ROOT": str(self.workspace / "missing-plugin"),
+            "PYTHONPATH": "",
+            "HOME": str(self.workspace / "unused-home"),
+        }
+
+    def run_cli(self, arguments: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-S", str(SCRIPTS / "launcher.py"), *arguments],
+            env=self.environment(),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_dry_run_without_site_packages_does_not_bootstrap_or_run_module(
+        self,
+    ) -> None:
+        before = self.all_deps()
+        result = self.run_cli(
+            ["--cleanup-deps", "--dry-run", "--plugin-id", "orphan@market"]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(len(report["candidates"]), 1)
+        self.assertFalse(report["removed"])
+        self.assertEqual(before, self.all_deps())
+        self.assertFalse((self.workspace / "unused-home").exists())
+        self.assertEqual(result.stderr, "")
+
+    def test_malformed_flags_fail_before_bootstrap(self) -> None:
+        for arguments in (
+            ["--dry-run"],
+            ["--apply"],
+            ["--plugin-id", "orphan@market"],
+            ["--cleanup-deps", "--dry-run", "--apply"],
+        ):
+            with self.subTest(arguments=arguments):
+                result = self.run_cli(arguments)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("usage:", result.stderr)
+                self.assertNotIn("backend", result.stderr)
+                self.assertNotIn("Installing", result.stderr)
+
+    def test_missing_explicit_environment_refuses_without_home_lookup(self) -> None:
+        output = io.StringIO()
+        with patch.dict(os.environ, {}, clear=True), redirect_stdout(output):
+            with self.assertLogs("launcher_cleanup", level="WARNING"):
+                result = launcher_cleanup.cli(["--cleanup-deps", "--dry-run"])
+        self.assertNotEqual(result, 0)
+        self.assertIn("CORTEX_CLAUDE_DIR", json.loads(output.getvalue())["refused"][0])
+
+    def test_unset_startup_is_silent_without_filesystem_access(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(launcher_cleanup, "sweep") as sweep:
+                with self.assertNoLogs("launcher_cleanup"):
+                    launcher_cleanup.audit_startup()
+        sweep.assert_not_called()
+
+    def test_startup_audits_without_applying(self) -> None:
+        before = self.all_deps()
+        with patch.dict(os.environ, self.environment(), clear=True):
+            with self.assertLogs("launcher_cleanup", level="WARNING") as logs:
+                launcher_cleanup.audit_startup()
+        self.assertIn("retained unverified", logs.output[0])
+        self.assertEqual(before, self.all_deps())
+
+    def test_startup_missing_current_is_logged_and_keeps_launching(self) -> None:
+        with patch.dict(os.environ, {"CORTEX_CLAUDE_DIR": str(self.root)}, clear=True):
+            with self.assertLogs("launcher_cleanup", level="WARNING") as logs:
+                launcher_cleanup.audit_startup()
+        self.assertIn("CLAUDE_PLUGIN_DATA", logs.output[0])
+
+    def test_module_dry_run_argument_reaches_normal_launcher_unchanged(self) -> None:
+        arguments = ["launcher.py", "example.module", "--dry-run"]
+        with (
+            patch.object(sys, "argv", arguments),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            with patch.object(launcher, "main") as main:
+                with patch.object(launcher_cleanup, "cli") as cli:
+                    launcher.entrypoint()
+        main.assert_called_once_with()
+        cli.assert_not_called()
+        self.assertEqual(arguments, ["launcher.py", "example.module", "--dry-run"])
+
+
+class TestCleanupLaunchBoundary(unittest.TestCase):
+    def test_hooks_and_workers_never_import_cleanup_even_with_explicit_root(
+        self,
+    ) -> None:
+        original_import = builtins.__import__
+
+        def guarded_import(name: str, *args: object, **kwargs: object) -> object:
+            if name.startswith("launcher_cleanup"):
+                raise AssertionError(f"per-tool cleanup import: {name}")
+            return original_import(name, *args, **kwargs)
+
+        for module in (
+            "mcp_server.hooks.post_tool_capture",
+            "mcp_server.hooks.preemptive_context",
+            "mcp_server.hooks.pipeline_impact_bump",
+            "mcp_server.hooks.post_commit_reindex",
+            "mcp_server.hooks.session_start",
+            "example.worker",
+        ):
+            with (
+                self.subTest(module=module),
+                patch.object(sys, "argv", ["launcher.py", module]),
+                patch.dict(os.environ, {"CORTEX_CLAUDE_DIR": "/unused"}, clear=True),
+                patch.object(builtins, "__import__", side_effect=guarded_import),
+                patch.object(launcher, "main") as main,
+            ):
+                launcher.entrypoint()
+                main.assert_called_once_with()
+
+    def test_server_audits_once_only_with_explicit_root(self) -> None:
+        for environment in ({}, {"CORTEX_CLAUDE_DIR": "/unused"}):
+            with (
+                self.subTest(environment=environment),
+                patch.object(
+                    sys, "argv", ["launcher.py", "mcp_server", "--install-deps"]
+                ),
+                patch.dict(os.environ, environment, clear=True),
+                patch.object(launcher_cleanup, "audit_startup") as audit,
+                patch.object(launcher, "main") as main,
+            ):
+                launcher.entrypoint()
+                self.assertEqual(audit.call_count, int(bool(environment)))
+                main.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/scripts/test_launcher_cleanup_fs.py
+++ b/tests_py/scripts/test_launcher_cleanup_fs.py
@@ -1,0 +1,112 @@
+"""Filesystem safety tests operate only on newly created temporary trees."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from tests_py.scripts._cleanup_fixture import HAS_SAFE_FS, CleanupFixture
+
+import launcher_cleanup
+from launcher_cleanup_registry import CleanupScope
+
+
+@unittest.skipUnless(HAS_SAFE_FS, "platform lacks no-follow descriptor operations")
+class TestCleanupFilesystem(CleanupFixture):
+    def assert_refused(self) -> None:
+        with self.assertLogs("launcher_cleanup", level="WARNING"):
+            report = launcher_cleanup.sweep(self.scope, ["orphan@market"], apply=True)
+        self.assertTrue(report.refused)
+        self.assertFalse(report.removed)
+
+    def test_root_parents_identity_deps_and_registry_symlinks_refuse(self) -> None:
+        paths = (
+            self.root,
+            self.root / "plugins",
+            self.scope.data_root,
+            self.scope.current_deps.parent,
+            self.scope.data_root / "orphan-market",
+            self.scope.data_root / "orphan-market/deps",
+            self.registry,
+            self.root / "settings.json",
+        )
+        for index, path in enumerate(paths):
+            with self.subTest(path=path):
+                target = self.workspace / f"link-target-{index}"
+                path.rename(target)
+                path.symlink_to(target, target_is_directory=target.is_dir())
+                self.assert_refused()
+                self.assertTrue(target.exists())
+                path.unlink()
+                target.rename(path)
+        self.assertTrue(
+            (self.scope.data_root / "orphan-market/deps/fixture.txt").is_file()
+        )
+
+    def test_descendant_symlink_refuses_and_leaves_target_untouched(self) -> None:
+        target = self.workspace / "outside.txt"
+        target.write_text("outside", encoding="utf-8")
+        link = self.scope.data_root / "orphan-market/deps/linked.txt"
+        link.symlink_to(target)
+        self.assert_refused()
+        self.assertEqual(target.read_text(), "outside")
+        self.assertTrue(link.is_symlink())
+
+    def test_non_directory_deps_refuses_without_deleting_the_file(self) -> None:
+        path = self.scope.data_root / "orphan-market/deps"
+        path.rename(path.parent / "saved")
+        path.write_text("user file", encoding="utf-8")
+        self.assert_refused()
+        self.assertEqual(path.read_text(), "user file")
+
+    def test_current_path_outside_exact_layout_refuses(self) -> None:
+        self.scope = CleanupScope(self.root, self.workspace / "other/deps")
+        self.assert_refused()
+
+    def test_python_310_rmtree_signature_refuses_without_call(self) -> None:
+        calls = []
+
+        def old_rmtree(path, ignore_errors=False, onerror=None):
+            calls.append(path)
+
+        old_rmtree.avoids_symlink_attacks = True
+        with patch("launcher_cleanup_fs.shutil.rmtree", old_rmtree):
+            with self.assertLogs("launcher_cleanup", level="WARNING"):
+                report = launcher_cleanup.sweep(
+                    self.scope, ["orphan@market"], apply=True
+                )
+        self.assertIn("Python 3.11", report.refused[0])
+        self.assertFalse(calls)
+        self.assertTrue((self.scope.data_root / "orphan-market/deps").is_dir())
+
+    def test_unsafe_rmtree_refuses_without_call(self) -> None:
+        calls = []
+
+        def unsafe_rmtree(path, *, dir_fd=None):
+            calls.append(path)
+
+        unsafe_rmtree.avoids_symlink_attacks = False
+        with patch("launcher_cleanup_fs.shutil.rmtree", unsafe_rmtree):
+            with self.assertLogs("launcher_cleanup", level="WARNING"):
+                report = launcher_cleanup.sweep(
+                    self.scope, ["orphan@market"], apply=True
+                )
+        self.assertIn("symlink-resistant", report.refused[0])
+        self.assertFalse(calls)
+
+    def test_unsupported_platform_refuses_explicitly(self) -> None:
+        with patch("launcher_cleanup_fs.os.supports_dir_fd", set()):
+            with self.assertLogs("launcher_cleanup", level="WARNING"):
+                report = launcher_cleanup.sweep(self.scope, [])
+        self.assertIn("descriptor-relative", report.refused[0])
+
+    def test_removal_error_is_reported_without_success_claim(self) -> None:
+        with patch("launcher_cleanup.require_removal_support"):
+            with patch(
+                "launcher_cleanup.remove_deps", side_effect=PermissionError("denied")
+            ):
+                self.assert_refused()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/scripts/test_launcher_cleanup_registry.py
+++ b/tests_py/scripts/test_launcher_cleanup_registry.py
@@ -1,0 +1,120 @@
+"""Registry failures must not convert incomplete knowledge into uninstallation."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from tests_py.scripts._cleanup_fixture import HAS_SAFE_FS, CleanupFixture
+
+import launcher_cleanup
+
+
+@unittest.skipUnless(HAS_SAFE_FS, "platform lacks no-follow descriptor operations")
+class TestCleanupRegistry(CleanupFixture):
+    def assert_refused(self, expected: str = "") -> None:
+        before = self.all_deps()
+        with self.assertLogs("launcher_cleanup", level="WARNING"):
+            report = launcher_cleanup.sweep(self.scope, ["orphan@market"], apply=True)
+        self.assertTrue(report.refused)
+        self.assertIn(expected, report.refused[0])
+        self.assertFalse(report.removed)
+        self.assertEqual(before, self.all_deps())
+
+    def add_project(self) -> None:
+        self.project = self.workspace / "project"
+        self.installs["project@market"] = [
+            {
+                **self.install_record("project"),
+                "projectPath": str(self.project),
+            }
+        ]
+        self.write(self.registry, {"plugins": self.installs})
+        self.write(
+            self.project / ".claude/settings.json",
+            {"enabledPlugins": {"orphan@market": False}},
+        )
+        self.write(
+            self.project / ".claude/settings.local.json",
+            {"enabledPlugins": {"local@market": True}},
+        )
+        self.make_deps("local@market")
+
+    def test_project_and_local_settings_protect_all_references(self) -> None:
+        self.add_project()
+        report = launcher_cleanup.sweep(self.scope, [])
+        self.assertFalse(report.refused)
+        self.assertIn(
+            str(self.scope.data_root / "orphan-market/deps"), report.protected
+        )
+        self.assertIn(str(self.scope.data_root / "local-market/deps"), report.protected)
+
+    def test_missing_registry_or_global_settings_refuses(self) -> None:
+        for path in (self.registry, self.root / "settings.json"):
+            contents = path.read_bytes()
+            path.unlink()
+            self.assert_refused("No such file")
+            path.write_bytes(contents)
+
+    def test_invalid_json_unicode_duplicate_keys_and_nonobject_refuse(self) -> None:
+        for contents in (b"{", b"\xff", b"[]", b'{"plugins":{},"plugins":{}}'):
+            with self.subTest(contents=contents):
+                self.registry.write_bytes(contents)
+                self.assert_refused()
+
+    def test_incomplete_registry_entries_refuse(self) -> None:
+        invalid = (
+            {},
+            {"plugins": []},
+            {"plugins": {"orphan@market": []}},
+            {"plugins": {"orphan@market": [None]}},
+            {
+                "plugins": {
+                    "orphan@market": [{"installPath": "relative", "scope": "user"}]
+                }
+            },
+        )
+        for value in invalid:
+            with self.subTest(value=value):
+                self.write(self.registry, value)
+                self.assert_refused()
+
+    def test_unknown_missing_and_invalid_scope_refuse(self) -> None:
+        for scope in (None, "managed", "unknown", {}, []):
+            with self.subTest(scope=scope):
+                record = {**self.install_record(), "scope": scope}
+                self.write(self.registry, {"plugins": {"installed@market": [record]}})
+                self.assert_refused("scope")
+
+    def test_incomplete_settings_refuse(self) -> None:
+        for value in ({}, {"enabledPlugins": []}, {"enabledPlugins": {"a@b": "false"}}):
+            with self.subTest(value=value):
+                self.write(self.root / "settings.json", value)
+                self.assert_refused("enabledPlugins")
+
+    def test_project_without_project_path_refuses(self) -> None:
+        self.write(
+            self.registry,
+            {"plugins": {"project@market": [self.install_record("project")]}},
+        )
+        self.assert_refused("projectPath")
+
+    def test_missing_project_or_local_settings_refuses(self) -> None:
+        self.add_project()
+        for name in ("settings.json", "settings.local.json"):
+            path = self.project / ".claude" / name
+            contents = path.read_bytes()
+            path.unlink()
+            self.assert_refused("No such file")
+            path.write_bytes(contents)
+
+    def test_unreadable_registry_refuses_with_diagnostic(self) -> None:
+        with patch(
+            "launcher_cleanup_registry.read_object",
+            side_effect=PermissionError("denied"),
+        ):
+            self.assert_refused("denied")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/scripts/test_log_migration_runbook.py
+++ b/tests_py/scripts/test_log_migration_runbook.py
@@ -1,0 +1,86 @@
+"""Run the documented owner migration only against synthetic temporary files."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestLogMigrationRunbook(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory(prefix="cortex-log-migration-")
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name).resolve()
+        folder = self.root / "methodology"
+        folder.mkdir()
+        self.legacy = folder / "session_log.json"
+        self.canonical = folder / "session-log.json"
+        self.canonical.write_text('{"sessions": []}', encoding="utf-8")
+        runbook = (
+            Path(__file__).resolve().parents[2] / "docs/runbooks/local-log-rotation.md"
+        )
+        self.script = runbook.read_text().split("<<'PY'\n", 1)[1].split("\nPY\n", 1)[0]
+
+    def run_migration(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-S", "-c", self.script],
+            env=dict(os.environ, CORTEX_CLAUDE_DIR=str(self.root)),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_exact_duplicate_is_removed_and_canonical_retained(self) -> None:
+        self.legacy.write_bytes(self.canonical.read_bytes())
+        result = self.run_migration()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(self.legacy.exists())
+        self.assertEqual(self.canonical.read_text(), '{"sessions": []}')
+
+    def test_different_malformed_or_duplicate_key_content_is_retained(self) -> None:
+        for contents in (
+            '{"sessions": ["unique"]}',
+            "{",
+            '{"sessions":["unique"],"sessions":[]}',
+        ):
+            with self.subTest(contents=contents):
+                self.legacy.write_text(contents, encoding="utf-8")
+                result = self.run_migration()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.legacy.read_text(), contents)
+                self.assertTrue(self.canonical.exists())
+
+    def test_json_types_and_non_finite_numbers_never_collapse_into_duplicates(
+        self,
+    ) -> None:
+        for old, new in (
+            ('{"sessions":[true]}', '{"sessions":[1]}'),
+            ('{"sessions":[false]}', '{"sessions":[0]}'),
+            ('{"sessions":[NaN]}', '{"sessions":[NaN]}'),
+            ('{"sessions":[Infinity]}', '{"sessions":[Infinity]}'),
+        ):
+            with self.subTest(old=old, new=new):
+                self.legacy.write_text(old, encoding="utf-8")
+                self.canonical.write_text(new, encoding="utf-8")
+                result = self.run_migration()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.legacy.read_text(), old)
+                self.assertEqual(self.canonical.read_text(), new)
+
+    @unittest.skipIf(
+        sys.platform == "win32", "symlink privilege is not assumed on Windows"
+    )
+    def test_symlink_is_retained_and_target_untouched(self) -> None:
+        self.legacy.symlink_to(self.canonical)
+        result = self.run_migration()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(self.legacy.is_symlink())
+        self.assertEqual(self.canonical.read_text(), '{"sessions": []}')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/shared/test_hook_state_paths.py
+++ b/tests_py/shared/test_hook_state_paths.py
@@ -1,0 +1,56 @@
+"""Private cooldown roots prevent tests and separate installs sharing state."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from mcp_server.shared.hook_state_paths import cooldown_path
+
+
+class TestHookStatePaths(unittest.TestCase):
+    def test_unset_or_blank_override_preserves_legacy_path_without_io(self) -> None:
+        for override in (None, "", " "):
+            environment = {} if override is None else {"CORTEX_CLAUDE_DIR": override}
+            with patch.dict(os.environ, environment, clear=True):
+                self.assertEqual(
+                    cooldown_path("fixture.json"), Path("/tmp/fixture.json")
+                )
+
+    def test_actual_hooks_create_and_read_only_the_explicit_root(self) -> None:
+        code = """
+import os
+from pathlib import Path
+from mcp_server.hooks import pipeline_impact_bump, preemptive_context
+root = Path(os.environ["CORTEX_CLAUDE_DIR"])
+assert not root.exists(), "imports must not create cooldown directories"
+for hook in (pipeline_impact_bump, preemptive_context):
+    assert hook._COOLDOWN_FILE.parent == root / "methodology/hook-cooldowns"
+    assert not hook._check_cooldown("fixture.py")
+    hook._update_cooldown("fixture.py")
+    assert hook._check_cooldown("fixture.py")
+    assert hook._COOLDOWN_FILE.is_file()
+"""
+        with tempfile.TemporaryDirectory(prefix="cortex-cooldown-root-") as directory:
+            for name in ("first", "second"):
+                environment = dict(
+                    os.environ, CORTEX_CLAUDE_DIR=str(Path(directory) / name)
+                )
+                result = subprocess.run(
+                    [sys.executable, "-S", "-c", code],
+                    cwd=Path(__file__).resolve().parents[2],
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_py/shared/test_log_rotation.py
+++ b/tests_py/shared/test_log_rotation.py
@@ -1,0 +1,144 @@
+"""Small stdlib rotation tests; all files and processes use synthetic data."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from mcp_server.shared import log_rotation
+
+
+def _stop_process(process: subprocess.Popen) -> None:
+    if process.poll() is None:
+        process.kill()
+        process.wait()
+
+
+class TestLogRotation(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory(prefix="cortex-rotation-test-")
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.path = self.root / "log.jsonl"
+        self.previous = self.path.with_name(self.path.name + ".1")
+
+    def append(self, text: str) -> None:
+        with log_rotation.open_rotating_log(
+            self.path, len(text.encode("utf-8"))
+        ) as stream:
+            stream.write(text)
+
+    def test_below_threshold_appends_without_rotation(self) -> None:
+        self.append("first\n")
+        self.append("second\n")
+        self.assertEqual(self.path.read_text(), "first\nsecond\n")
+        self.assertFalse(self.previous.exists())
+
+    def test_actual_f9_threshold_rotates_before_worker_open(self) -> None:
+        self.assertEqual(log_rotation.MAX_LOG_BYTES, 196_000 * 30)
+        with self.path.open("wb") as stream:
+            stream.truncate(
+                log_rotation.MAX_LOG_BYTES
+            )  # Sparse fixture, no log corpus.
+        with log_rotation.open_rotating_log(self.path) as stream:
+            self.assertEqual(self.previous.stat().st_size, log_rotation.MAX_LOG_BYTES)
+            self.assertEqual(self.path.stat().st_size, 0)
+            stream.write("worker\n")
+        self.assertEqual(self.path.read_text(), "worker\n")
+        self.assertTrue(stream.closed)
+
+    def test_utf8_bytes_trigger_rotation_and_keep_complete_records(self) -> None:
+        first, second = "é\n", "à\n"
+        with patch.object(
+            log_rotation, "MAX_LOG_BYTES", len((first + "x").encode("utf-8"))
+        ):
+            self.append(first)
+            self.append(second)
+        self.assertEqual(self.previous.read_text(), first)
+        self.assertEqual(self.path.read_text(), second)
+
+    def test_only_one_previous_segment_is_retained(self) -> None:
+        with patch.object(log_rotation, "MAX_LOG_BYTES", len("first\n")):
+            for line in ("first\n", "next!\n", "last!\n"):
+                self.append(line)
+        self.assertEqual(self.path.read_text(), "last!\n")
+        self.assertEqual(self.previous.read_text(), "next!\n")
+        self.assertEqual(
+            {path.name for path in self.root.iterdir()},
+            {"log.jsonl", "log.jsonl.1", "log.jsonl.lock"},
+        )
+
+    def test_single_oversized_record_is_preserved_whole(self) -> None:
+        with patch.object(log_rotation, "MAX_LOG_BYTES", len("old\n")):
+            self.append("old\n")
+            self.append("one oversized complete record\n")
+        self.assertEqual(self.previous.read_text(), "old\n")
+        self.assertEqual(self.path.read_text(), "one oversized complete record\n")
+
+    def test_error_closes_stream_and_releases_lock_for_next_write(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "fixture failure"):
+            with log_rotation.open_rotating_log(self.path) as stream:
+                raise RuntimeError("fixture failure")
+        self.assertTrue(stream.closed)
+        self.append("next write\n")
+        self.assertEqual(self.path.read_text(), "next write\n")
+
+    def test_rotation_error_preserves_existing_file_and_propagates(self) -> None:
+        self.path.write_text("first\n", encoding="utf-8")
+        with patch.object(log_rotation, "MAX_LOG_BYTES", len("first\n")):
+            with patch.object(
+                Path, "replace", side_effect=PermissionError("busy file")
+            ):
+                with self.assertRaisesRegex(PermissionError, "busy file"):
+                    self.append("next\n")
+        self.assertEqual(self.path.read_text(), "first\n")
+        self.assertFalse(self.previous.exists())
+
+    @unittest.skipIf(
+        sys.platform == "win32", "symlink privilege is not assumed on Windows"
+    )
+    def test_log_and_archive_symlinks_are_refused(self) -> None:
+        target = self.root / "target.txt"
+        target.write_text("untouched", encoding="utf-8")
+        self.path.symlink_to(target)
+        with self.assertRaisesRegex(OSError, "regular file"):
+            self.append("new\n")
+        self.path.unlink()
+        self.path.write_text("old\n", encoding="utf-8")
+        self.previous.symlink_to(target)
+        with patch.object(log_rotation, "MAX_LOG_BYTES", len("old\n")):
+            with self.assertRaisesRegex(OSError, "regular file"):
+                self.append("new\n")
+        self.assertEqual(target.read_text(), "untouched")
+
+    def test_two_independent_processes_keep_both_records_across_rotation(self) -> None:
+        script = """
+import json, sys
+from pathlib import Path
+from mcp_server.shared import log_rotation
+line = json.dumps({'writer': sys.argv[2]}) + '\\n'
+log_rotation.MAX_LOG_BYTES = len(line.encode('utf-8'))
+with log_rotation.open_rotating_log(
+    Path(sys.argv[1]), len(line.encode('utf-8'))
+) as out:
+    out.write(line)
+"""
+        processes = [
+            subprocess.Popen([sys.executable, "-c", script, str(self.path), label])
+            for label in ("one", "two")
+        ]
+        for process in processes:
+            self.addCleanup(_stop_process, process)
+        for process in processes:
+            self.assertEqual(process.wait(timeout=10), 0)
+        records = [json.loads(path.read_text()) for path in (self.path, self.previous)]
+        self.assertEqual({record["writer"] for record in records}, {"one", "two"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Symptôme

W2-4 / H4 : un miss ne pose aucun cooldown et répète les scans. Le compteur de cascade est remis à zéro à chaque processus PostToolUse et n'atteint jamais sa cadence de 20 appels. PR empilée sur #485.

## Cause racine

Le launcher exécute une seule enveloppe par nouveau processus ; `_tool_call_counter` démarre à zéro puis atteint seulement 1. Le matcher de capture reste `*` afin que tous les outils alimentent cette cadence. Les autres déclencheurs de cascade existent et restent inchangés : ce défaut ne justifie pas de supprimer l'algorithme.

Preemptive n'écrit le cooldown que si `count>0`. Impact le fait après une réponse contenant des symboles et des mémoires correspondantes ; les retours précoces restent donc non bornés.

## Changement

Un scan terminé, y compris sans résultat, pose le cooldown existant : 60 s pour preemptive, 30 s pour impact. Le `finally` d'impact couvre absence de symboles et erreurs sans perdre la garde de fermeture de store introduite en W2-1a. Les deux fichiers de cooldown respectent maintenant `CORTEX_CLAUDE_DIR/methodology/hook-cooldowns/` ; sans override, leurs chemins historiques `/tmp` sont préservés. Aucun répertoire n'est créé à l'import.

La cadence utilise un compteur JSON persistant par identité canonique de transcript, hachée pour le chemin. `tool_calls` et `completed` restent distincts. Un verrou court protège lecture/incrément/remplacement atomique ; un autre verrou d'exécution non bloquant coordonne les cascades de hooks d'une même racine. Aucun travail DB/modèle sous verrou compteur. Contention, exception ou résultat `{error: ...}` conservent l'échéance pour un événement futur. Une invocation traite au plus un intervalle.

Sources : identité canonique `injection_receipts.session_id_from_transcript` (champ événement parfois divergent, décision 4255039 correction 7) ; [fcntl.flock](https://docs.python.org/3/library/fcntl.html#fcntl.flock), [msvcrt.locking](https://docs.python.org/3/library/msvcrt.html#msvcrt.locking), [os.replace](https://docs.python.org/3/library/os.html#os.replace), patterns existants DecisionLock/atomic_write_json. Cadence 20 conservée, provenance du réglage initial inconnue ; aucun nouveau seuil empirique inventé.

## Preuve

Base exacte `3243dfed51d9b1b2e243918554ea2b83213de864`, Python 3.13.7, macOS ARM64. Probe source avant `/private/tmp/cortex-green-w2-4-exact-before.py`, sortie `/private/tmp/cortex-green-w2-4-exact-before.json`. Les corps sont chargés par `git show` sur cette base : **40 processus / 40 PID distincts, compteur 1 partout, zéro cascade** ; trois événements à début/juste avant échéance/échéance produisent **trois scans** dans chacun des trois scénarios miss.

Après : **25 tests passent en 3,838 s**, dont 40 nouveaux processus exécutant le vrai `hook.main` avec effets mémoire/cascade remplacés par espions. Ils prouvent zéro cascade aux appels 1–19, une aux appels 20–39, deux à 40 ; 40 incréments concurrents sans perte ; deux sessions indépendantes ; échéances conservées sous contention/erreur ; simulation du verrou Windows. Les trois scénarios miss réalisent désormais **deux scans**, reprise à l'échéance exacte. Deux nouveaux tests root exécutent les hooks réels sous deux racines explicites : écriture/lecture isolées, aucun état créé à l'import, chemin historique inchangé sans override.

```bash
bash /private/tmp/cortex-green-command-isolated.sh .venv/bin/python -S /private/tmp/cortex-green-w2-4-exact-before.py
bash /private/tmp/cortex-green-unit-isolated.sh tests_py.hooks.test_cascade_counter_processes tests_py.hooks.test_miss_cooldowns tests_py.infrastructure.test_hook_counter_lock tests_py.shared.test_hook_state_paths
bash /private/tmp/cortex-green-local-gates.sh w2-4-final tests_py/hooks/ tests_py/infrastructure/ tests_py/shared/ tests_py/invariants/
```

Le premier lancement du probe root ne trouvait pas le checkout depuis son chemin `/tmp` et ne pouvait mesurer impact ; il a été corrigé avec chemin source explicite et assertions des compteurs avant de produire la preuve ci-dessus. Aucune mesure en échec n'est utilisée.

Les fonctions `_prime_file_memories` et `_bump_heat_for_symbols` restent byte-identiques à la base, preuve `/private/tmp/cortex-green-w2-4-writer-proof.json`. Le registre invariant A3 a seulement été repointé de 145→148 et 182→184 après les imports ajoutés ; aucun writer ni exemption ajouté. Première suite complète : seul ce décalage de lignes échouait (7 683 autres tests réussis) ; ses trois tests ciblés passent après correction.

Gates finaux terminés code 0 : Ruff/format 1 442 fichiers, craftsmanship, Pyright zéro diagnostic ; couches affectées **1 536 passed, 123 skipped, 13 subtests en 37,14 s** ; suite complète **7 684 passed, 221 skipped, 361 subtests en 145,02 s**. Journal `/private/tmp/cortex-green-w2-4-final-gates.log`. Charge initiale 4,27 / 10 cœurs ; disque 60 GiB avant/après. PostgreSQL volontairement indisponible sur socket privé ; aucun accès production. SHA final `1292984d804e2e1f44afa4de75dc43eb22803730`. CI [34046091095](https://github.com/cdeust/Cortex/actions/runs/34046091095) verte sur ce SHA ; les deux builds Docker sont ignorés conformément au filtre W1-4.

Les fixtures n'ouvrent ni modèle ni DB. Le temps réel de la cascade désormais active n'est pas mesuré par ces espions ; aucun gain CPU/énergie extrapolé.

## Conformité

Baseline diminuée d'une entrée devenue obsolète pour `_CASCADE_INTERVAL` ; aucun ajout. Nouveaux modules sous 300 lignes, fonctions sous 40 lignes/quatre paramètres ; infrastructure n'importe aucun handler/core. Imports et fermeture paresseux W2-1a préservés. Le commentaire historique « <200 ms » sera corrigé avec la mesure W3-1a, conformément au découpage du plan.

## Candidats issues

Le déclenchement est best effort : un crash après effets DB et avant acquittement peut répéter une cascade. Une échéance pendante nécessite un futur événement. L'état reste conservé pour les reprises, sans TTL inventé. Le verrou global coordonne les seules cascades de hooks, pas les déclencheurs historiques. Une suspension sous verrou compteur peut retarder un hook ; aucun délai ou retry arbitraire ajouté. Aucun ticket créé.

## Runbook

Aucune opération de production. Le compteur sera créé sous `CORTEX_CLAUDE_DIR/methodology/hook-cascade/` à la première enveloppe portant une identité de transcript valide. La cadence retrouvée déclenche un travail synchrone aux échéances ; la PR ne le présente pas comme gratuit. Ne pas supprimer les fichiers de verrou pendant des sessions actives.
