### PR TITLE
fix(marketplace): deliver zetetic-team-subagents v2.39.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,11 +107,11 @@
       "source": {
         "source": "github",
         "repo": "cdeust/zetetic-team-subagents",
-        "ref": "v2.37.0",
-        "sha": "57a5723df4262c014f5b2a1992cbace0efa4429f"
+        "ref": "v2.39.0",
+        "sha": "f1a9bbd7683c7120a5e9a3390ed3e8ed3ad8a55e"
       },
       "description": "Zetetic agent team for Cortex — 97 genius reasoning patterns from history's greatest minds + 23 team specialists (architect, engineer, code-reviewer, refactorer, …), 78 skills, 26 commands, 42 tools, 20 hooks, under one epistemic standard none of them can bypass. Composes with Cortex memory: every agent recalls/remembers through the Cortex MCP and routes via /genius, /agent, /zetetic, /quality, /research commands.",
-      "version": "2.37.0",
+      "version": "2.39.0",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"


### PR DESCRIPTION
## Symptôme
La PR #479 échoue au contrôle Marketplace pin gate : zetetic-team-subagents reste épinglé à 2.37.0 alors que 2.39.0 est publiée.

## Cause racine
Le manifeste de distribution n’a pas suivi les deux releases amont.

## Changement
Aligne uniquement `ref`, `sha` et `version` de zetetic-team-subagents sur la release v2.39.0 et son commit `f1a9bbd7683c7120a5e9a3390ed3e8ed3ad8a55e`.

## Preuve
- Release officielle : https://github.com/cdeust/zetetic-team-subagents/releases/tag/v2.39.0 ; tag annoté résolu au commit ci-dessus.
- API compare commit…main : `behind_by=0`, merge base égale au commit épinglé ; le commit est présent sur main.
- Contrôle réel `python3 scripts/check_marketplace_pins.py` : `All marketplace pins current.` (exit 0).
- Contrôles locaux : dépendances verrouillées, Ruff (1394 fichiers formatés), craftsmanship et Pyright (0 erreur) passent ; tests ciblés 52 réussis/2 subtests (2.33 s), suite complète 7451 réussis/221 ignorés/123 subtests (161.94 s). PostgreSQL absent dans l’environnement local isolé : tests PG ignorés, couverture Linux/PG à vérifier en CI.

## Conformité
Trois champs de configuration modifiés ; aucune modification du contrôle de staleness ou des dérogations.

## Candidats issues
Aucun.

## Runbook
Fusionner avant la chaîne W0–W2 ; revérifier #479 avec la base main mise à jour lors de son tour. Ne pas contourner son contrôle rouge actuel.
