### PR TITLE
fix(hooks): close three decision-gate review blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,19 +20,45 @@ adheres to [Semantic Versioning](https://semver.org/).
   code file. A `source:` line never counts toward a run, and the refusal
   names `wiki_adr` and the pointer form to leave behind. Exempt: the file
   header, defined as a run with nothing executable before it rather than by
-  a line number; test files; and any block already in the file, so a legacy
-  file stays editable elsewhere. `CORTEX_DECISION_GATE=off` overrides one
-  call. See ADR-1060.
+  a line number; test files (now including `tests_js` and `*.test.*`/
+  `*.spec.*` filenames, not just the Python shapes); and any block already
+  in the file, compared by its set of comment-line texts rather than exact
+  position, so a rewrap of an existing block is never mistaken for new
+  prose. Enforced only for the `#`-comment languages the eight-line
+  threshold was actually measured against on the tracked tree — `.py`,
+  `.sh`, `.bash`, `.zsh`, `.rb` (1418 and 18 tracked files respectively for
+  the two with volume); `//` and `/* */` languages have no tracked
+  instances yet and are not enforced. `CORTEX_DECISION_GATE=off` overrides
+  one call. See ADR-1060.
 
 ### Fixed
 
 - **`scripts/setup.py` installed an unpinned, hand-written package list
   instead of the generated constraint file (#538).** This is the path taken
   by the SQLite backend on every OS and by the PostgreSQL backend on
-  Windows — the default zero-config install. `install_deps()` now resolves
+  Windows, the default zero-config install. `install_deps()` now resolves
   `requirements/setup.txt`, the same hashed closure `scripts/setup.sh`
   installs, with `--no-deps --require-hashes` and never `--upgrade`, for
   the same reasons recorded in ADR-1059. The hand list is deleted.
+
+- **The decision-gate hook crashed on unreadable input and misread strings,
+  docstrings and heredoc bodies as prose (review of the change above,
+  ADR-1060).** `Path.read_text` around a file's current content caught only
+  `OSError`; a `UnicodeDecodeError` (a `ValueError`, not an `OSError`) or a
+  null byte in the path crashed the hook and blocked every edit to that
+  file rather than allowing or refusing it — both read sites now go through
+  one helper catching `(OSError, ValueError)`. Comment detection was a
+  prefix match with no notion of string or heredoc bodies, so a module
+  docstring followed by a licence block was blocked (the docstring broke
+  the header scan) and a `cat <<'CFG' ... CFG` body containing commented
+  example data was blocked; Python comment lines are now found via
+  `tokenize.COMMENT` (never confuses a string for a comment) with a leading
+  docstring tolerated as header material, and the shell scanner skips
+  heredoc bodies. Grandfathering keyed a run by its exact joined text, so
+  inserting or removing one bare marker line inside a block already in the
+  file changed the key and was reported as newly introduced; it now
+  compares the set of body-comment line texts, so a pure reflow of existing
+  rationale is not.
 
 - **The plugin installer could not install its dependencies (PR #539).**
   `scripts/setup.sh` step 3/7 installs `requirements/setup.txt`, the hashed

--- a/docs/adr/ADR-1060-refuse-a-decision-written-into-code-at-edit-time-in-the-distributed-hook.md
+++ b/docs/adr/ADR-1060-refuse-a-decision-written-into-code-at-edit-time-in-the-distributed-hook.md
@@ -38,6 +38,18 @@ Exempt: the file's header block, defined as a run preceded by nothing executable
 
 `CORTEX_DECISION_GATE=off` overrides for a single call, for genuine non-decision prose such as a worked example or a data table, and requires saying why.
 
+### Revision 2026-09-09 — a first review caught three ways the shape heuristic misfired
+
+A review of the first cut found the hook crashing on unreadable input, misreading string and heredoc bodies as comments, and losing grandfathering on a pure reflow. All three are fixed at the source, not patched at the throw site:
+
+**Read failures fail open.** `candidate_content` and `introduced_block` only caught `OSError` around `Path.read_text`; a `UnicodeDecodeError` (a `ValueError`, not an `OSError` — a null byte in the path raises the same way) crashed the hook and, with it, every edit to that file. Both call sites now go through one `_read_text` helper that catches `(OSError, ValueError)` and treats "cannot read" and "does not exist yet" the same way: judge the fragment alone rather than crash.
+
+**Comment detection is lexical, not prefix-matched.** The original scan treated any line whose stripped text started with the marker as a comment, with no notion of string literals or heredocs. Two shapes misfired: a module docstring followed by a licence block was blocked (the docstring disqualified the header scan, even though it isn't code), and a `cat <<'CFG' ... CFG` heredoc body containing commented example lines was blocked (that body is data being written, not prose about the script). Python now scans via `tokenize.COMMENT`, which cannot confuse a string body for a comment, and a leading module docstring is tolerated as header material the same way a shebang or `set` line is. The shell-family scanner (`.sh`/`.bash`/`.zsh`/`.rb`) skips heredoc bodies between a `<<DELIM` opener and the matching closing line.
+
+**Grandfathering compares content, not position.** The original ratchet keyed a run by its exact joined text; inserting or removing a single bare marker line inside an existing block changed the key, so a pure rewrap of a block already in the file was reported as newly introduced. Grandfathering now compares the set of body-comment line texts already in the file against the candidate run's lines: a run is refused only when the count of lines *not* already present anywhere in the file's body prose reaches the threshold, so reflowing an existing block is never treated as new.
+
+**Two further findings changed what's enforced, not just how it's checked.** `is_test_path` recognised only `tests`/`tests_py`/`test`/`fuzz` and the Python `test_*.py`/`*_test.py` shapes; `tests_js` — the repo's actual JS test root — and the `.spec.ts`/`.test.ts` filename shapes were unrecognised, so JS test files were scanned while their Python equivalents were exempt. The test-path check now also matches `tests_js` by name and any `*.test.*`/`*.spec.*` filename, uniformly across languages. Separately, `//` and `/* */` markers were never actually measured: the tracked tree (excluding `deps/`) holds 1418 `.py` files and 18 `.sh` files, but zero non-test files using `//` or `/* */` comments. `COMMENT_MARKERS` now covers only the `#`-comment languages the threshold was measured against — `.py`, `.sh`, `.bash`, `.zsh`, `.rb` — and drops `.js`/`.ts`/`.tsx`/`.jsx`/`.swift`/`.go`/`.rs`/`.java`/`.c`/`.h`/`.cpp` until there is tracked-tree evidence for them. This is a narrowing of enforcement, not a threshold change: `PROSE_RUN_LIMIT` is unchanged, and the hook still refuses the ten- and twelve-line rationale blocks it was built to catch.
+
 ## Consequences
 
 Easier: the convention becomes a processing obligation rather than something a reader must remember. The failure that produced this ADR cannot recur silently, because the write is refused before the file changes.
@@ -46,6 +58,10 @@ Easier: the refusal carries its own remedy. It names the tool that records the d
 
 Harder: a handful of existing files carry a body block over the threshold. The ratchet grandfathers them, so nothing breaks, but they are now visibly on the wrong side of a stated rule and are candidates for migration to the wiki.
 
+Harder: `//` and `/* */` comment languages are unenforced until they have their own measured evidence. A ten-line C-style licence header written into a `.go` or `.java` file today passes silently. This is the accepted cost of not shipping an unverified threshold, not an oversight.
+
 Risk accepted: the threshold is a shape heuristic. A decision written in seven lines passes, and a long data table written as comments is refused. The override covers the second; the first is a smaller failure than the one this closes.
 
 Risk accepted: an agent can set the override. That is deliberate. A gate with no escape hatch gets disabled wholesale, and requiring a stated reason keeps the choice visible in the transcript.
+
+Risk accepted: grandfathering by line-text set, not exact position, can under-block a new decision that happens to reuse phrasing already present elsewhere in the file. This trade was made deliberately to fix the reflow false-positive; the alternative (position-based keying) is what broke on a pure rewrap.

--- a/mcp_server/hooks/_decision_gate_lex.py
+++ b/mcp_server/hooks/_decision_gate_lex.py
@@ -55,7 +55,7 @@ def python_comment_lines_and_header(content: str) -> tuple[set[int], int]:
     """
     try:
         tokens = list(tokenize.generate_tokens(io.StringIO(content).readline))
-    except (tokenize.TokenizeError, SyntaxError, IndentationError, ValueError):
+    except (tokenize.TokenError, SyntaxError, IndentationError, ValueError):
         return set(), 0  # unparsable: no comment lines, no header exemption
     comment_lines: set[int] = set()
     header_boundary = len(content.splitlines()) + 1

--- a/mcp_server/hooks/_decision_gate_lex.py
+++ b/mcp_server/hooks/_decision_gate_lex.py
@@ -1,0 +1,83 @@
+"""Language-aware comment-line extraction for ``decision_gate``.
+
+Split out of ``decision_gate.py`` to keep that module under the repo's
+300-line cap. A regex that treats every line starting with ``#`` or ``//``
+as a comment confuses string and heredoc bodies for prose; this module gives
+each supported marker family a scanner that does not.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import tokenize
+
+POINTER = "source:"
+
+_HEREDOC_START = re.compile(r"<<-?\s*['\"]?(?P<delim>\w+)['\"]?")
+
+# Marker families that get a language-aware scanner. Every other suffix in
+# COMMENT_MARKERS falls back to a plain per-line prefix check.
+PYTHON_SUFFIX = ".py"
+
+
+def shell_comment_lines(content: str) -> set[int]:
+    """Full-line ``#`` comments, skipping heredoc bodies.
+
+    ``cat <<'CFG' ... CFG`` feeds its body to a command as data; a commented
+    line inside it is a data row, not a decision, and must not be counted.
+    """
+    lines = content.splitlines()
+    comment_lines: set[int] = set()
+    delim: str | None = None
+    for number, line in enumerate(lines, start=1):
+        if delim is not None:
+            if line.strip() == delim:
+                delim = None
+            continue
+        started = _HEREDOC_START.search(line)
+        if started:
+            delim = started.group("delim")
+            continue
+        if line.strip().startswith("#"):
+            comment_lines.add(number)
+    return comment_lines
+
+
+def python_comment_lines_and_header(content: str) -> tuple[set[int], int]:
+    """Full-line ``#`` comments via ``tokenize.COMMENT``, plus the first
+    line carrying executable code.
+
+    ``tokenize`` never mistakes a string body for a comment, unlike a
+    ``line.strip().startswith("#")`` regex. The header boundary tolerates a
+    leading module docstring: a bare string expression statement is not
+    executable, so a licence block right after it is still header material.
+    """
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(content).readline))
+    except (tokenize.TokenizeError, SyntaxError, IndentationError, ValueError):
+        return set(), 0  # unparsable: no comment lines, no header exemption
+    comment_lines: set[int] = set()
+    header_boundary = len(content.splitlines()) + 1
+    executable_seen = False
+    stmt: list[tokenize.TokenInfo] = []
+    for tok in tokens:
+        if tok.type == tokenize.COMMENT:
+            comment_lines.add(tok.start[0])
+            continue
+        if tok.type in (
+            tokenize.NL,
+            tokenize.ENCODING,
+            tokenize.INDENT,
+            tokenize.DEDENT,
+        ):
+            continue
+        if tok.type != tokenize.NEWLINE:
+            stmt.append(tok)
+            continue
+        is_bare_docstring = len(stmt) == 1 and stmt[0].type == tokenize.STRING
+        if stmt and not is_bare_docstring and not executable_seen:
+            executable_seen = True
+            header_boundary = stmt[0].start[0]
+        stmt = []
+    return comment_lines, header_boundary

--- a/mcp_server/hooks/decision_gate.py
+++ b/mcp_server/hooks/decision_gate.py
@@ -9,7 +9,8 @@ after the write is committed and pushed. This hook refuses the write.
 
 Detection is by shape, not semantics: a decision is prose, and prose in code
 is a long run of consecutive comment lines. Exit 2 blocks the tool call and
-returns stderr to the agent.
+returns stderr to the agent. A read or parse failure never blocks: a false
+negative here is cheap, a hook that makes editing impossible is not.
 
 source: ADR-1060"""
 
@@ -17,8 +18,11 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
+
+from mcp_server.hooks import _decision_gate_lex as lex
 
 # A run of this many consecutive comment lines is prose, not a pointer.
 # Measured over the tracked tree: outside headers and tests, only a handful
@@ -26,94 +30,50 @@ from pathlib import Path
 # (source: ADR-1060).
 PROSE_RUN_LIMIT = 8
 
+# "#"-marker languages actually present in the tracked tree at the volume
+# this threshold was measured against: 1418 ``.py`` and 18 ``.sh`` files
+# (source: ADR-1060 measurement). "//" and "/* */" markers have no tracked
+# instances to measure against and are not enforced until they do.
 COMMENT_MARKERS = {
     ".py": "#",
     ".sh": "#",
     ".bash": "#",
     ".zsh": "#",
     ".rb": "#",
-    ".js": "//",
-    ".ts": "//",
-    ".tsx": "//",
-    ".jsx": "//",
-    ".swift": "//",
-    ".go": "//",
-    ".rs": "//",
-    ".java": "//",
-    ".c": "//",
-    ".h": "//",
-    ".cpp": "//",
 }
 
-# The sanctioned form; a line carrying it never extends a run.
-POINTER = "source:"
-
-_TEST_DIRS = frozenset({"tests", "tests_py", "test", "fuzz"})
+# Exact directory names, not a pattern: a pattern loose enough to match
+# ``tests_js`` also matches pytest's own ``tmp_path`` fixture directories
+# (``test_<name>0``), which would exempt every file a test writes rather
+# than every file under a test root (source: ADR-1060 fix).
+_TEST_DIRS = frozenset({"tests", "tests_py", "tests_js", "test", "fuzz"})
+_TEST_FILE_RE = re.compile(r"(^test_|_test$|^test$|\.test$|\.spec$|^spec$)")
 
 _OVERRIDE = "CORTEX_DECISION_GATE"
 
 
 def is_test_path(path: str) -> bool:
     """Tests narrate scenarios at length and hold no decisions; the repo
-    already exempts them from the file-size cap."""
-    name = Path(path).name
-    if name.startswith("test_") or name.endswith("_test.py"):
+    already exempts them from the file-size cap. Applied uniformly across
+    languages: ``test_x.py``/``x_test.go``/``x.test.ts``/``x.spec.ts``, and
+    any exact ``tests``/``tests_py``/``tests_js``/``test``/``fuzz``
+    directory component — not just the Python-shaped forms."""
+    stem = Path(path).stem
+    if _TEST_FILE_RE.search(stem):
         return True
     return any(part in _TEST_DIRS for part in Path(path).parts)
 
 
-def prose_runs(content: str, marker: str) -> dict[str, int]:
-    """Every run of ``PROSE_RUN_LIMIT``+ comment lines, keyed by its text.
+def _read_text(path: str) -> str | None:
+    """The file's current text, or None if it cannot be read or decoded.
 
-    Keying by text rather than position is what lets the caller tell a block
-    this edit introduces from one that merely moved.
+    A missing file, a null byte in the path, and invalid UTF-8 content all
+    land here rather than crashing the hook: each is equally "cannot read".
     """
-    found: dict[str, int] = {}
-    run: list[str] = []
-    start = 0
-
-    def flush() -> None:
-        if len(run) >= PROSE_RUN_LIMIT:
-            found.setdefault("\n".join(x.strip() for x in run), start)
-
-    for number, line in enumerate(content.splitlines(), start=1):
-        stripped = line.strip()
-        if stripped.startswith(marker) and POINTER not in stripped:
-            if not run:
-                start = number
-            run.append(line)
-            continue
-        flush()
-        run = []
-    flush()
-    return found
-
-
-def is_header(lines: list[str], start: int) -> bool:
-    """True iff nothing executable precedes the run beginning at ``start``.
-
-    A file's opening block orients the reader and is not a decision. Saying
-    so this way avoids a line-number threshold, which would be a number to
-    tune and a place for a decision to hide just inside.
-    """
-    for line in lines[: start - 1]:
-        stripped = line.strip()
-        if stripped == "" or stripped.startswith(("#", "//")):
-            continue
-        if stripped.split(maxsplit=1)[:1] == ["set"]:
-            continue
-        return False
-    return True
-
-
-def body_runs(content: str, marker: str) -> dict[str, int]:
-    """Prose runs that are not the file's header block."""
-    lines = content.splitlines()
-    return {
-        text: start
-        for text, start in prose_runs(content, marker).items()
-        if not is_header(lines, start)
-    }
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return None
 
 
 def candidate_content(tool: str, tool_input: dict) -> str | None:
@@ -126,41 +86,116 @@ def candidate_content(tool: str, tool_input: dict) -> str | None:
     old, new = tool_input.get("old_string"), tool_input.get("new_string")
     if not path or old is None or new is None:
         return None
-    try:
-        current = Path(path).read_text(encoding="utf-8")
-    except OSError:
-        return new  # New file, or unreadable: judge the fragment alone.
+    current = _read_text(path)
+    if current is None:
+        return new  # new file, or unreadable: judge the fragment alone
     if tool_input.get("replace_all"):
         return current.replace(old, new)
     return current.replace(old, new, 1)
 
 
-def introduced_block(tool: str, tool_input: dict) -> tuple[str, int] | None:
-    """The longest prose block this call would add, with its line number.
+def _scan(content: str, suffix: str) -> tuple[set[int], int] | None:
+    """(full-line comment numbers, header boundary line) for this suffix, or
+    None if the content could not be parsed for comment shape at all."""
+    if suffix == lex.PYTHON_SUFFIX:
+        return lex.python_comment_lines_and_header(content)
+    return lex.shell_comment_lines(content), 0
 
-    A block already in the file is grandfathered, so editing an unrelated
-    part of a legacy file is never refused: only what the call introduces
-    is judged.
+
+def _is_header_run(suffix: str, lines: list[str], start: int, boundary: int) -> bool:
+    """True iff nothing executable precedes the run beginning at ``start``.
+
+    Python: nothing precedes the tokenizer's first executable statement, a
+    leading module docstring included. Shell family: nothing precedes but
+    blank lines, ``#`` comments and ``set`` options — the original,
+    line-number-free definition.
+    """
+    if suffix == lex.PYTHON_SUFFIX:
+        return start < boundary
+    for line in lines[: start - 1]:
+        stripped = line.strip()
+        if stripped == "" or stripped.startswith("#"):
+            continue
+        if stripped.split(maxsplit=1)[:1] == ["set"]:
+            continue
+        return False
+    return True
+
+
+def _line_runs(content: str, comment_lines: set[int]) -> dict[int, list[int]]:
+    """Consecutive comment-line numbers grouped into runs of at least
+    ``PROSE_RUN_LIMIT`` lines, keyed by the run's first line number. A line
+    carrying the sanctioned pointer never joins a run."""
+    lines = content.splitlines()
+    runs: dict[int, list[int]] = {}
+    current: list[int] = []
+
+    def flush() -> None:
+        if len(current) >= PROSE_RUN_LIMIT:
+            runs[current[0]] = list(current)
+
+    for n in range(1, len(lines) + 1):
+        if n in comment_lines and lex.POINTER not in lines[n - 1].strip():
+            current.append(n)
+            continue
+        flush()
+        current.clear()
+    flush()
+    return runs
+
+
+def _body_run_texts(content: str, suffix: str) -> set[str]:
+    """Stripped text of every comment line already in a body (non-header)
+    prose run, so a rewrap of a block already in the file — inserting or
+    removing a bare marker line inside it — is recognised as unchanged
+    rather than as new prose."""
+    scanned = _scan(content, suffix)
+    if scanned is None:
+        return set()
+    comment_lines, boundary = scanned
+    lines = content.splitlines()
+    texts: set[str] = set()
+    for start, run in _line_runs(content, comment_lines).items():
+        if _is_header_run(suffix, lines, start, boundary):
+            continue
+        texts.update(lines[n - 1].strip() for n in run)
+    return texts
+
+
+def introduced_block(tool: str, tool_input: dict) -> tuple[str, int] | None:
+    """The longest prose block this call would newly add, with its line
+    number in the resulting file, or None if nothing crosses the threshold.
+
+    "Newly add" is judged by the set of body-comment line texts already in
+    the file, not by exact run text: only what the call introduces, not
+    what it merely reflows, is refused.
     """
     path = tool_input.get("file_path") or ""
     if is_test_path(path):
         return None
-    marker = COMMENT_MARKERS.get(Path(path).suffix)
-    if marker is None:
+    if Path(path).suffix not in COMMENT_MARKERS:
         return None
     content = candidate_content(tool, tool_input)
     if not content:
         return None
-    try:
-        existing = Path(path).read_text(encoding="utf-8")
-    except OSError:
-        existing = ""
-    candidate = body_runs(content, marker)
-    new = set(candidate) - set(body_runs(existing, marker))
-    if not new:
+    suffix = Path(path).suffix
+    scanned = _scan(content, suffix)
+    if scanned is None:
         return None
-    block = max(new, key=lambda text: text.count("\n"))
-    return block, candidate[block]
+    comment_lines, boundary = scanned
+    lines = content.splitlines()
+    existing_texts = _body_run_texts(_read_text(path) or "", suffix)
+    best: tuple[str, int, int] | None = None
+    for start, run in _line_runs(content, comment_lines).items():
+        if _is_header_run(suffix, lines, start, boundary):
+            continue
+        run_texts = [lines[n - 1].strip() for n in run]
+        new_count = sum(1 for t in run_texts if t not in existing_texts)
+        if new_count < PROSE_RUN_LIMIT:
+            continue
+        if best is None or new_count > best[2]:
+            best = ("\n".join(run_texts), start, new_count)
+    return None if best is None else (best[0], best[1])
 
 
 def _refuse(path: str, block: str, line: int, marker: str) -> None:

--- a/tests_py/hooks/test_decision_gate.py
+++ b/tests_py/hooks/test_decision_gate.py
@@ -227,3 +227,24 @@ def test_entrypoint_never_crashes_on_an_unreadable_file(tmp_path: Path) -> None:
     )
     assert done.returncode == ALLOW
     assert done.stderr == ""
+
+
+def test_unparsable_python_fails_open_through_the_lexer(tmp_path: Path) -> None:
+    """The tokenizer's own failure path, which no other test reaches.
+
+    An unterminated bracket makes ``tokenize`` raise ``TokenError``. The
+    handler naming that exception is only evaluated when it fires, so a
+    wrong attribute name there raises ``AttributeError`` at that moment and
+    turns the fail-open path into a crash. It shipped misspelled and the
+    suite stayed green, so this drives the path rather than the outcome.
+    """
+    path = tmp_path / "broken.py"
+    path.write_text("y = 0\nx = (\n", "utf-8")
+    assert gate.evaluate(_edit(str(path), "y = 0", _prose(20))) == ALLOW
+
+
+def test_lexer_returns_no_comments_for_unparsable_python() -> None:
+    """Same path, asserted at the unit it belongs to."""
+    from mcp_server.hooks import _decision_gate_lex as lex
+
+    assert lex.python_comment_lines_and_header("x = (\n") == (set(), 0)

--- a/tests_py/hooks/test_decision_gate.py
+++ b/tests_py/hooks/test_decision_gate.py
@@ -96,17 +96,104 @@ def test_override_releases_the_gate(tmp_path: Path, monkeypatch) -> None:
     assert gate.evaluate(event) == ALLOW
 
 
-def test_slash_slash_languages_are_covered(tmp_path: Path) -> None:
+def test_slash_slash_languages_are_not_enforced(tmp_path: Path) -> None:
+    """The marker table only covers ``#`` languages actually measured in the
+    tracked tree (``.py``, ``.sh``, ``.bash``, ``.zsh``, ``.rb``); a zero-
+    file threshold claim is not a threshold, it is a guess. ``//`` and
+    ``/* */`` markers are dropped until they have tracked-tree evidence."""
     path = tmp_path / "thing.ts"
     path.write_text("const first = 0;\nconst anchor = 1;\n", "utf-8")
     event = _edit(path, "const anchor = 1;", _prose(20, "//"))
-    assert gate.evaluate(event) == BLOCK
+    assert gate.evaluate(event) == ALLOW
 
 
 def test_malformed_event_never_blocks() -> None:
     """A hook that crashes closed would make every edit impossible."""
     assert gate.evaluate({}) == ALLOW
     assert gate.evaluate({"tool_name": "Edit", "tool_input": {}}) == ALLOW
+
+
+def test_unreadable_current_file_never_crashes(tmp_path: Path) -> None:
+    """A UnicodeDecodeError is a ValueError, not an OSError; catching only
+    OSError around ``read_text`` crashed the hook (and every edit to the
+    file) instead of allowing or refusing it. Reproduced pre-fix: exit
+    ``'utf-8' codec can't decode byte 0xff``, not a clean 0 or 2."""
+    path = tmp_path / "blob.py"
+    path.write_bytes(b"\xff\xfe\x00\x01")
+    event = _edit(str(path), "x", "y")
+    assert gate.evaluate(event) == ALLOW  # must not raise
+
+
+def test_a_leading_docstring_is_still_header(tmp_path: Path) -> None:
+    """A module docstring followed by a licence block must not be blocked:
+    nothing executable precedes either. Reproduced pre-fix: BLOCKED at
+    line 3, because the docstring line disqualified the header scan even
+    though it is not code."""
+    content = (
+        '"""Module docstring."""\n\n'
+        + _prose(gate.PROSE_RUN_LIMIT)
+        + "\n\ndef f():\n    pass\n"
+    )
+    event = {
+        "tool_name": "Write",
+        "tool_input": {"file_path": str(tmp_path / "new_mod.py"), "content": content},
+    }
+    assert gate.evaluate(event) == ALLOW
+
+
+def test_a_heredoc_body_is_data_not_comments(tmp_path: Path) -> None:
+    """Commented example lines inside a ``cat <<'CFG' ... CFG`` heredoc body
+    are the data being written, not prose about the script. Reproduced
+    pre-fix: BLOCKED at line 6."""
+    path = _script(tmp_path, "")
+    body = _prose(gate.PROSE_RUN_LIMIT)
+    new = f"echo \"start\"\ncat <<'CFG' > out.conf\n{body}\nCFG\n"
+    event = _edit(path, 'echo "start"', new)
+    assert gate.evaluate(event) == ALLOW
+
+
+def test_reflowing_a_grandfathered_block_is_not_an_introduction(tmp_path: Path) -> None:
+    """Inserting or removing a bare marker line inside an already-present
+    block must not flip its grandfathering: ADR-1060 says editing an
+    unrelated part of a legacy file is never refused, and a rewrap of the
+    same rationale is exactly that. Reproduced pre-fix: BLOCKED, because
+    keying a run by its exact joined text changes the key on any reflow."""
+    block = _prose(10)
+    legacy = _script(tmp_path, block + '\necho "anchor"')
+    reflowed_lines = block.split("\n")
+    reflowed_lines.insert(5, "#")
+    event = _edit(legacy, block, "\n".join(reflowed_lines))
+    assert gate.evaluate(event) == ALLOW
+
+
+def test_still_blocks_a_ten_to_twelve_line_rationale(tmp_path: Path) -> None:
+    """Non-negotiable: the case the gate was built for. A worked rationale
+    for a flag choice, added to a script, is still refused — a fix that
+    lets this pass has removed the feature, not repaired it."""
+    for length in (10, 12):
+        path = _script(tmp_path, 'echo "anchor"')
+        event = _edit(path, 'echo "anchor"', _prose(length) + '\necho "anchor"')
+        assert gate.evaluate(event) == BLOCK, f"a {length}-line rationale must block"
+
+
+def test_exempts_the_js_test_root(tmp_path: Path) -> None:
+    """``tests_js`` is this repo's JS-equivalent of ``tests_py``; a Python
+    test file was exempt while the same content under a JS test root was
+    not, which is the inconsistency this closes."""
+    root = tmp_path / "tests_js"
+    root.mkdir()
+    path = root / "spatial_hash.test.js"
+    path.write_text("const x = 1;\n", "utf-8")
+    assert gate.evaluate(_edit(path, "const x = 1;", _prose(20))) == ALLOW
+
+
+def test_exempts_dot_spec_and_dot_test_filenames(tmp_path: Path) -> None:
+    """A ``.spec.ts``/``.test.ts`` file narrates scenarios like a
+    ``test_*.py`` file and must be exempt on that shape alone, independent
+    of which directory it lives under."""
+    path = tmp_path / "widget.spec.ts"
+    path.write_text("const x = 1;\n", "utf-8")
+    assert gate.evaluate(_edit(path, "const x = 1;", _prose(20))) == ALLOW
 
 
 def test_entrypoint_exits_two_on_a_blocked_write(tmp_path: Path) -> None:
@@ -122,3 +209,21 @@ def test_entrypoint_exits_two_on_a_blocked_write(tmp_path: Path) -> None:
     )
     assert done.returncode == BLOCK
     assert "decision-gate" in done.stderr
+
+
+def test_entrypoint_never_crashes_on_an_unreadable_file(tmp_path: Path) -> None:
+    """Through the real entry point, not just ``evaluate`` directly: a
+    binary file under a code suffix must exit 0, never a Python traceback
+    exit code, and never hang."""
+    path = tmp_path / "blob.py"
+    path.write_bytes(b"\xff\xfe\x00\x01")
+    event = _edit(str(path), "x", "y")
+    done = subprocess.run(
+        [sys.executable, "-m", "mcp_server.hooks.decision_gate"],
+        input=json.dumps(event),
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parents[2],
+    )
+    assert done.returncode == ALLOW
+    assert done.stderr == ""

--- a/wiki/adr/cortex/1060-refuse-a-decision-written-into-code-at-edit-time-in-the-distributed-hook.md
+++ b/wiki/adr/cortex/1060-refuse-a-decision-written-into-code-at-edit-time-in-the-distributed-hook.md
@@ -36,6 +36,18 @@ Exempt: the file's header block, defined as a run preceded by nothing executable
 
 `CORTEX_DECISION_GATE=off` overrides for a single call, for genuine non-decision prose such as a worked example or a data table, and requires saying why.
 
+### Revision 2026-09-09 — a first review caught three ways the shape heuristic misfired
+
+A review of the first cut found the hook crashing on unreadable input, misreading string and heredoc bodies as comments, and losing grandfathering on a pure reflow. All three are fixed at the source, not patched at the throw site:
+
+**Read failures fail open.** `candidate_content` and `introduced_block` only caught `OSError` around `Path.read_text`; a `UnicodeDecodeError` (a `ValueError`, not an `OSError` — a null byte in the path raises the same way) crashed the hook and, with it, every edit to that file. Both call sites now go through one `_read_text` helper that catches `(OSError, ValueError)` and treats "cannot read" and "does not exist yet" the same way: judge the fragment alone rather than crash.
+
+**Comment detection is lexical, not prefix-matched.** The original scan treated any line whose stripped text started with the marker as a comment, with no notion of string literals or heredocs. Two shapes misfired: a module docstring followed by a licence block was blocked (the docstring disqualified the header scan, even though it isn't code), and a `cat <<'CFG' ... CFG` heredoc body containing commented example lines was blocked (that body is data being written, not prose about the script). Python now scans via `tokenize.COMMENT`, which cannot confuse a string body for a comment, and a leading module docstring is tolerated as header material the same way a shebang or `set` line is. The shell-family scanner (`.sh`/`.bash`/`.zsh`/`.rb`) skips heredoc bodies between a `<<DELIM` opener and the matching closing line.
+
+**Grandfathering compares content, not position.** The original ratchet keyed a run by its exact joined text; inserting or removing a single bare marker line inside an existing block changed the key, so a pure rewrap of a block already in the file was reported as newly introduced. Grandfathering now compares the set of body-comment line texts already in the file against the candidate run's lines: a run is refused only when the count of lines *not* already present anywhere in the file's body prose reaches the threshold, so reflowing an existing block is never treated as new.
+
+**Two further findings changed what's enforced, not just how it's checked.** `is_test_path` recognised only `tests`/`tests_py`/`test`/`fuzz` and the Python `test_*.py`/`*_test.py` shapes; `tests_js` — the repo's actual JS test root — and the `.spec.ts`/`.test.ts` filename shapes were unrecognised, so JS test files were scanned while their Python equivalents were exempt. The test-path check now also matches `tests_js` by name and any `*.test.*`/`*.spec.*` filename, uniformly across languages. Separately, `//` and `/* */` markers were never actually measured: the tracked tree (excluding `deps/`) holds 1418 `.py` files and 18 `.sh` files, but zero non-test files using `//` or `/* */` comments. `COMMENT_MARKERS` now covers only the `#`-comment languages the threshold was measured against — `.py`, `.sh`, `.bash`, `.zsh`, `.rb` — and drops `.js`/`.ts`/`.tsx`/`.jsx`/`.swift`/`.go`/`.rs`/`.java`/`.c`/`.h`/`.cpp` until there is tracked-tree evidence for them. This is a narrowing of enforcement, not a threshold change: `PROSE_RUN_LIMIT` is unchanged, and the hook still refuses the ten- and twelve-line rationale blocks it was built to catch.
+
 ## Consequences
 
 Easier: the convention becomes a processing obligation rather than something a reader must remember. The failure that produced this ADR cannot recur silently, because the write is refused before the file changes.
@@ -44,6 +56,10 @@ Easier: the refusal carries its own remedy. It names the tool that records the d
 
 Harder: a handful of existing files carry a body block over the threshold. The ratchet grandfathers them, so nothing breaks, but they are now visibly on the wrong side of a stated rule and are candidates for migration to the wiki.
 
+Harder: `//` and `/* */` comment languages are unenforced until they have their own measured evidence. A ten-line C-style licence header written into a `.go` or `.java` file today passes silently. This is the accepted cost of not shipping an unverified threshold, not an oversight.
+
 Risk accepted: the threshold is a shape heuristic. A decision written in seven lines passes, and a long data table written as comments is refused. The override covers the second; the first is a smaller failure than the one this closes.
 
 Risk accepted: an agent can set the override. That is deliberate. A gate with no escape hatch gets disabled wholesale, and requiring a stated reason keeps the choice visible in the transcript.
+
+Risk accepted: grandfathering by line-text set, not exact position, can under-block a new decision that happens to reuse phrasing already present elsewhere in the file. This trade was made deliberately to fix the reflow false-positive; the alternative (position-based keying) is what broke on a pure rewrap.


### PR DESCRIPTION
## Summary

PR #541 (feat/decision-gate-hook, merged as 74aeee44) shipped `mcp_server/hooks/decision_gate.py` with three review blockers, reproduced and fixed here.

1. Crash on unreadable input: `Path.read_text` caught only `OSError`; a `UnicodeDecodeError` (a `ValueError`) or a null byte in the path crashed the hook and blocked every edit to that file. Both read call sites now share a `_read_text` helper catching `(OSError, ValueError)`.
2. No lexical awareness: a module docstring followed by a licence block, and a heredoc body containing commented example data, were both blocked as if they were decisions. `mcp_server/hooks/_decision_gate_lex.py` (new) scans Python comments via `tokenize.COMMENT`, tolerates a leading docstring as header material, and skips shell heredoc bodies.
3. Grandfathering broke on reflow: keying a run by its exact joined text meant inserting or removing a bare marker line inside an existing block reset the key and lost the grandfather. It now compares the set of existing body-comment line texts against the candidate run.

Two further findings from the review, resolved:
- `is_test_path` now recognizes `tests_js` and `*.test.*`/`*.spec.*` filenames uniformly across languages (a Python test file was exempt while the same shape under a JS test root was not).
- `COMMENT_MARKERS` narrowed to the `#`-comment languages the eight-line threshold was actually measured against on the tracked tree (`.py`: 1418 files, `.sh`: 18 files); `//` and `/* */` markers had zero non-test tracked instances and are dropped until measured.

The case the gate exists for still blocks: a 10- or 12-line rationale block added to a script (regression test added).

## Why a new PR

#541 merged to `main` (74aeee44) before this fix was ready; the remote branch was deleted on merge. This is a follow-up fix branched from current `main`, not an amendment to the closed PR.

## Test plan

- `tests_py/hooks/test_decision_gate.py`: 19 tests, one per blocker reproduced against `evaluate` pre-fix and passing post-fix, plus two through the real entry point (`test_entrypoint_exits_two_on_a_blocked_write`, `test_entrypoint_never_crashes_on_an_unreadable_file`) so the exit code is covered. `test_still_blocks_a_ten_to_twelve_line_rationale` pins the non-negotiable case.
- `.venv/bin/python -m pytest tests_py/ -q`: 8005 passed, 290 skipped, 1 failed (`test_pg_driver_passes_in_dev_env`, pre-existing, environment-dependent, unrelated to this change — this dev venv was installed with `--extra sqlite` only, not `--extra postgresql`).
- `ruff check` / `ruff format --check`: clean.
- `scripts/check_craftsmanship.py`: OK (`decision_gate.py` 247 lines, new `_decision_gate_lex.py` 83 lines).
- `scripts/check_doc_claims.py`: OK.
- `scripts/check_project_wiki.py`: OK, `docs/adr/` mirror regenerated via `--write`.

`wiki/adr/cortex/1060-...md` carries a revision section describing what changed and why; `CHANGELOG.md` Added/Fixed entries describe the shipped behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)