### PR TITLE
docs: reflect the v4.20.0 LongMemEval-S measurement in the README, with its artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ v4.14.1, 2026-07-14: [artifact JSON](benchmarks/results/repro/20260714-v4.14.1-p
 This is the run the ablation campaign in [Verification](#verification) was built around.
 
 v4.20.0, 2026-09-09: [artifact JSON](benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/longmemeval-s.json) and its
-[manifest](benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/MANIFEST.json); [code SHA](https://github.com/cdeust/Cortex/commit/86251ab8fc27a18f80f9b09b99a75f3b60edd9cb).
-A single run of the LongMemEval-S leg alone (`benchmarks/reproduce.sh --only longmemeval
+[manifest](benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/MANIFEST.json); [code SHA](https://github.com/cdeust/Cortex/commit/86251ab8fc27a18f80f9b09b99a75f3b60edd9cb),
+dirty=false. A single run of the LongMemEval-S leg alone (`benchmarks/reproduce.sh --only longmemeval
 --no-ablation`) in an isolated ephemeral PostgreSQL container, reranker loaded, consolidation
 disabled. Against v4.14.1 the change is 0.4 points of Recall@10 and 0.012 of MRR. The run's own
 floor check reports Recall@10 within the 0.005 tolerance of the July floor (0.982) and MRR

--- a/README.md
+++ b/README.md
@@ -188,14 +188,28 @@ from it.
 
 **LongMemEval**: 500 human-curated questions buried in about 40 sessions of history.
 
-| Historical Cortex run (v4.14.1) | Result |
-|---|---|
-| Recall@10 | **98.2%** |
-| MRR | **0.9167** |
+| | v4.14.1 (historical) | v4.20.0 (current release) |
+|---|---|---|
+| Recall@10 | **98.2%** | **97.8%** |
+| MRR | **0.9167** | **0.905** |
 
-Historical single run from v4.14.1, not a v4.20.0 performance result: n=500, clean database,
-consolidation disabled. [Artifact JSON](benchmarks/results/repro/20260714-v4.14.1-pretag/longmemeval-s.json);
+Both are single runs: n=500, clean database, consolidation disabled, retrieval only.
+
+v4.14.1, 2026-07-14: [artifact JSON](benchmarks/results/repro/20260714-v4.14.1-pretag/longmemeval-s.json);
 [code SHA](https://github.com/cdeust/Cortex/commit/28145f0b7a113fc06e22568de6feea7f8444eaf5).
+This is the run the ablation campaign in [Verification](#verification) was built around.
+
+v4.20.0, 2026-09-09: [artifact JSON](benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/longmemeval-s.json) and its
+[manifest](benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/MANIFEST.json); [code SHA](https://github.com/cdeust/Cortex/commit/86251ab8fc27a18f80f9b09b99a75f3b60edd9cb).
+A single run of the LongMemEval-S leg alone (`benchmarks/reproduce.sh --only longmemeval
+--no-ablation`) in an isolated ephemeral PostgreSQL container, reranker loaded, consolidation
+disabled. Against v4.14.1 the change is 0.4 points of Recall@10 and 0.012 of MRR. The run's own
+floor check reports Recall@10 within the 0.005 tolerance of the July floor (0.982) and MRR
+0.0093 below its floor (0.914), which the script treats as non-blocking by design;
+[docs/agent-guidance.md](docs/agent-guidance.md) records that `main` no longer clears those
+floors and that the release gate is `--no-regression` against `origin/main`. The same tree has
+no LoCoMo or BEAM figure yet.
+
 Reproduce with `benchmarks/reproduce.sh`, which runs in an isolated ephemeral container, never
 against a live store.
 
@@ -363,7 +377,7 @@ measured one.
 
 ## Verification
 
-Every benchmark headline above is backed by a per-mechanism ablation campaign — full *n*, single-seed, with code SHAs, dirty flags, manifests, and per-row JSON preserved:
+The v4.14.1 figures above are backed by a per-mechanism ablation campaign — full *n*, single-seed, with code SHAs, dirty flags, manifests, and per-row JSON preserved; the v4.20.0 figures are a single measurement without one:
 
 - **LongMemEval-S, 17 rows, n=500** — `docs/benchmarks/e1-v3-results.md`. Per-mechanism deltas at the calibrated equilibrium + category-specialization analysis.
 - **LoCoMo, 14 rows, n=1986** — `docs/benchmarks/e1-v3-locomo-results.md` (pre-fix) and `docs/benchmarks/e1-v3-locomo-results-post-fix.md` (post plasticity result-shape fix). Two-baseline design (NO_CONSOLIDATION / WITH_CONSOLIDATION).

--- a/benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/MANIFEST.json
+++ b/benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/MANIFEST.json
@@ -1,0 +1,55 @@
+{
+  "git_sha": "86251ab8fc27a18f80f9b09b99a75f3b60edd9cb",
+  "machine_load_at_start": {
+    "load_average_1m": 4.45703125,
+    "load_average_5m": 5.33642578125,
+    "load_average_15m": 5.6650390625,
+    "cpu_count": 10,
+    "concurrent_pytest_processes": 0,
+    "concurrent_docker_containers": 1
+  },
+  "disk_space_at_start": {
+    "repo_root": {
+      "path": "/Users/cdeust/Developments/anthropic-partnership/Cortex/.claude/worktrees/bench-v4200",
+      "free_bytes": 12583370752,
+      "total_bytes": 494384795648
+    },
+    "docker_root": null
+  },
+  "machine_load_at_end": {
+    "load_average_1m": 10.8740234375,
+    "load_average_5m": 7.60400390625,
+    "load_average_15m": 6.87109375,
+    "cpu_count": 10,
+    "concurrent_pytest_processes": 0,
+    "concurrent_docker_containers": 2
+  },
+  "disk_space_at_end": {
+    "repo_root": {
+      "path": "/Users/cdeust/Developments/anthropic-partnership/Cortex/.claude/worktrees/bench-v4200",
+      "free_bytes": 10084896768,
+      "total_bytes": 494384795648
+    },
+    "docker_root": null
+  },
+  "longmemeval_dataset_sha256": "08d8dad4be43ee2049a22ff5674eb86725d0ce5ff434cde2627e5e8e7e117894",
+  "pg_image": "pgvector/pgvector:pg16",
+  "bench_container_name": "cortex-bench-pg-39984-6be2ee96",
+  "bench_container_port": 32771,
+  "bench_runner_pid": 39984,
+  "python": "3.12.11",
+  "packages": {
+    "datasets": "5.0.1",
+    "sentence-transformers": "5.6.1",
+    "torch": "2.13.0",
+    "psycopg": "3.3.5",
+    "psycopg-pool": "3.3.1"
+  },
+  "embedding_model_revision": "1110a243fdf4706b3f48f1d95db1a4f5529b4d41",
+  "reranker_active": true,
+  "reranker_state": "loaded",
+  "reranker_model_sha256": "d3dd7b09fcf06b0c070081d6819b5effbb40b667bcad78b2d7543400271141d1",
+  "results_files": [
+    "longmemeval-s.json"
+  ]
+}

--- a/benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/START_SNAPSHOT.json
+++ b/benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/START_SNAPSHOT.json
@@ -1,0 +1,19 @@
+{
+  "captured_at_utc": "2026-09-09T18:20:19.768111+00:00",
+  "machine_load": {
+    "load_average_1m": 4.45703125,
+    "load_average_5m": 5.33642578125,
+    "load_average_15m": 5.6650390625,
+    "cpu_count": 10,
+    "concurrent_pytest_processes": 0,
+    "concurrent_docker_containers": 1
+  },
+  "disk_space": {
+    "repo_root": {
+      "path": "/Users/cdeust/Developments/anthropic-partnership/Cortex/.claude/worktrees/bench-v4200",
+      "free_bytes": 12583370752,
+      "total_bytes": 494384795648
+    },
+    "docker_root": null
+  }
+}

--- a/benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/longmemeval-s.json
+++ b/benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/longmemeval-s.json
@@ -1,0 +1,54 @@
+{
+  "overall_mrr": 0.9046547619047619,
+  "overall_recall10": 0.978,
+  "category_mrr": {
+    "Single-session (user)": 0.8347789115646259,
+    "Multi-session reasoning": 0.9563492063492063,
+    "Single-session (preference)": 0.6692592592592593,
+    "Temporal reasoning": 0.9001969208736127,
+    "Knowledge updates": 0.9089031339031339,
+    "Single-session (assistant)": 1.0
+  },
+  "category_recall10": {
+    "Single-session (user)": 0.9571428571428572,
+    "Multi-session reasoning": 0.9924812030075187,
+    "Single-session (preference)": 0.9,
+    "Temporal reasoning": 0.9774436090225563,
+    "Knowledge updates": 0.9871794871794872,
+    "Single-session (assistant)": 1.0
+  },
+  "elapsed_s": 1903.5971871659858,
+  "consolidation_total_wall_s": 0.0,
+  "consolidation_call_count": 0,
+  "manifest": {
+    "with_consolidation": false,
+    "with_consolidation_note": "Scores collected with consolidation=False do NOT reflect production behaviour.  Consolidation-only mechanisms (CASCADE, INTERFERENCE, HOMEOSTATIC_PLASTICITY, SYNAPTIC_PLASTICITY, MICROGLIAL_PRUNING, TWO_STAGE_MODEL, EMOTIONAL_DECAY, TRIPARTITE_SYNAPSE, SCHEMA_ENGINE) are exercised only when with_consolidation=True.  Delta between the two conditions is unmeasured in this run.",
+    "ablate_mechanism": null,
+    "ablate_env_var": null,
+    "n_questions": 500,
+    "n_runs": 1,
+    "consolidation_call_count": 0,
+    "consolidation_total_wall_s": 0.0,
+    "repro": {
+      "git_commit": "86251ab8fc27a18f80f9b09b99a75f3b60edd9cb",
+      "git_dirty": false,
+      "python_version": "3.12.11 (main, Sep 18 2025, 19:41:45) [Clang 20.1.4 ]",
+      "platform_system": "Darwin",
+      "platform_machine": "arm64",
+      "platform_node": "mac-1.home",
+      "timestamp_utc": "2026-09-09T18:20:23.150679+00:00",
+      "lib_versions": {
+        "sentence-transformers": "5.6.1",
+        "torch": "2.13.0",
+        "numpy": "2.5.1",
+        "psycopg": "3.3.5",
+        "pgvector": "0.5.0",
+        "flashrank": "0.2.10"
+      },
+      "reranker_active": true,
+      "reranker_state": "loaded",
+      "reranker_model_path": "/Users/cdeust/.cache/flashrank/ms-marco-MiniLM-L-12-v2/flashrank-MiniLM-L-12-v2_Q.onnx",
+      "reranker_model_sha256": "d3dd7b09fcf06b0c070081d6819b5effbb40b667bcad78b2d7543400271141d1"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The README's retrieval table cited only the v4.14.1 pre-tag run. This adds the v4.20.0 figure beside it, backed by artifacts produced for this change on the exact tagged tree, and scopes the Verification lead-in so it no longer claims an ablation campaign behind a figure that has none.

### The measurement

`benchmarks/reproduce.sh --only longmemeval --no-ablation`, run from a detached worktree at the v4.20.0 commit (86251ab8), isolated ephemeral `pgvector/pgvector:pg16` container, reranker loaded, consolidation disabled, n=500.

| | v4.14.1 | v4.20.0 |
|---|---|---|
| Recall@10 | 98.2% | 97.8% |
| MRR | 0.9167 | 0.905 (0.9047) |

Artifacts committed under `benchmarks/results/repro/20260909-v4.20.0-longmemeval-s/`: `longmemeval-s.json` (overall and per-category metrics, elapsed 1903.6 s, zero consolidation calls, embedded manifest), `MANIFEST.json` (git SHA, dataset sha256, image, embedding model revision, reranker state, Python 3.12.11), `START_SNAPSHOT.json`. The standalone MANIFEST.json has no dirty flag field, but the JSON's embedded `manifest.repro.git_dirty` is `false`, and the README now states dirty=false from it; the first cut of this body claimed no flag existed, which the fresh-context review corrected.

The run's own floor check: Recall@10 0.978 against the July floor 0.982 is within the 0.005 tolerance and passes; MRR 0.9047 against 0.914 is 0.0093 below and fails, which the script treats as non-blocking by design. `docs/agent-guidance.md` already records that `main` no longer clears those floors and that the release gate is `--no-regression` against `origin/main`. LoCoMo and BEAM have no v4.20.0 figure; both legs of the earlier full run were killed by the host for memory pressure, and this change measures only the leg it cites.

### README changes

- The retrieval table gains a v4.20.0 column with its own provenance paragraph: artifact JSON, manifest, code SHA, run conditions, delta against v4.14.1, and the floor-check outcome stated as the script reports it.
- The Verification lead-in now reads that the v4.14.1 figures are backed by the ablation campaign and that the v4.20.0 figures are a single measurement without one. The previous sentence covered "every benchmark headline above", which would have been false once this column existed.

### Why this run and not the earlier one

A full `reproduce.sh` run on the same tree earlier today completed this leg with the same numbers (0.905 / 0.978) before the host killed it, and its `longmemeval-s.json` was then lost. The surviving run log could not be committed: `.gitignore` excludes `benchmarks/results/**/*.log`, and citing an artifact absent from the tree is not allowed here. Re-measuring was the only honest route, and the first attempt at that exposed a script defect fixed separately in #550 (`--only longmemeval-s` silently selected nothing).

## Type of change

- [x] Documentation
- [x] Benchmark artifact

## Test plan

- Every relative link resolves, including the three new artifact paths.
- `scripts/check_doc_claims.py`, `scripts/check_version_surfaces.py` (17 sites): green.
- `tests_py/scripts/test_codex_plugin_contract.py` and `test_version_surfaces.py`: 33 pass.
- Table cells were asserted against the JSON in the script that edited the README (0.978 exact; MRR rounds to 0.905).

- [x] All existing tests pass.
- [x] Manual verification: link resolution and cell-to-artifact assertion.

## Audit notes

Self-review plus the artifacts. A fresh-context review is requested before merge.

## Reviewer checklist

- [x] CHANGELOG.md unchanged; documentation and artifact addition.
- [x] No secrets or PII in the diff.
- [ ] CI passes on the latest commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)