### PR TITLE
fix(benchmarks): reproduce.sh --only fails closed on a selector that runs nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`benchmarks/reproduce.sh --only` no longer accepts a selector that runs nothing.**
+  `--only` was compared token for token against `longmemeval`, `locomo`, `beam`
+  and `decision-ids`, while the script itself prints the artifact names
+  `longmemeval-s` and `beam-100K`. Passing one of those, or any typo, matched
+  no benchmark: the script built the package, started and stopped an ephemeral
+  container, wrote `MANIFEST.json` and `START_SNAPSHOT.json`, measured nothing
+  and exited 0. Observed on 2026-09-09 while re-measuring v4.20.0. A new
+  sourced library, `benchmarks/lib/bench_only.sh`, normalises the two aliases to
+  the tokens `want_bench` matches and fails closed on an unknown or empty token
+  with exit 2 and the accepted list, before any `uv run` or container start.
+
 ## [4.20.0] - 2026-09-09
 
 ### Added

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -52,7 +52,7 @@ deterministic.
 
 | Flag | Effect |
 |---|---|
-| `--only longmemeval,locomo,beam` | run only these benchmarks |
+| `--only longmemeval,locomo,beam` | run only these benchmarks; `decision-ids` is also accepted, and the artifact names `longmemeval-s` and `beam-100K` are aliases. An unknown or empty token fails closed with exit 2 before anything runs |
 | `--no-ablation` / `--ablation-only` | skip the sweep / skip the plain benchmarks |
 | `--ablate-on locomo\|beam\|longmemeval` | which benchmark the sweep drives (default `locomo`) |
 | `--quick` | small per-benchmark limits (fast end-to-end check) |

--- a/benchmarks/lib/bench_only.sh
+++ b/benchmarks/lib/bench_only.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# source: ADR-0859
+# Sourced by benchmarks/reproduce.sh. Pure functions, no side effects.
+
+# Canonical selection tokens want_bench() matches, plus the aliases the
+# script itself prints as artifact names (ablation_bench_id).
+# source: ADR-0859
+BENCH_ONLY_CANONICAL="longmemeval locomo beam decision-ids"
+
+bench_only_canonical_token() {
+    case "$1" in
+        longmemeval|longmemeval-s) echo "longmemeval" ;;
+        beam|beam-100K)            echo "beam" ;;
+        locomo)                    echo "locomo" ;;
+        decision-ids)              echo "decision-ids" ;;
+        *)                         return 1 ;;
+    esac
+}
+
+# Rewrites ONLY as canonical comma-separated tokens, or fails closed with
+# the accepted list on stderr. An empty ONLY means every benchmark.
+# source: ADR-0859
+validate_only() {
+    [ -z "${ONLY:-}" ] && return 0
+    case ",$ONLY," in (*,,*)
+        echo "error: --only contains an empty token in '$ONLY'" >&2
+        echo "accepted: $BENCH_ONLY_CANONICAL (aliases: longmemeval-s, beam-100K)" >&2
+        return 2 ;;
+    esac
+    local raw token canonical out=""
+    IFS=',' read -r -a raw <<< "$ONLY"
+    for token in "${raw[@]}"; do
+        if [ -z "$token" ]; then
+            echo "error: --only contains an empty token in '$ONLY'" >&2
+            echo "accepted: $BENCH_ONLY_CANONICAL (aliases: longmemeval-s, beam-100K)" >&2
+            return 2
+        fi
+        if ! canonical="$(bench_only_canonical_token "$token")"; then
+            echo "error: --only '$token' selects no benchmark; nothing would run." >&2
+            echo "accepted: $BENCH_ONLY_CANONICAL (aliases: longmemeval-s, beam-100K)" >&2
+            return 2
+        fi
+        out="${out:+$out,}$canonical"
+    done
+    ONLY="$out"
+}

--- a/benchmarks/reproduce.sh
+++ b/benchmarks/reproduce.sh
@@ -161,6 +161,8 @@ started_container=0
 
 # shellcheck source=benchmarks/lib/bench_regression.sh
 . "$REPO_ROOT/benchmarks/lib/bench_regression.sh"
+# shellcheck source=benchmarks/lib/bench_only.sh
+. "$REPO_ROOT/benchmarks/lib/bench_only.sh"
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 need_cmd() {
@@ -193,6 +195,7 @@ parse_args() {
             *)               PASSTHROUGH+=("$1"); shift ;;
         esac
     done
+    validate_only || exit 2
     check_reranker_cell
 }
 

