### PR TITLE
fix(benchmarks): make floor check non-blocking, add --no-regression gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`benchmarks/reproduce.sh`'s published `FLOOR_*` check no longer blocks
+  the build.** `main` itself measures below the published floors (LongMemEval
+  MRR 0.904988 < 0.914, LoCoMo MRR 3-run mean 0.779868 < 0.805, Recall@10
+  0.889506 < 0.915 — cdeust/Cortex PR #492), so every PR built on `main`
+  inherited an already-failing gate. `check_floors` stays informational
+  (rounds `got` to the same 4-decimal precision it prints before comparing,
+  matching what's on screen) but no longer `exit 1`s — same disposition as
+  the pyright ratchet (issue #188). Added `--no-regression` /
+  `--baseline-ref`: the blocking gate a PR should use instead of lowering
+  `FLOOR_*`, comparing HEAD against a baseline ref's own measured scores
+  rather than a fixed number.
+
 ## [4.19.1] - 2026-09-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,11 @@ coding write gates, causal graphs, and intent-aware retrieval.
   same-machine checks against it drift ±0.003 on LoCoMo MRR intra-day
   (measured 2026-07-14, `benchmarks/results/repro/20260714-floors-rebaseline/`)
   and nearly false-failed a floor that passes cleanly under `reproduce.sh`.
+  The published `FLOOR_*` check inside `reproduce.sh` is non-blocking
+  (source: main no longer clears them — see the script's own `FLOOR_*`
+  comment, cdeust/Cortex PR #492): gate a PR with `--no-regression` instead,
+  which fails only if HEAD is worse than its own `--baseline-ref` (default
+  `origin/main`), not against a published number nothing currently clears.
 - Iteration benchmarks: `python3 benchmarks/{longmemeval,locomo,beam}/run_benchmark.py`
   ⚠ Consolidation is OFF by default → scores collapse to ≈0%. This is a
   harness artifact (every candidate is prefiltered by the read-path heat

--- a/benchmarks/lib/bench_regression.sh
+++ b/benchmarks/lib/bench_regression.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# No-regression gate: compares the checked-out tree's benchmark scores
+# against the SAME benchmarks run on a baseline ref (default origin/main),
+# in the SAME ephemeral container/DB, instead of gating on the fixed
+# FLOOR_* constants in reproduce.sh.
+#
+# Why this exists (source: cdeust/Cortex PR #492, 2026-09-07): the
+# published floors (README benchmark tables, E1 v3 campaign) no longer
+# match what main itself measures — LongMemEval MRR 0.904988 vs floor
+# 0.914, LoCoMo MRR 3-run mean 0.779868 vs floor 0.805, LoCoMo Recall@10
+# 0.889506 vs floor 0.915 — all measured on main@6ec76a0e via this same
+# reproduce.sh. That gap predates and is independent of any pending PR:
+# every PR built on top of that commit inherits an already-failing floor
+# gate it did not cause and cannot pass by itself. Lowering FLOOR_* to
+# match would hide the drift (same anti-pattern rejected for the pyright
+# ratchet in issue #188: "raising the floor would just hide the debt").
+# The fix is the same shape as that issue's resolution and as
+# scripts/check_craftsmanship.py's own baseline discipline (diff against
+# the base ref, never the working tree, never a hand-edited threshold):
+# gate on whether THIS tree is worse than its own baseline, not on
+# whether it clears a number nothing currently clears.
+#
+# Contract with the caller (reproduce.sh):
+#   REPO_ROOT, RESULTS_DIR, BENCH_DB_URL, PASSTHROUGH[]   (read)
+#   ONLY, QUICK, LIMIT                                    (read, scope which
+#                                                           benchmarks/limits
+#                                                           the baseline run
+#                                                           mirrors)
+#   want_bench(), run_bench()                             (read, reused so
+#                                                           the baseline run
+#                                                           takes the exact
+#                                                           same code path)
+#   REGRESSION_TOLERANCE                                  (read; reproduce.sh
+#                                                           default below)
+#
+# source: tolerance reuses FLOOR_TOLERANCE's own provenance (0.5 percentage
+# points, benchmarks/results/a3_longmemeval_post_refactor.md design §8) —
+# a regression gate has no reason to be stricter than the floor gate it
+# replaces as the blocking check.
+REGRESSION_TOLERANCE="${REGRESSION_TOLERANCE:-0.005}"
+BASELINE_REF="${BASELINE_REF:-origin/main}"
+BASELINE_RESULTS_DIR=""
+
+# Run the same benchmark set (respecting --only/--quick/--limit) against
+# BASELINE_REF's code, in an isolated git worktree, writing results under
+# $RESULTS_DIR/baseline/. Reuses the already-running container: harnesses
+# self-clean (purge is_benchmark rows on open, per reproduce.sh's header),
+# so a second harness run against the same DB is safe and does not require
+# a second container.
+run_baseline_benchmarks() {
+    local baseline_sha
+    baseline_sha="$(git -C "$REPO_ROOT" rev-parse "$BASELINE_REF" 2>/dev/null)" || {
+        echo "error: could not resolve baseline ref '$BASELINE_REF' (fetch it first?)." >&2
+        exit 1
+    }
+    local head_sha; head_sha="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+    if [ "$baseline_sha" = "$head_sha" ]; then
+        echo "==> Baseline ref '$BASELINE_REF' is HEAD itself — nothing to compare against." >&2
+        echo "    (running from a checkout of the baseline ref, or the ref is stale)." >&2
+        exit 1
+    fi
+
+    BASELINE_RESULTS_DIR="$RESULTS_DIR/baseline"
+    mkdir -p "$BASELINE_RESULTS_DIR"
+
+    local wt_dir; wt_dir="$(mktemp -d "${TMPDIR:-/tmp}/cortex-bench-baseline-XXXXXX")"
+    echo
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  NO-REGRESSION BASELINE: $BASELINE_REF (${baseline_sha:0:12}) in $wt_dir"
+    echo "════════════════════════════════════════════════════════════════════"
+    git -C "$REPO_ROOT" worktree add --detach "$wt_dir" "$baseline_sha" >/dev/null
+
+    local lm_args=(); local lo_args=()
+    if [ -n "$LIMIT" ]; then lm_args+=(--limit "$LIMIT"); lo_args+=(--limit "$LIMIT")
+    elif [ "$QUICK" = "1" ]; then lm_args+=(--limit 10); lo_args+=(--limit 1); fi
+
+    # cd into the worktree so `uv run` resolves ITS pyproject.toml/uv.lock —
+    # the baseline may pin different dependency versions than HEAD, and
+    # running it under HEAD's resolved env would not actually measure the
+    # baseline's code.
+    (
+        cd "$wt_dir"
+        if want_bench longmemeval; then
+            echo "==> [baseline] longmemeval-s"
+            DATABASE_URL="$BENCH_DB_URL" uv run --extra benchmarks python \
+                "$wt_dir/benchmarks/longmemeval/run_benchmark.py" \
+                --results-out "$BASELINE_RESULTS_DIR/longmemeval-s.json" \
+                ${lm_args[@]+"${lm_args[@]}"} \
+                ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
+        fi
+        if want_bench locomo; then
+            echo "==> [baseline] locomo"
+            DATABASE_URL="$BENCH_DB_URL" uv run --extra benchmarks python \
+                "$wt_dir/benchmarks/locomo/run_benchmark.py" \
+                --results-out "$BASELINE_RESULTS_DIR/locomo.json" \
+                ${lo_args[@]+"${lo_args[@]}"} \
+                ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
+        fi
+    )
+    local status=$?
+
+    git -C "$REPO_ROOT" worktree remove --force "$wt_dir" >/dev/null 2>&1 || true
+    if [ "$status" -ne 0 ]; then
+        echo "error: baseline benchmark run failed (exit $status)." >&2
+        exit "$status"
+    fi
+}
+
+# Compare $RESULTS_DIR/<stem>.json (HEAD, already produced by run_bench)
+# against $RESULTS_DIR/baseline/<stem>.json (just produced above). Fails
+# only when HEAD is more than REGRESSION_TOLERANCE below its own baseline —
+# never against a fixed published number. BEAM is intentionally excluded,
+# matching FLOOR check_floors' own scope note (its numbers predate the
+# 200->395-question split rebasing and are within-system comparison only,
+# which is exactly what this gate does — but BEAM still has no committed
+# per-question stability data to size a tolerance from).
+check_regression() {
+    uv run --extra benchmarks python - "$RESULTS_DIR" "$BASELINE_RESULTS_DIR" \
+        "$REGRESSION_TOLERANCE" <<'PY'
+import json, sys
+from pathlib import Path
+rd, bd = Path(sys.argv[1]), Path(sys.argv[2])
+tol = float(sys.argv[3])
+stems = {"longmemeval-s": ["overall_recall10", "overall_mrr"],
+         "locomo": ["overall_recall10", "overall_mrr"]}
+failed = False
+for stem, keys in stems.items():
+    head_p, base_p = rd / f"{stem}.json", bd / f"{stem}.json"
+    if not head_p.exists() or not base_p.exists():
+        continue  # benchmark scoped out via --only
+    head, base = json.loads(head_p.read_text()), json.loads(base_p.read_text())
+    for key in keys:
+        got, ref = head.get(key), base.get(key)
+        if not isinstance(got, (int, float)) or not isinstance(ref, (int, float)):
+            print(f"REGRESSION CHECK {stem}.{key}: metric missing — FAIL")
+            failed = True
+            continue
+        # Round to the same 4-decimal precision reproduce.sh prints, so the
+        # pass/fail line matches exactly what a reader sees in this log —
+        # comparing at higher hidden precision than what's displayed is the
+        # rounding mismatch that made single-run borderline cases confusing
+        # to bisect (reproduce.sh's own check_floors docstring, LoCoMo
+        # same-commit noise note, stdev 0.0022 measured 2026-07-14).
+        got_r, ref_r = round(got, 4), round(ref, 4)
+        delta = got_r - ref_r
+        status = "PASS" if delta >= -tol else "FAIL"
+        if status == "FAIL":
+            failed = True
+        print(f"REGRESSION CHECK {stem}.{key}: {got_r:.4f} vs baseline {ref_r:.4f} ({delta:+.4f}) {status}")
+if failed:
+    print("\nREGRESSION CHECK FAILED: HEAD scores below its own baseline by more than the tolerance.")
+    print("This means the code under test is worse than the ref it was compared against — do not ship.")
+    sys.exit(1)
+print("\nREGRESSION CHECK PASSED: no score regressed vs baseline beyond tolerance.")
+PY
+}

--- a/benchmarks/reproduce.sh
+++ b/benchmarks/reproduce.sh
@@ -30,6 +30,17 @@
 #   --quick               Small per-benchmark limits (fast end-to-end verification).
 #   --limit N             Explicit per-benchmark question/conversation cap.
 #   --keep-db             Leave the container running afterwards (debugging).
+#   --no-regression       Blocking gate: also run --baseline-ref's benchmarks
+#                          in the same container and fail only if HEAD is
+#                          worse than ITS OWN baseline by more than
+#                          REGRESSION_TOLERANCE — use this instead of
+#                          lowering FLOOR_* when main itself no longer
+#                          clears the published floors (see check_floors'
+#                          comment below and benchmarks/lib/bench_regression.sh).
+#                          Full runs (no --quick/--limit) only; roughly
+#                          doubles wall time (runs the suite twice).
+#   --baseline-ref <ref>   Ref --no-regression compares HEAD against.
+#                          Default: origin/main.
 #   Anything else is passed through to the underlying run_benchmark.py calls.
 #
 # Environment overrides:
@@ -91,13 +102,26 @@ DATASET_URL="https://huggingface.co/datasets/xiaowu0162/LongMemEval/resolve/main
 # byte-identical to the file behind every published Cortex result.
 DATASET_SHA256="08d8dad4be43ee2049a22ff5674eb86725d0ce5ff434cde2627e5e8e7e117894"
 
-# ── Published floors the FULL runs are gated against. --limit/--quick runs
-# skip the gate (partial runs are not comparable to n=500 / n=1986 figures).
+# ── Published floors the FULL runs are checked against. --limit/--quick runs
+# skip the check (partial runs are not comparable to n=500 / n=1986 figures).
 # Values: README benchmark tables (E1 v3 campaign). Tolerance 0.005 (0.5 pp)
 # per the regression gate in benchmarks/results/a3_longmemeval_post_refactor.md
-# (design §8). BEAM-100K is intentionally NOT gated: its published proxy
+# (design §8). BEAM-100K is intentionally NOT checked: its published proxy
 # numbers predate the 200→395-question split re-basing, and the README scopes
 # BEAM to within-system comparison only.
+#
+# NON-BLOCKING as of the fix below (same disposition as the pyright ratchet,
+# issue #188: "raising the floor would just hide the debt" — NO rebaseline,
+# keep the drift visible without failing builds). Source: main@6ec76a0e
+# measures LongMemEval MRR 0.904988 (< 0.914), LoCoMo MRR 3-run mean
+# 0.779868 (< 0.805) and Recall@10 0.889506 (< 0.915) via THIS SAME script
+# (cdeust/Cortex PR #492, 2026-09-07) — main itself no longer clears these
+# floors, so treating them as blocking fails every PR built on top of main
+# regardless of what that PR changes. The blocking gate for a PR is
+# --no-regression (benchmarks/lib/bench_regression.sh): whether HEAD is
+# worse than its OWN baseline, not whether it clears a number nothing
+# currently clears. check_floors below still prints PASS/FAIL per metric —
+# that visibility is the point — it just no longer exits 1.
 FLOOR_LME_R10=0.982
 FLOOR_LME_MRR=0.914
 FLOOR_LOCOMO_R10=0.915
@@ -130,8 +154,12 @@ ABLATE_ON="locomo"
 QUICK=0
 LIMIT=""
 KEEP_DB=0
+NO_REGRESSION=0
 PASSTHROUGH=()
 started_container=0
+
+# shellcheck source=benchmarks/lib/bench_regression.sh
+. "$REPO_ROOT/benchmarks/lib/bench_regression.sh"
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 need_cmd() {
@@ -156,6 +184,9 @@ parse_args() {
             --limit)         LIMIT="$2"; shift 2 ;;
             --limit=*)       LIMIT="${1#*=}"; shift ;;
             --keep-db)       KEEP_DB=1; shift ;;
+            --no-regression) NO_REGRESSION=1; shift ;;
+            --baseline-ref)  BASELINE_REF="$2"; shift 2 ;;
+            --baseline-ref=*) BASELINE_REF="${1#*=}"; shift ;;
             *)               PASSTHROUGH+=("$1"); shift ;;
         esac
     done
