### PR TITLE
fix(worktrees): create every worktree inside the repo under .claude/worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,14 @@ separate **cortex-viz** MCP (reads this same store read-only).
 - Do NOT write model caches under `/tmp` — the FlashRank incident (silently
   absent re-ranker, 6 benchmarks invalidated) came from exactly this.
   `HF_HOME`/`cache_dir` must be persistent.
+- Do NOT create git worktrees outside this repository — no `/private/tmp/cortex-*`,
+  no `../Cortex-wt-*` sibling, no `~/.claude/worktrees/`. The only location is
+  `.claude/worktrees/<name>/` (already gitignored via `.claude/*`): it is where
+  Claude Code's own worktree tooling (`isolation: worktree`, `EnterWorktree`,
+  `--worktree`) puts them and the only directory its cleanup sweep looks at.
+  Owner correction 2026-09-08, after 76 outside worktrees (43 detached + 33 on
+  branches, all under `/private/tmp/cortex-green-*`) had to be removed by hand.
+  `scripts/spawn-agent.sh` and `benchmarks/lib/bench_regression.sh` follow this.
 
 ## Scientific Implementation Standard (Zetetic Principle)
 

--- a/benchmarks/lib/bench_regression.sh
+++ b/benchmarks/lib/bench_regression.sh
@@ -63,7 +63,11 @@ run_baseline_benchmarks() {
     BASELINE_RESULTS_DIR="$RESULTS_DIR/baseline"
     mkdir -p "$BASELINE_RESULTS_DIR"
 
-    local wt_dir; wt_dir="$(mktemp -d "${TMPDIR:-/tmp}/cortex-bench-baseline-XXXXXX")"
+    # Inside the repo, under the directory Claude Code's own worktree tooling
+    # uses (gitignored via .claude/*) — never /tmp or a sibling directory, where
+    # a killed run leaves a worktree nothing reclaims (owner correction 2026-09-08).
+    mkdir -p "$REPO_ROOT/.claude/worktrees"
+    local wt_dir; wt_dir="$(mktemp -d "$REPO_ROOT/.claude/worktrees/bench-baseline-XXXXXX")"
     echo
     echo "════════════════════════════════════════════════════════════════════"
     echo "  NO-REGRESSION BASELINE: $BASELINE_REF (${baseline_sha:0:12}) in $wt_dir"

--- a/scripts/spawn-agent.sh
+++ b/scripts/spawn-agent.sh
@@ -10,7 +10,9 @@
 #
 # What it does:
 #   1. Resolves the agent file (.claude/agents/<name>.md) and strips YAML frontmatter.
-#   2. Creates a git worktree at ../<repo>-<agent>-<timestamp> on a new branch.
+#   2. Creates a git worktree at <target-repo>/.claude/worktrees/<agent>-<timestamp>
+#      on a new branch — inside the repo, where Claude Code's own worktree sweep
+#      can see it (never a sibling directory or /tmp; owner correction 2026-09-08).
 #   3. Launches `claude` there with:
 #        --append-system-prompt  <agent body>   (installs the agent persona)
 #        --permission-mode bypassPermissions    (no interactive approval prompts)
@@ -54,11 +56,14 @@ AGENT_BODY="$(awk 'BEGIN{f=0} /^---$/{f++; next} f>=2{print}' "$AGENT_FILE")"
 # Target project = current working directory's git root (the repo you want the
 # agent to work ON), not this subagents repo.
 TARGET_REPO="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-TARGET_NAME="$(basename "$TARGET_REPO")"
 STAMP="$(date +%Y%m%d-%H%M%S)"
-WORKTREE="$TARGET_REPO/../${TARGET_NAME}-${AGENT}-${STAMP}"
+WORKTREE="$TARGET_REPO/.claude/worktrees/${AGENT}-${STAMP}"
 BRANCH="agent/${AGENT}/${STAMP}"
 
+mkdir -p "$TARGET_REPO/.claude/worktrees"
+if ! git -C "$TARGET_REPO" check-ignore -q .claude/worktrees; then
+  echo "warning: .claude/worktrees/ is not gitignored in $TARGET_REPO; add it so the worktree does not show up as untracked content" >&2
+fi
 echo "→ creating worktree: $WORKTREE (branch $BRANCH)"
 git -C "$TARGET_REPO" worktree add -b "$BRANCH" "$WORKTREE"
 


### PR DESCRIPTION
## Why

`scripts/spawn-agent.sh` created its worktree as a sibling directory beside the repo, and `benchmarks/lib/bench_regression.sh` created its detached baseline worktree under `/tmp`. Worktrees outside the repo are invisible to Claude Code's own cleanup sweep and accumulate: on 2026-09-08, 43 detached and 33 branch worktrees under `/private/tmp/cortex-green-*` had to be removed by hand. Owner correction: the only sanctioned location is `<repo>/.claude/worktrees/<name>/`, already gitignored here via `.claude/*`.

## What

- `scripts/spawn-agent.sh`: worktree at `<repo>/.claude/worktrees/<agent>-<timestamp>`; warns if `.claude/worktrees/` is not gitignored; drops the now-unused `TARGET_NAME`.
- `benchmarks/lib/bench_regression.sh`: `mktemp -d` under `$REPO_ROOT/.claude/worktrees/bench-baseline-XXXXXX` instead of `${TMPDIR:-/tmp}`; the existing `worktree remove --force` cleanup is unchanged.
- `CLAUDE.md` "What NOT to do": the rule, with the measured incident.

## Verification

- `bash -n` on both scripts: ok.
- `python scripts/check_craftsmanship.py`: "Craftsmanship gate: OK".
- No Python touched; the doc-contract and lint jobs are the relevant CI checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)