### PR TITLE
fix(setup): stop labeling a failed model pre-cache [ok] (#537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ adheres to [Semantic Versioning](https://semver.org/).
   `requirements/setup.txt`, the same hashed closure `scripts/setup.sh`
   installs, with `--no-deps --require-hashes` and never `--upgrade`, for
   the same reasons recorded in ADR-1059. The hand list is deleted.
+- **`scripts/setup.sh` step 5/7 reported `[ok]` even when the embedding
+  model was never cached (issue #537).** The pre-cache ran inside a
+  `try/except` that printed a warning and then fell off the end of the
+  block, so the subprocess always exited 0 — the `[ok]` label was driven
+  by reaching the end of the step, not by the step succeeding. The
+  try/except is gone; a failed import or load now raises, so the label is
+  derived from the pre-cache subprocess's real exit code
+  (`scripts/lib/precache_embedding_model.sh`, extracted from `setup.sh` so
+  the two outcomes are drivable in isolation —
+  `tests_py/scripts/test_precache_embedding_model_step.py`). The step
+  still isn't fatal: a real failure now prints `[!!] Model not pre-cached,
+  will download on first use` plus the captured traceback, instead of
+  scrolling past unread under a false `[ok]`.
 
 - **The plugin installer could not install its dependencies (PR #539).**
   `scripts/setup.sh` step 3/7 installs `requirements/setup.txt`, the hashed

--- a/scripts/lib/precache_embedding_model.sh
+++ b/scripts/lib/precache_embedding_model.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Library: pre-cache the sentence-transformers embedding model and report
+# an honest [ok]/[!!] outcome derived from the pre-cache subprocess's exit
+# code — never from merely reaching the end of the step.
+#
+# Extracted from scripts/setup.sh step 5 (issue #537) so the two outcomes
+# can be driven and asserted in isolation: source this file, override
+# python3 on PATH, then call precache_embedding_model_step directly.
+# Function-only — sourcing this file runs nothing by itself.
+#
+# source: ADR-0783
+
+# precache_embedding_model_step <project_dir> <deps_dir>
+# Pre:  caller has already defined ok() and warn() (color-coded [ok]/[!!]
+#       line printers) and spinner() (animates a backgrounded pid, returns
+#       that pid's exit code via `wait`) — scripts/setup.sh defines all
+#       three before sourcing this file.
+# Post: prints exactly one [ok] or [!!] line, and on failure also prints
+#       the pre-cache subprocess's captured output so the real cause does
+#       not scroll past unread. Returns the pre-cache subprocess's exit
+#       code (0 on success, non-zero otherwise) — this step never raises;
+#       the caller decides whether that makes the run fatal.
+precache_embedding_model_step() {
+    local project_dir="$1"
+    local deps_dir="$2"
+    local cache_log
+    cache_log="$(mktemp)"
+
+    echo "  Pre-caching sentence-transformers model (one-time ~100MB download)..."
+    PYTHONPATH="${project_dir}:${deps_dir}:${PYTHONPATH:-}" python3 -c "
+from sentence_transformers import SentenceTransformer
+model = SentenceTransformer('all-MiniLM-L6-v2')
+emb = model.encode(['test'])
+print(f'Model loaded: {emb.shape[1]}D embeddings')
+" >"$cache_log" 2>&1 &
+    local pid=$!
+
+    local outcome=0
+    if spinner "$pid"; then
+        ok "Embedding model cached"
+    else
+        outcome=1
+        warn "Model not pre-cached, will download on first use"
+        sed 's/^/    /' "$cache_log"
+    fi
+
+    rm -f "$cache_log"
+    return "$outcome"
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -43,6 +43,10 @@ spinner() {
     return $spin_exit
 }
 
+# source: issue #537 — extracted so the [ok]/[!!] outcome can be driven
+# and asserted in isolation; see scripts/lib/precache_embedding_model.sh.
+source "$SCRIPT_DIR/lib/precache_embedding_model.sh"
+
 # ── OS Detection ────────────────────────────────────────────────────────
 
 detect_os() {
@@ -250,21 +254,10 @@ fi
 
 step "Embedding model"
 
-echo "  Pre-caching sentence-transformers model (one-time ~100MB download)..."
-PYTHONPATH="${PROJECT_DIR}:${DEPS_DIR}" python3 -c "
-try:
-    from sentence_transformers import SentenceTransformer
-    model = SentenceTransformer('all-MiniLM-L6-v2')
-    emb = model.encode(['test'])
-    print(f'Model loaded: {emb.shape[1]}D embeddings')
-except Exception as e:
-    print(f'Warning: model cache failed ({e}). Will download on first use.')
-" 2>/dev/null &
-if spinner $!; then
-    ok "Embedding model cached"
-else
-    warn "Embedding model cache step failed — will download on first use"
-fi
+# Non-fatal by design: precache_embedding_model_step already reports the
+# honest [ok]/[!!] label itself; `|| true` only keeps this step from
+# aborting the run under `set -e` on a cache miss.
+precache_embedding_model_step "$PROJECT_DIR" "$DEPS_DIR" || true
 
 # ── Step 6: Verify ──────────────────────────────────────────────────────
 

--- a/tests_py/scripts/test_precache_embedding_model_step.py
+++ b/tests_py/scripts/test_precache_embedding_model_step.py
@@ -1,0 +1,112 @@
+"""scripts/lib/precache_embedding_model.sh must never label a failed
+pre-cache [ok] — issue #537.
+
+Source: issue #537. Step 5/7 of scripts/setup.sh printed
+"[ok] Embedding model cached" even when the pre-cache raised, because the
+inline python one-liner caught the exception, printed a warning to a
+stream the shell never inspected, and then exited 0 by falling off the
+end of the try/except — reaching the end of the step, not succeeding at
+it, was what drove the label. The fix removes the swallow so the outcome
+is derived from the subprocess exit code, and extracts the step into
+scripts/lib/precache_embedding_model.sh so both outcomes are drivable
+here without running the rest of scripts/setup.sh (no PostgreSQL, no
+brew, no real ~100MB download).
+
+Each test sources the real library file and defines the same three
+helper functions scripts/setup.sh defines before sourcing it
+(ok/warn/spinner) — the production strings, not reimplementations of the
+label logic. A shadow ``sentence_transformers`` module on PYTHONPATH
+forces the real failure this issue observed (an import raising inside
+the pre-cache) without mocking python3 itself.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB_PATH = REPO_ROOT / "scripts" / "lib" / "precache_embedding_model.sh"
+
+_HARNESS = """
+set -euo pipefail
+GREEN='\\033[0;32m'
+YELLOW='\\033[1;33m'
+NC='\\033[0m'
+ok()   {{ echo -e "${{GREEN}}[ok]${{NC}} $1"; }}
+warn() {{ echo -e "${{YELLOW}}[!!]${{NC}} $1"; }}
+spinner() {{
+    local pid=$1
+    wait "$pid"
+    spin_exit=$?
+    return $spin_exit
+}}
+source "{lib_path}"
+precache_embedding_model_step "{project_dir}" "{deps_dir}"
+"""
+
+
+def _run_step(
+    tmp_path: Path, shadow_pythonpath: str | None
+) -> subprocess.CompletedProcess:
+    script = _HARNESS.format(
+        lib_path=LIB_PATH, project_dir=REPO_ROOT, deps_dir=tmp_path / "deps"
+    )
+    env = {"PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"}
+    if shadow_pythonpath is not None:
+        env["PYTHONPATH"] = shadow_pythonpath
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def test_forced_failure_prints_warn_not_ok(tmp_path):
+    """A real exception inside the pre-cache must yield [!!], never [ok]."""
+    shadow_dir = tmp_path / "shadow"
+    shadow_dir.mkdir()
+    (shadow_dir / "sentence_transformers.py").write_text(
+        "raise ModuleNotFoundError("
+        "\"No module named 'numpy._core._multiarray_umath'\")\n"
+    )
+
+    result = _run_step(tmp_path, str(shadow_dir))
+
+    print("--- forced-failure stdout ---")
+    print(result.stdout)
+    print("--- forced-failure stderr ---")
+    print(result.stderr)
+
+    assert "[ok]" not in result.stdout
+    assert "[!!]" in result.stdout
+    assert result.returncode == 1
+
+
+def test_forced_success_prints_ok_not_warn(tmp_path):
+    """A pre-cache that actually loads the model must yield [ok]."""
+    shadow_dir = tmp_path / "shadow"
+    shadow_dir.mkdir()
+    (shadow_dir / "sentence_transformers.py").write_text(
+        "class SentenceTransformer:\n"
+        "    def __init__(self, *a, **k):\n"
+        "        pass\n"
+        "\n"
+        "    def encode(self, texts):\n"
+        "        class _Shape:\n"
+        "            shape = (len(texts), 384)\n"
+        "        return _Shape()\n"
+    )
+
+    result = _run_step(tmp_path, str(shadow_dir))
+
+    print("--- forced-success stdout ---")
+    print(result.stdout)
+    print("--- forced-success stderr ---")
+    print(result.stderr)
+
+    assert "[ok]" in result.stdout
+    assert "[!!]" not in result.stdout
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

Step 5/7 of `scripts/setup.sh` prints `[ok] Embedding model cached` even when the pre-cache failed. The pre-cache ran inside a python `try/except` that caught the exception, printed a warning, and fell off the end of the block — the subprocess always exited 0, so the shell's honest-looking `if spinner $!; then ok; else warn; fi` was fed a lie: the outcome was "reached the end of the step," not "succeeded at it."

Fix: remove the swallow so a failed import/load raises and the subprocess exits non-zero — the label is now derived from that exit code, never from control reaching the end of the step. The step's logic is extracted into `scripts/lib/precache_embedding_model.sh` (function-only, no top-level execution) so the outcome is drivable and assertable in isolation, since it wasn't reachable that way before. The step stays non-fatal by design (`|| true` in `setup.sh`, unchanged intent).

Closes #537

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- `tests_py/scripts/test_precache_embedding_model_step.py` — two new tests, each sourcing the real `scripts/lib/precache_embedding_model.sh` with the production `ok()`/`warn()`/`spinner()` helpers and shadowing `sentence_transformers` on `PYTHONPATH` to force a real exception (the same failure mode from the issue transcript) or a real success, with no python3 mocking:
  - `test_forced_failure_prints_warn_not_ok` — asserts `[!!]` present, `[ok]` absent, exit code 1.
  - `test_forced_success_prints_ok_not_warn` — asserts `[ok]` present, `[!!]` absent, exit code 0.
  - Verified by hand against the pre-fix code path too: the same forced-failure harness against the old inline logic prints `[ok] Embedding model cached` — confirms the gate fails on `origin/main` and passes after this change.
- `bash -n scripts/setup.sh` — pass.
- `shellcheck -S warning scripts/setup.sh scripts/lib/precache_embedding_model.sh` — clean.
- `pytest tests_py/ -q` — full suite green (all tests passing, only expected sqlite/postgres-mode skips) after `uv sync --no-default-groups --extra dev --extra sqlite --extra postgresql`.
- `ruff check` / `ruff format --check` — clean.
- `python scripts/check_craftsmanship.py` — `Craftsmanship gate: OK`.
- `python scripts/check_doc_claims.py` — `doc claims OK`.
- [x] All existing tests pass.
- [x] New tests added for new behavior.
- [x] Mutation survival check: the two tests bracket both outcomes (exit 0 vs non-zero) of the sole branch point (`precache_embedding_model_step`'s `if spinner "$pid"`), so a mutant flipping that condition or reintroducing the swallow is caught by one of the two.
- [x] Manual verification: ran the fixed step end to end against the real `sentence-transformers` install (forced-success path) and against a shadowed `ModuleNotFoundError` (forced-failure path); raw output for both shown in the PR discussion / commit history.

## Audit notes

- Engineering review (self, engineer persona / Move 1-7 discipline applied): layer is `scripts/` (install tooling, not core/handlers/infrastructure) — no layer-boundary concern. Stakes classification: Low (install-tooling script, no auth/billing/schema/concurrency touch) but the fix itself required Move 3/4 discipline (root cause, not a symptom patch) given the explicit diagnosis.
- Outstanding deferred findings: none.

## Coding-standards compliance

- [x] §2.2 N/A — bash script, no layer imports.
- [x] §3.2 N/A — bash/python, no `any`.
- [x] §4.1 No file > 500 lines (new lib file is 44 lines; new test file is ~110 lines).
- [x] §4.2 No function > 50 lines (`precache_embedding_model_step` is ~25 lines).
- [x] §4.4 No function with > 4 parameters (2 params).
- [x] §7 Local reasoning preserved — no clever constructs; extraction makes the control flow more locally reasoned than before, not less.
- [x] §8 No new numeric constants.
- [x] §9 No dead code; no TODOs.

## Breaking changes

None. Step 5/7 output changes (an honest `[!!] Model not pre-cached, will download on first use` plus traceback replaces a false `[ok]`), the step remains non-fatal, and the overall install still proceeds identically either way.

## Reviewer checklist

- [x] CHANGELOG.md updated under `## [Unreleased]` / `### Fixed`.
- [x] Documentation updated — N/A (no README/SKILL.md claims about this step's exact output).
- [x] No secret keys or PII in the diff.
- [ ] CI passes on the latest commit (pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