@@ -330,12 +361,15 @@ print("=" * 68)
 PY
 }
 
-# Gate full-run results against the published floors: any score more than
-# FLOOR_TOLERANCE below its floor fails the whole run with exit 1. A deviation
-# from the published numbers means the code is wrong — this makes that loud
-# instead of silent.
+# Report full-run results against the published floors: any score more than
+# FLOOR_TOLERANCE below its floor prints FAIL. NON-BLOCKING (see the
+# FLOOR_* comment above) — informational only, never exits 1. Rounds `got`
+# to the same 4-decimal precision this prints before computing delta/status,
+# so the verdict matches exactly what's on screen: comparing at a hidden
+# precision beyond what's displayed is how a value that reads "0.9140" on
+# one line could judge differently than "0.9140" on another.
 #
-# CAVEAT — this gates a SINGLE run, but LoCoMo's own same-commit noise is
+# CAVEAT — this checks a SINGLE run, but LoCoMo's own same-commit noise is
 # large relative to FLOOR_TOLERANCE. Measured 2026-07-14 at HEAD 5542aa71
 # (v4.14.1), 3 isolated reps via `--only locomo`: MRR 0.7978 / 0.8019 / 0.8010
 # (mean 0.8002, stdev 0.0022) against FLOOR_LOCOMO_MRR=0.805 tol=0.005 (needs
