### PR TITLE
chore(marketplace): deliver zetetic-team-subagents v2.41.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,11 +107,11 @@
       "source": {
         "source": "github",
         "repo": "cdeust/zetetic-team-subagents",
-        "ref": "v2.40.1",
-        "sha": "586e439e575e9759c3224b840768d15c3604ac2f"
+        "ref": "v2.41.0",
+        "sha": "77b4f78503e6842928039b75440e20ea670584c8"
       },
       "description": "Zetetic agent team for Cortex — 97 genius reasoning patterns from history's greatest minds + 23 team specialists (architect, engineer, code-reviewer, refactorer, …), 78 skills, 26 commands, 42 tools, 20 hooks, under one epistemic standard none of them can bypass. Composes with Cortex memory: every agent recalls/remembers through the Cortex MCP and routes via /genius, /agent, /zetetic, /quality, /research commands.",
-      "version": "2.40.1",
+      "version": "2.41.0",
       "author": {
         "name": "Clement Deust",
         "email": "admin@ai-architect.tools"


### PR DESCRIPTION
## Summary

Moves the zetetic-team-subagents pin to `v2.41.0` (sha `77b4f78503e6842928039b75440e20ea670584c8`, GitHub release published after a re-run of the attestation step that GitHub's trust-metadata service had refused once). One change since v2.40.1, zetetic-team-subagents #137 (owner issue #136): every state file the plugin owns lives under `~/.claude/zetetic/`, an existing flat install is migrated once without overwriting anything, and `setup.sh` ends with a layout report.

## Verification

`python3 scripts/check_marketplace_pins.py` exits 0 on this branch: "All marketplace pins current".

🤖 Generated with [Claude Code](https://claude.com/claude-code)