--- a/tests_py/benchmarks/test_reproduce_only_validation.py
+++ b/tests_py/benchmarks/test_reproduce_only_validation.py
@@ -1,0 +1,103 @@
+"""`--only` fails closed: an unknown selector must never yield an empty run.
+
+Observed on 2026-09-09: `reproduce.sh --only longmemeval-s` (the artifact
+name the script itself prints) matched nothing, started and stopped a
+container, wrote MANIFEST.json and START_SNAPSHOT.json, measured nothing and
+exited 0. These tests pin the library that now validates the flag, and the
+script's behaviour end to end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+LIBRARY = REPO / "benchmarks/lib/bench_only.sh"
+SCRIPT = REPO / "benchmarks/reproduce.sh"
+
+
+def _validate(only: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; ONLY="$2"; validate_only && printf "%s" "$ONLY"',
+            "bash",
+            str(LIBRARY),
+            only,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        ("longmemeval", "longmemeval"),
+        ("longmemeval-s", "longmemeval"),
+        ("beam-100K", "beam"),
+        ("longmemeval-s,beam-100K,locomo", "longmemeval,beam,locomo"),
+        ("decision-ids", "decision-ids"),
+    ],
+)
+def test_aliases_normalise_to_the_tokens_want_bench_matches(
+    given: str, expected: str
+) -> None:
+    done = _validate(given)
+    assert done.returncode == 0, done.stderr
+    assert done.stdout == expected
+
+
+@pytest.mark.parametrize(
+    "given", ["bogus", "longmemeval,bogus", "longmemeval,", ",locomo"]
+)
+def test_unknown_or_empty_token_fails_closed_naming_the_accepted_values(
+    given: str,
+) -> None:
+    done = _validate(given)
+    assert done.returncode == 2
+    assert "accepted:" in done.stderr
+    for token in ("longmemeval", "locomo", "beam", "decision-ids"):
+        assert token in done.stderr
+
+
+def test_empty_only_means_every_benchmark() -> None:
+    done = _validate("")
+    assert done.returncode == 0
+    assert done.stdout == ""
+
+
+def test_script_rejects_an_unknown_selector_before_doing_anything(
+    tmp_path: Path,
+) -> None:
+    """End to end on the real script: exit 2, the message, and no artifact.
+
+    Validation runs before any `uv run` or container start, so this test
+    needs neither Docker nor a synced environment and returns in well under a
+    second. The pre-fix script instead built the package, started a container
+    and wrote MANIFEST.json for an empty run.
+    """
+    out = tmp_path / "out"
+    done = subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "--only",
+            "bogus",
+            "--no-ablation",
+            "--results-dir",
+            str(out),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert done.returncode == 2, done.stdout + done.stderr
+    assert "selects no benchmark" in done.stderr
+    assert not out.exists() or not any(out.iterdir())


### PR DESCRIPTION
## Summary

`benchmarks/reproduce.sh --only` compared its value token for token against `longmemeval`, `locomo`, `beam` and `decision-ids`, while the script itself prints the artifact names `longmemeval-s` and `beam-100K`. Passing one of those, or any typo, matched no benchmark: the script built the package, started and stopped an ephemeral container, wrote `MANIFEST.json` and `START_SNAPSHOT.json`, measured nothing and exited 0.

Observed on 2026-09-09 while re-measuring v4.20.0, and reproduced on `main` before writing the fix (see the test plan). An empty run that reports success is the silent fallback this repository forbids elsewhere.

### The fix

A new sourced library, `benchmarks/lib/bench_only.sh`, on the pattern of `benchmarks/lib/bench_regression.sh`: `bench_only_canonical_token` maps the two aliases to the tokens `want_bench` matches, and `validate_only` rewrites `ONLY` as canonical comma-separated tokens or fails closed with exit 2 and the accepted list on stderr. It runs at the end of `parse_args`, before `check_reranker_cell`, so before any `uv run` or container start. An empty token (leading, trailing or doubled comma) is rejected too; `read -a` would otherwise drop a trailing empty field silently.

`benchmarks/README.md` documents the aliases and the fail-closed behaviour. `--ablate-on` takes benchmark names through the same alias table but is not validated here; noted, not folded in.

## Type of change

- [x] Bug fix

## Test plan

RED, on `main`, before the change: `bash benchmarks/reproduce.sh --only bogus --no-ablation --results-dir <tmp>` exited 0 after building the package, starting container `cortex-bench-pg-17377`, and writing `MANIFEST.json` and `START_SNAPSHOT.json`; no error, nothing measured.

GREEN, after: the same invocation prints `error: --only 'bogus' selects no benchmark; nothing would run.` plus the accepted list, exits 2 in well under a second, and writes nothing. `ONLY="longmemeval-s,beam-100K"` is rewritten to `longmemeval,beam`.

`tests_py/benchmarks/test_reproduce_only_validation.py`, 11 tests: alias normalisation for each alias and a mixed list, `decision-ids` accepted, unknown token, unknown token in a list, trailing and leading empty tokens all rejected with the accepted list named, empty `--only` meaning every benchmark, and one end-to-end test of the real script that needs neither Docker nor a synced environment because validation precedes both.

Mutations these catch: removing the alias table (the normalisation cases fail), removing the empty-token guard (the trailing-comma case passes silently again), and moving `validate_only` after `check_reranker_cell` or the container start (the end-to-end test would need Docker and stop returning in under a second).

Gates on the final state: `bash -n` on both scripts, `shellcheck -S warning` clean on the new library (the three SC2034 warnings on `reproduce.sh` pre-date this change and CI's shellcheck step covers workflow files only), `ruff check` and `ruff format --check` on the tree, `scripts/check_craftsmanship.py`, `scripts/check_doc_claims.py`, and `tests_py/benchmarks/test_bench_regression_datasets.py` still green.

- [x] All existing tests pass.
- [x] New tests added for new behavior.
- [x] Mutation survival check: listed above.
- [x] Manual verification: the RED and GREEN runs above.

## Audit notes

Self-review plus the RED/GREEN evidence. A fresh-context review is requested before merge.

## Reviewer checklist

- [x] CHANGELOG.md updated under Fixed.
- [x] Documentation updated (`benchmarks/README.md`).
- [x] No secrets or PII in the diff.
- [ ] CI passes on the latest commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)