### PR TITLE
test: close the provenance mutation gap (#389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,14 @@ adheres to [Semantic Versioning](https://semver.org/).
   mutants (188 killed). That count was filed on 2026-08-08 and re-measured
   unchanged on 2026-09-09. 29 of the 43 were real gaps, and
   `tests_py/core/test_provenance.py` closes every one. `_build_reason` held 13
-  of them: three of its four branches are unreachable through
-  `grade_provenance`, whose empty-outcome path hardcodes its own reason string
-  rather than calling the helper, so the wording the helper produces was never
-  asserted anywhere; those branches are now pinned by direct tests.
+  of them: no test asserted the wording it produces, because
+  `grade_provenance`'s empty-outcome path hardcodes its own reason string
+  rather than calling the helper. Its four branches are now pinned by direct
+  unit tests carrying the boundary inputs, notably the three-ref join cap.
+  One of the four, `grade == UNVERIFIABLE` with `dead` empty, is unreachable
+  through `grade_provenance`, since every path that appends an UNVERIFIABLE
+  outcome also appends to `dead`; the other three are reachable and are also
+  pinned end-to-end by `TestGradeReportFields`.
   `grade_provenance` held 12: every field of the returned `ProvenanceReport`
   other than `grade` (`memory_id`, `ref_counts`, `dead_refs`,
   `uncheckable_refs`, `reason`) went unread by the existing tests, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,38 @@ adheres to [Semantic Versioning](https://semver.org/).
   `FLOOR_*`, comparing HEAD against a baseline ref's own measured scores
   rather than a fixed number.
 
+- **`mcp_server/core/provenance.py`'s 43 surviving mutants, closed** (#389). A
+  scoped `scripts/mutation_check.sh` run left 43 genuine survivors out of 232
+  mutants (188 killed). That count was filed on 2026-08-08 and re-measured
+  unchanged on 2026-09-09. 29 of the 43 were real gaps, and
+  `tests_py/core/test_provenance.py` closes every one. `_build_reason` held 13
+  of them: three of its four branches are unreachable through
+  `grade_provenance`, whose empty-outcome path hardcodes its own reason string
+  rather than calling the helper, so the wording the helper produces was never
+  asserted anywhere; those branches are now pinned by direct tests.
+  `grade_provenance` held 12: every field of the returned `ProvenanceReport`
+  other than `grade` (`memory_id`, `ref_counts`, `dead_refs`,
+  `uncheckable_refs`, `reason`) went unread by the existing tests, and the
+  documented least-favorable case, a ref absent from its verdicts dict, was
+  never exercised. Extraction held 3: the `continue` that skips a non-path
+  token could become a `break` unnoticed, the `rstrip` cut set could widen and
+  eat a real path character, and a repeated artifact path was never deduped.
+  `_ref_counts` held 1: the citation count was only ever asserted with a
+  citation present, so the zero arm was free. 12 further survivors are
+  **documented equivalents**, registered in `memory/mutation-equivalents.json`
+  (13 for this module in total, counting the one already on file), each pinned
+  to its exact removed/added pair as ADR-0771 requires. The last 2 had no
+  third disposition available: `dead_refs=[]` and `uncheckable_refs=[]` on the
+  empty-outcome `ProvenanceReport` restate the dataclass defaults verbatim,
+  and a pure-deletion mutant of a line like that carries no `added` text,
+  which the registry rejects, so both arguments are deleted with a comment at
+  the site saying why. Every constructed report stays field-for-field
+  identical, and both values stay pinned by `TestGradeReportFields`.
+  Re-running the reproduction after the fix: `scripts/mutation_check.sh`
+  reports 0 unregistered survivors, the full suite passes, and ruff, the
+  craftsmanship gate and pyright are clean. No absolute test total is stated
+  here, per #293/#294.
+
 ## [4.19.1] - 2026-09-03
 
 ### Fixed

--- a/mcp_server/core/provenance.py
+++ b/mcp_server/core/provenance.py
@@ -173,8 +173,9 @@ def grade_provenance(
             ref_counts=_ref_counts(
                 file_refs, commit_refs, url_refs, artifact_refs, has_citation
             ),
-            dead_refs=[],
-            uncheckable_refs=[],
+            # dead_refs/uncheckable_refs are left to the dataclass defaults:
+            # restating the empty lists here duplicates the default in two
+            # places and produces only equivalent mutants (issue #389).
             reason="no_extractable_reference",
         )
 

--- a/memory/mutation-equivalents.json
+++ b/memory/mutation-equivalents.json
@@ -402,6 +402,102 @@
       "issue": "#369"
     },
     {
+      "mutant": "mcp_server.core.provenance.x_extract_commit_refs__mutmut_5",
+      "removed": "for m in _COMMIT_RE.finditer(content or \"\"):",
+      "added": "for m in _COMMIT_RE.finditer(content or \"XXXX\"):",
+      "kind": "equivalent-by-construction",
+      "rationale": "The empty-string fallback is only reached when `content` is falsy, and _COMMIT_RE (`\\b[0-9a-f]{7,40}\\b`) cannot match \"XXXX\": 'X' is outside the character class and the token is 4 characters, under the 7-character minimum. Both the original and the mutant therefore iterate over a subject with zero matches and return the same empty result, so no input distinguishes them.",
+      "issue": "#389"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_extract_url_refs__mutmut_5",
+      "removed": "for m in _URL_RE.finditer(content or \"\"):",
+      "added": "for m in _URL_RE.finditer(content or \"XXXX\"):",
+      "kind": "equivalent-by-construction",
+      "rationale": "The empty-string fallback is only reached when `content` is falsy, and _URL_RE (`https?://\\S+`) cannot match \"XXXX\": the marker carries no scheme prefix. Both the original and the mutant therefore iterate over a subject with zero matches and return the same empty result, so no input distinguishes them.",
+      "issue": "#389"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_extract_artifact_refs__mutmut_5",
+      "removed": "for m in _ARTIFACT_RE.finditer(content or \"\"):",
+      "added": "for m in _ARTIFACT_RE.finditer(content or \"XXXX\"):",
+      "kind": "equivalent-by-construction",
+      "rationale": "The empty-string fallback is only reached when `content` is falsy, and _ARTIFACT_RE cannot match \"XXXX\": it requires the literal 'artifacts/', a yyyy-mm segment, 16 hex digits and a '.md' suffix. Both the original and the mutant therefore iterate over a subject with zero matches and return the same empty result, so no input distinguishes them.",
+      "issue": "#389"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_has_citation_ref__mutmut_4",
+      "removed": "return bool(_CITATION_RE.search(content or \"\"))",
+      "added": "return bool(_CITATION_RE.search(content or \"XXXX\"))",
+      "kind": "equivalent-by-construction",
+      "rationale": "The empty-string fallback is only reached when `content` is falsy, and _CITATION_RE cannot match \"XXXX\": it requires a '10.NNNN/' DOI stem or an 'arXiv:NNNN.NNNN' identifier. Both the original and the mutant therefore iterate over a subject with zero matches and return the same empty result, so no input distinguishes them.",
+      "issue": "#389"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_grade_provenance__mutmut_9",
+      "removed": "if commit_verdicts.get(sha, False):",
+      "added": "if commit_verdicts.get(sha, None):",
+      "kind": "equivalent-by-construction",
+      "rationale": "The looked-up value is consumed by nothing but the enclosing `if`, so only its truthiness is observable, and the original default False is falsy exactly like None. Every ref, present or absent from the verdicts dict, takes the same branch in both versions; the absent-ref behaviour itself is pinned by TestGradeMissingVerdictEntries.",
+      "issue": "#389"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_grade_provenance__mutmut_11",
+      "removed": "if commit_verdicts.get(sha, False):",
+      "added": "if commit_verdicts.get(sha, ):",
+      "kind": "equivalent-by-construction",
+      "rationale": "The looked-up value is consumed by nothing but the enclosing `if`, so only its truthiness is observable, and the original default False is falsy exactly like the implicit None of a one-argument .get(). Every ref, present or absent from the verdicts dict, takes the same branch in both versions; the absent-ref behaviour itself is pinned by TestGradeMissingVerdictEntries.",
+      "issue": "#389"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_grade_provenance__mutmut_26",
+      "removed": "if artifact_verdicts.get(path, False):",
+      "added": "if artifact_verdicts.get(path, None):",
+      "kind": "equivalent-by-construction",
+      "rationale": "The looked-up value is consumed by nothing but the enclosing `if`, so only its truthiness is observable, and the original default False is falsy exactly like None. Every ref, present or absent from the verdicts dict, takes the same branch in both versions; the absent-ref behaviour itself is pinned by TestGradeMissingVerdictEntries.",
+      "issue": "#389"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_grade_provenance__mutmut_28",
+      "removed": "if artifact_verdicts.get(path, False):",
+      "added": "if artifact_verdicts.get(path, ):",
+      "kind": "equivalent-by-construction",
+      "rationale": "The looked-up value is consumed by nothing but the enclosing `if`, so only its truthiness is observable, and the original default False is falsy exactly like the implicit None of a one-argument .get(). Every ref, present or absent from the verdicts dict, takes the same branch in both versions; the absent-ref behaviour itself is pinned by TestGradeMissingVerdictEntries.",
+      "issue": "#389"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_grade_provenance__mutmut_42",
+      "removed": "reason=\"no_extractable_reference\",",
+      "added": ")",
+      "kind": "equivalent-by-construction",
+      "rationale": "Dropping the keyword falls back to the ProvenanceReport field default, which is the very same literal \"no_extractable_reference\", so the constructed report is identical field for field. The value is pinned by TestGradeNoRefs; only the redundancy, not the behaviour, differs.",
+      "issue": "#389"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_grade_provenance__mutmut_47",
+      "removed": "file_refs, commit_refs, url_refs, artifact_refs, has_citation",
+      "added": "file_refs, commit_refs, url_refs, artifact_refs, None",
+      "kind": "unreachable-branch",
+      "rationale": "This call site sits inside `if not outcomes:`, and the statement just above appends VERIFIABLE to outcomes whenever has_citation is true. The branch is therefore reachable only with has_citation False, and `1 if False else 0` and `1 if None else 0` both yield the 0 that TestGradeReportFields pins.",
+      "issue": "#389"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_grade_provenance__mutmut_57",
+      "removed": "grade = min(outcomes, key=lambda g: _RANK[g])",
+      "added": "grade = min(outcomes, key=None)",
+      "kind": "equivalent-by-construction",
+      "rationale": "The only values ever placed in `outcomes` are the three grade literals, and their lexicographic order (\"unverifiable\" < \"verifiable\" < \"verified\") coincides element for element with the _RANK order (0 < 1 < 2), so natural-order min selects the same worst grade for every possible combination. Should a grade ever be renamed out of that coincidence the mutant becomes killable and this entry fails as stale, which is the intended alarm.",
+      "issue": "#389"
+    },
+    {
+      "mutant": "mcp_server.core.provenance.x_grade_provenance__mutmut_59",
+      "removed": "grade = min(outcomes, key=lambda g: _RANK[g])",
+      "added": "grade = min(outcomes, )",
+      "kind": "equivalent-by-construction",
+      "rationale": "The only values ever placed in `outcomes` are the three grade literals, and their lexicographic order (\"unverifiable\" < \"verifiable\" < \"verified\") coincides element for element with the _RANK order (0 < 1 < 2), so key-less min selects the same worst grade for every possible combination. Should a grade ever be renamed out of that coincidence the mutant becomes killable and this entry fails as stale, which is the intended alarm.",
+      "issue": "#389"
+    },
+    {
       "mutant": "mcp_server.core.provenance.x_write_time_hint__mutmut_1",
       "removed": "write_class: str = \"\",",
       "added": "write_class: str = \"XXXX\",",

--- a/tests_py/core/test_provenance.py
+++ b/tests_py/core/test_provenance.py
@@ -14,6 +14,7 @@ from mcp_server.core.provenance import (
     VERIFIABLE,
     VERIFIED,
     ProvenanceReport,
+    _build_reason,
     extract_artifact_refs,
     extract_commit_refs,
     extract_url_refs,
@@ -44,6 +45,16 @@ class TestExtractCommitRefs:
         refs = extract_commit_refs("8872d56 and again 8872d56")
         assert refs.count("8872d56") == 1
 
+    def test_a_skipped_all_digit_token_does_not_abort_the_scan(self):
+        # `continue`, not `break`: an ignored token must not truncate the
+        # scan, or every SHA after the first counter/timestamp is lost.
+        assert extract_commit_refs("1234567890 then 8872d56") == ["8872d56"]
+
+    def test_a_repeated_token_does_not_abort_the_scan(self):
+        # Same guard for the dedupe arm of that same `continue`.
+        content = "8872d56 again 8872d56 then deadbee"
+        assert extract_commit_refs(content) == ["8872d56", "deadbee"]
+
 
 class TestExtractUrlRefs:
     def test_extracts_url(self):
@@ -57,6 +68,12 @@ class TestExtractUrlRefs:
     def test_dedupes(self):
         refs = extract_url_refs("https://a.com and https://a.com again")
         assert refs.count("https://a.com") == 1
+
+    def test_a_trailing_letter_is_not_stripped(self):
+        # The cut set is exactly `).,;:'"` — widening it would silently eat
+        # the last character of a legitimate path.
+        url = "https://example.com/PATHX"
+        assert extract_url_refs(f"see {url} for details") == [url]
 
 
 class TestExtractArtifactRefs:
@@ -73,6 +90,11 @@ class TestExtractArtifactRefs:
 
     def test_no_artifact_ref_returns_empty(self):
         assert extract_artifact_refs("plain text, no artifact pointer") == []
+
+    def test_dedupes_a_repeated_path(self):
+        path = "artifacts/2026-07/0123456789abcdef.md"
+        refs = extract_artifact_refs(f"{path} and again {path}")
+        assert refs == [(path, "0123456789abcdef")]
 
 
 class TestHasCitationRef:
@@ -238,6 +260,104 @@ class TestGradeCombination:
             "artifact": 0,
             "citation": 1,
         }
+
+
+# ── Missing verdict entries ──────────────────────────────────────────────
+
+
+class TestGradeMissingVerdictEntries:
+    """The documented precondition: a ref absent from its verdicts dict
+    takes the LEAST-favorable outcome for its type, never the favorable
+    one. A verdict dict truncated by a bounded sample must never silently
+    promote a memory (issue #389)."""
+
+    def test_commit_absent_from_verdicts_is_uncheckable_not_verified(self):
+        report = _grade(commit_refs=["8872d56"], commit_verdicts={})
+        assert report.grade == VERIFIABLE
+        assert report.uncheckable_refs == ["8872d56"]
+
+    def test_artifact_absent_from_verdicts_is_dead_not_verified(self):
+        report = _grade(artifact_refs=[("art.md", "abc123")], artifact_verdicts={})
+        assert report.grade == UNVERIFIABLE
+        assert report.dead_refs == ["art.md"]
+
+
+# ── Reported fields ──────────────────────────────────────────────────────
+
+
+class TestGradeReportFields:
+    """Every field the caller reads back, on both return paths (issue #389).
+
+    The grade itself is covered above; these pin the identity, counts and
+    reason that travel with it.
+    """
+
+    def test_empty_report_carries_id_zeroed_counts_and_empty_lists(self):
+        report = _grade(memory_id=7)
+        assert report.memory_id == 7
+        assert report.ref_counts == {
+            "file": 0,
+            "commit": 0,
+            "url": 0,
+            "artifact": 0,
+            "citation": 0,
+        }
+        assert report.dead_refs == []
+        assert report.uncheckable_refs == []
+
+    def test_graded_report_carries_id_and_all_verified_reason(self):
+        report = _grade(memory_id=7, file_refs=["a.py"], existing_paths={"a.py"})
+        assert report.memory_id == 7
+        assert report.reason == "all_refs_verified"
+
+    def test_dead_file_ref_is_named_in_the_reason(self):
+        report = _grade(file_refs=["a.py"], existing_paths=set())
+        assert report.reason == "dead_refs: a.py"
+
+    def test_uncheckable_commit_is_named_in_the_reason(self):
+        report = _grade(commit_refs=["deadbee"], commit_verdicts={"deadbee": False})
+        assert report.reason == "uncheckable_refs: deadbee"
+
+    def test_citation_count_is_zero_when_no_citation_is_present(self):
+        report = _grade(file_refs=["a.py"], existing_paths={"a.py"})
+        assert report.ref_counts["citation"] == 0
+
+
+# ── Reason wording ───────────────────────────────────────────────────────
+
+
+class TestBuildReason:
+    """`_build_reason` maps (grade, dead, uncheckable) to the stored reason.
+
+    Three of its four branches are unreachable through `grade_provenance`'s
+    empty-outcome path, which hardcodes its own reason rather than calling
+    this — so they are pinned here directly (issue #389).
+    """
+
+    def test_unverifiable_with_dead_refs_names_them(self):
+        assert _build_reason(UNVERIFIABLE, ["a.py"], []) == "dead_refs: a.py"
+
+    def test_dead_refs_are_comma_joined_and_capped_at_three(self):
+        reason = _build_reason(UNVERIFIABLE, ["a.py", "b.py", "c.py", "d.py"], [])
+        assert reason == "dead_refs: a.py, b.py, c.py"
+
+    def test_unverifiable_without_dead_refs_reports_no_reference(self):
+        assert _build_reason(UNVERIFIABLE, [], []) == "no_extractable_reference"
+
+    def test_dead_refs_alone_do_not_explain_a_passing_grade(self):
+        # `and`, not `or`: dead refs only ever explain an UNVERIFIABLE grade.
+        assert _build_reason(VERIFIED, ["a.py"], []) == "all_refs_verified"
+
+    def test_verifiable_with_uncheckable_refs_names_them(self):
+        reason = _build_reason(VERIFIABLE, [], ["deadbee"])
+        assert reason == "uncheckable_refs: deadbee"
+
+    def test_uncheckable_refs_are_comma_joined_and_capped_at_three(self):
+        reason = _build_reason(VERIFIABLE, [], ["a", "b", "c", "d"])
+        assert reason == "uncheckable_refs: a, b, c"
+
+    def test_uncheckable_refs_alone_do_not_explain_a_verified_grade(self):
+        assert _build_reason(VERIFIED, [], ["deadbee"]) == "all_refs_verified"
 
 
 # ── write_time_hint (M-D5, 7.5) ─────────────────────────────────────────────

--- a/tests_py/core/test_provenance.py
+++ b/tests_py/core/test_provenance.py
@@ -329,9 +329,14 @@ class TestGradeReportFields:
 class TestBuildReason:
     """`_build_reason` maps (grade, dead, uncheckable) to the stored reason.
 
-    Three of its four branches are unreachable through `grade_provenance`'s
-    empty-outcome path, which hardcodes its own reason rather than calling
-    this — so they are pinned here directly (issue #389).
+    One of its four branches is unreachable through `grade_provenance`:
+    every path that appends an UNVERIFIABLE outcome also appends to `dead`,
+    so `grade == UNVERIFIABLE and not dead` never reaches this helper, and
+    the empty-outcome path hardcodes the same string rather than calling it.
+    The other three are reachable and are also pinned end-to-end by
+    `TestGradeReportFields`; they are asserted here as well because these
+    unit-level cases carry the boundary inputs (the three-ref join cap in
+    particular) the end-to-end tests do not supply (issue #389).
     """
 
     def test_unverifiable_with_dead_refs_names_them(self):


### PR DESCRIPTION
## Summary

Mutation testing on `mcp_server/core/provenance.py` left 43 genuine survivors out of 232 mutants (188 killed). That count was filed on 2026-08-08 and re-measured unchanged on 2026-09-09. This PR closes the gap: 29 survivors killed with new tests, and the remaining 13 registered as justified equivalents, each pinned to its exact removed/added pair as ADR-0771 requires.

Where the 29 came from:

- `_build_reason`, 13 mutants. No test asserted the wording it produces, because `grade_provenance`'s empty-outcome path hardcodes its own reason string instead of calling the helper. Its four branches are now pinned by direct unit tests carrying the boundary inputs, notably the three-ref join cap. One branch, `grade == UNVERIFIABLE` with `dead` empty, is unreachable through `grade_provenance`; the other three are reachable and are also pinned end-to-end by `TestGradeReportFields`.
- `grade_provenance`, 12 mutants. Every report field other than the grade (`memory_id`, `ref_counts`, `dead_refs`, `uncheckable_refs`, `reason`) went unread by the tests, and the documented least-favorable case, a ref absent from its verdicts dict, was never exercised.
- extraction, 3 mutants. The `continue` that skips a token could become a `break` unnoticed, the `rstrip` cut set could widen and eat a real path character, and a repeated artifact path was never deduped.
- `_ref_counts`, 1 mutant. The citation count was only ever asserted with a citation present, so the zero arm was free.

One production-code change, and it is a deletion: `dead_refs=[]` and `uncheckable_refs=[]` drop from the empty-outcome `ProvenanceReport`. They restate the dataclass defaults verbatim, and a pure-deletion mutant of a line like that carries no `added` text, which the equivalents registry rejects. Both values stay pinned by `TestGradeReportFields`.

Closes #389

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor (no functional change; rules/coding-standards.md compliance)
- [ ] Documentation only
- [x] Audit-finding closure (#389, provenance mutation coverage)

## Test plan

- `scripts/mutation_check.sh` on `mcp_server/core/provenance.py`: no unregistered survivors (29 newly killed, 13 registered equivalents).
- `pytest`: 8423 tests pass.
- `ruff check && ruff format --check`: clean.
- `python scripts/check_craftsmanship.py`: clean.
- pyright gate (CONTRIBUTING.md § *Reproducing the pyright gate locally*): clean.
- `python scripts/check_doc_claims.py`: OK, with 1 declared not-a-claim exemption.
- `python scripts/generate_repo_badges.py --check`: badges OK, 4 checked.

- [x] All existing tests pass.
- [x] New tests added for new behavior.
- [x] Mutation survival check: this PR is itself the mutation survival check. Every surviving mutant is either killed or registered with its exact removed/added pair.
- [x] Manual verification: n/a. No UI, CLI or MCP-tool behavior changes; the only production edit removes two keyword arguments whose values equal the dataclass defaults.

## Audit notes

- Engineering review (code-reviewer and test-engineer passes, verdicts posted as a PR comment): the 43 survivors were triaged one by one against the real call path rather than by mutant count. Both passes disputed the original claim that three of `_build_reason`'s four branches are unreachable; a direct probe confirmed only one is, and the wording is corrected in 52336a94.
- Genius review (popper lens): the equivalence claim for each of the 13 remaining mutants is pinned to the literal diff pair, so an equivalence that stops holding fails the registry instead of surviving silently.
- Outstanding deferred findings: none.

## Coding-standards compliance

- [x] §2.2 Layer dependency direction preserved; no import changed.
- [x] §3.2 No `any` or untyped dicts at boundaries.
- [x] §4.1 No production file over 500 lines. `provenance.py` is 350; the test file is exempt.
- [x] §4.2 No function over 50 lines.
- [x] §4.4 No function with more than 4 parameters.
- [x] §7 Local reasoning preserved.
- [x] §8 No new numeric constants.
- [x] §9 No TODOs without issue references, and no dead code added. One
  pre-existing dead branch is now documented rather than removed:
  `_build_reason`'s `grade == UNVERIFIABLE` with `dead` empty cannot be
  reached through `grade_provenance`, and it duplicates the string the
  empty-outcome path already hardcodes. Deleting it is a production change
  needing its own mutation run, so it is left for a follow-up rather than
  folded into a test-coverage PR.

## Breaking changes

None. The two removed keyword arguments were equal to the dataclass defaults, so every constructed `ProvenanceReport` is field-for-field identical to before.

## Screenshots / logs

n/a. Test and registry changes plus a two-argument deletion.

## Reviewer checklist

- [x] CHANGELOG.md updated under `[Unreleased] / Fixed` (commit a70eba04), with no absolute test total per #293/#294.
- [x] Documentation updated: nothing else needed.
- [x] No secrets or PII in the diff.
- [x] Review passes run and their verdicts posted as a PR comment. One blocking finding was raised and fixed in 52336a94.
- [ ] CI passes on the latest commit, pending the run on 52336a94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