@@ -373,16 +407,16 @@ for stem, expected in floors.items():
             print(f"FLOOR CHECK {stem}.{key}: metric missing — FAIL")
             failed = True
             continue
+        got = round(got, 4)
         delta = got - floor
         status = "PASS" if delta >= -tol else "FAIL"
         if status == "FAIL":
             failed = True
         print(f"FLOOR CHECK {stem}.{key}: {got:.4f} vs floor {floor:.4f} ({delta:+.4f}) {status}")
 if failed:
-    print("\nFLOOR CHECK FAILED: full-run scores deviate from the published numbers.")
-    print("A deviation means the code is wrong — do not ship. Bisect against the")
-    print("last passing commit recorded in benchmarks/results/repro/.")
-    sys.exit(1)
+    print("\nFLOOR CHECK: full-run scores deviate from the published numbers (non-blocking).")
+    print("This does not fail the build — see the FLOOR_* comment above for why, and use")
+    print("--no-regression to gate a PR against its own baseline instead.")
 PY
 }
 
@@ -441,6 +475,21 @@ main() {
     if [ "$RUN_BENCHMARKS" = "1" ] && [ -z "$LIMIT" ] && [ "$QUICK" = "0" ]; then
         check_floors
     fi
+
+    # No-regression gate (blocking): run the same suite on BASELINE_REF in
+    # this same container, then fail only if HEAD is worse than that
+    # baseline by more than REGRESSION_TOLERANCE. See --no-regression above
+    # and benchmarks/lib/bench_regression.sh's header for why this replaces
+    # the (now non-blocking) floor check as the thing a PR must pass.
+    if [ "$NO_REGRESSION" = "1" ]; then
+        if [ "$RUN_BENCHMARKS" != "1" ] || [ -n "$LIMIT" ] || [ "$QUICK" = "1" ]; then
+            echo "error: --no-regression requires a full benchmark run (no --ablation-only, --quick or --limit)." >&2
+            exit 1
+        fi
+        run_baseline_benchmarks
+        check_regression
+    fi
+
     echo
     echo "==> All artifacts under: $RESULTS_DIR"
     if [ "$RUN_ABLATION" = "1" ]; then


### PR DESCRIPTION
## Summary

`main` itself no longer clears the published `FLOOR_*` thresholds in `benchmarks/reproduce.sh`: PR #492 measured LongMemEval MRR 0.904988 (< floor 0.914), LoCoMo MRR 3-run mean 0.779868 (< floor 0.805) and LoCoMo Recall@10 0.889506 (< floor 0.915), all via this same script on `main@6ec76a0e`. Every PR built on top of `main` therefore inherited an already-failing gate it did not cause and could not pass — this is the structural issue currently blocking the `perf/green-*` PR stack (#492→#502).

Closes the two issues named for this: rounding and the floor-vs-regression conflation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

1. **Rounding.** `check_floors` now rounds `got` to the same 4-decimal precision it prints *before* computing `delta`/`status`, so the printed verdict always matches what a reader sees on screen instead of comparing at a hidden higher precision.
2. **Floor check is now non-blocking.** Same disposition as the pyright ratchet (issue #188: "raising the floor would just hide the debt" — no rebaseline, keep the drift visible without failing the build). `check_floors` still prints PASS/FAIL per metric; it no longer `exit 1`s.
3. **New `--no-regression` / `--baseline-ref <ref>` gate** (`benchmarks/lib/bench_regression.sh`, sourced by `reproduce.sh`): runs the same benchmark suite against a baseline ref (default `origin/main`) in an isolated git worktree, inside the same already-running ephemeral container (harnesses self-clean, so a second run against the same DB is safe), then fails only if HEAD is worse than **its own baseline** by more than the existing 0.005 (0.5pp) tolerance. This is the gate a PR should use to prove it doesn't regress — instead of lowering `FLOOR_*` to match wherever `main` currently sits.
4. `CLAUDE.md` and `CHANGELOG.md` updated to point at `--no-regression` as the PR-blocking gate.

## Test plan

- `bash -n benchmarks/reproduce.sh benchmarks/lib/bench_regression.sh` — syntax OK.
- Extracted and `ast.parse()`'d every embedded Python heredoc in both files — OK.
- Sourced `bench_regression.sh` standalone and confirmed `REGRESSION_TOLERANCE`/`BASELINE_REF` defaults resolve correctly.
- Did **not** run a full `reproduce.sh --no-regression` pass here (needs Docker + ~1-2h wall time per PR #492's own measured durations, ~1700-2050s per benchmark, doubled). This should be exercised by a maintainer with the isolated container before relying on it to gate a release.

- [ ] All existing tests pass. *(no Python production code touched; nothing under `mcp_server/` changed)*
- [ ] New tests added for new behavior. *(bash harness script, not covered by `pytest`; verified via syntax/AST checks above)*
- [x] Manual verification of any UI / CLI / MCP-tool behavior changes. *(CLI flag behavior traced by hand; not executed end-to-end — see caveat above)*

## Audit notes

- No engineering/genius review cycle run for this change (single-file bash + doc change, no `mcp_server/` code touched).
- Outstanding: an actual `--no-regression` run against a live Docker daemon has not been executed in this session (no Docker available here). Flagging for a maintainer to run once before relying on it for a release decision.

## Coding-standards compliance

- [x] §2.2 N/A — no layer-dependency code touched.
- [x] §3.2 N/A — bash, not TypeScript.
- [x] §4.1 No file > 500 lines (`bench_regression.sh` is ~150 lines; `reproduce.sh` is bash, not gated by the Python-only craftsmanship AST check).
- [x] §4.4 N/A.
- [x] §7 Local reasoning preserved — each function has a single responsibility, factored the same way `bench_container.sh` already is.
- [x] §8 Every numeric constant sourced: `REGRESSION_TOLERANCE` reuses `FLOOR_TOLERANCE`'s own provenance (design §8, `benchmarks/results/a3_longmemeval_post_refactor.md`); the floor drift numbers are sourced to PR #492 and measured commit `6ec76a0e`.
- [x] §9 No dead code.

## Breaking changes

None. `check_floors` behavior changes from blocking to non-blocking (a relaxation, not a tightening); `--no-regression` is strictly additive/opt-in.

## Reviewer checklist

- [x] CHANGELOG.md updated under `[Unreleased]`.
- [x] Documentation updated (CLAUDE.md `FLOOR_*` pointer).
- [x] No secrets / credentials / PII in the diff.
- [ ] CI passes on the latest commit — this repo has no automated CI job that runs `reproduce.sh` (it's a manual, Docker-requiring release gate); the standard `lint`/`typecheck`/`test` CI jobs should be unaffected since no `mcp_server/` code changed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1

---
_Generated by [Claude Code](https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1)_