### PR TITLE
chore(marketplace): deliver zetetic-team-subagents v2.40.0 and hypermnesia-mcp-viz v3.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,11 +62,11 @@
       "source": {
         "source": "github",
         "repo": "cdeust/cortex-viz",
-        "ref": "v3.1.1",
-        "sha": "33fa1646ec3eb4f9045b4d4df91bc6872ac951a7"
+        "ref": "v3.1.2",
+        "sha": "cd471aa9750c356ced8048394c9ac28fff0da605"
       },
       "description": "Canonical Claude Code publication for the standalone Hypermnesia MCP Viz server — a live neural-graph galaxy of every project, file, symbol, memory, discussion and wiki page, plus a per-session execution trace, a consolidation kanban, and a curated knowledge/wiki browser. Read-only bridge over Cortex's shared PostgreSQL store and the ~/.claude artifacts; it renders, it never remembers. Restores the open_visualization and get_methodology_graph tools removed from Cortex; launch with /cortex-visualize.",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"
@@ -107,11 +107,11 @@
       "source": {
         "source": "github",
         "repo": "cdeust/zetetic-team-subagents",
-        "ref": "v2.39.0",
-        "sha": "f1a9bbd7683c7120a5e9a3390ed3e8ed3ad8a55e"
+        "ref": "v2.40.0",
+        "sha": "657795b87d884f465d218492cc368ba25525307d"
       },
       "description": "Zetetic agent team for Cortex — 97 genius reasoning patterns from history's greatest minds + 23 team specialists (architect, engineer, code-reviewer, refactorer, …), 78 skills, 26 commands, 42 tools, 20 hooks, under one epistemic standard none of them can bypass. Composes with Cortex memory: every agent recalls/remembers through the Cortex MCP and routes via /genius, /agent, /zetetic, /quality, /research commands.",
-      "version": "2.39.0",
+      "version": "2.40.0",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"


### PR DESCRIPTION
## Summary

Moves the two GitHub-sourced pins in `.claude-plugin/marketplace.json` to the releases cut today:

- zetetic-team-subagents `v2.40.0` (sha `657795b87d884f465d218492cc368ba25525307d`), release run 34403584553 green with attested assets
- hypermnesia-mcp-viz `v3.1.2` (sha `cd471aa9750c356ced8048394c9ac28fff0da605`, squash commit of cdeust/cortex-viz#155), Release.yaml run 34404519539: test, build/attest/GitHub Release green

Until this lands both releases reach zero installs (docs/agent-guidance.md, Releasing; #179).

## Verification

`python3 scripts/check_marketplace_pins.py` exits 0 on this branch with both pins current (the only NOTICE is the pre-existing registry lag on hypermnesia-mcp 4.19.1 vs 4.20.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)