### PR TITLE
chore(marketplace): deliver zetetic-team-subagents v2.40.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,11 +107,11 @@
       "source": {
         "source": "github",
         "repo": "cdeust/zetetic-team-subagents",
-        "ref": "v2.40.0",
-        "sha": "657795b87d884f465d218492cc368ba25525307d"
+        "ref": "v2.40.1",
+        "sha": "586e439e575e9759c3224b840768d15c3604ac2f"
       },
       "description": "Zetetic agent team for Cortex — 97 genius reasoning patterns from history's greatest minds + 23 team specialists (architect, engineer, code-reviewer, refactorer, …), 78 skills, 26 commands, 42 tools, 20 hooks, under one epistemic standard none of them can bypass. Composes with Cortex memory: every agent recalls/remembers through the Cortex MCP and routes via /genius, /agent, /zetetic, /quality, /research commands.",
-      "version": "2.40.0",
+      "version": "2.40.1",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"


### PR DESCRIPTION
## Summary

Moves the zetetic-team-subagents pin to `v2.40.1` (sha `586e439e575e9759c3224b840768d15c3604ac2f`, GitHub release published, run 34414208829 green). The release carries one change, zetetic-team-subagents #135: the worktree sweep recognises squash merges and `<repo>/.claude/worktrees`, the Linux age probe is fixed, and `worktree-manager.sh inventory` reports every worktree with the verdict sweep will apply. Until this pin moves, installs keep the sweep that removed nothing for two months (30 merged worktrees measured standing on 2026-09-10).

## Verification

`python3 scripts/check_marketplace_pins.py` exits 0 on this branch: "All marketplace pins current" (the only NOTICE is the pre-existing registry lag on hypermnesia-mcp 4.19.1 vs 4.20.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)