### PR TITLE
ci: stop exporting the docker-smoke layer cache on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -906,7 +906,16 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docker == 'true'
     name: Docker Smoke (bare-container DB-less contract)
     runs-on: ubuntu-latest
-    # source: run 33951959734 (2026-09-05), max 369s; ceil(2 * 369 / 60).
+    # source: run 34217523633 job 102032799571 (2026-09-08, push to main,
+    # warm cache): whole job 242s, of which the build step 225s — the steady
+    # state this bound is sized against; ceil(2 * 242 / 60) = 9, kept at 13
+    # for headroom over the 369s tail measured on run 33951959734
+    # (2026-09-05). The bound is NOT sized against a cold `mode=max` cache
+    # EXPORT: run 34225008423 job 102057139452 (2026-09-08, PR #492) finished
+    # building at 70.8s and was still in `exporting to GitHub Actions Cache`
+    # when the 13-minute bound fired at 827s, so the smoke-test body never
+    # ran. That export is removed from pull_request runs below rather than
+    # budgeted for — see the cache-to comment.
     timeout-minutes: 13
     # BLOCKING: this job asserts the exact contract that silently broke for
     # two months (fix/bare-container-contract, commit 5d71069c) — third-party
@@ -939,7 +948,25 @@ jobs:
           tags: cortex-smoke:local
           load: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Write the layer cache only on pushes to a branch, never on a
+          # pull_request run. GitHub Actions scopes a cache entry to the ref
+          # that created it: the default branch's entries are readable from
+          # every branch, but an entry a PR run writes is readable only by
+          # that same PR's later runs. This job runs once per head commit, so
+          # a PR-written entry is exported and then never read — pure cost on
+          # the critical path. `cache-from` is unconditional, so PRs keep
+          # reading main's warm cache and the torch CPU-wheel layer is still
+          # not re-downloaded.
+          # source: GitHub Actions cache "Restrictions for accessing a cache"
+          # (docs.github.com/actions/writing-workflows/choosing-what-your-
+          # workflow-does/caching-dependencies-to-speed-up-workflows), and
+          # the measurement below.
+          # The condition is written as `!= 'pull_request' && <value> || ''`
+          # and not `== 'pull_request' && '' || <value>`: GitHub expressions
+          # return the operand, not a boolean, and the empty string is
+          # falsy, so the latter form would fall through to <value> on
+          # every event and disable nothing.
+          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
 
       # Reuses the build above (load: true made it visible to the local
       # docker daemon) instead of rebuilding — scripts/docker_smoke.sh is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Docker Smoke no longer times out on pull requests.** The job wrote its
+  buildx layer cache with `cache-to: type=gha,mode=max` on every event. On
+  run 34225008423 (PR #492) the image build finished at 70.8s and the job
+  was still in `exporting to GitHub Actions Cache` when the 13-minute bound
+  fired at 827s — the smoke-test body never ran, so the PR went red on a
+  step that asserts nothing. GitHub scopes a cache entry to the ref that
+  wrote it, and this job runs once per head commit, so a PR-written entry is
+  exported and never read. The export is now skipped on `pull_request`;
+  `cache-from` stays unconditional, so PRs keep reading `main`'s warm cache
+  (whole job 242s there, run 34217523633). The two sibling `Docker Build`
+  jobs already used `mode=min`; this removes the odd one out.
+
 - **`benchmarks/reproduce.sh`'s published `FLOOR_*` check no longer blocks
   the build.** `main` itself measures below the published floors (LongMemEval
   MRR 0.904988 < 0.914, LoCoMo MRR 3-run mean 0.779868 < 0.805, Recall@10


### PR DESCRIPTION
## Problem

`Docker Smoke (bare-container DB-less contract)` went red on PR #492 — **cancelled at its 13-minute bound before the smoke-test body ran**. Same signature as the first attempt on #503.

Reading the job log (run `34225008423`, job `102057139452`) rather than guessing: the image **built successfully** (`#20 exporting to docker image format … DONE 70.8s`, image loaded). What then consumed the remaining ~12 minutes was the buildx **cache export**:

```
#22 exporting to GitHub Actions Cache
#22 preparing build cache for export 46.3s done
#22 sending cache export
#22 writing layer sha256:eadf4b3c… 38.8s done
#22 writing layer sha256:fc852874…
##[error]The operation was canceled.       ← 12:31:31, t+827s
```

So the PR was marked red by a step that asserts nothing about the code under review.

## Measurement

Same job, same workflow, two contexts:

| Run | Context | Build step | Whole job |
|---|---|---|---|
| `34217523633` job `102032799571` | push to main, warm cache | 225 s | **242 s** ✅ |
| `34225008423` job `102057139452` | PR #492, cold `mode=max` export | build done at 70.8 s | **>827 s**, cancelled ❌ |

The existing `# source:` on `timeout-minutes: 13` cited "run 33951959734 (2026-09-05), max 369s". Today's 827 s observation invalidates 369 s as an upper bound.

## Root cause

`cache-to: type=gha,mode=max` ran on every event. GitHub Actions [scopes a cache entry to the ref that created it](``https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache):`` the default branch's entries are readable from every branch, but an entry a PR run writes is readable **only by that same PR's later runs**. This job runs once per head commit — so the PR-written entry is exported and then never read. Pure cost on the critical path.

`mode=max` also exports every intermediate build stage, including the ~421 MB layer visible in the log above.

## Fix

Skip the export on `pull_request` only:

```yaml
cache-from: type=gha
cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
```

- `cache-from` stays **unconditional** — PRs keep reading main's warm cache, so the torch CPU-wheel layer is still not re-downloaded. The stated intent of the existing comment block is preserved.
- Pushes to main still populate the cache, in `mode=max`, at the measured 242 s steady state.
- The two sibling `Docker Build` jobs already use `mode=min`; this job was the odd one out.

The condition is deliberately written `!= 'pull_request' && <value> || ''` rather than `== 'pull_request' && '' || <value>`: GitHub expressions return the operand rather than a boolean and the empty string is falsy, so the latter form falls through to `<value>` on every event and disables nothing. That pitfall is called out in a comment beside the line.

`timeout-minutes: 13` is kept and re-sourced to the warm-path steady state it actually bounds, recording explicitly that the cold export is removed rather than budgeted for.

## What is NOT changed

The `BLOCKING` contract this job asserts is untouched — it still builds the bare repo and runs `tools/list` with zero env vars and zero external services. No `continue-on-error`, no skip, no test disabled.

## Verification

- `actionlint` v1.7.12 (the version pinned in `ci.yml`, checksum-verified release binary) — clean on `ci.yml`
- `python scripts/check_ci_gate_complete.py` — OK (no job names change)
- `python scripts/check_craftsmanship.py --base origin/main` — OK
- `python scripts/check_doc_claims.py`, `check_version_surfaces.py` — OK
- `ruff check .`, `ruff format --check .` — clean
- YAML parses

The real proof is this PR's own `Docker Smoke` run: it exercises the `pull_request` branch of the new condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1

---
_Generated by [Claude Code](https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1)_