### PR TITLE
fix(readme): restore the canonical hypermnesia-mcp-viz identity anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 </p>
 
 <p align="center">
-  <sub>One of three MCP servers that each run standalone and keep evolving — memory (this), <a href="https://github.com/cdeust/ai-architect-mcp-codebase">code graph</a>, <a href="https://github.com/cdeust/ai-architect-mcp-spec">spec verification</a> — plus visualization and reasoning-agent companions. <a href="#the-rest-of-the-stack">Compare them all ↓</a></sub>
+  <sub>One of three MCP servers that each run standalone and keep evolving — memory (this), <a href="https://github.com/cdeust/ai-architect-mcp-codebase">code graph</a>, <a href="https://github.com/cdeust/ai-architect-mcp-spec">spec verification</a> — alongside the <a href="https://github.com/cdeust/cortex-viz">hypermnesia-mcp-viz</a> visualization companion and the <a href="https://github.com/cdeust/zetetic-team-subagents">zetetic-team-subagents</a> reasoning agents. <a href="#the-rest-of-the-stack">Compare them all ↓</a></sub>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## main is red, and it is my defect

Run [34238410970](https://github.com/cdeust/Cortex/actions/runs/34238410970) on `089361ad` — the #509 merge — failed on `Test (3.10)`, `(3.11)`, `(3.12)`, `(3.13)` and `Test (SQLite backend)`. **7663 passed, 1 failed:**

```
FAILED tests_py/scripts/test_codex_plugin_contract.py::
       test_current_companion_docs_use_canonical_publication_identities
assert '<a href="https://github.com/cdeust/cortex-viz">hypermnesia-mcp-viz</a>' in readme
```

Collapsing the seven-line four-piece-stack block in #509 dropped that anchor. My replacement line said *"visualization and reasoning-agent companions"* in prose, naming neither.

**The assertion is not decorative.** The repository is named `cortex-viz`; the *published plugin identity* is `hypermnesia-mcp-viz`. That test is the mechanical guard that the README keeps naming the canonical published identity rather than the repo slug — the same class of guard the sibling test `test_readme_carries_the_complete_viz_and_spec_identity_migrations` enforces for the spec migration. I deleted the thing it protects.

## The fix

Name both companions with their links instead of alluding to them. That satisfies the contract and reads better than the vague form it replaces:

> …memory (this), [code graph], [spec verification] — alongside the **[hypermnesia-mcp-viz]** visualization companion and the **[zetetic-team-subagents]** reasoning agents.

## Verification — failure reproduced, then fixed

| | |
|---|---|
| On `origin/main`, before | `1 failed, 7 passed` in that file |
| After | `8 passed` |
| `tests_py/scripts/` whole directory | `879 passed`, **0 failed** (8 errors in `test_groomer.py`, an optional-dependency gap in this container — CI passes those, they are in the 7663) |
| `check_doc_claims.py`, `check_version_surfaces.py`, `ruff format --check` | clean |

## Why this reached main — a real gap, filed separately

The CI `changes` filter classifies `*.md` out of `code`:

```yaml
code:
  - '**'
  - '!{*.md,docs/**/*.md,…}'
```

So a README-only PR sets `code=false` and **every test job is skipped** — while `test_codex_plugin_contract.py`'s *input is `README.md`*. The guard is gated off exactly when its subject changes. #509 was therefore merged on a green PR that had never run the test its diff would break.

That is the root cause, and it will recur on the next README edit. I have **not** widened this PR with it: main is red now and this fix is the minimal thing that clears it. I'll raise the filter gap separately so it gets its own review — the cheap shape is a small docs-triggered job running just the doc-contract tests, rather than the full matrix on every prose change, which would undo the CI-efficiency work in #475–#481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1

---
_Generated by [Claude Code](https://claude.ai/code/session_01StMBvNd7eVJGtpnC2zNsx1)_