### PR TITLE
feat(session_start): keep a fetch key on truncated banner lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A truncated SessionStart banner line is no longer a dead end.** Every
+  memory line in the banner is cut at 120 characters by `_short`, but the
+  rendered line carried no id — the reader could see that content had been
+  cut and had no handle to fetch the rest, only a fresh search whose top hit
+  is not guaranteed to be the same row. This was the one truncation path in
+  the system that dropped the key: `core/response_budget.py` already states
+  "Truncated items ... keep their id, so truncation is never a dead end", and
+  `core/gist_extraction.py` keeps its artifact pointer. Truncated banner
+  lines now end in `\u27e6mem:<id>\u27e7`, readable back with
+  `recall(memory_id=...)`. Untruncated lines are unchanged (no key needed —
+  the whole memory is already there), so the cost is proportional to what was
+  actually lost, and the one-line legend is emitted only when a key was.
+  Where lines are cut is byte-identical; only what a cut line carries
+  changes. Distinct from the `\u27e6rcpt:id\u27e7` receipt, which answers
+  *which* memories were in context (`why`, Pearl rung-1) and never hands back
+  content.
+
 - **`benchmarks/reproduce.sh`'s published `FLOOR_*` check no longer blocks
   the build.** `main` itself measures below the published floors (LongMemEval
   MRR 0.904988 < 0.914, LoCoMo MRR 3-run mean 0.779868 < 0.805, Recall@10

--- a/mcp_server/handlers/injection_receipts.py
+++ b/mcp_server/handlers/injection_receipts.py
@@ -40,6 +40,30 @@ def receipt_marker(receipt_id: int) -> str:
     return f"⟦rcpt:{receipt_id}⟧"
 
 
+# Prefix of the per-memory fetch key below. Named so the one string has a
+# single definition: renderers emit it, readers scan for it.
+MEMORY_MARKER_PREFIX = "⟦mem:"
+
+
+def memory_marker(memory_id: int) -> str:
+    """Render the in-context fetch key for ONE truncated memory line.
+
+    Distinct from ``receipt_marker``: a receipt answers "which memories
+    were in context" (``why``, Pearl rung-1 presence evidence), it does
+    not hand back content. This marker answers "how do I read the rest of
+    THIS line" — the model passes the id to ``recall(memory_id=...)``.
+
+    Same stance ``core/response_budget.py`` already takes for bounded MCP
+    responses: "Truncated items ... keep their id, so truncation is never
+    a dead end: full content stays dynamically loadable by id". Injected
+    banner text was the one truncation path in the system that did not
+    keep it, so its truncation WAS a dead end — the reader could see that
+    a memory had been cut but had no handle to fetch the remainder, only
+    a fresh search whose top hit is not guaranteed to be the same row.
+    """
+    return f"{MEMORY_MARKER_PREFIX}{memory_id}⟧"
+
+
 def session_id_from_transcript(transcript_path: object) -> str | None:
     """Derive the session identity from the transcript file name.
 

--- a/mcp_server/hooks/session_start.py
+++ b/mcp_server/hooks/session_start.py
@@ -27,6 +27,8 @@ from pathlib import Path
 from mcp_server.handlers.injection_receipts import (
     emit_hook_receipt,
     emit_injection_receipt,
+    MEMORY_MARKER_PREFIX,
+    memory_marker,
     receipt_marker,
     session_id_from_transcript,
 )
@@ -81,6 +83,25 @@ def _has_sentence_transformers() -> bool:
 def _short(text: str, max_len: int = 120) -> str:
     text = text.strip().replace("\n", " ")
     return text if len(text) <= max_len else text[: max_len - 1] + "..."
+
+
+def _body(memory: dict, max_len: int = 120) -> str:
+    """Render one memory's content for a banner line, keeping a fetch key
+    when — and only when — the line is actually truncated.
+
+    An untruncated line needs no key: the whole memory is already there.
+    A truncated one does, otherwise the reader can see that content was
+    cut but has no way to ask for the rest (``memory_marker`` docstring).
+    Emitting the key only on cut lines keeps the cost proportional to the
+    loss instead of taxing every line.
+
+    Truncation itself is byte-identical to ``_short`` — this changes what
+    a cut line CARRIES, not where it is cut.
+    """
+    content = memory["content"].strip().replace("\n", " ")
+    if len(content) <= max_len:
+        return content
+    return f"{content[: max_len - 1]}... {memory_marker(memory['id'])}"
 
 
 # ── Database checks ──────────────────────────────────────────────────────
@@ -652,7 +673,7 @@ def _build_context(
     if anchors:
         lines.append("### Anchored Memories (critical)")
         for a in anchors:
-            lines.append(f"- {_short(a['content'])}{_freshness(a, now)}")
+            lines.append(f"- {_body(a)}{_freshness(a, now)}")
         lines.append("")
 
     # Team decisions from other agents (TMS directory layer, Wegner 1987)
@@ -661,7 +682,7 @@ def _build_context(
         for d in team_decisions:
             agent = d.get("agent", "")
             prefix = f"[{agent}] " if agent else ""
-            lines.append(f"- {prefix}{_short(d['content'])}{_freshness(d, now)}")
+            lines.append(f"- {prefix}{_body(d)}{_freshness(d, now)}")
         lines.append("")
 
     if hot:
@@ -669,7 +690,7 @@ def _build_context(
         for m in hot:
             heat_bar = "+" * min(5, int(m["heat"] * 5))
             domain_hint = f" [{m['domain']}]" if m.get("domain") else ""
-            bullet = f"- [{heat_bar}]{domain_hint} {_short(m['content'])}"
+            bullet = f"- [{heat_bar}]{domain_hint} {_body(m)}"
             lines.append(f"{bullet}{_freshness(m, now)}")
         lines.append("")
 
@@ -709,6 +730,13 @@ def _build_context(
         "*Use `recall` to retrieve full memories. "
         "Use `anchor` to protect critical facts.*"
     )
+    # Only explain the key when at least one line actually carries one —
+    # a legend for a notation absent from the text above is pure noise.
+    if any(MEMORY_MARKER_PREFIX in line for line in lines):
+        lines.append(
+            f"*Lines ending in `{MEMORY_MARKER_PREFIX}id\u27e7` are truncated; "
+            "read the full memory with `recall(memory_id=id)`.*"
+        )
 
     # Warn if semantic search is degraded
     if not _has_sentence_transformers():

--- a/tests_py/hooks/test_session_start.py
+++ b/tests_py/hooks/test_session_start.py
@@ -396,6 +396,49 @@ def test_build_context_renders_all_sections_and_receipt_marker():
     assert "Use `recall` to retrieve full memories." in out
 
 
+def test_short_line_carries_no_fetch_key():
+    """An untruncated line needs no key — the whole memory is already there."""
+    hot = [{"id": 42, "content": "short", "domain": "", "heat": 0.1}]
+    out = hook._build_context([], hot, None)
+    assert "short" in out
+    assert hook.MEMORY_MARKER_PREFIX not in out
+    assert "are truncated" not in out, "legend must not appear without a key"
+
+
+def test_truncated_line_carries_its_memory_id_as_a_fetch_key():
+    """The regression this closes: a cut banner line used to be a dead end.
+
+    The reader could see content had been cut but had no handle to fetch
+    the remainder — only a fresh search whose top hit is not guaranteed
+    to be the same row. Every truncated line now ends in its own id.
+    """
+    long_content = "x" * 500
+    anchors = [{"id": 7, "content": long_content, "domain": "", "is_global": False}]
+    hot = [{"id": 8, "content": long_content, "domain": "cortex", "heat": 0.9}]
+    team = [{"id": 9, "content": long_content, "domain": "", "agent": "dba"}]
+
+    out = hook._build_context([], hot, None, team_decisions=team)
+    out += hook._build_context(anchors, [], None)
+
+    for memory_id in (7, 8, 9):
+        assert hook.memory_marker(memory_id) in out, f"id {memory_id} lost"
+    assert "..." in out, "still truncated — the key is added, not a bypass"
+    assert long_content not in out, "the key must not smuggle in full content"
+
+
+def test_fetch_key_legend_appears_only_when_a_key_was_emitted():
+    truncated = [{"id": 3, "content": "y" * 500, "domain": "", "heat": 0.5}]
+    assert "are truncated" in hook._build_context([], truncated, None)
+
+
+def test_truncation_boundary_is_unchanged_by_the_fetch_key():
+    """The key changes what a cut line CARRIES, never where it is cut."""
+    content = "z" * 500
+    body = hook._body({"id": 1, "content": content})
+    assert body.startswith(hook._short(content))
+    assert body == f"{hook._short(content)} {hook.memory_marker(1)}"
+
+
 def test_build_context_without_receipt_has_no_marker():
     hot = [{"id": 2, "content": "hot", "domain": "", "heat": 0.1}]
     out = hook._build_context([], hot, None)


### PR DESCRIPTION
## The gap

Every memory line in the SessionStart banner is cut at 120 characters by `_short` (`hooks/session_start.py:81`), but **the rendered line carried no id**. The reader could see content had been cut and had no handle to fetch the remainder — only a fresh search, whose top hit is not guaranteed to be the same row.

This was the **one truncation path in the system that dropped the key**. Everywhere else the repo already states the opposite stance:

- `core/response_budget.py:46-49` — *"Truncated items carry `truncated: True` plus `content_length` (original size) **and keep their id, so truncation is never a dead end**: full content stays dynamically loadable by id (`recall` `memory_id` + `content_offset` args, `wiki_read` `offset` arg)."*
- `core/gist_extraction.py` — an oversized auto-capture keeps only a gist in the row, with the artifact pointer as the link to the full raw text.

The banner's footer already told the model to *"Use `recall` to retrieve full memories"* — with nothing to pass it.

Note this is **not** what the receipt covers: `⟦rcpt:id⟧` answers *which* memories were in context (`why`, Pearl rung-1 presence evidence) and by design never hands back content.

## The change

Truncated lines now end in the memory's own id:

```
### Hot Memories
- [++++] [cortex] Le gate de floors publie des valeurs que main lui-meme ne franchit plus depuis le rebase E1 v3, donc chaque PR herite d... ⟦mem:4821⟧
- [++] Court.

*Use `recall` to retrieve full memories. Use `anchor` to protect critical facts.*
*Lines ending in `⟦mem:id⟧` are truncated; read the full memory with `recall(memory_id=id)`.*
```

- New `memory_marker` sits beside `receipt_marker` in `handlers/injection_receipts.py` — same module, same notation family, docstring stating explicitly how the two differ.
- Applied at all three memory-rendering sites: anchors, team decisions, hot.
- **Untruncated lines are unchanged** — the whole memory is already there, so no key is emitted and no tokens are spent. Cost is proportional to what was actually lost.
- **The legend is emitted only when at least one key was**, so a notation absent from the text above is never explained.
- **Where a line is cut is byte-identical.** `_body` reuses `_short`'s exact slice; only what a cut line *carries* changes. Asserted by test.

## Scope note

This closes the dead end on the truncation that already exists. It does **not** change `_HOT_LIMIT` (8), `_ANCHOR_LIMIT` (5), `_MIN_HEAT` (0.4) or the 120-character bound — those are separate calls, and the measured banner is ~2 KB either way.

## Tests

Four arms, all in `tests_py/hooks/test_session_start.py`:

| Test | Asserts |
|---|---|
| `test_short_line_carries_no_fetch_key` | no key and no legend on an untruncated line |
| `test_truncated_line_carries_its_memory_id_as_a_fetch_key` | each of the three sections emits its own id; still truncated; the key does not smuggle in full content |
| `test_fetch_key_legend_appears_only_when_a_key_was_emitted` | legend is conditional |
| `test_truncation_boundary_is_unchanged_by_the_fetch_key` | `_body(m) == f"{_short(content)} {memory_marker(id)}"` |

## Verification

- `tests_py/hooks/test_session_start.py` — **74 passed**, 5 failed; those same 5 fail identically on unmodified `origin/main` in this container (an optional SQLite dependency the pytorch index is unreachable to install here), so they are environmental and pre-existing, not caused by this change. CI has the full environment.
- `tests_py/hooks/test_hook_receipts_unit.py`, `test_auto_recall.py`, `test_agent_briefing.py` — 41 passed, 3 skipped
- `python scripts/check_craftsmanship.py --base origin/main` — OK
- `ruff check .`, `ruff format --check .` — clean
- `check_doc_claims.py`, `check_version_surfaces.py` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1

---
_Generated by [Claude Code](https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1)_