### PR TITLE
fix(hooks): the decision gate judges every language, test file and header (ADR-1060 revision, no exception)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The decision gate no longer exempts a language, a test file or a file
+  header (#555).** Owner ruling of 2026-09-10 on ADR-1060, no exception. On
+  that day six lines of `///` rationale written into a `tests/*.rs` file
+  passed `mcp_server/hooks/decision_gate.py` because each of its three
+  exemptions sufficed alone: `//` and `/* */` languages were deferred "until
+  measured", the path was under a test root, and the run sat before anything
+  executable. All three are removed. `mcp_server/hooks/_decision_gate_lex.py`
+  now reads `//` and `/* */` (`.rs .js .jsx .ts .tsx .go .java .c .h .cpp
+  .hpp .cc .swift .kt .kts .cs .scala .m .mm .dart .php`), `--` (`.sql .lua
+  .hs`) and `;` (`.el .clj .lisp`) through one scanner that tracks string
+  literals and block comments, alongside the `#` family (`.py .sh .bash .zsh
+  .rb .pl .toml .yaml .yml .r .cfg .ini`), so a `//` inside a string literal
+  is never a comment; a Python comment after code on the same line no longer
+  counts as a comment line. Unchanged: the eight-line threshold,
+  grandfathering of blocks already in the file (only what the call introduces
+  is judged, so the ten tracked files with a long header stay editable), the
+  `source:` pointer line, fail-open on unreadable input and the explicit
+  `CORTEX_DECISION_GATE=off` override. The refusal states the new scope. The
+  measurement behind the header ruling is in the ADR's revision section.
+
 - **`benchmarks/reproduce.sh --only` no longer accepts a selector that runs nothing.**
   `--only` was compared token for token against `longmemeval`, `locomo`, `beam`
   and `decision-ids`, while the script itself prints the artifact names

--- a/docs/adr/ADR-1060-refuse-a-decision-written-into-code-at-edit-time-in-the-distributed-hook.md
+++ b/docs/adr/ADR-1060-refuse-a-decision-written-into-code-at-edit-time-in-the-distributed-hook.md
@@ -34,7 +34,7 @@ Two exemptions are needed or the rule is unusable. A file's opening block orient
 
 A line carrying a `source:` pointer never counts toward a run: that is the sanctioned way to reference a decision, and the refusal message names `wiki_adr` as where the prose belongs and the pointer form to leave behind.
 
-Exempt: the file's header block, defined as a run preceded by nothing executable; test files; and any block already present in the file, so editing an unrelated part of a legacy file is never refused. Only what the call introduces is judged.
+Only what the call introduces is judged: a block already present in the file is grandfathered, so editing an unrelated part of a legacy file is never refused. No path, header block or comment-marker language is exempt. (The first revision exempted the file's header block, defined as a run preceded by nothing executable, and test files; both exemptions were withdrawn on 2026-09-10, see the revision below.)
 
 `CORTEX_DECISION_GATE=off` overrides for a single call, for genuine non-decision prose such as a worked example or a data table, and requires saying why.
 
@@ -48,7 +48,34 @@ A review of the first cut found the hook crashing on unreadable input, misreadin
 
 **Grandfathering compares content, not position.** The original ratchet keyed a run by its exact joined text; inserting or removing a single bare marker line inside an existing block changed the key, so a pure rewrap of a block already in the file was reported as newly introduced. Grandfathering now compares the set of body-comment line texts already in the file against the candidate run's lines: a run is refused only when the count of lines *not* already present anywhere in the file's body prose reaches the threshold, so reflowing an existing block is never treated as new.
 
-**Two further findings changed what's enforced, not just how it's checked.** `is_test_path` recognised only `tests`/`tests_py`/`test`/`fuzz` and the Python `test_*.py`/`*_test.py` shapes; `tests_js` — the repo's actual JS test root — and the `.spec.ts`/`.test.ts` filename shapes were unrecognised, so JS test files were scanned while their Python equivalents were exempt. The test-path check now also matches `tests_js` by name and any `*.test.*`/`*.spec.*` filename, uniformly across languages. Separately, `//` and `/* */` markers were never actually measured: the tracked tree (excluding `deps/`) holds 1418 `.py` files and 18 `.sh` files, but zero non-test files using `//` or `/* */` comments. `COMMENT_MARKERS` now covers only the `#`-comment languages the threshold was measured against — `.py`, `.sh`, `.bash`, `.zsh`, `.rb` — and drops `.js`/`.ts`/`.tsx`/`.jsx`/`.swift`/`.go`/`.rs`/`.java`/`.c`/`.h`/`.cpp` until there is tracked-tree evidence for them. This is a narrowing of enforcement, not a threshold change: `PROSE_RUN_LIMIT` is unchanged, and the hook still refuses the ten- and twelve-line rationale blocks it was built to catch.
+**Two further findings changed what's enforced, not just how it's checked** (both withdrawn by the revision of 2026-09-10 below). `is_test_path` recognised only `tests`/`tests_py`/`test`/`fuzz` and the Python `test_*.py`/`*_test.py` shapes; `tests_js` — the repo's actual JS test root — and the `.spec.ts`/`.test.ts` filename shapes were unrecognised, so JS test files were scanned while their Python equivalents were exempt. The test-path check now also matches `tests_js` by name and any `*.test.*`/`*.spec.*` filename, uniformly across languages. Separately, `//` and `/* */` markers were never actually measured: the tracked tree (excluding `deps/`) holds 1418 `.py` files and 18 `.sh` files, but zero non-test files using `//` or `/* */` comments. `COMMENT_MARKERS` now covers only the `#`-comment languages the threshold was measured against — `.py`, `.sh`, `.bash`, `.zsh`, `.rb` — and drops `.js`/`.ts`/`.tsx`/`.jsx`/`.swift`/`.go`/`.rs`/`.java`/`.c`/`.h`/`.cpp` until there is tracked-tree evidence for them. This is a narrowing of enforcement, not a threshold change: `PROSE_RUN_LIMIT` is unchanged, and the hook still refuses the ten- and twelve-line rationale blocks it was built to catch.
+
+### Revision 2026-09-10 — no exception
+
+Owner ruling, verbatim intent: "Révision de l'ADR-1060, pas d'exception". The gate applies to every comment-marker language, to test files and to header blocks alike.
+
+**The leak.** On 2026-09-10 six lines of `///` rationale were written into `ai-architect-mcp-codebase/tests/rust_local_receiver_static_resolution.rs` and the hook allowed the write. Three of its exemptions each sufficed on their own: (1) `COMMENT_MARKERS` covered only the `#` languages (`.py .sh .bash .zsh .rb`) and deferred `//`, `///` and `/* */` "until measured"; (2) `is_test_path` exempted the `tests` directory (with `tests_py`, `tests_js`, `test`, `fuzz`, and the `test_*`, `*_test`, `*.test.*`, `*.spec.*` file shapes); (3) the run was preceded by nothing executable, so it read as the file header. An exemption is a place for a decision to hide, and this one hid in all three at once.
+
+**Removed.** The language deferral: `mcp_server/hooks/_decision_gate_lex.py` now lexes `//` and `/* */` (`.rs .js .jsx .ts .tsx .go .java .c .h .cpp .hpp .cc .swift .kt .kts .cs .scala .m .mm .dart .php`), `--` (`.sql .lua .hs`), `;` (`.el .clj .lisp`) and the full `#` family (`.py .sh .bash .zsh .rb .pl .toml .yaml .yml .r .cfg .ini`). The new families go through one character-level scanner that tracks string literals (Rust raw strings and backtick strings included) and block comments, so a `//` or `/* */` inside a string literal never reads as a comment and every line a block comment crosses does; Python stays on `tokenize` and the shell family keeps its heredoc skip. The test-path exemption (`is_test_path`, `_TEST_DIRS`, `_TEST_FILE_RE`) is deleted. The header exemption (`_is_header_run` and the tokenizer's header boundary) is deleted. The refusal now states that no header, test file or language is exempt, so an agent that remembers the first revision is corrected at the point of refusal.
+
+**Kept, and why.** `PROSE_RUN_LIMIT` stays at 8: the threshold was measured, and the ruling changes where it applies, not what it is. Grandfathering stays: only what the call introduces is judged, so a legacy file with a thirty-line header is still editable, and the measurement below is what shows the ruling breaks nothing. A `source:` pointer line never counts toward a run: it is the sanctioned form. Unreadable or unparsable input still fails open. `CORTEX_DECISION_GATE=off` stays: it is a visible act in the transcript with a stated reason, not a silent exemption, and a gate with no escape hatch gets disabled wholesale.
+
+One narrowing of the Python scanner came with the rewrite: a comment token that follows code on the same line (`x = 1  # note`) no longer counts as a comment line, which is what that scanner's docstring already claimed and what the new scanner does for every other language.
+
+**Measurement.** Tracked tree at `8d71210f` (`origin/main` on 2026-09-10), every file whose suffix the gate now judges, scanned with the revised lexer. A header run is a run of eight or more comment lines preceded only by blank lines, comment lines, a shebang, a shell `set` line or the Python module docstring; test paths are the ones the deleted `is_test_path` used to exempt.
+
+| suffix | tracked files | header run of 8+ (code / test) | body run of 8+ (code / test) |
+|---|---|---|---|
+| `.py` | 1427 | 0 / 0 | 10 / 33 |
+| `.sh` | 20 | 4 / 0 | 1 / 0 |
+| `.yml` | 17 | 0 / 0 | 1 / 0 |
+| `.sql` | 12 | 5 / 0 | 1 / 0 |
+| `.yaml` | 1 | 0 / 0 | 0 / 0 |
+| `.toml` | 1 | 0 / 0 | 1 / 0 |
+| `.js` | 1 | 0 / 1 | 0 / 0 |
+| total | 1479 | 9 / 1 | 14 / 33 |
+
+Ten files carry a header run at or over the threshold, among them `benchmarks/reproduce.sh`, `scripts/install-plugin.sh`, `scripts/phase_0_4_5_backfill.sql` and `tests_js/spatial_hash.test.js`. Every one is grandfathered: editing any of them elsewhere is allowed, and only a new header of eight or more comment lines, or eight new lines added to an existing one, is refused. Nothing in the tree is blocked by the ruling. The number is recorded here so the owner decides on it, not the implementer.
 
 ## Consequences
 
@@ -56,12 +83,16 @@ Easier: the convention becomes a processing obligation rather than something a r
 
 Easier: the refusal carries its own remedy. It names the tool that records the decision and the pointer to leave, so the correction is mechanical rather than a research task.
 
-Harder: a handful of existing files carry a body block over the threshold. The ratchet grandfathers them, so nothing breaks, but they are now visibly on the wrong side of a stated rule and are candidates for migration to the wiki.
+Harder: existing files carry blocks over the threshold (at `8d71210f`: 10 with a header run, 47 with a body run, 33 of those under test roots). The ratchet grandfathers them, so nothing breaks, but they are now visibly on the wrong side of a stated rule and are candidates for migration to the wiki.
 
-Harder: `//` and `/* */` comment languages are unenforced until they have their own measured evidence. A ten-line C-style licence header written into a `.go` or `.java` file today passes silently. This is the accepted cost of not shipping an unverified threshold, not an oversight.
+Harder: a new file cannot open with eight or more comment lines, whatever the language. A licence or orientation header of that length is either shortened, replaced by a `source:` pointer to the page that holds the text, or written under `CORTEX_DECISION_GATE=off` with the reason stated. Since the revision of 2026-09-10 this is the chosen cost: a header exemption is a place for a decision to hide, and it did.
+
+Harder: a test file is judged like any other. A scenario narrated in eight or more comment lines moves into the test's docstring or the wiki; the same override applies.
 
 Risk accepted: the threshold is a shape heuristic. A decision written in seven lines passes, and a long data table written as comments is refused. The override covers the second; the first is a smaller failure than the one this closes.
 
 Risk accepted: an agent can set the override. That is deliberate. A gate with no escape hatch gets disabled wholesale, and requiring a stated reason keeps the choice visible in the transcript.
 
 Risk accepted: grandfathering by line-text set, not exact position, can under-block a new decision that happens to reuse phrasing already present elsewhere in the file. This trade was made deliberately to fix the reflow false-positive; the alternative (position-based keying) is what broke on a pure rewrap.
+
+Risk accepted: the scanner for the `//`, `--` and `;` families is a small state machine, not a parser. It tracks quoted strings (single-line unless the language lets them span lines, backtick and Rust raw strings always), character literals and block comments; it does not know every literal form of every language. Its failure mode is a comment hidden inside what it took for a string, which fails open, never a block refused for a string it took for a comment on a line holding code.

--- a/mcp_server/hooks/_decision_gate_lex.py
+++ b/mcp_server/hooks/_decision_gate_lex.py
@@ -3,22 +3,182 @@
 Split out of ``decision_gate.py`` to keep that module under the repo's
 300-line cap. A regex that treats every line starting with ``#`` or ``//``
 as a comment confuses string and heredoc bodies for prose; this module gives
-each supported marker family a scanner that does not.
-"""
+each supported marker family a scanner that does not. Python goes through
+``tokenize``, the shell family skips heredoc bodies, and every other family
+goes through one character-level scanner that tracks string literals and
+block comments (``_Scanner``).
+
+source: ADR-1060"""
 
 from __future__ import annotations
 
 import io
 import re
 import tokenize
+from dataclasses import dataclass
+from functools import partial
+from typing import Callable
 
 POINTER = "source:"
 
 _HEREDOC_START = re.compile(r"<<-?\s*['\"]?(?P<delim>\w+)['\"]?")
+_RAW_STRING = re.compile(r'r(#*)"')
+_CHAR_LITERAL = re.compile(r"'(?:\\.[^'\\\n]{0,8}|[^'\\\n])'")
 
-# Marker families that get a language-aware scanner. Every other suffix in
-# COMMENT_MARKERS falls back to a plain per-line prefix check.
-PYTHON_SUFFIX = ".py"
+
+@dataclass(frozen=True)
+class Family:
+    """How one comment-marker family is lexed by ``_Scanner``."""
+
+    line: tuple[str, ...]
+    block: tuple[str, str] | None
+    quotes: str
+    char_literal: bool = False
+    multiline_strings: bool = False
+    raw_strings: bool = False
+
+
+@dataclass(frozen=True)
+class Language:
+    """The pointer marker shown in a refusal, and the scanner for the suffix."""
+
+    marker: str
+    scan: Callable[[str], set[int]]
+
+
+C_FAMILY = Family(("//",), ("/*", "*/"), '"`', char_literal=True)
+RUST = Family(
+    ("//",),
+    ("/*", "*/"),
+    '"',
+    char_literal=True,
+    multiline_strings=True,
+    raw_strings=True,
+)
+SCRIPT_FAMILY = Family(("//",), ("/*", "*/"), "\"'`")
+PHP = Family(("//", "#"), ("/*", "*/"), "\"'`")
+SQL = Family(("--",), ("/*", "*/"), "\"'", multiline_strings=True)
+LUA = Family(("--",), ("--[[", "]]"), "\"'")
+HASKELL = Family(("--",), ("{-", "-}"), '"', char_literal=True)
+LISP = Family((";",), ("#|", "|#"), '"', multiline_strings=True)
+R_LANG = Family(("#",), None, "\"'")
+HASH_CONFIG = Family(("#",), None, "")
+
+
+class _Scanner:
+    """Full-line comments: lines holding comment text and no code outside it.
+
+    A string literal is code, so a ``//`` or ``/* */`` inside one never reads
+    as a comment; a block comment marks every line it crosses as comment.
+    """
+
+    def __init__(self, text: str, family: Family) -> None:
+        self.text = text
+        self.family = family
+        self.i = 0
+        self.line = 1
+        self.has_code = False
+        self.has_comment = False
+        self.comment_lines: set[int] = set()
+
+    def run(self) -> set[int]:
+        text = self.text
+        while self.i < len(text):
+            ch = text[self.i]
+            if ch == "\n":
+                self._end_line()
+            elif ch in " \t\r\f\v":
+                self.i += 1
+            elif not self._comment_at() and not self._string_at():
+                self.has_code = True
+                self.i += 1
+        self._end_line()
+        return self.comment_lines
+
+    def _end_line(self) -> None:
+        if self.has_comment and not self.has_code:
+            self.comment_lines.add(self.line)
+        self.has_code = self.has_comment = False
+        self.line += 1
+        self.i += 1
+
+    def _mark(self, comment: bool) -> None:
+        if comment:
+            self.has_comment = True
+        else:
+            self.has_code = True
+
+    def _consume_span(self, stop: int, *, comment: bool) -> None:
+        """Advance to ``stop``, closing each line crossed as comment or code."""
+        while self.i < stop:
+            if self.text[self.i] == "\n":
+                self._mark(comment)
+                self._end_line()
+            else:
+                self.i += 1
+        self._mark(comment)
+
+    def _comment_at(self) -> bool:
+        family, text = self.family, self.text
+        if family.block and text.startswith(family.block[0], self.i):
+            opener, closer = family.block
+            end = text.find(closer, self.i + len(opener))
+            stop = len(text) if end < 0 else end + len(closer)
+            self._consume_span(stop, comment=True)
+            return True
+        if any(text.startswith(marker, self.i) for marker in family.line):
+            end = text.find("\n", self.i)
+            self._consume_span(len(text) if end < 0 else end, comment=True)
+            return True
+        return False
+
+    def _string_at(self) -> bool:
+        ch, family = self.text[self.i], self.family
+        if family.raw_strings and self._raw_string_at():
+            return True
+        if ch in family.quotes:
+            self._consume_quoted(ch)
+            return True
+        if family.char_literal and ch == "'":
+            match = _CHAR_LITERAL.match(self.text, self.i)
+            if match:
+                self._consume_span(match.end(), comment=False)
+                return True
+        return False
+
+    def _raw_string_at(self) -> bool:
+        match = _RAW_STRING.match(self.text, self.i)
+        if not match:
+            return False
+        closer = '"' + match.group(1)
+        end = self.text.find(closer, match.end())
+        stop = len(self.text) if end < 0 else end + len(closer)
+        self._consume_span(stop, comment=False)
+        return True
+
+    def _consume_quoted(self, quote: str) -> None:
+        """A quoted literal ends at its closing quote; unless the family lets
+        strings span lines (or the quote is a backtick), at the end of the
+        line too, so a stray apostrophe swallows one line, never a file."""
+        text = self.text
+        spans_lines = quote == "`" or self.family.multiline_strings
+        j = self.i + 1
+        while j < len(text):
+            ch = text[j]
+            if ch == "\\":
+                j += 2
+                continue
+            if ch == quote:
+                j += 1
+                break
+            if ch == "\n" and not spans_lines:
+                break
+            j += 1
+        self._consume_span(min(j, len(text)), comment=False)
+
+
+def family_comment_lines(content: str, family: Family) -> set[int]:
+    return _Scanner(content, family).run()
 
 
 def shell_comment_lines(content: str) -> set[int]:
@@ -44,40 +204,54 @@ def shell_comment_lines(content: str) -> set[int]:
     return comment_lines
 
 
-def python_comment_lines_and_header(content: str) -> tuple[set[int], int]:
-    """Full-line ``#`` comments via ``tokenize.COMMENT``, plus the first
-    line carrying executable code.
+def python_comment_lines(content: str) -> set[int]:
+    """Full-line ``#`` comments via ``tokenize.COMMENT``.
 
     ``tokenize`` never mistakes a string body for a comment, unlike a
-    ``line.strip().startswith("#")`` regex. The header boundary tolerates a
-    leading module docstring: a bare string expression statement is not
-    executable, so a licence block right after it is still header material.
+    ``line.strip().startswith("#")`` regex. Unparsable content yields no
+    comment lines at all: the gate fails open rather than guessing.
     """
     try:
         tokens = list(tokenize.generate_tokens(io.StringIO(content).readline))
     except (tokenize.TokenError, SyntaxError, IndentationError, ValueError):
-        return set(), 0  # unparsable: no comment lines, no header exemption
-    comment_lines: set[int] = set()
-    header_boundary = len(content.splitlines()) + 1
-    executable_seen = False
-    stmt: list[tokenize.TokenInfo] = []
-    for tok in tokens:
-        if tok.type == tokenize.COMMENT:
-            comment_lines.add(tok.start[0])
-            continue
-        if tok.type in (
-            tokenize.NL,
-            tokenize.ENCODING,
-            tokenize.INDENT,
-            tokenize.DEDENT,
-        ):
-            continue
-        if tok.type != tokenize.NEWLINE:
-            stmt.append(tok)
-            continue
-        is_bare_docstring = len(stmt) == 1 and stmt[0].type == tokenize.STRING
-        if stmt and not is_bare_docstring and not executable_seen:
-            executable_seen = True
-            header_boundary = stmt[0].start[0]
-        stmt = []
-    return comment_lines, header_boundary
+        return set()
+    return {
+        tok.start[0]
+        for tok in tokens
+        if tok.type == tokenize.COMMENT and not tok.line[: tok.start[1]].strip()
+    }
+
+
+def _languages(
+    marker: str, scan: Callable[[str], set[int]], *suffixes: str
+) -> dict[str, Language]:
+    return {suffix: Language(marker, scan) for suffix in suffixes}
+
+
+def _family_languages(
+    marker: str, family: Family, *suffixes: str
+) -> dict[str, Language]:
+    return _languages(marker, partial(family_comment_lines, family=family), *suffixes)
+
+
+# Every suffix the gate judges, with the scanner that reads it. No suffix
+# here is exempt for any path (source: ADR-1060, revision 2026-09-10).
+LANGUAGES: dict[str, Language] = {
+    **_languages("#", python_comment_lines, ".py"),
+    **_languages("#", shell_comment_lines, ".sh", ".bash", ".zsh", ".rb", ".pl"),
+    **_family_languages("#", R_LANG, ".r"),
+    **_family_languages("#", HASH_CONFIG, ".toml", ".yaml", ".yml", ".cfg", ".ini"),
+    **_family_languages("//", RUST, ".rs"),
+    **_family_languages(
+        "//", C_FAMILY, ".go", ".java", ".c", ".h", ".cpp", ".hpp", ".cc"
+    ),
+    **_family_languages(
+        "//", C_FAMILY, ".swift", ".kt", ".kts", ".cs", ".scala", ".m", ".mm"
+    ),
+    **_family_languages("//", SCRIPT_FAMILY, ".js", ".jsx", ".ts", ".tsx", ".dart"),
+    **_family_languages("//", PHP, ".php"),
+    **_family_languages("--", SQL, ".sql"),
+    **_family_languages("--", LUA, ".lua"),
+    **_family_languages("--", HASKELL, ".hs"),
+    **_family_languages(";", LISP, ".el", ".clj", ".lisp"),
+}

--- a/mcp_server/hooks/decision_gate.py
+++ b/mcp_server/hooks/decision_gate.py
@@ -12,13 +12,16 @@ is a long run of consecutive comment lines. Exit 2 blocks the tool call and
 returns stderr to the agent. A read or parse failure never blocks: a false
 negative here is cheap, a hook that makes editing impossible is not.
 
+No path is exempt: the file header, a test file and a ``//`` language are
+judged like any other code (owner ruling of 2026-09-10). Only what the call
+introduces is judged, so a block already in the file stays editable.
+
 source: ADR-1060"""
 
 from __future__ import annotations
 
 import json
 import os
-import re
 import sys
 from pathlib import Path
 
@@ -30,38 +33,7 @@ from mcp_server.hooks import _decision_gate_lex as lex
 # (source: ADR-1060).
 PROSE_RUN_LIMIT = 8
 
-# "#"-marker languages actually present in the tracked tree at the volume
-# this threshold was measured against: 1418 ``.py`` and 18 ``.sh`` files
-# (source: ADR-1060 measurement). "//" and "/* */" markers have no tracked
-# instances to measure against and are not enforced until they do.
-COMMENT_MARKERS = {
-    ".py": "#",
-    ".sh": "#",
-    ".bash": "#",
-    ".zsh": "#",
-    ".rb": "#",
-}
-
-# Exact directory names, not a pattern: a pattern loose enough to match
-# ``tests_js`` also matches pytest's own ``tmp_path`` fixture directories
-# (``test_<name>0``), which would exempt every file a test writes rather
-# than every file under a test root (source: ADR-1060 fix).
-_TEST_DIRS = frozenset({"tests", "tests_py", "tests_js", "test", "fuzz"})
-_TEST_FILE_RE = re.compile(r"(^test_|_test$|^test$|\.test$|\.spec$|^spec$)")
-
 _OVERRIDE = "CORTEX_DECISION_GATE"
-
-
-def is_test_path(path: str) -> bool:
-    """Tests narrate scenarios at length and hold no decisions; the repo
-    already exempts them from the file-size cap. Applied uniformly across
-    languages: ``test_x.py``/``x_test.go``/``x.test.ts``/``x.spec.ts``, and
-    any exact ``tests``/``tests_py``/``tests_js``/``test``/``fuzz``
-    directory component — not just the Python-shaped forms."""
-    stem = Path(path).stem
-    if _TEST_FILE_RE.search(stem):
-        return True
-    return any(part in _TEST_DIRS for part in Path(path).parts)
 
 
 def _read_text(path: str) -> str | None:
@@ -94,34 +66,6 @@ def candidate_content(tool: str, tool_input: dict) -> str | None:
     return current.replace(old, new, 1)
 
 
-def _scan(content: str, suffix: str) -> tuple[set[int], int] | None:
-    """(full-line comment numbers, header boundary line) for this suffix, or
-    None if the content could not be parsed for comment shape at all."""
-    if suffix == lex.PYTHON_SUFFIX:
-        return lex.python_comment_lines_and_header(content)
-    return lex.shell_comment_lines(content), 0
-
-
-def _is_header_run(suffix: str, lines: list[str], start: int, boundary: int) -> bool:
-    """True iff nothing executable precedes the run beginning at ``start``.
-
-    Python: nothing precedes the tokenizer's first executable statement, a
-    leading module docstring included. Shell family: nothing precedes but
-    blank lines, ``#`` comments and ``set`` options — the original,
-    line-number-free definition.
-    """
-    if suffix == lex.PYTHON_SUFFIX:
-        return start < boundary
-    for line in lines[: start - 1]:
-        stripped = line.strip()
-        if stripped == "" or stripped.startswith("#"):
-            continue
-        if stripped.split(maxsplit=1)[:1] == ["set"]:
-            continue
-        return False
-    return True
-
-
 def _line_runs(content: str, comment_lines: set[int]) -> dict[int, list[int]]:
     """Consecutive comment-line numbers grouped into runs of at least
     ``PROSE_RUN_LIMIT`` lines, keyed by the run's first line number. A line
@@ -144,20 +88,13 @@ def _line_runs(content: str, comment_lines: set[int]) -> dict[int, list[int]]:
     return runs
 
 
-def _body_run_texts(content: str, suffix: str) -> set[str]:
-    """Stripped text of every comment line already in a body (non-header)
-    prose run, so a rewrap of a block already in the file — inserting or
-    removing a bare marker line inside it — is recognised as unchanged
-    rather than as new prose."""
-    scanned = _scan(content, suffix)
-    if scanned is None:
-        return set()
-    comment_lines, boundary = scanned
+def _run_texts(content: str, language: lex.Language) -> set[str]:
+    """Stripped text of every comment line already in a prose run, so a
+    rewrap of a block already in the file (inserting or removing a bare
+    marker line inside it) is recognised as unchanged, not as new prose."""
     lines = content.splitlines()
     texts: set[str] = set()
-    for start, run in _line_runs(content, comment_lines).items():
-        if _is_header_run(suffix, lines, start, boundary):
-            continue
+    for run in _line_runs(content, language.scan(content)).values():
         texts.update(lines[n - 1].strip() for n in run)
     return texts
 
@@ -166,29 +103,21 @@ def introduced_block(tool: str, tool_input: dict) -> tuple[str, int] | None:
     """The longest prose block this call would newly add, with its line
     number in the resulting file, or None if nothing crosses the threshold.
 
-    "Newly add" is judged by the set of body-comment line texts already in
-    the file, not by exact run text: only what the call introduces, not
-    what it merely reflows, is refused.
+    "Newly add" is judged by the set of comment line texts already in the
+    file's prose runs, not by exact run text: only what the call introduces,
+    not what it merely reflows, is refused.
     """
     path = tool_input.get("file_path") or ""
-    if is_test_path(path):
-        return None
-    if Path(path).suffix not in COMMENT_MARKERS:
+    language = lex.LANGUAGES.get(Path(path).suffix.lower())
+    if language is None:
         return None
     content = candidate_content(tool, tool_input)
     if not content:
         return None
-    suffix = Path(path).suffix
-    scanned = _scan(content, suffix)
-    if scanned is None:
-        return None
-    comment_lines, boundary = scanned
     lines = content.splitlines()
-    existing_texts = _body_run_texts(_read_text(path) or "", suffix)
+    existing_texts = _run_texts(_read_text(path) or "", language)
     best: tuple[str, int, int] | None = None
-    for start, run in _line_runs(content, comment_lines).items():
-        if _is_header_run(suffix, lines, start, boundary):
-            continue
+    for start, run in _line_runs(content, language.scan(content)).items():
         run_texts = [lines[n - 1].strip() for n in run]
         new_count = sum(1 for t in run_texts if t not in existing_texts)
         if new_count < PROSE_RUN_LIMIT:
@@ -203,7 +132,8 @@ def _refuse(path: str, block: str, line: int, marker: str) -> None:
     print(
         f"[decision-gate] BLOCKED: {path}:{line} would add {run} consecutive"
         " comment lines. A block that long is a decision, and the wiki is"
-        " the only decision index.",
+        " the only decision index. No header, test file or language is"
+        " exempt (ADR-1060, revision 2026-09-10).",
         file=sys.stderr,
     )
     print(
@@ -225,7 +155,7 @@ def evaluate(event: dict) -> int:
         return 0
     path = tool_input.get("file_path") or ""
     block, line = found
-    _refuse(path, block, line, COMMENT_MARKERS[Path(path).suffix])
+    _refuse(path, block, line, lex.LANGUAGES[Path(path).suffix.lower()].marker)
     return 2
 
 

--- a/tests_py/hooks/test_decision_gate.py
+++ b/tests_py/hooks/test_decision_gate.py
@@ -1,7 +1,9 @@
 """The decision gate refuses prose where a pointer belongs.
 
-Each test states the shape it protects, because the gate is a heuristic and
-its exemptions are the part most likely to be loosened by accident.
+Each test states the shape it protects, because the gate is a heuristic.
+Since the owner ruling of 2026-09-10 (ADR-1060, revision "no exception") no
+path, header or language is exempt; the tests below pin that as firmly as
+they pin the refusals the gate was built for.
 """
 
 from __future__ import annotations
@@ -29,8 +31,6 @@ def _edit(path: Path, old: str, new: str) -> dict:
 
 def _script(tmp_path: Path, body: str) -> Path:
     path = tmp_path / "thing.sh"
-    # `echo "start"` matters: it makes the body a body. A run with nothing
-    # executable before it is the file header, which is exempt by design.
     path.write_text(
         f'#!/usr/bin/env bash\nset -euo pipefail\n\necho "start"\n{body}\n', "utf-8"
     )
@@ -58,15 +58,23 @@ def test_allows_the_sanctioned_pointer_form(tmp_path: Path) -> None:
     assert gate.evaluate(_edit(path, 'echo "anchor"', pointers)) == ALLOW
 
 
-def test_allows_a_long_header_on_a_new_file(tmp_path: Path) -> None:
-    """A header is orientation. It is exempt because nothing executable
-    precedes it, not because of where its line number falls."""
+def test_refuses_a_long_header_on_a_new_file(tmp_path: Path) -> None:
+    """The header used to be exempt as orientation; the owner ruled that a
+    decision hides there as easily as anywhere else. Refused like a body."""
     content = "#!/usr/bin/env bash\nset -e\n\n" + _prose(30) + "\necho hi\n"
     event = {
         "tool_name": "Write",
         "tool_input": {"file_path": str(tmp_path / "new.sh"), "content": content},
     }
-    assert gate.evaluate(event) == ALLOW
+    assert gate.evaluate(event) == BLOCK
+
+
+def test_grandfathers_a_long_header_already_in_the_file(tmp_path: Path) -> None:
+    """Removing the header exemption must not make legacy files uneditable:
+    the header is grandfathered like any block already present."""
+    path = tmp_path / "legacy.sh"
+    path.write_text("#!/usr/bin/env bash\n" + _prose(30) + "\necho anchor\n", "utf-8")
+    assert gate.evaluate(_edit(path, "echo anchor", "echo changed")) == ALLOW
 
 
 def test_grandfathers_a_block_already_in_the_file(tmp_path: Path) -> None:
@@ -75,10 +83,12 @@ def test_grandfathers_a_block_already_in_the_file(tmp_path: Path) -> None:
     assert gate.evaluate(_edit(legacy, 'echo "anchor"', 'echo "changed"')) == ALLOW
 
 
-def test_exempts_tests(tmp_path: Path) -> None:
+def test_judges_a_test_file_like_any_other(tmp_path: Path) -> None:
+    """Tests used to be exempt because they narrate scenarios; the ruling
+    is that a decision narrated in a test is still a decision."""
     path = tmp_path / "test_thing.py"
     path.write_text("y = 0\nx = 1\n", "utf-8")
-    assert gate.evaluate(_edit(path, "x = 1", _prose(20))) == ALLOW
+    assert gate.evaluate(_edit(path, "x = 1", _prose(20))) == BLOCK
 
 
 def test_ignores_file_types_with_no_comment_marker(tmp_path: Path) -> None:
@@ -96,15 +106,15 @@ def test_override_releases_the_gate(tmp_path: Path, monkeypatch) -> None:
     assert gate.evaluate(event) == ALLOW
 
 
-def test_slash_slash_languages_are_not_enforced(tmp_path: Path) -> None:
-    """The marker table only covers ``#`` languages actually measured in the
-    tracked tree (``.py``, ``.sh``, ``.bash``, ``.zsh``, ``.rb``); a zero-
-    file threshold claim is not a threshold, it is a guess. ``//`` and
-    ``/* */`` markers are dropped until they have tracked-tree evidence."""
+def test_slash_slash_languages_are_enforced(tmp_path: Path) -> None:
+    """``//`` markers were deferred "until measured"; that deferral is what
+    let a Rust ``///`` block through on 2026-09-10. The threshold is the
+    same eight lines for every marker (``test_decision_gate_languages.py``
+    covers each suffix)."""
     path = tmp_path / "thing.ts"
     path.write_text("const first = 0;\nconst anchor = 1;\n", "utf-8")
     event = _edit(path, "const anchor = 1;", _prose(20, "//"))
-    assert gate.evaluate(event) == ALLOW
+    assert gate.evaluate(event) == BLOCK
 
 
 def test_malformed_event_never_blocks() -> None:
@@ -124,11 +134,9 @@ def test_unreadable_current_file_never_crashes(tmp_path: Path) -> None:
     assert gate.evaluate(event) == ALLOW  # must not raise
 
 
-def test_a_leading_docstring_is_still_header(tmp_path: Path) -> None:
-    """A module docstring followed by a licence block must not be blocked:
-    nothing executable precedes either. Reproduced pre-fix: BLOCKED at
-    line 3, because the docstring line disqualified the header scan even
-    though it is not code."""
+def test_a_block_after_the_module_docstring_is_refused(tmp_path: Path) -> None:
+    """Formerly allowed as header material. A docstring is not a comment
+    and does not count; the eight ``#`` lines after it do."""
     content = (
         '"""Module docstring."""\n\n'
         + _prose(gate.PROSE_RUN_LIMIT)
@@ -138,7 +146,7 @@ def test_a_leading_docstring_is_still_header(tmp_path: Path) -> None:
         "tool_name": "Write",
         "tool_input": {"file_path": str(tmp_path / "new_mod.py"), "content": content},
     }
-    assert gate.evaluate(event) == ALLOW
+    assert gate.evaluate(event) == BLOCK
 
 
 def test_a_heredoc_body_is_data_not_comments(tmp_path: Path) -> None:
@@ -176,24 +184,20 @@ def test_still_blocks_a_ten_to_twelve_line_rationale(tmp_path: Path) -> None:
         assert gate.evaluate(event) == BLOCK, f"a {length}-line rationale must block"
 
 
-def test_exempts_the_js_test_root(tmp_path: Path) -> None:
-    """``tests_js`` is this repo's JS-equivalent of ``tests_py``; a Python
-    test file was exempt while the same content under a JS test root was
-    not, which is the inconsistency this closes."""
+def test_judges_the_js_test_root(tmp_path: Path) -> None:
+    """``tests_js`` and the ``*.test.js``/``*.spec.ts`` shapes were the
+    last test exemptions added; they go with the rest."""
     root = tmp_path / "tests_js"
     root.mkdir()
     path = root / "spatial_hash.test.js"
     path.write_text("const x = 1;\n", "utf-8")
-    assert gate.evaluate(_edit(path, "const x = 1;", _prose(20))) == ALLOW
+    assert gate.evaluate(_edit(path, "const x = 1;", _prose(20, "//"))) == BLOCK
 
 
-def test_exempts_dot_spec_and_dot_test_filenames(tmp_path: Path) -> None:
-    """A ``.spec.ts``/``.test.ts`` file narrates scenarios like a
-    ``test_*.py`` file and must be exempt on that shape alone, independent
-    of which directory it lives under."""
+def test_judges_dot_spec_filenames(tmp_path: Path) -> None:
     path = tmp_path / "widget.spec.ts"
     path.write_text("const x = 1;\n", "utf-8")
-    assert gate.evaluate(_edit(path, "const x = 1;", _prose(20))) == ALLOW
+    assert gate.evaluate(_edit(path, "const x = 1;", _prose(20, "//"))) == BLOCK
 
 
 def test_entrypoint_exits_two_on_a_blocked_write(tmp_path: Path) -> None:
@@ -247,4 +251,4 @@ def test_lexer_returns_no_comments_for_unparsable_python() -> None:
     """Same path, asserted at the unit it belongs to."""
     from mcp_server.hooks import _decision_gate_lex as lex
 
-    assert lex.python_comment_lines_and_header("x = (\n") == (set(), 0)
+    assert lex.python_comment_lines("x = (\n") == set()

--- a/tests_py/hooks/test_decision_gate_languages.py
+++ b/tests_py/hooks/test_decision_gate_languages.py
@@ -1,0 +1,186 @@
+"""The decision gate judges every comment-marker language, every path.
+
+Owner ruling of 2026-09-10 (ADR-1060, revision "no exception"): a run of
+eight or more consecutive comment lines is refused whether it is written
+with ``#``, ``//``, ``/* */``, ``--`` or ``;``, whether the file is a test,
+and whether the run sits at the top of the file. What stays is the lexical
+reading: a string literal never reads as a comment.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mcp_server.hooks import _decision_gate_lex as lex
+from mcp_server.hooks import decision_gate as gate
+
+ALLOW, BLOCK = 0, 2
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _prose(lines: int, marker: str) -> str:
+    return "\n".join(f"{marker} rationale line {n}" for n in range(lines))
+
+
+def _edit(path: Path, old: str, new: str) -> dict:
+    return {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": str(path), "old_string": old, "new_string": new},
+    }
+
+
+def _write(path: Path, content: str) -> dict:
+    return {
+        "tool_name": "Write",
+        "tool_input": {"file_path": str(path), "content": content},
+    }
+
+
+def _rust_test_file(tmp_path: Path) -> Path:
+    """The file shape that leaked on 2026-09-10: a ``tests/*.rs`` file."""
+    root = tmp_path / "tests"
+    root.mkdir()
+    path = root / "rust_local_receiver_static_resolution.rs"
+    path.write_text("use std::path::Path;\n\n#[test]\nfn anchor() {}\n", "utf-8")
+    return path
+
+
+def test_refuses_a_doc_comment_block_in_a_rust_test_file(tmp_path: Path) -> None:
+    """Six lines of ``///`` rationale passed on 2026-09-10 because the file
+    was under ``tests/``, the language used ``//`` markers, and nothing
+    executable preceded the run. None of the three is an exemption now."""
+    path = _rust_test_file(tmp_path)
+    event = _edit(path, "#[test]", _prose(10, "///") + "\n#[test]")
+    assert gate.evaluate(event) == BLOCK
+
+
+def test_the_process_entrypoint_refuses_the_rust_test_file(tmp_path: Path) -> None:
+    """The owner's simulation, a PreToolUse event on stdin, through the
+    hook's process entry point. ``scripts/launcher.py`` adds only a
+    dependency install into ``deps/`` before ``runpy`` reaches this same
+    ``__main__``; a unit test must not perform that install."""
+    path = _rust_test_file(tmp_path)
+    event = _edit(path, "#[test]", _prose(10, "///") + "\n#[test]")
+    done = subprocess.run(
+        [sys.executable, "-m", "mcp_server.hooks.decision_gate"],
+        input=json.dumps(event),
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert done.returncode == BLOCK, done.stderr
+    assert "would add 10 consecutive comment lines" in done.stderr
+    assert "`// source: ADR-NNNN`" in done.stderr
+
+
+@pytest.mark.parametrize("suffix", [".ts", ".go"])
+def test_refuses_a_line_comment_block(tmp_path: Path, suffix: str) -> None:
+    path = tmp_path / f"thing{suffix}"
+    path.write_text("var first = 0\nvar anchor = 1\n", "utf-8")
+    event = _edit(path, "var anchor = 1", _prose(10, "//") + "\nvar anchor = 1")
+    assert gate.evaluate(event) == BLOCK
+
+
+def test_refuses_a_block_comment_in_java(tmp_path: Path) -> None:
+    """Every line a ``/* */`` block crosses is a comment line."""
+    path = tmp_path / "Thing.java"
+    path.write_text("class Thing {\n    int anchor = 1;\n}\n", "utf-8")
+    body = "\n".join(f"     * rationale line {n}" for n in range(8))
+    block = f"    /*\n{body}\n     */\n    int anchor = 1;"
+    assert gate.evaluate(_edit(path, "    int anchor = 1;", block)) == BLOCK
+
+
+def test_refuses_a_header_block_on_a_new_python_file(tmp_path: Path) -> None:
+    """A licence or orientation block at the top of a file is judged like
+    any other run: the header is not exempt."""
+    content = "#!/usr/bin/env python3\n" + _prose(10, "#") + "\nimport os\n"
+    assert gate.evaluate(_write(tmp_path / "new_mod.py", content)) == BLOCK
+
+
+def test_a_rust_string_holding_slash_slash_text_is_code(tmp_path: Path) -> None:
+    path = tmp_path / "thing.rs"
+    path.write_text("fn main() {\n    let anchor = 1;\n}\n", "utf-8")
+    text = "\n".join(f"// not a comment, line {n}" for n in range(10))
+    literal = f'    let s = "\n{text}\n";\n    let anchor = 1;'
+    assert gate.evaluate(_edit(path, "    let anchor = 1;", literal)) == ALLOW
+
+
+def test_a_block_comment_inside_a_rust_string_is_not_a_comment(tmp_path: Path) -> None:
+    path = tmp_path / "thing.rs"
+    path.write_text("fn main() {\n    let anchor = 1;\n}\n", "utf-8")
+    body = "\n".join(f" * not a comment, line {n}" for n in range(10))
+    literal = f'    let s = r#"/*\n{body}\n */"#;\n    let anchor = 1;'
+    assert gate.evaluate(_edit(path, "    let anchor = 1;", literal)) == ALLOW
+
+
+def test_allows_a_run_one_line_under_the_limit(tmp_path: Path) -> None:
+    path = tmp_path / "thing.rs"
+    path.write_text("fn main() {}\n", "utf-8")
+    event = _edit(path, "fn main() {}", _prose(gate.PROSE_RUN_LIMIT - 1, "//"))
+    assert gate.evaluate(event) == ALLOW
+
+
+def test_grandfathers_a_block_already_in_a_go_file(tmp_path: Path) -> None:
+    """Only what the call introduces is judged, so a legacy file with a long
+    header stays editable."""
+    path = tmp_path / "thing.go"
+    path.write_text(_prose(12, "//") + "\npackage thing\n\nvar anchor = 1\n", "utf-8")
+    assert gate.evaluate(_edit(path, "var anchor = 1", "var anchor = 2")) == ALLOW
+
+
+def test_pointer_lines_never_count(tmp_path: Path) -> None:
+    path = tmp_path / "thing.ts"
+    path.write_text("const anchor = 1;\n", "utf-8")
+    pointers = "\n".join(f"// source: ADR-{1000 + n}" for n in range(20))
+    assert gate.evaluate(_edit(path, "const anchor = 1;", pointers)) == ALLOW
+
+
+def test_override_releases_the_gate(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "Thing.java"
+    path.write_text("class Thing {}\n", "utf-8")
+    event = _edit(path, "class Thing {}", _prose(20, "//"))
+    assert gate.evaluate(event) == BLOCK
+    monkeypatch.setenv("CORTEX_DECISION_GATE", "off")
+    assert gate.evaluate(event) == ALLOW
+
+
+@pytest.mark.parametrize("suffix", sorted(lex.LANGUAGES))
+def test_every_declared_suffix_is_enforced(tmp_path: Path, suffix: str) -> None:
+    """The suffix table and the scanner table are one table: a suffix the
+    gate names is a suffix the gate refuses, in that suffix's own marker."""
+    marker = lex.LANGUAGES[suffix].marker
+    content = _prose(10, marker) + "\n"
+    assert gate.evaluate(_write(tmp_path / f"thing{suffix}", content)) == BLOCK
+
+
+def test_suffix_match_is_case_insensitive(tmp_path: Path) -> None:
+    content = _prose(10, "//") + "\n"
+    assert gate.evaluate(_write(tmp_path / "Thing.RS", content)) == BLOCK
+
+
+def test_a_rust_lifetime_does_not_swallow_the_next_comment() -> None:
+    """``'a`` is not a character literal; treating it as one opened a string
+    that hid every comment until the next apostrophe."""
+    text = "fn f<'a>(x: &'a str) {}\n// real\nlet c = '\\'';\n// real too\n"
+    assert lex.LANGUAGES[".rs"].scan(text) == {2, 4}
+
+
+def test_an_unterminated_block_comment_runs_to_the_end_of_the_file() -> None:
+    assert lex.LANGUAGES[".c"].scan("int x;\n/* open\nline\n") == {2, 3, 4}
+
+
+def test_a_trailing_comment_on_a_code_line_is_not_a_comment_line() -> None:
+    assert lex.LANGUAGES[".py"].scan("x = 1  # trailing\n# full\ny = '# no'\n") == {2}
+    assert lex.LANGUAGES[".go"].scan("x := 1 // trailing\n// full\n") == {2}
+
+
+def test_the_refusal_names_the_language_marker(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "schema.sql"
+    path.write_text("SELECT 1;\n", "utf-8")
+    assert gate.evaluate(_edit(path, "SELECT 1;", _prose(10, "--"))) == BLOCK
+    assert "`-- source: ADR-NNNN`" in capsys.readouterr().err

--- a/wiki/adr/cortex/1060-refuse-a-decision-written-into-code-at-edit-time-in-the-distributed-hook.md
+++ b/wiki/adr/cortex/1060-refuse-a-decision-written-into-code-at-edit-time-in-the-distributed-hook.md
@@ -32,7 +32,7 @@ Two exemptions are needed or the rule is unusable. A file's opening block orient
 
 A line carrying a `source:` pointer never counts toward a run: that is the sanctioned way to reference a decision, and the refusal message names `wiki_adr` as where the prose belongs and the pointer form to leave behind.
 
-Exempt: the file's header block, defined as a run preceded by nothing executable; test files; and any block already present in the file, so editing an unrelated part of a legacy file is never refused. Only what the call introduces is judged.
+Only what the call introduces is judged: a block already present in the file is grandfathered, so editing an unrelated part of a legacy file is never refused. No path, header block or comment-marker language is exempt. (The first revision exempted the file's header block, defined as a run preceded by nothing executable, and test files; both exemptions were withdrawn on 2026-09-10, see the revision below.)
 
 `CORTEX_DECISION_GATE=off` overrides for a single call, for genuine non-decision prose such as a worked example or a data table, and requires saying why.
 
@@ -46,7 +46,34 @@ A review of the first cut found the hook crashing on unreadable input, misreadin
 
 **Grandfathering compares content, not position.** The original ratchet keyed a run by its exact joined text; inserting or removing a single bare marker line inside an existing block changed the key, so a pure rewrap of a block already in the file was reported as newly introduced. Grandfathering now compares the set of body-comment line texts already in the file against the candidate run's lines: a run is refused only when the count of lines *not* already present anywhere in the file's body prose reaches the threshold, so reflowing an existing block is never treated as new.
 
-**Two further findings changed what's enforced, not just how it's checked.** `is_test_path` recognised only `tests`/`tests_py`/`test`/`fuzz` and the Python `test_*.py`/`*_test.py` shapes; `tests_js` — the repo's actual JS test root — and the `.spec.ts`/`.test.ts` filename shapes were unrecognised, so JS test files were scanned while their Python equivalents were exempt. The test-path check now also matches `tests_js` by name and any `*.test.*`/`*.spec.*` filename, uniformly across languages. Separately, `//` and `/* */` markers were never actually measured: the tracked tree (excluding `deps/`) holds 1418 `.py` files and 18 `.sh` files, but zero non-test files using `//` or `/* */` comments. `COMMENT_MARKERS` now covers only the `#`-comment languages the threshold was measured against — `.py`, `.sh`, `.bash`, `.zsh`, `.rb` — and drops `.js`/`.ts`/`.tsx`/`.jsx`/`.swift`/`.go`/`.rs`/`.java`/`.c`/`.h`/`.cpp` until there is tracked-tree evidence for them. This is a narrowing of enforcement, not a threshold change: `PROSE_RUN_LIMIT` is unchanged, and the hook still refuses the ten- and twelve-line rationale blocks it was built to catch.
+**Two further findings changed what's enforced, not just how it's checked** (both withdrawn by the revision of 2026-09-10 below). `is_test_path` recognised only `tests`/`tests_py`/`test`/`fuzz` and the Python `test_*.py`/`*_test.py` shapes; `tests_js` — the repo's actual JS test root — and the `.spec.ts`/`.test.ts` filename shapes were unrecognised, so JS test files were scanned while their Python equivalents were exempt. The test-path check now also matches `tests_js` by name and any `*.test.*`/`*.spec.*` filename, uniformly across languages. Separately, `//` and `/* */` markers were never actually measured: the tracked tree (excluding `deps/`) holds 1418 `.py` files and 18 `.sh` files, but zero non-test files using `//` or `/* */` comments. `COMMENT_MARKERS` now covers only the `#`-comment languages the threshold was measured against — `.py`, `.sh`, `.bash`, `.zsh`, `.rb` — and drops `.js`/`.ts`/`.tsx`/`.jsx`/`.swift`/`.go`/`.rs`/`.java`/`.c`/`.h`/`.cpp` until there is tracked-tree evidence for them. This is a narrowing of enforcement, not a threshold change: `PROSE_RUN_LIMIT` is unchanged, and the hook still refuses the ten- and twelve-line rationale blocks it was built to catch.
+
+### Revision 2026-09-10 — no exception
+
+Owner ruling, verbatim intent: "Révision de l'ADR-1060, pas d'exception". The gate applies to every comment-marker language, to test files and to header blocks alike.
+
+**The leak.** On 2026-09-10 six lines of `///` rationale were written into `ai-architect-mcp-codebase/tests/rust_local_receiver_static_resolution.rs` and the hook allowed the write. Three of its exemptions each sufficed on their own: (1) `COMMENT_MARKERS` covered only the `#` languages (`.py .sh .bash .zsh .rb`) and deferred `//`, `///` and `/* */` "until measured"; (2) `is_test_path` exempted the `tests` directory (with `tests_py`, `tests_js`, `test`, `fuzz`, and the `test_*`, `*_test`, `*.test.*`, `*.spec.*` file shapes); (3) the run was preceded by nothing executable, so it read as the file header. An exemption is a place for a decision to hide, and this one hid in all three at once.
+
+**Removed.** The language deferral: `mcp_server/hooks/_decision_gate_lex.py` now lexes `//` and `/* */` (`.rs .js .jsx .ts .tsx .go .java .c .h .cpp .hpp .cc .swift .kt .kts .cs .scala .m .mm .dart .php`), `--` (`.sql .lua .hs`), `;` (`.el .clj .lisp`) and the full `#` family (`.py .sh .bash .zsh .rb .pl .toml .yaml .yml .r .cfg .ini`). The new families go through one character-level scanner that tracks string literals (Rust raw strings and backtick strings included) and block comments, so a `//` or `/* */` inside a string literal never reads as a comment and every line a block comment crosses does; Python stays on `tokenize` and the shell family keeps its heredoc skip. The test-path exemption (`is_test_path`, `_TEST_DIRS`, `_TEST_FILE_RE`) is deleted. The header exemption (`_is_header_run` and the tokenizer's header boundary) is deleted. The refusal now states that no header, test file or language is exempt, so an agent that remembers the first revision is corrected at the point of refusal.
+
+**Kept, and why.** `PROSE_RUN_LIMIT` stays at 8: the threshold was measured, and the ruling changes where it applies, not what it is. Grandfathering stays: only what the call introduces is judged, so a legacy file with a thirty-line header is still editable, and the measurement below is what shows the ruling breaks nothing. A `source:` pointer line never counts toward a run: it is the sanctioned form. Unreadable or unparsable input still fails open. `CORTEX_DECISION_GATE=off` stays: it is a visible act in the transcript with a stated reason, not a silent exemption, and a gate with no escape hatch gets disabled wholesale.
+
+One narrowing of the Python scanner came with the rewrite: a comment token that follows code on the same line (`x = 1  # note`) no longer counts as a comment line, which is what that scanner's docstring already claimed and what the new scanner does for every other language.
+
+**Measurement.** Tracked tree at `8d71210f` (`origin/main` on 2026-09-10), every file whose suffix the gate now judges, scanned with the revised lexer. A header run is a run of eight or more comment lines preceded only by blank lines, comment lines, a shebang, a shell `set` line or the Python module docstring; test paths are the ones the deleted `is_test_path` used to exempt.
+
+| suffix | tracked files | header run of 8+ (code / test) | body run of 8+ (code / test) |
+|---|---|---|---|
+| `.py` | 1427 | 0 / 0 | 10 / 33 |
+| `.sh` | 20 | 4 / 0 | 1 / 0 |
+| `.yml` | 17 | 0 / 0 | 1 / 0 |
+| `.sql` | 12 | 5 / 0 | 1 / 0 |
+| `.yaml` | 1 | 0 / 0 | 0 / 0 |
+| `.toml` | 1 | 0 / 0 | 1 / 0 |
+| `.js` | 1 | 0 / 1 | 0 / 0 |
+| total | 1479 | 9 / 1 | 14 / 33 |
+
+Ten files carry a header run at or over the threshold, among them `benchmarks/reproduce.sh`, `scripts/install-plugin.sh`, `scripts/phase_0_4_5_backfill.sql` and `tests_js/spatial_hash.test.js`. Every one is grandfathered: editing any of them elsewhere is allowed, and only a new header of eight or more comment lines, or eight new lines added to an existing one, is refused. Nothing in the tree is blocked by the ruling. The number is recorded here so the owner decides on it, not the implementer.
 
 ## Consequences
 
@@ -54,12 +81,16 @@ Easier: the convention becomes a processing obligation rather than something a r
 
 Easier: the refusal carries its own remedy. It names the tool that records the decision and the pointer to leave, so the correction is mechanical rather than a research task.
 
-Harder: a handful of existing files carry a body block over the threshold. The ratchet grandfathers them, so nothing breaks, but they are now visibly on the wrong side of a stated rule and are candidates for migration to the wiki.
+Harder: existing files carry blocks over the threshold (at `8d71210f`: 10 with a header run, 47 with a body run, 33 of those under test roots). The ratchet grandfathers them, so nothing breaks, but they are now visibly on the wrong side of a stated rule and are candidates for migration to the wiki.
 
-Harder: `//` and `/* */` comment languages are unenforced until they have their own measured evidence. A ten-line C-style licence header written into a `.go` or `.java` file today passes silently. This is the accepted cost of not shipping an unverified threshold, not an oversight.
+Harder: a new file cannot open with eight or more comment lines, whatever the language. A licence or orientation header of that length is either shortened, replaced by a `source:` pointer to the page that holds the text, or written under `CORTEX_DECISION_GATE=off` with the reason stated. Since the revision of 2026-09-10 this is the chosen cost: a header exemption is a place for a decision to hide, and it did.
+
+Harder: a test file is judged like any other. A scenario narrated in eight or more comment lines moves into the test's docstring or the wiki; the same override applies.
 
 Risk accepted: the threshold is a shape heuristic. A decision written in seven lines passes, and a long data table written as comments is refused. The override covers the second; the first is a smaller failure than the one this closes.
 
 Risk accepted: an agent can set the override. That is deliberate. A gate with no escape hatch gets disabled wholesale, and requiring a stated reason keeps the choice visible in the transcript.
 
 Risk accepted: grandfathering by line-text set, not exact position, can under-block a new decision that happens to reuse phrasing already present elsewhere in the file. This trade was made deliberately to fix the reflow false-positive; the alternative (position-based keying) is what broke on a pure rewrap.
+
+Risk accepted: the scanner for the `//`, `--` and `;` families is a small state machine, not a parser. It tracks quoted strings (single-line unless the language lets them span lines, backtick and Rust raw strings always), character literals and block comments; it does not know every literal form of every language. Its failure mode is a comment hidden inside what it took for a string, which fails open, never a block refused for a string it took for a comment on a line holding code.


### PR DESCRIPTION
## Summary

Implements the owner ruling of 2026-09-10 on ADR-1060 ("Révision de l'ADR-1060, pas d'exception"). On 2026-09-10 six lines of `///` rationale were written into `ai-architect-mcp-codebase/tests/rust_local_receiver_static_resolution.rs` and `mcp_server/hooks/decision_gate.py` let them through, because each of its three exemptions sufficed alone: `//` languages were deferred "until measured", the path was under a test root, and the run sat before anything executable. All three exemptions are removed. The gate now judges every comment-marker language (`#`, `//` and `/* */`, `--`, `;`), test files and header blocks alike. `PROSE_RUN_LIMIT` (8), grandfathering of blocks already in the file, the `source:` pointer line, fail-open on unreadable input and the explicit `CORTEX_DECISION_GATE=off` override are unchanged.

No issue is linked: the owner ruling is recorded in the canonical wiki page `wiki/adr/cortex/1060-*.md` (section "Revision 2026-09-10 — no exception"), with the read-only mirror `docs/adr/ADR-1060-*.md` regenerated through `scripts/check_project_wiki.py --write`.

Closes #N/A (owner ruling, no issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing behavior): a new file can no longer open with 8+ comment lines, and test files are judged; the ADR records this as the chosen cost
- [ ] Refactor (no functional change; rules/coding-standards.md compliance)
- [ ] Documentation only
- [ ] Audit-finding closure (cite the finding ID)

## What changed

- `mcp_server/hooks/_decision_gate_lex.py`: one character-level scanner (`_Scanner`) for the `//`, `--` and `;` families that tracks quoted strings (single-line unless the language lets them span lines; backtick and Rust `r#"..."#` raw strings always), character literals (so a Rust lifetime `'a` does not open a string) and block comments; every line a block comment crosses is a comment line, a line holding code is never one. Python stays on `tokenize`, the shell family keeps its heredoc skip. `LANGUAGES` is the single table of suffix, refusal marker and scanner, covering `.py .sh .bash .zsh .rb .pl .r .toml .yaml .yml .cfg .ini .rs .js .jsx .ts .tsx .go .java .c .h .cpp .hpp .cc .swift .kt .kts .cs .scala .m .mm .dart .php .sql .lua .hs .el .clj .lisp`.
- `mcp_server/hooks/decision_gate.py`: `is_test_path`, `_TEST_DIRS`, `_TEST_FILE_RE`, `_is_header_run` and the header boundary are deleted; suffix lookup is case-insensitive; the refusal states that no header, test file or language is exempt. One narrowing on Python: a comment token after code on the same line (`x = 1  # note`) no longer counts as a comment line, which is what the scanner's docstring already claimed.
- Tests: `tests_py/hooks/test_decision_gate.py` flips the former exemption tests to refusals and adds the grandfathered-header case; `tests_py/hooks/test_decision_gate_languages.py` pins the Rust `tests/*.rs` `///` case (direct and through the process entry point), `//` in `.ts`/`.go`, `/* */` in `.java`, a 10-line header on a new `.py`, `//` text and a block comment inside Rust string literals (not comments), the 7-line run, grandfathering in `.go`, `source:` lines, the override, every declared suffix, lifetimes, unterminated block comments and trailing comments.

## Gate

The owner's simulation (a PreToolUse Edit event on stdin adding ten `///` lines to `tests/rust_local_receiver_static_resolution.rs`, through `python3 scripts/launcher.py mcp_server.hooks.decision_gate`):

- origin/main `8d71210f`: `exit=0` (allowed)
- this branch: `[decision-gate] BLOCKED: .../tests/rust_local_receiver_static_resolution.rs:3 would add 10 consecutive comment lines. ... No header, test file or language is exempt (ADR-1060, revision 2026-09-10).` then `... leave only `// source: ADR-NNNN` here ...`, `exit=2`

`tests_py/hooks/test_decision_gate_languages.py` on origin/main (detached worktree at `8d71210f`, the module-level parametrize over `lex.LANGUAGES` stripped because it cannot collect there): `12 failed, 5 passed`; the 5 that pass are the ALLOW-shaped invariants (string literals, the 7-line run, grandfathering, pointer lines). On the branch: `78 passed` across both gate test files.

## Measurement (header exemption removal)

Tracked tree at `8d71210f`, every file whose suffix the gate now judges, scanned with the revised lexer. A header run is a run of 8+ comment lines preceded only by blank lines, comment lines, a shebang, a shell `set` line or the Python module docstring.

| suffix | tracked files | header run 8+ (code / test) | body run 8+ (code / test) |
|---|---|---|---|
| `.py` | 1427 | 0 / 0 | 10 / 33 |
| `.sh` | 20 | 4 / 0 | 1 / 0 |
| `.yml` | 17 | 0 / 0 | 1 / 0 |
| `.sql` | 12 | 5 / 0 | 1 / 0 |
| `.yaml` | 1 | 0 / 0 | 0 / 0 |
| `.toml` | 1 | 0 / 0 | 1 / 0 |
| `.js` | 1 | 0 / 1 | 0 / 0 |
| total | 1479 | 9 / 1 | 14 / 33 |

Ten files carry a header run at or over the threshold (for example `benchmarks/reproduce.sh`, `scripts/install-plugin.sh`, `scripts/phase_0_4_5_backfill.sql`, `tests_js/spatial_hash.test.js`). All are grandfathered: editing them elsewhere is allowed. Nothing in the tree is blocked by the ruling; the number is recorded in the ADR for the owner to decide on.

## Test plan

- [x] All existing tests pass: `pytest tests_py/hooks/` = 465 passed (13 subtests).
- [x] New tests added for new behavior: 17 in `test_decision_gate_languages.py` plus the flipped and added cases in `test_decision_gate.py` (78 total across the two files).
- [x] Mutation survival check: removing any suffix from `LANGUAGES` fails `test_every_declared_suffix_is_enforced`; re-adding a test-path or header exemption fails the flipped tests; treating a string body as a comment fails the two Rust string tests; dropping the char-literal rule fails the lifetime test; counting trailing comments fails the trailing-comment test. Not caught: a scanner that mis-lexes a literal form no test uses (a C++ `R"(...)"` raw string, for instance); that fails open, never closed, and the ADR records it as a risk accepted.
- [x] Manual verification: the launcher simulation above, both sides. The committed entry-point test uses `python -m mcp_server.hooks.decision_gate` rather than `scripts/launcher.py`, because the launcher runs `ensure_deps(<repo>/deps)` first and pip-installs the base packages over the network when that directory is empty (which it is in CI); a unit test must not perform that install.

## Gates as CI runs them (final state)

- `ruff check .` and `ruff format --check .` (ruff 0.16.6 from `requirements/lint.txt`): clean
- `python scripts/check_craftsmanship.py`: OK
- `python scripts/check_project_wiki.py`: mirrors match
- `python scripts/check_doc_claims.py`: OK
- `python scripts/check_no_deps_invariant.py`: clean
- `python3 scripts/check_marketplace_pins.py`: all pins current (untouched)
- pyright per CONTRIBUTING.md § Reproducing the pyright gate locally (`uv sync ... --group typecheck`, `.venv/bin/python -m pyright mcp_server/`): exit 0

## Audit notes

- Engineering review: the launcher-driven test was found to depend on a network install and replaced by the module entry point (above). The Python trailing-comment narrowing was found while making the languages consistent and is recorded in the ADR.
- Genius review: none run.
- Outstanding deferred findings: none. Adjacent observation, not folded in: the tracked tree holds 47 files with a body run over the threshold (33 under test roots), all grandfathered; they are migration candidates the ADR already names.

## Coding-standards compliance

- [x] §2.2 Layer dependency direction preserved (hooks import only hooks and stdlib).
- [x] §3.2 No `any` in production code.
- [x] §4.1 No file > 500 lines (repo cap 300: `_decision_gate_lex.py` 257, `decision_gate.py` 177).
- [x] §4.2 No function > 50 lines (repo cap 40, checked by the craftsmanship gate).
- [x] §4.4 No function with > 4 parameters.
- [x] §7 Local reasoning preserved.
- [x] §8 Every numeric constant carries a `# source:` annotation (`PROSE_RUN_LIMIT`, unchanged).
- [x] §9 No dead code, no TODOs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSTGMnuSuUXWs7ZBofW1AW
