### PR TITLE
ci: size the mcp-host-config timeout against its measured tail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,8 +262,25 @@ jobs:
     # untrusted fork; same-repository PRs and main/workflow_dispatch remain
     # covered by this vendor-parser contract.
     runs-on: ubuntu-latest
-    # source: run 33951959734 (2026-09-05), max 61s; ceil(2 * 61 / 60).
-    timeout-minutes: 3
+    # source: run 34217620888 job 102033099129 (2026-09-08), whole job 52s;
+    # run 34210128951 job 102009142706 (2026-09-08), whole job 194s.
+    # ceil(2 * 194 / 60) = 7.
+    #
+    # The former bound was ceil(2 * 61 / 60) = 3 from run 33951959734
+    # (2026-09-05, max 61s). That 2x margin was computed against a sample
+    # that never saw this job's real tail, and 180s sits INSIDE the range
+    # of a legitimate passing run: the dominant cost is the last step's
+    # `scripts/verify_mcp_hosts.py`, which boots the plugin through `uvx`
+    # against a deliberately COLD uv cache (UV_CACHE_DIR/UV_TOOL_DIR under
+    # RUNNER_TEMP, --allow-bootstrap-network), so it pays a full network
+    # package resolve+build every run. Both samples above PASS the same
+    # assertions and differ only in that bootstrap: 23.98s vs 179.86s
+    # ("PASS codex-cli/lean: initialize + discovery + memory_stats
+    # (10 tools, …)"), a 7.5x spread. The coldness is the point of the
+    # test — it is the path a first-time user hits — so the variance
+    # cannot be engineered away without destroying what the job asserts;
+    # the bound has to cover the measured tail instead.
+    timeout-minutes: 7
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary

`mcp-host-config` (`Validate MCP host configurations`) carried `timeout-minutes: 3`. 180 s sits **inside** the range of a legitimate, passing run of that job, so the job decided pass/fail on network luck rather than on the assertions it makes. It killed PR #504 twice on a diff that touches nothing it exercises.

## Root cause

The job's cost is not the config parsing — those three validators take ~6 s combined. It is the last step's `scripts/verify_mcp_hosts.py`, which boots the plugin through `uvx` against a **deliberately cold** uv cache (`UV_CACHE_DIR`/`UV_TOOL_DIR` under `RUNNER_TEMP`, `--allow-bootstrap-network`), paying a full network package resolve + build on every run.

Two samples, same PR, same assertions, both `PASS`:

| Run | Job | Bootstrap (`initialize + discovery + memory_stats`) | Whole job |
|---|---|---:|---:|
| 34217620888 | 102033099129 | **23.98 s** | 52 s |
| 34210128951 | 102009142706 | **179.86 s** | 194 s |

A 7.5× spread, entirely inside that bootstrap. The 179.86 s run *passed its assertions* and was killed anyway, at 194 s, by the 180 s ceiling.

The old bound was `ceil(2 * 61 / 60) = 3`, sourced to run 33951959734 (2026-09-05, max 61 s). The 2× margin was real; the sample it was computed against had simply never seen this job's tail.

## Change

`timeout-minutes: 3` → `7`, re-applying the repository's own convention (`ceil(2 * max_seconds / 60)`) to the measured max: `ceil(2 * 194 / 60) = 7`. The `# source:` comment records both samples, the job ids, and why the variance exists.

**Not** attempted: warming the cache to remove the variance. The coldness is the point of the test — it is the path a first-time user hits — so flattening it would destroy what the job asserts. The bound has to cover the tail instead.

## Test plan

- `yaml.safe_load` on the edited workflow; `jobs.mcp-host-config.timeout-minutes == 7`, job name unchanged.
- `actionlint` + `shellcheck` run on workflow files in the `Lint` job of this PR's own CI — the authoritative check for this file.
- No job added or removed, so the `Check the aggregate CI gate covers every job` assertion in `Lint` is unaffected.

- [x] All existing tests pass. *(no application code touched; this PR's own CI run is the verification)*
- [ ] New tests added for new behavior. *(N/A — a workflow bound, not behaviour; the two measurements in the source comment are the evidence)*

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Coding-standards compliance

- [x] §8 Every numeric constant sourced: the new `7` cites two dated, job-identified measurements and the arithmetic that derives it from them.
- [x] §9 No dead code.
- Other sections N/A — single-line workflow bound plus its provenance comment.

## Breaking changes

None. A ceiling is raised; nothing that passed before fails now.

## Reviewer checklist

- [ ] CHANGELOG.md — not updated; CI-internal bound with no user-facing surface. Say the word if you want an entry anyway.
- [x] Documentation updated (the `# source:` block in the workflow is the documentation for this constant).
- [x] No secrets / credentials / PII in the diff.
- [ ] CI passes on the latest commit — pending.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1

---
_Generated by [Claude Code](https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1)_