### PR TITLE
docs+test: replace exact-identity gate with ULP + rank-stability tolerance

### DIFF
--- a/benchmarks/lib/numeric_equivalence.py
+++ b/benchmarks/lib/numeric_equivalence.py
@@ -1,0 +1,126 @@
+"""Tolerance-based equivalence for float32 embedding/scoring comparisons.
+
+Replaces bitwise-exact ("delta == 0") identity as the acceptance gate for
+perf changes that reorder floating-point work (e.g. batching N scalar
+encoder calls into one batched call). That gate is unsatisfiable by
+construction: IEEE 754 float addition/multiplication is not associative,
+so a batched matmul reduces in a different element order than N independent
+scalar calls and will not, in general, reproduce the same bit pattern —
+not because the batched result is wrong, but because both results are
+independently-rounded approximations of the same real-valued computation.
+
+Source: cdeust/Cortex PR #495 ("perf(remember): reuse embeddings for
+identical merge text") and PR #497 ("perf(embeddings): batch codebase
+imports and preserve cache contexts"), both measured 2026-09-07 on the
+pinned sentence-transformers/all-MiniLM-L6-v2 CPU float32 encoder
+(revision 1110a243fdf4706b3f48f1d95db1a4f5529b4d41). Both PRs declined a
+measured batching speedup (PR #495: 7 encoder calls -> 2, CPU 18.112ms ->
+10.507ms median) under an exact-identity gate, and recorded the deltas
+that failed it:
+  PR #495 vector delta: 1.6391277313232422e-07  (~1.375 ULP)
+  PR #495 score  delta: 1.1920928955078125e-07  (exactly 1 float32 ULP)
+  PR #497 vector delta: 1.0617077350616455e-07  (~0.89 ULP)
+  PR #497 lessons delta: 9.313225746154785e-08   (~0.78 ULP)
+  PR #497 compression delta: 1.3969838619232178e-07 (~1.17 ULP)
+FLOAT32_ULP (2**-23, the spacing between adjacent float32 values near 1.0)
+is 1.1920928955078125e-07 — every one of the above deltas is within 2 ULP
+of it. That is the signature of independent rounding, not a computational
+error: a real defect would not track machine epsilon this tightly across
+five unrelated code paths.
+
+DEFAULT_MAX_ULP=4 gives roughly 3x headroom over the largest observed
+delta (~1.4 ULP) — provisional heuristic, not a derived bound; widen only
+with a new measured counter-example, and cite it here.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+# source: IEEE 754 binary32, machine epsilon = 2**-23 (spacing between
+# adjacent representable values in [1.0, 2.0)) — the sentence-transformers
+# CPU encoder path measured above runs in float32.
+FLOAT32_ULP = 2.0**-23
+
+# source: see module docstring — largest observed delta across PR #495/#497
+# was ~1.4 ULP; this multiplier is a provisional heuristic leaving ~3x
+# headroom, not a derived statistical bound.
+DEFAULT_MAX_ULP = 4
+
+
+def ulp_delta(a: float, b: float, *, ulp: float = FLOAT32_ULP) -> float:
+    """How many float32 ULPs apart a and b are (0.0 if a == b)."""
+    if a == b:
+        return 0.0
+    return abs(a - b) / ulp
+
+
+def scalars_equivalent(a: float, b: float, *, max_ulp: float = DEFAULT_MAX_ULP) -> bool:
+    """True if a and b differ by no more than max_ulp float32 ULPs."""
+    return ulp_delta(a, b) <= max_ulp
+
+
+def vectors_equivalent(
+    a: Sequence[float], b: Sequence[float], *, max_ulp: float = DEFAULT_MAX_ULP
+) -> bool:
+    """True if every paired component of a and b is ULP-equivalent.
+
+    Pre: len(a) == len(b). Post: False on any length mismatch or any
+    component pair exceeding max_ulp (fails fast, does not report which).
+    """
+    if len(a) != len(b):
+        return False
+    return all(
+        scalars_equivalent(x, y, max_ulp=max_ulp) for x, y in zip(a, b, strict=True)
+    )
+
+
+def rank_stable(
+    scores_before: Sequence[float],
+    scores_after: Sequence[float],
+    *,
+    max_ulp: float = DEFAULT_MAX_ULP,
+) -> bool:
+    """True if reordering by scores_after never separates two items that
+    were NOT already within tolerance under scores_before.
+
+    This is the criterion that actually matters for a write-gate decision
+    or a retrieval ranking: a score shift small enough to be numerical
+    noise must not flip which candidate wins UNLESS the two candidates
+    were already tied to within tolerance, in which case either order was
+    already an acceptable outcome. Pre: len(scores_before) ==
+    len(scores_after), same candidate at the same index in both.
+    """
+    n = len(scores_before)
+    if len(scores_after) != n:
+        return False
+    order_before = sorted(range(n), key=lambda i: scores_before[i], reverse=True)
+    order_after = sorted(range(n), key=lambda i: scores_after[i], reverse=True)
+    if order_before == order_after:
+        return True
+    for i in range(n):
+        idx_before, idx_after = order_before[i], order_after[i]
+        if idx_before == idx_after:
+            continue
+        # A swap at this rank is acceptable only if the two candidates it
+        # swapped were already within tolerance under EITHER score set —
+        # i.e. the pre-optimization ranking already treated them as tied.
+        if not (
+            scalars_equivalent(
+                scores_before[idx_before], scores_before[idx_after], max_ulp=max_ulp
+            )
+            or scalars_equivalent(
+                scores_after[idx_before], scores_after[idx_after], max_ulp=max_ulp
+            )
+        ):
+            return False
+    return True
+
+
+def is_finite_vector(v: Sequence[float]) -> bool:
+    """True if every component is finite (guards NaN/inf slipping past a
+    tolerance comparison — abs(nan - x) is nan, and nan <= max_ulp is
+    always False, so this is a belt-and-suspenders explicit check, not a
+    silent behavior change)."""
+    return all(math.isfinite(x) for x in v)

--- a/docs/provenance/numeric-equivalence-tolerance.md
+++ b/docs/provenance/numeric-equivalence-tolerance.md
@@ -1,0 +1,89 @@
+# Numeric equivalence tolerance for perf changes (retracts the exact-identity gate)
+
+## Retraction
+
+`docs/provenance/green-w3-2-encoding-identity.md` (PR #495) recorded: "The
+requested contract is exact score identity, not a numeric tolerance" and
+"No tolerance has been adopted." That decision is retracted here. It was
+evaluated against the wrong predicate, not against insufficient evidence.
+
+## Why the exact-identity gate was wrong
+
+IEEE 754 float32 addition and multiplication are not associative. A batched
+matmul (one call, N rows reduced together) does not sum its terms in the
+same order as N independent scalar calls, so it will not, in general,
+reproduce the same bit pattern as the scalar path — this is true even when
+both computations are numerically correct, because both are independently-
+rounded approximations of the same real-valued result. An acceptance gate
+specified as exact bitwise equality between a scalar and a batched path is
+therefore not a test of "is batching safe" — structurally, no batched
+implementation can ever pass it, regardless of correctness. It will reject
+every future attempt at this optimization, for the same reason, forever.
+
+**Evidence that this is what actually happened, not a coincidence:**
+`FLOAT32_ULP = 2**-23 = 1.1920928955078125e-07` (float32 machine epsilon).
+Every delta recorded as a rejection in PR #495 and PR #497 is within ~1.4x
+of exactly this number:
+
+| Source | Recorded delta | In float32 ULP |
+|---|---:|---:|
+| PR #495 normalized-vector delta | 1.6391277313232422e-07 | ~1.375 |
+| PR #495 score delta | 1.1920928955078125e-07 | **exactly 1.000** |
+| PR #497 vector delta | 1.0617077350616455e-07 | ~0.891 |
+| PR #497 lessons delta | 9.313225746154785e-08 | ~0.781 |
+| PR #497 compression delta | 1.3969838619232178e-07 | ~1.172 |
+
+A genuine computational defect does not track machine epsilon this tightly
+across five unrelated code paths measured on two different PRs. This is
+the signature of independent rounding order, not a bug — the score delta
+in PR #495 is not merely *close to* one ULP, it equals one ULP to every
+digit reported.
+
+## The replacement gate
+
+Two conditions, both implemented in `benchmarks/lib/numeric_equivalence.py`
+(with unit tests in `tests_py/benchmarks/test_numeric_equivalence.py`
+reproducing the exact deltas in the table above):
+
+1. **`vectors_equivalent(a, b, max_ulp=4)`** — every paired component of
+   the scalar-path and batched-path vectors must be within `max_ulp`
+   float32 ULPs of each other. `DEFAULT_MAX_ULP=4` gives ~3x headroom over
+   the largest observed delta (~1.4 ULP); it is a provisional heuristic,
+   not a derived bound — widen it only against a new measured
+   counter-example, cited the same way this document cites its own.
+2. **`rank_stable(scores_before, scores_after, max_ulp=4)`** — the more
+   meaningful criterion for a write-gate decision or a retrieval ranking.
+   A score shift of a few ULP must not change which candidate wins UNLESS
+   the two candidates were already tied to within tolerance under the
+   scalar path — in which case either order was already an acceptable
+   outcome before the optimization existed. This is stricter than "the
+   final ranked list is unchanged" would be misleading to require: it is
+   exactly as strict as the scalar path's own output already was.
+
+Neither condition is a general "close enough" fudge: both are sized to the
+one physical quantity that actually bounds float32 rounding order noise
+(1 ULP), sourced to the two PRs' own measurements, not chosen to make a
+particular result pass.
+
+## What this means for PR #495 / #497
+
+The batching this policy retracted (PR #495 commit `60e5646b`, "batch
+normalized neighbors and reuse unchanged merge vectors"; PR #497's shared
+scalar/batch cache context) measured real gains under the old gate before
+being reverted for failing it:
+
+- PR #495: CPU median 18.112ms -> 10.507ms (seven encoder calls -> two).
+- PR #497: CPU median 342.974ms -> 180.310ms, wall 277.694ms -> 103.447ms
+  (64 scalar calls -> 1 batched call), on the codebase-import path.
+
+Applying `vectors_equivalent`/`rank_stable` (see the test file) to the
+already-recorded deltas above, both would now pass. That is not, by
+itself, a decision to merge the reverted batching back in: it substitutes
+the correct predicate for the wrong one on data already collected, but a
+maintainer with the real pinned MiniLM encoder available should re-run
+each PR's own harness (`docs/provenance/green-w3-2-encoding-identity.md`'s
+`/private/tmp/cortex-green-w3-2-neural-final-measure.py` for #495;
+`docs/provenance/bulk-embedding-boundaries.md` for #497) against this
+gate before restoring either batched code path, rather than trusting a
+transcription of numbers already in a closed PR body. This session had no
+`torch`/`sentence-transformers` available to re-run either harness itself.

--- a/tests_py/benchmarks/test_numeric_equivalence.py
+++ b/tests_py/benchmarks/test_numeric_equivalence.py
@@ -19,11 +19,14 @@ from benchmarks.lib.numeric_equivalence import (
 # source: PR #495 body, measured 2026-09-07, sentence-transformers/
 # all-MiniLM-L6-v2 rev 1110a243, CPU float32.
 PR_495_VECTOR_DELTA = 1.6391277313232422e-07
+# source: PR #495 body, same measurement conditions as above.
 PR_495_SCORE_DELTA = 1.1920928955078125e-07
 
 # source: PR #497 body, same measurement conditions.
 PR_497_VECTOR_DELTA = 1.0617077350616455e-07
+# source: PR #497 body, same measurement conditions.
 PR_497_LESSONS_DELTA = 9.313225746154785e-08
+# source: PR #497 body, same measurement conditions.
 PR_497_COMPRESSION_DELTA = 1.3969838619232178e-07
 
 

--- a/tests_py/benchmarks/test_numeric_equivalence.py
+++ b/tests_py/benchmarks/test_numeric_equivalence.py
@@ -1,0 +1,92 @@
+"""benchmarks.lib.numeric_equivalence — ULP-tolerance + rank-stability gate.
+
+Contract under test: the tolerance-based equivalence check that replaces
+bitwise-exact identity for validating perf changes that reorder float32
+work (see the module docstring for the PR #495/#497 provenance). Uses the
+exact deltas those PRs measured and rejected, to confirm they now pass.
+"""
+
+from __future__ import annotations
+
+from benchmarks.lib.numeric_equivalence import (
+    FLOAT32_ULP,
+    rank_stable,
+    scalars_equivalent,
+    ulp_delta,
+    vectors_equivalent,
+)
+
+# source: PR #495 body, measured 2026-09-07, sentence-transformers/
+# all-MiniLM-L6-v2 rev 1110a243, CPU float32.
+PR_495_VECTOR_DELTA = 1.6391277313232422e-07
+PR_495_SCORE_DELTA = 1.1920928955078125e-07
+
+# source: PR #497 body, same measurement conditions.
+PR_497_VECTOR_DELTA = 1.0617077350616455e-07
+PR_497_LESSONS_DELTA = 9.313225746154785e-08
+PR_497_COMPRESSION_DELTA = 1.3969838619232178e-07
+
+
+class TestUlpDelta:
+    def test_identical_values_are_zero_ulp(self):
+        assert ulp_delta(0.7978, 0.7978) == 0.0
+
+    def test_one_float32_ulp_reports_one(self):
+        assert ulp_delta(1.0 + FLOAT32_ULP, 1.0) == 1.0
+
+    def test_measured_pr495_score_delta_is_one_ulp(self):
+        assert ulp_delta(0.8010, 0.8010 + PR_495_SCORE_DELTA) == 1.0
+
+
+class TestScalarsEquivalent:
+    def test_exact_match(self):
+        assert scalars_equivalent(0.914, 0.914)
+
+    def test_pr495_score_delta_within_default_tolerance(self):
+        assert scalars_equivalent(0.8010, 0.8010 + PR_495_SCORE_DELTA)
+
+    def test_pr497_deltas_within_default_tolerance(self):
+        base = 0.75
+        assert scalars_equivalent(base, base + PR_497_VECTOR_DELTA)
+        assert scalars_equivalent(base, base + PR_497_LESSONS_DELTA)
+        assert scalars_equivalent(base, base + PR_497_COMPRESSION_DELTA)
+
+    def test_a_real_regression_is_still_rejected(self):
+        # 0.01 is four orders of magnitude larger than every measured
+        # rounding delta above — not noise, a real behavior change.
+        assert not scalars_equivalent(0.80, 0.81)
+
+
+class TestVectorsEquivalent:
+    def test_measured_pr495_vector_delta_passes(self):
+        a = [0.1, 0.2, 0.3]
+        b = [0.1 + PR_495_VECTOR_DELTA, 0.2, 0.3 - PR_495_VECTOR_DELTA]
+        assert vectors_equivalent(a, b)
+
+    def test_length_mismatch_fails(self):
+        assert not vectors_equivalent([0.1, 0.2], [0.1])
+
+    def test_large_divergence_fails(self):
+        assert not vectors_equivalent([0.1, 0.2], [0.1, 0.9])
+
+
+class TestRankStable:
+    def test_identical_order_is_stable(self):
+        assert rank_stable([0.9, 0.5, 0.1], [0.9, 0.5, 0.1])
+
+    def test_ulp_noise_swap_among_already_tied_candidates_is_stable(self):
+        # Two candidates tied to 7 decimals pre-optimization; the
+        # post-optimization run breaks the tie the other way. That is
+        # exactly the "already tied" case the docstring describes as an
+        # acceptable outcome either way.
+        before = [0.9, 0.5000000, 0.5000000]
+        after = [0.9, 0.5000000 - PR_495_SCORE_DELTA, 0.5000000 + PR_495_SCORE_DELTA]
+        assert rank_stable(before, after)
+
+    def test_a_real_reordering_of_distinct_candidates_is_not_stable(self):
+        before = [0.9, 0.5, 0.1]
+        after = [0.5, 0.9, 0.1]  # top two candidates actually swapped
+        assert not rank_stable(before, after)
+
+    def test_length_mismatch_fails(self):
+        assert not rank_stable([0.9, 0.5], [0.9])


### PR DESCRIPTION
## Summary

Captures, in a pushable form, an analysis that was done on a machine that cannot push to this repo: `docs/provenance/green-w3-2-encoding-identity.md` (PR #495) recorded "The requested contract is exact score identity, not a numeric tolerance" and "No tolerance has been adopted." That decision is retracted here — not for lack of evidence, but because it was evaluated against the wrong predicate.

IEEE 754 float32 addition/multiplication is not associative, so a batched matmul reduces its terms in a different order than N independent scalar calls and will not, in general, reproduce the same bit pattern — even when both results are correct. A gate specified as exact bitwise equality between a scalar path and a batched path is therefore unsatisfiable by construction: no batched implementation can ever pass it, regardless of correctness, and it will reject the same optimization forever.

**The tell that this is what actually happened:** float32 machine epsilon is `2**-23 = 1.1920928955078125e-07`. Every delta PR #495 and PR #497 recorded as a rejection is within ~1.4x of exactly this number — PR #495's score delta *equals* it, to every reported digit:

| Source | Recorded delta | In float32 ULP |
|---|---:|---:|
| PR #495 normalized-vector delta | 1.6391277313232422e-07 | ~1.375 |
| PR #495 score delta | 1.1920928955078125e-07 | **exactly 1.000** |
| PR #497 vector delta | 1.0617077350616455e-07 | ~0.891 |
| PR #497 lessons delta | 9.313225746154785e-08 | ~0.781 |
| PR #497 compression delta | 1.3969838619232178e-07 | ~1.172 |

A genuine computational defect does not track machine epsilon this tightly across five unrelated code paths on two different PRs.

## Changes

- `benchmarks/lib/numeric_equivalence.py` — `vectors_equivalent()` (ULP tolerance per component, `DEFAULT_MAX_ULP=4`, ~3x headroom over the largest observed delta) and `rank_stable()` (the criterion that actually matters for a write-gate decision or retrieval ordering: a score shift of a few ULP must not flip which candidate wins *unless* the two were already tied within tolerance on the scalar path — in which case either order was already an acceptable outcome).
- `tests_py/benchmarks/test_numeric_equivalence.py` — reproduces the exact deltas from the table above and confirms both functions now pass them, while still rejecting a real regression (tested at 0.01, four orders of magnitude larger than any measured rounding delta).
- `docs/provenance/numeric-equivalence-tolerance.md` — the retraction, the sourced table, and what remains open (see below).

## What this does NOT do

It does not restore the batched code paths PR #495 (`60e5646b`, "batch normalized neighbors and reuse unchanged merge vectors") or PR #497 reverted. This session has no `torch`/`sentence-transformers` available to re-run either PR's own harness against the new gate. Applying the new functions to the already-recorded deltas above says they'd now pass, but a maintainer with the pinned MiniLM encoder available should re-run each PR's harness (cited in the new doc) before restoring either batched path, rather than trusting a transcription of numbers already in a closed PR body.

## Test plan

- `ruff check` / `ruff format --check` on both new Python files — clean.
- `python scripts/check_craftsmanship.py benchmarks/lib/numeric_equivalence.py` — `Craftsmanship gate: OK`.
- `ast.parse()` on both files — OK.
- Manually executed every function in `numeric_equivalence.py` against the exact PR #495/#497 deltas outside pytest (no `pytest` binary available in this sandbox) — matches every assertion in the committed test file.
- Did not run the full `pytest` suite in this sandbox (no `numpy`/`torch` installed here — `benchmarks/lib/__init__.py` eagerly imports `numpy` via `embedding_engine.py`, by existing design, since numpy is a hard `mcp_server` dependency in the real dev environment). A maintainer should run `pytest tests_py/benchmarks/test_numeric_equivalence.py` once to confirm collection.

- [ ] All existing tests pass. *(new file only; not run in this sandbox — see above)*
- [x] New tests added for new behavior.
- [ ] Manual verification of any UI / CLI / MCP-tool behavior changes. *(not applicable — no runtime code path changed)*

## Audit notes

- No engineering/genius review cycle run (docs + a new pure-function module, no `mcp_server/` production code touched).
- Outstanding: the actual re-validation of PR #495/#497's batching under this gate, flagged above, needs a maintainer with the real model.

## Coding-standards compliance

- [x] §2.2 N/A — no layer-dependency code touched (new module lives in `benchmarks/lib/`, not a layered `mcp_server/` package).
- [x] §4.1 No file > 500 lines (126 lines).
- [x] §4.4 N/A.
- [x] §7 Local reasoning preserved.
- [x] §8 Every numeric constant sourced: `FLOAT32_ULP` to IEEE 754 binary32; `DEFAULT_MAX_ULP` to the measured deltas in the table above, both in the module docstring and the doc.
- [x] §9 No dead code.

## Breaking changes

None. Purely additive (new module + doc), touches no existing code path.

## Reviewer checklist

- [ ] CHANGELOG.md — not updated; this is an unreleased internal methodology doc + utility with no user-facing behavior change yet (the actual batching restoration, if a maintainer validates it, is the change that should carry a CHANGELOG entry).
- [x] Documentation updated (`docs/provenance/numeric-equivalence-tolerance.md`).
- [x] No secrets / credentials / PII in the diff.
- [ ] CI passes on the latest commit — pending.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1

---
_Generated by [Claude Code](https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1)_